### PR TITLE
Fix path to script for CI

### DIFF
--- a/pipelines/templates/tasks/versionmetadata.yml
+++ b/pipelines/templates/tasks/versionmetadata.yml
@@ -7,7 +7,7 @@ steps:
   displayName: 'Version Metadata'
   inputs:
     targetType: filePath
-    filePath: ./scripts/ci/versionmetadata.ps1
+    filePath: ./scripts/packaging/versionmetadata.ps1
     arguments: >
       -Directory: '$(Build.SourcesDirectory)'
       -Version: '$(parameters.MRTKVersion)'


### PR DESCRIPTION
## Overview

#8133 had an incorrect path to a `.ps1` script for the CI to run, causing CI failures. This updates it to correctly point to [scripts/packaging/versionmetadata.ps1](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/scripts/packaging/versionmetadata.ps1)