### PR TITLE
Made hands free input simulation more responsive

### DIFF
--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
@@ -29,16 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         // Activate the pinch gesture
         // Pinch is a special gesture that triggers the Select and TriggerPress input actions
         // The pinch action doesn't occur until the gesture is completed.
-        public bool IsPinching
-        {
-            get
-            {
-                if (handedness == Handedness.None)
-                    return gesture == ArticulatedHandPose.GestureId.Pinch;
-                else
-                    return gesture == ArticulatedHandPose.GestureId.Pinch && gestureBlending == 1.0f;
-            }
-        }
+        public bool IsPinching => gesture == ArticulatedHandPose.GestureId.Pinch && gestureBlending == 1.0f;
 
         // Position of the hand in viewport space
         public Vector3 ViewportPosition = Vector3.zero;
@@ -332,7 +323,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             float gestureAnimDelta = profile.HandGestureAnimationSpeed * Time.unscaledDeltaTime;
             HandStateLeft.GestureBlending += gestureAnimDelta;
             HandStateRight.GestureBlending += gestureAnimDelta;
-            HandStateGaze.GestureBlending += gestureAnimDelta;
+            HandStateGaze.GestureBlending = 1.0f;
         }
 
         /// Apply changes to one hand and update tracking

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
@@ -29,7 +29,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
         // Activate the pinch gesture
         // Pinch is a special gesture that triggers the Select and TriggerPress input actions
         // The pinch action doesn't occur until the gesture is completed.
-        public bool IsPinching => gesture == ArticulatedHandPose.GestureId.Pinch && gestureBlending == 1.0f;
+        public bool IsPinching
+        {
+            get
+            {
+                if (handedness == Handedness.None)
+                    return gesture == ArticulatedHandPose.GestureId.Pinch;
+                else
+                    return gesture == ArticulatedHandPose.GestureId.Pinch && gestureBlending == 1.0f;
+            }
+        }
 
         // Position of the hand in viewport space
         public Vector3 ViewportPosition = Vector3.zero;


### PR DESCRIPTION
## Overview
Add on to PR #8156 

The previous PR makes it so the pinch gesture isn't raised immediately when using hands free input simulation. This PR improves the responsiveness by making the pinch gesture get raised as soon as the pinch button is pressed.
