### PR TITLE
Add note about UWP in editor support for Leap

### DIFF
--- a/Documentation/CrossPlatform/LeapMotionMRTK.md
+++ b/Documentation/CrossPlatform/LeapMotionMRTK.md
@@ -6,6 +6,8 @@ The Leap Motion Data Provider enables articulated hand tracking for VR and could
 
 ![LeapMotionIntroGif](../Images/CrossPlatform/LeapMotion/LeapHandsGif3.gif)
 
+This provider can be used in editor and on device while on the Standalone platform.  It can also be used in editor while on the UWP platform but NOT in a UWP build.
+
 ## Using Leap Motion (by Ultraleap) hand tracking in MRTK
 
 1. Prepare MRTK project for Leap Motion


### PR DESCRIPTION
## Overview
Adds a note at the top of the leap documentation that says the leap provider can be used in editor while on UWP but not in a build.

Also clarifies that the provider only supports standalone builds at the top instead of only in step 5.

## Changes
- Fixes: #7945 
