### PR TITLE
Added smoothing factor for near object interaction

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/SpherePointerInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/SpherePointerInspector.cs
@@ -14,6 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private SerializedProperty sphereCastRadius;
         private SerializedProperty pullbackDistance;
         private SerializedProperty nearObjectMargin;
+        private SerializedProperty nearObjectSmoothingFactor;
         private SerializedProperty grabLayerMasks;
         private SerializedProperty triggerInteraction;
         private SerializedProperty sceneQueryBufferSize;
@@ -31,6 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             sceneQueryBufferSize = serializedObject.FindProperty("sceneQueryBufferSize");
             nearObjectSectorAngle = serializedObject.FindProperty("nearObjectSectorAngle");
             nearObjectMargin = serializedObject.FindProperty("nearObjectMargin");
+            nearObjectSmoothingFactor = serializedObject.FindProperty("nearObjectSmoothingFactor");
             grabLayerMasks = serializedObject.FindProperty("grabLayerMasks");
             triggerInteraction = serializedObject.FindProperty("triggerInteraction");
             ignoreCollidersNotInFOV = serializedObject.FindProperty("ignoreCollidersNotInFOV");
@@ -53,6 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     EditorGUILayout.PropertyField(pullbackDistance);
                     EditorGUILayout.PropertyField(sceneQueryBufferSize);
                     EditorGUILayout.PropertyField(nearObjectMargin);
+                    EditorGUILayout.PropertyField(nearObjectSmoothingFactor);
                     EditorGUILayout.PropertyField(triggerInteraction);
                     EditorGUILayout.PropertyField(grabLayerMasks, true);
                     EditorGUILayout.PropertyField(ignoreCollidersNotInFOV);

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ConicalGrabPointer.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ConicalGrabPointer.prefab
@@ -75,6 +75,7 @@ MonoBehaviour:
   nearObjectSectorAngle: 66
   nearObjectMargin: 0.2
   nearObjectAxisLerp: 0.9
+  nearObjectSmoothingFactor: 0.4
   grabLayerMasks:
   - serializedVersion: 2
     m_Bits: 563

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/GrabPointer.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/GrabPointer.prefab
@@ -75,6 +75,7 @@ MonoBehaviour:
   nearObjectSectorAngle: 360
   nearObjectMargin: 0.2
   nearObjectAxisLerp: 0.9
+  nearObjectSmoothingFactor: 0.4
   grabLayerMasks:
   - serializedVersion: 2
     m_Bits: 563

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -95,7 +95,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Min(0.0f)]
         [Tooltip("Smoothing factor for near object detection sensitivity")]
         private float nearObjectSmoothingFactor = 0.4f;
-
+        /// <summary>
+        /// Smoothing factor for near object detection sensitivity.
+        /// </summary>
+        public float NearObjectSmoothingFactor
+        {
+            get => nearObjectSmoothingFactor;
+            set => nearObjectSmoothingFactor = value;
+        }
         /// <summary>
         /// Distance at which the pointer is considered "near" an object.
         /// </summary>
@@ -419,7 +426,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     grabbable = null;
                     numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(
                         pointerPosition,
-                        queryRadius,
+                        radius,
                         queryBuffer,
                         layerMask,
                         triggerInteraction);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -93,10 +93,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Min(0.0f)]
-        [Tooltip("Smoothing factor for near object detection sensitivity")]
+        [Tooltip("Smoothing factor for query detection. If an object is detected in the NearObjectRadius, the queried radius then becomes NearObjectRadius * (1 + nearObjectSmoothingFactor) to reduce the sensitivity")]
         private float nearObjectSmoothingFactor = 0.4f;
         /// <summary>
