### PR TITLE
scroll view graduation part 2

### DIFF
--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
@@ -117,7 +117,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
                 scrollCollection.CellWidth = 0.032f;
                 scrollCollection.Tiers = 3;
                 scrollCollection.ViewableArea = 5;
-                scrollCollection.DragTimeThreshold = 0.75f;
                 scrollCollection.HandDeltaMagThreshold = 0.02f;
                 scrollCollection.TypeOfVelocity = ScrollingObjectCollection.VelocityType.FalloffPerItem;
             }

--- a/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
@@ -324,7 +324,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
             var scrollContainer = (ScrollingObjectCollection)target;
             // now that its running lets show the press plane so users have feedback about touch
-            center = scrollContainer.transform.TransformPoint(Vector3.forward * -1.0f * frontPlaneDistance.floatValue);
+            center = scrollContainer.transform.TransformPoint(Vector3.forward * -1.0f * releaseThresholdFront.floatValue);
 
             UnityEditor.Handles.color = arrowColor;
 

--- a/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
@@ -31,7 +31,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private SerializedProperty setupAtRuntime;
         private SerializedProperty occlusionPositionPadding;
         private SerializedProperty occlusionScalePadding;
-        private SerializedProperty dragTimeThreshold;
         private SerializedProperty handDeltaMagThreshold;
         private SerializedProperty snapListItems;
 
@@ -53,8 +52,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
         // Serialized properties purely for inspector visualization
         private SerializedProperty nodeList;
-        private SerializedProperty releaseDistance;
-
+        private SerializedProperty releaseThresholdFront;
+        private SerializedProperty releaseThresholdBack;
+        private SerializedProperty releaseThresholdLeftRight;
+        private SerializedProperty releaseThresholdTopBottom;
+        private SerializedProperty frontPlaneDistance;
         private Shader MRTKtmp;
 
         private void OnEnable()
@@ -66,7 +68,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             tiers = serializedObject.FindProperty("tiers");
             canScroll = serializedObject.FindProperty("canScroll");
             scrollDirection = serializedObject.FindProperty("scrollDirection");
-            useNearScrollBoundary = serializedObject.FindProperty("useNearScrollBoundary");
             viewableArea = serializedObject.FindProperty("viewableArea");
             setupAtRuntime = serializedObject.FindProperty("setupAtRuntime");
             useCameraPreRender = serializedObject.FindProperty("useOnPreRender");
@@ -74,7 +75,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             occlusionPositionPadding = serializedObject.FindProperty("occlusionPositionPadding");
             occlusionScalePadding = serializedObject.FindProperty("occlusionScalePadding");
 
-            dragTimeThreshold = serializedObject.FindProperty("dragTimeThreshold");
             handDeltaMagThreshold = serializedObject.FindProperty("handDeltaMagThreshold");
 
             snapListItems = serializedObject.FindProperty("snapListItems");
@@ -90,10 +90,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             untouchEvent = serializedObject.FindProperty("TouchEnded");
             momentumEvent = serializedObject.FindProperty("ListMomentumEnded");
 
-            disableClippedItems = serializedObject.FindProperty("disableClippedItems");
             // Serialized properties for visualization
             nodeList = serializedObject.FindProperty("nodeList");
-            releaseDistance = serializedObject.FindProperty("releaseDistance");
+            releaseThresholdFront = serializedObject.FindProperty("releaseThresholdFront");
+            releaseThresholdBack = serializedObject.FindProperty("releaseThresholdBack");
+            releaseThresholdLeftRight = serializedObject.FindProperty("releaseThresholdLeftRight");
+            releaseThresholdTopBottom = serializedObject.FindProperty("releaseThresholdTopBottom");
+            frontPlaneDistance = serializedObject.FindProperty("frontPlaneDistance");
         }
 
         public override void OnInspectorGUI()
