### PR TITLE
Update the MRTK object inspector tabs to properly render selection in Unity 2019

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -403,7 +403,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             GUI.enabled = true; // Force enable so we can view profile defaults
 
             int prefsSelectedTab = SessionState.GetInt(SelectedTabPreferenceKey, 0);
-            SelectedProfileTab = GUILayout.SelectionGrid(prefsSelectedTab, ProfileTabTitles, 1, EditorStyles.boldLabel, GUILayout.MaxWidth(125));
+            SelectedProfileTab = GUILayout.SelectionGrid(prefsSelectedTab, ProfileTabTitles, 1, GUILayout.MaxWidth(125));
             if (SelectedProfileTab != prefsSelectedTab)
             {
                 SessionState.SetInt(SelectedTabPreferenceKey, SelectedProfileTab);


### PR DESCRIPTION
It turns out that with the styling changes in Unity 2019, the "selection" state doesn't actually show up when we use boldLabel. We could probably do some custom styling so that it has the right highlight/select thing, but in this case using the default selection style works:

Before:
![image](https://user-images.githubusercontent.com/5840182/87485271-44c67800-c5ed-11ea-8d63-f6739b3a6902.png)

After:
![image](https://user-images.githubusercontent.com/5840182/87485279-4859ff00-c5ed-11ea-97eb-38932bb31579.png)

Unity 2018:
![image](https://user-images.githubusercontent.com/5840182/87485542-e0f07f00-c5ed-11ea-8639-a80601c385df.png)
