### PR TITLE
The Dependency Window Now Searches for Meta Files Within Packages

### DIFF
--- a/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
+++ b/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
@@ -312,12 +312,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             dependencyGraph.Clear();
 
-            var metaExtension = ".meta";
-            string[] metaFiles = Directory.GetFiles(Application.dataPath, "*" + metaExtension, SearchOption.AllDirectories);
+            // Get all meta files from the assets and package cache directories. 
+            const string metaExtension = ".meta";
+            var metaFiles = new List<string>();
+            metaFiles.AddRange(Directory.GetFiles(Application.dataPath, "*" + metaExtension, SearchOption.AllDirectories));
+            metaFiles.AddRange(Directory.GetFiles(Path.Combine(Directory.GetParent(Application.dataPath).FullName, "Library\\PackageCache"), "*" + metaExtension, SearchOption.AllDirectories));
 
-            for (int i = 0; i < metaFiles.Length; ++i)
+            for (int i = 0; i < metaFiles.Count; ++i)
             {
-                var progress = (float)i / metaFiles.Length;
+                var progress = (float)i / metaFiles.Count;
 
                 if (EditorUtility.DisplayCancelableProgressBar(windowTitle, "Building dependency graph...", progress))
                 {


### PR DESCRIPTION
## Overview

Files that exist within the unity `Packages` folder do not get tracked by the Dependency Window. This could be especially bad if the MRTK is a package within a project.

When a user clicks on a file within a package they are greeted with this cryptic warning:
![image](https://user-images.githubusercontent.com/13305729/87118749-04ec4300-c231-11ea-8c43-1df7411dc9f7.png)

With this change files within packages are correctly added to the dependency graph.
 
## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8161

## Verification
> Please open the Dependency Window and note that more files are now searched.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