@@ -157,9 +160,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
             using (new EditorGUI.IndentLevelScope())
             {
-                EditorGUILayout.PropertyField(dragTimeThreshold);
                 EditorGUILayout.PropertyField(handDeltaMagThreshold);
-                EditorGUILayout.PropertyField(useNearScrollBoundary);
                 EditorGUILayout.Space();
 
                 EditorGUILayout.PropertyField(occlusionPositionPadding);
@@ -168,7 +169,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
                 EditorGUILayout.PropertyField(animationCurve);
                 EditorGUILayout.PropertyField(animationLength);
-                EditorGUILayout.PropertyField(disableClippedItems);
+                EditorGUILayout.Space();
+
+                EditorGUILayout.PropertyField(releaseThresholdFront);
+                EditorGUILayout.PropertyField(releaseThresholdBack);
+                EditorGUILayout.PropertyField(releaseThresholdLeftRight);
+                EditorGUILayout.PropertyField(releaseThresholdTopBottom);
+                EditorGUILayout.PropertyField(frontPlaneDistance);
             }
 
             EditorGUILayout.Space();
@@ -317,7 +324,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
             var scrollContainer = (ScrollingObjectCollection)target;
             // now that its running lets show the press plane so users have feedback about touch
-            center = scrollContainer.transform.TransformPoint(Vector3.forward * -1.0f * releaseDistance.floatValue);
+            center = scrollContainer.transform.TransformPoint(Vector3.forward * -1.0f * frontPlaneDistance.floatValue);
 
             UnityEditor.Handles.color = arrowColor;
 

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -89,7 +89,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         private float handDeltaMagThreshold = 0.02f;
 
         /// <summary>
