### PR TITLE
Perform null check on glTF material parsing

### DIFF
--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -273,7 +273,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 material.renderQueue = 3000;
             }
 
-            if (gltfMaterial.emissiveTexture.index >= 0 && material.HasProperty("_EmissionMap"))
+            if (gltfMaterial.emissiveTexture?.index >= 0 && material.HasProperty("_EmissionMap"))
             {
                 material.EnableKeyword("_EMISSION");
                 material.SetColor(EmissiveColorId, gltfMaterial.emissiveFactor.GetColorValue());

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -355,7 +355,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 name = string.IsNullOrEmpty(gltfMaterial.name) ? $"glTF Material {materialId}" : gltfMaterial.name
             };
 
-            if (gltfMaterial.pbrMetallicRoughness.baseColorTexture.index >= 0)
+            if (gltfMaterial.pbrMetallicRoughness.baseColorTexture?.index >= 0)
             {
                 material.mainTexture = gltfObject.images[gltfMaterial.pbrMetallicRoughness.baseColorTexture.index].Texture;
             }
@@ -387,7 +387,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 material.renderQueue = 3000;
             }
 
-            if (gltfMaterial.emissiveTexture.index >= 0)
+            if (gltfMaterial.emissiveTexture?.index >= 0)
             {
                 material.EnableKeyword("_EmissionMap");
                 material.EnableKeyword("_EMISSION");
@@ -395,7 +395,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 material.SetColor(EmissionColorId, gltfMaterial.emissiveFactor.GetColorValue());
             }
 
-            if (gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture.index >= 0)
+            if (gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture?.index >= 0)
             {
                 var texture = gltfObject.images[gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture.index].Texture;
 
@@ -428,7 +428,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 material.EnableKeyword("_METALLICGLOSSMAP");
             }
 
-            if (gltfMaterial.normalTexture.index >= 0)
+            if (gltfMaterial.normalTexture?.index >= 0)
             {
                 material.SetTexture(BumpMapId, gltfObject.images[gltfMaterial.normalTexture.index].Texture);
                 material.EnableKeyword("_BumpMap");

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -241,7 +241,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 name = string.IsNullOrEmpty(gltfMaterial.name) ? $"glTF Material {materialId}" : gltfMaterial.name
             };
 
-            if (gltfMaterial.pbrMetallicRoughness.baseColorTexture.index >= 0)
+            if (gltfMaterial.pbrMetallicRoughness.baseColorTexture?.index >= 0)
             {
                 material.mainTexture = gltfObject.images[gltfMaterial.pbrMetallicRoughness.baseColorTexture.index].Texture;
             }
@@ -279,7 +279,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 material.SetColor(EmissiveColorId, gltfMaterial.emissiveFactor.GetColorValue());
             }
 
-            if (gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture.index >= 0)
+            if (gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture?.index >= 0)
             {
                 var texture = gltfObject.images[gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture.index].Texture;
 
@@ -328,7 +328,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
             }
 
 
-            if (gltfMaterial.normalTexture.index >= 0)
+            if (gltfMaterial.normalTexture?.index >= 0)
             {
                 material.SetTexture(NormalMapId, gltfObject.images[gltfMaterial.normalTexture.index].Texture);
                 material.SetFloat(NormalMapScaleId, (float)gltfMaterial.normalTexture.scale);


### PR DESCRIPTION
The parser sometimes fails when one of the texture channels is null. This simply add a null check so things can continue on without failing.