### PR TITLE
Add None to AxisFlags

### DIFF
--- a/Assets/MRTK/Core/Definitions/Utilities/AxisFlags.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/AxisFlags.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     [System.Flags]
     public enum AxisFlags
     {
+        None = 0,
         XAxis = 1 << 0,
         YAxis = 1 << 1,
         ZAxis = 1 << 2

--- a/Assets/MRTK/Core/Definitions/Utilities/RotationConstraintType.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/RotationConstraintType.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 case RotationConstraintType.ZAxisOnly:
                     return AxisFlags.XAxis | AxisFlags.YAxis;
                 default:
-                    return 0;
+                    return AxisFlags.None;
             }
         }
     }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/MoveAxisConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/MoveAxisConstraint.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [EnumFlags]
         [Tooltip("Constrain movement along an axis")]
-        private AxisFlags constraintOnMovement = 0;
+        private AxisFlags constraintOnMovement = AxisFlags.None;
 
         /// <summary>
         /// Constrain movement along an axis

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/RotationAxisConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/RotationAxisConstraint.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [EnumFlags]
         [Tooltip("Constrain rotation about an axis")]
-        private AxisFlags constraintOnRotation = 0;
+        private AxisFlags constraintOnRotation = AxisFlags.None;
 
         /// <summary>
         /// Constrain rotation about an axis


### PR DESCRIPTION
## Overview
Previously the AxisFlags Enum does not have a "None" member, but 0 is used as a "None" member in some part of the MRTK. While this does not seem to create problems when running relevant code in the Editor, @fast-slow-still reported that this may be a problem on Android builds.

## Changes
- Fixes: #7463.