### PR TITLE
Update the Unity AR configuration checker to not run during play mode changes

### DIFF
--- a/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
@@ -20,7 +20,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 
         static UnityARConfigurationChecker()
         {
-            UpdateAsmDef(ReconcileArFoundationDefine());
+            // TODO(https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8188)
+            // This should be updated to only run on editor launch and on large asset changes
+            // (i.e. post import of asset packages). This should remove this from the inner compile
+            // loop.
+            if (!EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                UpdateAsmDef(ReconcileArFoundationDefine());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This is a slight mitigation for: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8188

The issue here is that anything that we have that is InitializeOnLoad, it ends up running on editor launch, on recompile, and on play mode entrance. 

This is a workaround to make it not happen on play mode entrance.

The bigger fix here is going to require more work to do correctly.