### PR TITLE
Fix parameter expansion in CI versioning

### DIFF
--- a/pipelines/templates/tasks/versionmetadata.yml
+++ b/pipelines/templates/tasks/versionmetadata.yml
@@ -10,4 +10,4 @@ steps:
     filePath: ./scripts/packaging/versionmetadata.ps1
     arguments: >
       -Directory: '$(Build.SourcesDirectory)'
-      -Version: '$(parameters.MRTKVersion)'
+      -Version: '${{ parameters.MRTKVersion }}'

--- a/scripts/packaging/versionmetadata.ps1
+++ b/scripts/packaging/versionmetadata.ps1
@@ -214,7 +214,7 @@ function CheckProjectSettings {
                 # For the metroPackageVersion (which is used to generate the MRTK project
                 # AppX versions, they need to have an additional .0 tacked onto the end)
                 if ($line -match " metroPackageVersion") {
-                    $expected = "$expected.0" 
+                    $expected = "$expected.0"
                 }
 
                 if ($expected -ne $version) {


### PR DESCRIPTION
## Overview

The CI yaml format uses `${{ ... }}` for parameter expansion, which is apparently different from how you can specify things like `$(Build.SourcesDirectory)` on the line above.

This was causing

>Formatted command: . 'f:\aipmragent_work\9\s\scripts\packaging\versionmetadata.ps1' -Directory: 'f:\aipmragent_work\9\s' -Version: '$(parameters.MRTKVersion)'

when CI runs.