### PR TITLE
Fix a TapToPlace issue caused by Start() execution order

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
@@ -216,6 +216,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         protected float DoubleClickTimeout = 0.5f;
 
+        // Used to mark whether Start() has been called.
+        private bool startCalled;
+
         #region MonoBehaviour Implementation
         protected override void Start()
         {
@@ -229,6 +232,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             UnityPhysics.SyncTransforms();
 
             ignoreRaycastLayer = LayerMask.NameToLayer("Ignore Raycast");
+
+            startCalled = true;
 
             if (AutoStart)
             {
@@ -255,6 +260,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public void StartPlacement()
         {
+            // Check to see if Start() has been called, if not set AutoStart to true. This will make sure StartPlacement() will be
+            // called again when Start() is called.
+            if (!startCalled)
+            {
+                AutoStart = true;
+                return;
+            }
+
             // Added for code configurability to avoid multiple calls to StartPlacement in a row
             if (!IsBeingPlaced)
             {

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
@@ -219,6 +219,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         // Used to mark whether Start() has been called.
         private bool startCalled;
 
+        // Used to mark whether StartPlacement() is called before Start() is called.
+        private bool placementRequested;
+
         #region MonoBehaviour Implementation
         protected override void Start()
         {
@@ -235,7 +238,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
             startCalled = true;
 
-            if (AutoStart)
+            if (AutoStart || placementRequested)
             {
                 StartPlacement();
             }
@@ -260,11 +263,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public void StartPlacement()
         {
-            // Check to see if Start() has been called, if not set AutoStart to true. This will make sure StartPlacement() will be
+            // Check to see if Start() has been called, if not set placementRequested to true. This will make sure StartPlacement() will be
             // called again when Start() is called.
             if (!startCalled)
             {
-                AutoStart = true;
+                placementRequested = true;
                 return;
             }
 

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -910,7 +910,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Make sure it is not in beingPlace state
             Assert.False(tapToPlace.IsBeingPlaced);
 
-            //Set the cube to active which causes Start() to be called
+            // Set the cube to active which causes Start() to be called
             tapToPlaceObj.target.SetActive(true);
 
             // Wait until the next frame

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -817,7 +817,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.False(tapToPlace.IsBeingPlaced);
         }
 
-
         /// <summary>
         /// Tests the UseDefaultSurfaceNormalOffset property for Tap to Place while the object is in the placing state. If the 
         /// UseDefaultSurfaceNormalOffset is true, the object should appear flat against a collider. If false, the object will
@@ -890,6 +889,58 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             tapToPlace.StopPlacement();
 
             Assert.False(tapToPlace.IsBeingPlaced);
+        }
+
+        /// <summary>
+        /// Tests the functionality of StartPlacement() when called before Start() is called. In this case, StartPlacement should
+        /// do its normal job after Start() is called.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTapToPlaceStartPlacementBeforeStart()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Create an inactive cube with Tap to Place attached
+            var tapToPlaceObj = InstantiateTestSolver<TapToPlace>(false);
+            TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
+
+            // Call StartPlament() before its Start() is called
+            tapToPlace.StartPlacement();
+
+            // Make sure it is not in beingPlace state
+            Assert.False(tapToPlace.IsBeingPlaced);
+
+            //Set the cube to active which causes Start() to be called
+            tapToPlaceObj.target.SetActive(true);
+
+            // Wait until the next frame
+            yield return null;
+
+            // Make sure it is now in beingPlace state
+            Assert.True(tapToPlace.IsBeingPlaced);
+        }
+
+        /// <summary>
+        /// Tests the functionality of StartPlacement() when called after Start() is called. In this case, StartPlacement should
+        /// do its normal job.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTapToPlaceStartPlacementAfterStart()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Create an active cube with Tap to Place attached
+            var tapToPlaceObj = InstantiateTestSolver<TapToPlace>();
+            TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
+
+            // Wait until the next frame
+            yield return null;
+
+            // Call StartPlament() after its Start() is called
+            tapToPlace.StartPlacement();
+
+            // Make sure it is now in beingPlace state
+            Assert.True(tapToPlace.IsBeingPlaced);
         }
 
         #endregion
@@ -1218,11 +1269,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return WaitForFrames(2);
         }
 
-        private SetupData InstantiateTestSolver<T>() where T : Solver
+        private SetupData InstantiateTestSolver<T>(bool setGameObjectActive = true) where T : Solver
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.name = typeof(T).Name;
             cube.transform.localScale = new Vector3(0.1f, 0.2f, 0.1f);
+            cube.SetActive(setGameObjectActive);
 
             Solver solver = AddSolverComponent<T>(cube);
 


### PR DESCRIPTION
## Overview
Due to the unpredictable execution order of Start() in Unity, StartPlacement() could be called by the Start() of another script before its own Start() is called, where expected behavior will not happen and user receives no warning.

## Changes
- Fixes: #8080 .