-        /// Smoothing factor for near object detection sensitivity.
+        /// Smoothing factor for query detection. If an object is detected in the NearObjectRadius, the queried radius then becomes NearObjectRadius * (1 + nearObjectSmoothingFactor) to reduce the sensitivity.
         /// </summary>
         public float NearObjectSmoothingFactor
         {
@@ -419,9 +419,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     float radius;
                     if (ContainsGrabbable)
+                    {
                         radius = queryRadius * (1 + querySmoothingFactor);
+                    }
                     else
+                    {
                         radius = queryRadius;
+                    }
 
                     grabbable = null;
                     numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(

--- a/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             var pointer = rightHand.GetPointer<SpherePointer>();
             Vector3 margin = new Vector3(0, 0, 0.001f);
-            Vector3 farMargin = new Vector3(0, 0, 0.001f + pointer.NearObjectSmoothingFactor);
+            Vector3 nearObjectMargin = new Vector3(0, 0, 0.001f + (pointer.NearObjectSmoothingFactor + 1) * pointer.NearObjectRadius);
             Assert.IsNotNull(pointer, "Expected to find SpherePointer in the hand controller");
             Vector3 nearObjectPos = new Vector3(0.05f, 0, colliderSurfaceZ - pointer.NearObjectRadius);
             Vector3 interactionEnabledPos = new Vector3(0.05f, 0, colliderSurfaceZ - pointer.SphereCastRadius);
@@ -196,7 +196,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.False(pointer.IsInteractionEnabled);
 
             // Move hand closer to the collider to enable IsNearObject
-            yield return rightHand.MoveTo(nearObjectPos - farMargin, numFramesPerMove);
+            yield return rightHand.MoveTo(nearObjectPos - nearObjectMargin, numFramesPerMove);
             Assert.False(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
             yield return rightHand.MoveTo(nearObjectPos + margin, numFramesPerMove);
@@ -219,14 +219,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return rightHand.MoveTo(nearObjectPos + margin, numFramesPerMove);
             Assert.True(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
-            yield return rightHand.MoveTo(nearObjectPos - farMargin, numFramesPerMove);
+            yield return rightHand.MoveTo(nearObjectPos - nearObjectMargin, numFramesPerMove);
             Assert.False(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
 
             // Testing that we have more leeway when the pointer's nearObject smoothing factor is set
             // Move hand back out to disable IsNearObject
-            Debug.Log(pointer.NearObjectSmoothingFactor);
-            pointer.NearObjectSmoothingFactor = 0.0f;
             yield return rightHand.MoveTo(nearObjectPos + margin, numFramesPerMove);
             Assert.True(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
@@ -246,7 +244,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator SpherePointerPullbackDistance()
         {
-            Vector3 margin = new Vector3(0, 0, 0.001f);
             // Approximate distance covered by the pullback distance;
             Vector3 pullbackDelta = new Vector3(0, 0, 0.08f);
 
@@ -261,6 +258,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             pointer.PullbackDistance = 0.08f;
             pointer.TryGetNearGraspPoint(out Vector3 graspPoint);
             // Orient the right hand so the grab axis is approximately aligned with the z axis
+
+            Vector3 margin = new Vector3(0, 0, 0.001f);
+            Vector3 nearObjectMargin = new Vector3(0, 0, 0.001f + (pointer.NearObjectSmoothingFactor + 1) * pointer.NearObjectRadius);
 
             Assert.IsNotNull(pointer, "Expected to find SpherePointer in the hand controller");
             Vector3 nearObjectPos = new Vector3(0.05f, 0, colliderSurfaceZ - (pointer.NearObjectRadius));
@@ -283,7 +283,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.False(pointer.IsInteractionEnabled);
             
             // Move hand back out to disable IsNearObject
-            yield return rightHand.MoveTo(nearObjectPos - margin, numFramesPerMove);
+            yield return rightHand.MoveTo(nearObjectPos - nearObjectMargin, numFramesPerMove);
             Assert.False(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
 
@@ -299,8 +299,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator SpherePointerSectorAngle()
         {
-            Vector3 margin = new Vector3(0, 0, 0.001f);
-
             var rightHand = new TestHand(Handedness.Right);
 
             // Show hand far enough from the test collider
@@ -311,6 +309,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var pointer = rightHand.GetPointer<SpherePointer>();
             pointer.NearObjectSectorAngle = 180.0f;
             // Orient the right hand so the grab axis is approximately aligned with the z axis
+
+            Vector3 margin = new Vector3(0, 0, 0.001f);
+            Vector3 nearObjectMargin = new Vector3(0, 0, 0.001f + (pointer.NearObjectSmoothingFactor + 1) * pointer.NearObjectRadius);
 
             Assert.IsNotNull(pointer, "Expected to find SpherePointer in the hand controller");
             Vector3 nearObjectPos = new Vector3(0.05f, 0, colliderSurfaceZ - pointer.NearObjectRadius);
@@ -360,7 +361,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return rightHand.MoveTo(nearObjectPos + margin, numFramesPerMove);
             Assert.True(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
-            yield return rightHand.MoveTo(nearObjectPos - margin, numFramesPerMove);
+            yield return rightHand.MoveTo(nearObjectPos - nearObjectMargin, numFramesPerMove);
             Assert.False(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
 


### PR DESCRIPTION
## Overview
Currently the IsNearObject detection is very sensitive, meaning the user can be subject to hand rays suddenly flickering in and out of view. This PR adds a smoothing factor in order to reduce the sensitivity of the IsNearObject detection. 

Basically, when an object is inside the query radius, it then has to be outside queryRadius * (1+smoothingFactor) to no longer be detected

![nearobjectflicker](https://user-images.githubusercontent.com/39840334/87099818-980c8500-c1ff-11ea-9ef0-8ba9a3aa8c31.gif)

## Changes
- Fixes: #7938

