### PR TITLE
Re-implement hand bounds in local space, and added palm-based hand constraint safe zone targeting

### DIFF
--- a/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
@@ -14,12 +14,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public class HandBounds : MonoBehaviour, IMixedRealitySourceStateHandler, IMixedRealityHandJointHandler
     {
         /// <summary>
-        /// Accessor for the bounds associated with a handedness.
+        /// Accessor for the bounds associated with a handedness, calculated in global-axis-aligned space.
         /// </summary>
         public Dictionary<Handedness, Bounds> Bounds { get; private set; } = new Dictionary<Handedness, Bounds>();
         
         /// <summary>
-        /// Accessor for the bounds associated with a handedness, but calculated in local hand-space.
+        /// Accessor for the bounds associated with a handedness, calculated in local hand-space, locally axis aligned.
         /// </summary>
         public Dictionary<Handedness, Bounds> LocalBounds { get; private set; } = new Dictionary<Handedness, Bounds>();
 

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -332,14 +332,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             var goalPosition = SolverHandler.TransformTarget.position;
             Bounds trackedHandBounds;
 
-            MixedRealityPose? palmPose = GetPalmPose(trackedController);
-
             if (trackedController != null &&
                 handBounds.LocalBounds.TryGetValue(trackedController.ControllerHandedness, out trackedHandBounds))
             {
                 float distance;
                 Ray ray = CalculateProjectedSafeZoneRay(goalPosition, SolverHandler.TransformTarget, trackedController, safeZone, OffsetBehavior);
                 trackedHandBounds.Expand(safeZoneBuffer);
+
+                MixedRealityPose? palmPose = GetPalmPose(trackedController);
 
                 // We need to transform the ray into hand-space before performing the AABB intersection.
                 ray.origin = Quaternion.Inverse(palmPose.Value.Rotation) * (ray.origin - palmPose.Value.Position);

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -38,7 +38,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             /// <summary>
             /// Below where the controller meets the arm.
             /// </summary>
-            BelowWrist = 3
+            BelowWrist = 3,
+            /// <summary>
+            /// Floating above the palm.
+            /// </summary>
+            AtopPalm = 4
         }
 
         [Header("Hand Constraint")]
@@ -66,6 +70,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         {
             get => safeZoneBuffer;
             set => safeZoneBuffer = value;
+        }
+
+        [SerializeField]
+        [Tooltip("Use raycasting when attaching to palm, instead of using palm joint directly.")]
+        private bool usePalmRaycast = false;
+
+        /// <summary>
+        /// Use raycasting when attaching to palm, instead of using palm joint directly.
+        /// </summary>
+        public bool UsePalmRaycast
+        {
+            get => usePalmRaycast;
+            set => usePalmRaycast = value;
         }
 
         [SerializeField]
@@ -330,13 +347,27 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             if (trackedController != null &&
                 handBounds.Bounds.TryGetValue(trackedController.ControllerHandedness, out trackedHandBounds))
             {
-                float distance;
-                Ray ray = CalculateProjectedSafeZoneRay(goalPosition, SolverHandler.TransformTarget, trackedController, safeZone, OffsetBehavior);
-                trackedHandBounds.Expand(safeZoneBuffer);
-
-                if (trackedHandBounds.IntersectRay(ray, out distance))
+                // If we are mounting to the palm, and don't want to use raycasting to find the
+                // palm goal position, we will calculate the goal position using the palm joint directly.
+                if (safeZone == SolverSafeZone.AtopPalm && !UsePalmRaycast)
                 {
-                    goalPosition = ray.origin + ray.direction * distance;
+                    MixedRealityPose? palmPose = GetPalmPose(trackedController);
+                    if(palmPose.HasValue)
+                    {
+                        // We also apply the buffer value manually here.
+                        goalPosition = palmPose.Value.Position - palmPose.Value.Up * safeZoneBuffer;
+                    }
+                }
+                else
+                {
+                    float distance;
+                    Ray ray = CalculateProjectedSafeZoneRay(goalPosition, SolverHandler.TransformTarget, trackedController, safeZone, OffsetBehavior);
+                    trackedHandBounds.Expand(safeZoneBuffer);
+
+                    if (trackedHandBounds.IntersectRay(ray, out distance))
+                    {
+                        goalPosition = ray.origin + ray.direction * distance;
+                    }
                 }
             }
 
@@ -378,7 +409,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
                 goalRotation *= Quaternion.Euler(additionalRotation.x, additionalRotation.y, additionalRotation.z);
             }
-
+            
             return goalRotation;
         }
 
@@ -507,6 +538,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                         }
                     }
                     break;
+                case SolverSafeZone.AtopPalm:
+                    {
+                        // This is always palm-pose dependent, as we are extruding
+                        // the up vector away from the palm pose, regardless of the desired
+                        // rotation behavior. If no palm pose is available, we use the
+                        // camera view vector as an approximation.
+                        direction = -GetPalmPose(hand)?.Up ?? -lookAtCamera;
+                    }
+                    break;
             }
 
             return new Ray(origin + direction, -direction);
@@ -523,6 +563,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             }
 
             return false;
