### PR TITLE
Fix dockable object assertion failure

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Dock/Dockable.cs
+++ b/Assets/MRTK/SDK/Experimental/Dock/Dockable.cs
@@ -111,6 +111,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
 
             overlappingPositions.Clear();
+            dockingState = DockingState.Undocked;
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
Currently dockable objects create assertion failures when being reenabled after being disabled in the docked state. The fix resets the docking state back to undocked when the object gets disabled.

## Changes
- Fixes: #8065 .