-        /// The distance the user's pointer can make before its considered a drag.
+        /// The distance, in meters, the user's pointer can make before its considered a drag.
         /// </summary>
         public float HandDeltaMagThreshold
         {
@@ -102,7 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         [Range(0.0f, 0.30f)]
         private float releaseThresholdFront = 0.03f;
         /// <summary>
-        /// Withdraw amount from the front of the scroll boundary needed to transition from touch engaged to released.
+        /// Withdraw amount, in meters, from the front of the scroll boundary needed to transition from touch engaged to released.
         /// </summary>
         public float ReleaseThresholdFront
         {
@@ -115,7 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         [Range(0.0f, 0.30f)]
         private float releaseThresholdBack = 0.20f;
         /// <summary>
-        /// Withdraw amount from the back of the scroll boundary needed to transition from touch engaged to released.
+        /// Withdraw amount, in meters, from the back of the scroll boundary needed to transition from touch engaged to released.
         /// </summary>
         public float ReleaseThresholdBack
         {
@@ -128,7 +128,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         [Range(0.0f, 0.30f)]
         private float releaseThresholdLeftRight = 0.20f;
         /// <summary>
-        /// Withdraw amount from the right or left of the scroll boundary needed to transition from touch engaged to released.
+        /// Withdraw amount, in meters, from the right or left of the scroll boundary needed to transition from touch engaged to released.
         /// </summary>
         public float ReleaseThresholdLeftRight
         {
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         [Range(0.0f, 0.30f)]
         private float releaseThresholdTopBottom = 0.20f;
         /// <summary>
-        /// Withdraw amount from the top or bottom of the scroll boundary needed to transition from touch engaged to released.
+        /// Withdraw amount, in meters, from the top or bottom of the scroll boundary needed to transition from touch engaged to released.
         /// </summary>
         public float ReleaseThresholdTopBottom
         {

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -84,7 +84,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         [SerializeField]
-        [Tooltip("The distance the user's pointer can make before its considered a drag.")]
+        [Tooltip("The distance, in meters, the user's pointer can make before its considered a drag.")]
         [Range(0.0f, 0.2f)]
         private float handDeltaMagThreshold = 0.02f;
 
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         [SerializeField]
-        [Tooltip("Withdraw amount from the front of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip("Withdraw amount, in meters, from the front of the scroll boundary needed to transition from touch engaged to released.")] 
         [Range(0.0f, 0.30f)]
         private float releaseThresholdFront = 0.03f;
         /// <summary>
@@ -111,7 +111,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         [SerializeField]
-        [Tooltip("Withdraw amount from the back of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip("Withdraw amount, in meters, from the back of the scroll boundary needed to transition from touch engaged to released.")]
         [Range(0.0f, 0.30f)]
         private float releaseThresholdBack = 0.20f;
         /// <summary>
@@ -124,7 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         [SerializeField]
-        [Tooltip("Withdraw amount from the right or left of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip("Withdraw amount, in meters, from the right or left of the scroll boundary needed to transition from touch engaged to released.")]
         [Range(0.0f, 0.30f)]
         private float releaseThresholdLeftRight = 0.20f;
         /// <summary>
@@ -137,7 +137,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         [SerializeField]
-        [Tooltip("Withdraw amount from the top or bottom of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip("Withdraw amount, in meters, from the top or bottom of the scroll boundary needed to transition from touch engaged to released.")]
         [Range(0.0f, 0.30f)]
         private float releaseThresholdTopBottom = 0.20f;
         /// <summary>
@@ -150,7 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         [SerializeField]
-        [Tooltip("Distance to position a local xy plane used to verify if a touch interaction started in the front of the scroll view.")]
+        [Tooltip("Distance, in meters, to position a local xy plane used to verify if a touch interaction started in the front of the scroll view.")]
         [Range(0.0f, 0.05f)]
         private float frontPlaneDistance = 0.005f;
 
@@ -1685,13 +1685,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                     // The object we grabbed isn't a ScrollingObjectCollectionNode
                     NodeList[i] = new ScrollingObjectCollectionNode(NodeList[i]);
                     node = NodeList[i] as ScrollingObjectCollectionNode;
-                }
-
-                // Node object was not properly removed
-                if (node.Transform == null)
-                {
-                    //Reset();
-                    //return;
                 }
 
                 // Hide the items that have no chance of being seen

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -7,7 +7,6 @@ using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using System.Collections;
-using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;


### PR DESCRIPTION
## Overview
This PR is part of Scroll View graduation and addresses the following issues / fixes:

 #8148 
- **Issue:** Scroll Object collection should only engage if touch comes from front of scroll slate but currently the user is able to trigger scroll even when hand comes from behind, top, bottom or sides of the scroll slate
- **Fix:** Checking for previous position of poke pointer when touch started is handled
![scroll_touch_from_back](https://user-images.githubusercontent.com/16922045/86943373-49e37d00-c13e-11ea-9fce-d3cddd22daa1.gif)


 #8064 
- **Issue:** Currently there is no safe way of deleting child items from scroll collection. Destroying an object throw errors on console.
- **Fix:** Added methods for safely for adding and deleting items.
![image](https://user-images.githubusercontent.com/16922045/86942859-97abb580-c13d-11ea-9a96-61ae99775fb3.png)

MissingReferenceException: The object of type 'BoxCollider' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
Microsoft.MixedReality.Toolkit.Experimental.UI.ScrollingObjectCollection.HideItems () (at Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs:1664)
Microsoft.MixedReality.Toolkit.Experimental.UI.ScrollingObjectCollection.LateUpdate () (at Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs:1038

#7449 . 
- **Issue:** scroll view should allow for near interaction area buffer in front, back, top, bottom and sides of scroll slate boundary o match shell behaviour. Currently only front buffer exists. 
- **Fix:** Exposing near interaction releaseThreshoulds for different axis / sides
![scroll_buffer](https://user-images.githubusercontent.com/16922045/86945066-7bf5de80-c140-11ea-905e-6514723693d8.gif)


This PR is based on the Event Propagation feature branch.

- Fixes #8148
- Fixes #7449  
- Fixes #8064 
