### PR TITLE
Fixed issue of object shifting when doing a near grab interaction

### DIFF
--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
@@ -27,10 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         // Show a tracked hand device
         public bool IsTracked = false;
         // Activate the pinch gesture
-        public bool IsPinching
-        {
-            get { return gesture == ArticulatedHandPose.GestureId.Pinch; }
-        }
+        public bool IsPinching { get; private set; }
 
         // Position of the hand in viewport space
         public Vector3 ViewportPosition = Vector3.zero;
@@ -61,6 +58,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             set
             {
                 gestureBlending = Mathf.Clamp(value, gestureBlending, 1.0f);
+                // Pinch is a special gesture that triggers the Select and TriggerPress input actions
+                // The pinch action doesn't occur until the gesture is completed.
+                IsPinching = (gesture == ArticulatedHandPose.GestureId.Pinch && gestureBlending == 1.0f);
             }
         }
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
@@ -27,7 +27,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         // Show a tracked hand device
         public bool IsTracked = false;
         // Activate the pinch gesture
-        public bool IsPinching { get; private set; }
+        // Pinch is a special gesture that triggers the Select and TriggerPress input actions
+        // The pinch action doesn't occur until the gesture is completed.
+        public bool IsPinching => gesture == ArticulatedHandPose.GestureId.Pinch && gestureBlending == 1.0f;
 
         // Position of the hand in viewport space
         public Vector3 ViewportPosition = Vector3.zero;
@@ -58,9 +60,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             set
             {
                 gestureBlending = Mathf.Clamp(value, gestureBlending, 1.0f);
-                // Pinch is a special gesture that triggers the Select and TriggerPress input actions
-                // The pinch action doesn't occur until the gesture is completed.
-                IsPinching = (gesture == ArticulatedHandPose.GestureId.Pinch && gestureBlending == 1.0f);
             }
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             KeyInputSystem.PressKey(iss.InputSimulationProfile.InteractionButton);
             yield return null;
             KeyInputSystem.AdvanceSimulation();
-            yield return null;
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
             // release the click on the cube
             KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.InteractionButton);


### PR DESCRIPTION
## Overview
Object no longer shifts when performing a near grab interaction

## Changes
- Fixes: #7936

Old behavior

![grabold](https://user-images.githubusercontent.com/39840334/86976604-b1460080-c12f-11ea-880c-0fb33eff8fc0.gif)


New behavior

![grabfix](https://user-images.githubusercontent.com/39840334/86976611-b4d98780-c12f-11ea-907d-fbe1447751d7.gif)