+        }
+
+        private static MixedRealityPose? GetPalmPose(IMixedRealityController hand)
+        {
+            MixedRealityPose palmPose;
+            var jointedHand = hand as IMixedRealityHand;
+
+            if ((jointedHand != null) && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
+            {
+                return palmPose;
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -537,12 +537,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         private static bool IsPalmFacingCamera(IMixedRealityController hand)
         {
-            MixedRealityPose palmPose;
-            var jointedHand = hand as IMixedRealityHand;
+            MixedRealityPose? palmPose = GetPalmPose(hand);
 
-            if ((jointedHand != null) && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
+            if (palmPose.HasValue)
             {
-                return (Vector3.Dot(palmPose.Up, CameraCache.Main.transform.forward) > 0.0f);
+                return (Vector3.Dot(palmPose.Value.Up, CameraCache.Main.transform.forward) > 0.0f);
             }
 
             return false;

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -40,7 +40,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             /// </summary>
             BelowWrist = 3,
             /// <summary>
-            /// Floating above the palm.
+            /// Floating above the palm, towards the "inside" of the hand (opposite side of knuckles),
+            /// based on the "down" vector of the palm joint (i.e., the grabbing-side of the hand)
             /// </summary>
             AtopPalm = 4
         }

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -355,6 +355,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                     {
                         return false;
                     }
+                case SolverSafeZone.AtopPalm:
+                    referenceJoint1 = TrackedHandJoint.Palm;
+                    referenceJoint2 = TrackedHandJoint.Palm;
+                    break;
                 case SolverSafeZone.RadialSide:
                     referenceJoint1 = TrackedHandJoint.IndexKnuckle;
                     referenceJoint2 = TrackedHandJoint.ThumbProximalJoint;

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -1336,6 +1336,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 case HandConstraint.SolverSafeZone.BelowWrist:
                     return Vector3.up * WristTestActivationPointModifier;
 
+                // AtopPalm uses the same test zone as AboveFingerTips because
+                // the hand must move to a similar position to activate.
                 case HandConstraint.SolverSafeZone.AtopPalm:
                 case HandConstraint.SolverSafeZone.AboveFingerTips:
                     return Vector3.down * AboveFingerTipsTestActivationPointModifier;

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -400,6 +400,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test the HandConstraintPalm up to make sure the activation methods work as intended for the AtopPalm safe zone
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestHandConstraintPalmUpSolverActivationAtopPalm()
+        {
+            yield return TestHandConstraintPalmUpGazeActivationByZoneAndHand(HandConstraint.SolverSafeZone.AtopPalm, Handedness.Left);
+            yield return TestHandConstraintPalmUpGazeActivationByZoneAndHand(HandConstraint.SolverSafeZone.AtopPalm, Handedness.Right);
+        }
+
+        /// <summary>
         /// Test the HandConstraintPalm up to make sure the FollowHandUntilFacingCamera behavior works as expected
         /// </summary>
         [UnityTest]
@@ -1269,7 +1279,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             handConstraintSolver.FollowHandUntilFacingCamera = true;
             handConstraintSolver.UseGazeActivation = true;
 
-            // First test the Ulnar safe zone
             handConstraintSolver.SafeZone = safeZone;
 
             // Ensure that FacingCameraTrackingThreshold is greater than FollowHandCameraFacingThresholdAngle
@@ -1327,6 +1336,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 case HandConstraint.SolverSafeZone.BelowWrist:
                     return Vector3.up * WristTestActivationPointModifier;
 
+                case HandConstraint.SolverSafeZone.AtopPalm:
                 case HandConstraint.SolverSafeZone.AboveFingerTips:
                     return Vector3.down * AboveFingerTipsTestActivationPointModifier;
 


### PR DESCRIPTION
![handsolver](https://user-images.githubusercontent.com/5544935/87112332-00676080-c218-11ea-960e-a5955d72dfe3.gif)

<img src="https://user-images.githubusercontent.com/5544935/87213937-269f0600-c2d5-11ea-8e7a-26d4fcbcaa4a.gif" width=400px> <img src="https://user-images.githubusercontent.com/5544935/87213938-2999f680-c2d5-11ea-8554-ac3a3a508aa1.gif" width=400px>


## Overview
The HandConstraint system is quite robust, including the HandConstraintPalmUp extension; however, there is currently no way to constrain to the palm joint. Different safe zones targeting modes are available, but the palm is not one of them!

This small PR adds the ability to target an `AtopPalm` safe zone, which is either generated with the same raycast method that is already used for the other safe zones (not recommended) or is directly bound to the palm joint (recommended).

Most notably, this palm-based target is compatible with all existing palm-up hand constraint systems (gaze targeting, proximity checks, etc).

Note: above-palm targeting is _NOT_ recommended for menu placement, as noted in the official hand menu documentation! This feature is intended to constrain/target _other_ kinds of objects, like widgets and props.

In addition, **this re-implements/converts the existing hand bounds calculation system to also produce bounds that are represented in local palm-aligned coordinates**; this results in **significantly improved accuracy** when raycasting against hand bounds to find attachment safe-zones.

## Changes
- Adds the `AtopPalm` solver safe zone.
- Adds palm raycasting to the raycast zone calculation system
- Adds a special case for non-raycasting-based safe zone targeting
- Adds a gaze target point for the palm-centered safe zone to the `HandConstraintPalmUp` component.
- Adds a `LocalBounds` dictionary to the `HandBounds` component, and switches `HandConstraint` to use the `LocalBounds` when computing ray intersections.

## Verification
Unit test has been added to verify the `AtopHand` attachment safe-zone.
