### PR TITLE
Fix + test coverage for broken near interactions with ObjectManipulator and legacy ManipulationHandler

### DIFF
--- a/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
@@ -328,6 +328,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #endregion MonoBehaviour Functions
 
         #region Private Methods
+
+        /// <summary>
+        /// Calculates the unweighted average, or centroid, of all pointers'
+        /// grab points, as defined by the PointerData.GrabPoint property.
+        /// Does not use the rotation of each pointer; represents a pure
+        /// geometric centroid  of the grab points in world space.
+        /// </summary>
+        /// <returns>
+        /// Worldspace grab point centroid of all pointers 
+        /// in pointerIdToPointerMap.
+        /// </returns>
         private Vector3 GetPointersCentroid()
         {
             Vector3 sum = Vector3.zero;
@@ -340,6 +351,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return sum / Math.Max(1, count);
         }
 
+        /// <summary>
+        /// Calculates the multiple-handed pointer pose, used for
+        /// far-interaction hand-ray-based manipulations. Uses the
+        /// unweighted vector average of the pointers' forward vectors
+        /// to calculate a compound pose that takes into account the
+        /// pointing direction of each pointer.
+        /// </summary>
+        /// <returns>
+        /// Compound pose calculated as the average of the poses
+        /// corresponding to all of the pointers in pointerIdToPointerMap.
+        /// </returns>
         private MixedRealityPose GetAveragePointerPose()
         {
             Vector3 sumPos = Vector3.zero;
@@ -660,7 +682,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             if ((currentState & State.Moving) > 0)
             {
-                MixedRealityPose pose = GetAveragePointerPose();
+                // If near manipulation, a pure grabpoint centroid is used for
+                // the initial pointer pose; if far manipulation, a more complex
+                // look-rotation-based pointer pose is used.
+                MixedRealityPose pose = IsNearManipulation() ? new MixedRealityPose(GetPointersCentroid()) : GetAveragePointerPose();
                 targetTransform.Position = moveLogic.Update(pose, targetTransform.Rotation, targetTransform.Scale, true);
                 if (constraintOnMovement == MovementConstraintType.FixDistanceFromHead && moveConstraint != null)
                 {
@@ -748,7 +773,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             if ((newState & State.Moving) > 0)
             {
-                MixedRealityPose pointerPose = GetAveragePointerPose();
+                // If near manipulation, a pure grabpoint centroid is used for
+                // the initial pointer pose; if far manipulation, a more complex
+                // look-rotation-based pointer pose is used.
+                MixedRealityPose pointerPose = IsNearManipulation() ? new MixedRealityPose(GetPointersCentroid()) : GetAveragePointerPose();
                 MixedRealityPose hostPose = new MixedRealityPose(hostTransform.position, hostTransform.rotation);
                 moveLogic.Setup(pointerPose, GetPointersCentroid(), hostPose, hostTransform.localScale);
             }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -323,6 +323,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #endregion MonoBehaviour Functions
 
         #region Private Methods
+
+        /// <summary>
+        /// Calculates the unweighted average, or centroid, of all pointers'
+        /// grab points, as defined by the PointerData.GrabPoint property.
+        /// Does not use the rotation of each pointer; represents a pure
+        /// geometric centroid  of the grab points in world space.
+        /// </summary>
+        /// <returns>
+        /// Worldspace grab point centroid of all pointers 
+        /// in pointerIdToPointerMap.
+        /// </returns>
         private Vector3 GetPointersGrabPoint()
         {
             Vector3 sum = Vector3.zero;
@@ -335,6 +346,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return sum / Math.Max(1, count);
         }
 
+        /// <summary>
+        /// Calculates the multiple-handed pointer pose, used for
+        /// far-interaction hand-ray-based manipulations. Uses the
+        /// unweighted vector average of the pointers' forward vectors
+        /// to calculate a compound pose that takes into account the
+        /// pointing direction of each pointer.
+        /// </summary>
+        /// <returns>
+        /// Compound pose calculated as the average of the poses
+        /// corresponding to all of the pointers in pointerIdToPointerMap.
+        /// </returns>
         private MixedRealityPose GetPointersPose()
         {
             Vector3 sumPos = Vector3.zero;
@@ -538,7 +560,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             if (twoHandedManipulationType.HasFlag(TransformFlags.Move))
             {
-                MixedRealityPose pointerPose = GetPointersPose();
+                // If near manipulation, a pure grabpoint centroid is used for
+                // the initial pointer pose; if far manipulation, a more complex
+                // look-rotation-based pointer pose is used.
+                MixedRealityPose pointerPose = IsNearManipulation() ? new MixedRealityPose(GetPointersGrabPoint()) : GetPointersPose();
                 MixedRealityPose hostPose = new MixedRealityPose(HostTransform.position, HostTransform.rotation);
                 moveLogic.Setup(pointerPose, GetPointersGrabPoint(), hostPose, HostTransform.localScale);
             }
@@ -566,7 +591,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             if (twoHandedManipulationType.HasFlag(TransformFlags.Move))
             {
-                MixedRealityPose pose = GetPointersPose();
+                // If near manipulation, a pure GrabPoint centroid is used for
+                // the pointer pose; if far manipulation, a more complex
+                // look-rotation-based pointer pose is used.
+                MixedRealityPose pose = IsNearManipulation() ? new MixedRealityPose(GetPointersGrabPoint()) : GetPointersPose();
                 targetTransform.Position = moveLogic.Update(pose, targetTransform.Rotation, targetTransform.Scale, true);
                 constraints.ApplyTranslationConstraints(ref targetTransform, false, IsNearManipulation());
             }

--- a/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -1257,6 +1257,128 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test that the grab centroid is calculated correctly while rotating
+        /// the hands during a two-hand near interaction grab.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulationHandlerTwoHandedCentroid()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Set up cube with manipulation handler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.transform.localScale = Vector3.one * 0.5f;
+            Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
+            Quaternion initialObjectRotation = testObject.transform.rotation;
+            testObject.transform.position = initialObjectPosition;
+
+            var manipHandler = testObject.AddComponent<ManipulationHandler>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingActive = false;
+
+            // Add NearInteractionGrabbable to be able to grab the cube with articulated hands.
+            testObject.AddComponent<NearInteractionGrabbable>();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+
+            yield return rightHand.Show(new Vector3(0.2f, -0.1f, 0.8f));
+            yield return leftHand.Show(new Vector3(-0.2f, -0.1f, 0.8f));
+            yield return null;
+
+            // Two Handed
+            manipHandler.ManipulationType = ManipulationHandler.HandMovementType.TwoHandedOnly;
+
+            // Only testing move/rotate centroid position
+            manipHandler.TwoHandedManipulationType = ManipulationHandler.TwoHandedManipulation.MoveRotate;
+
+            // Only testing near manipulation
+            manipHandler.AllowFarManipulation = false;
+
+            int manipulationStartedCount = 0;
+            int manipulationEndedCount = 0;
+            manipHandler.OnManipulationStarted.AddListener((med) => manipulationStartedCount++);
+            manipHandler.OnManipulationEnded.AddListener((med) => manipulationEndedCount++);
+
+            // Grab the box.
+            yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            // Should not have moved (yet!)
+            Assert.IsTrue(testObject.transform.position == initialObjectPosition);
+
+            // The ObjectManipulator should recognize that we've begun manipulation.
+            Assert.IsTrue(manipulationStartedCount == 1);
+
+            // Move both hands outwards; the object may be scaled but the position should remain the same.
+            yield return rightHand.MoveTo(new Vector3(0.2f, -0.1f, 0.8f));
+            yield return leftHand.MoveTo(new Vector3(-0.2f, -0.1f, 0.8f));
+
+            // Should *still* not have moved!
+            TestUtilities.AssertAboutEqual(testObject.transform.position, new Vector3(0, 0, 1), $"Object moved when it shouldn't have! Position: {testObject.transform.position:F5}", 0.00001f);
+
+            // Manipulation should not yet have ended.
+            Assert.IsTrue(manipulationEndedCount == 0);
+
+            // Get the grab points before we rotate the hands.
+            var leftGrabPoint = manipHandler.GetPointerGrabPoint(leftHand.GetPointer<SpherePointer>().PointerId);
+            var rightGrabPoint = manipHandler.GetPointerGrabPoint(rightHand.GetPointer<SpherePointer>().PointerId);
+            var originalCentroid = (leftGrabPoint + rightGrabPoint) / 2.0f;
+
+            // List of test conditions for test fuzzing.
+            // (position, rotation)
+            List<(Vector3, Vector3)> testConditions = new List<(Vector3, Vector3)>
+            {
+                (new Vector3(0, 90, 0), new Vector3(0.2f, -0.1f, 0.8f)),
+                (new Vector3(25, 30, 45), new Vector3(0.3f, -0.2f, 0.7f)),
+                (new Vector3(75, 140, 0), new Vector3(0.1f, -0.1f, 0.8f)),
+                (new Vector3(10, 90, 20), new Vector3(0.5f, -0.2f, 0.5f)),
+                (new Vector3(45, 110, 0), new Vector3(0.3f, -0.1f, 0.8f))
+            };
+
+            // Fuzz test.
+            foreach (var testCondition in testConditions)
+            {
+                yield return MoveHandsAndCheckCentroid(testCondition.Item1, testCondition.Item2, leftHand, rightHand, manipHandler, initialObjectPosition, originalCentroid, testObject.transform);
+            }
+
+            yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+        }
+
+        /// <summary>
+        /// Helper function for ObjectManipulatorTwoHandedCentroid. Will mirror desired handRotation
+        /// and handPosition across the two hands, and verify that the centroid was still respected
+        /// by the manipulated object.
+        /// </summary>
+        private IEnumerator MoveHandsAndCheckCentroid(Vector3 handRotationEuler, Vector3 handPosition,
+                                                      TestHand leftHand, TestHand rightHand,
+                                                      ManipulationHandler mh,
+                                                      Vector3 originalObjectPosition, Vector3 originalGrabCentroid,
+                                                      Transform testObject)
+        {
+            // Rotate the hands.
+            yield return rightHand.SetRotation(Quaternion.Euler(handRotationEuler.x, handRotationEuler.y, handRotationEuler.z));
+            yield return leftHand.SetRotation(Quaternion.Euler(handRotationEuler.x, -handRotationEuler.y, -handRotationEuler.z));
+
+            // Move the hands.
+            yield return rightHand.MoveTo(new Vector3(handPosition.x, handPosition.y, handPosition.z));
+            yield return leftHand.MoveTo(new Vector3(-handPosition.x, handPosition.y, handPosition.z));
+
+            // Recalculate the new grab centroid.
+            var leftGrabPoint = mh.GetPointerGrabPoint(leftHand.GetPointer<SpherePointer>().PointerId);
+            var rightGrabPoint = mh.GetPointerGrabPoint(rightHand.GetPointer<SpherePointer>().PointerId);
+            var centroid = (leftGrabPoint + rightGrabPoint) / 2.0f;
+
+            // Compute delta between original grab centroid and the new centroid.
+            var centroidDelta = centroid - originalGrabCentroid;
+
+            // Ensure grab consistency.
+            TestUtilities.AssertAboutEqual(testObject.transform.position, originalObjectPosition + centroidDelta,
+                                           $"Object moved did not move according to the delta! Actual position: {testObject.transform.position:F5}, should be {originalObjectPosition + centroidDelta}", 0.00001f);
+        }
+
+        /// <summary>
         /// Ensure that a manipulated object has the same rotation as the hand
         /// when RotateAboutObjectCenter is used
         /// </summary>

--- a/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -1305,7 +1305,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
 
             // Should not have moved (yet!)
-            Assert.IsTrue(testObject.transform.position == initialObjectPosition);
+            TestUtilities.AssertAboutEqual(testObject.transform.position, initialObjectPosition, $"Object moved when it shouldn't have! Position: {testObject.transform.position:F5}", 0.00001f);
 
             // The ObjectManipulator should recognize that we've begun manipulation.
             Assert.IsTrue(manipulationStartedCount == 1);
@@ -1315,7 +1315,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return leftHand.MoveTo(new Vector3(-0.2f, -0.1f, 0.8f));
 
             // Should *still* not have moved!
-            TestUtilities.AssertAboutEqual(testObject.transform.position, new Vector3(0, 0, 1), $"Object moved when it shouldn't have! Position: {testObject.transform.position:F5}", 0.00001f);
+            TestUtilities.AssertAboutEqual(testObject.transform.position, initialObjectPosition, $"Object moved when it shouldn't have! Position: {testObject.transform.position:F5}", 0.00001f);
 
             // Manipulation should not yet have ended.
             Assert.IsTrue(manipulationEndedCount == 0);

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -1230,6 +1230,128 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test that the grab centroid is calculated correctly while rotating
+        /// the hands during a two-hand near interaction grab.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ObjectManipulatorTwoHandedCentroid()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Set up cube with ObjectManipulator
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.transform.localScale = Vector3.one * 0.5f;
+            Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
+            Quaternion initialObjectRotation = testObject.transform.rotation;
+            testObject.transform.position = initialObjectPosition;
+
+            var manipHandler = testObject.AddComponent<ObjectManipulator>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingActive = false;
+
+            // Add NearInteractionGrabbable to be able to grab the cube with articulated hands.
+            testObject.AddComponent<NearInteractionGrabbable>();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+
+            yield return rightHand.Show(new Vector3(0.2f, -0.1f, 0.8f));
+            yield return leftHand.Show(new Vector3(-0.2f, -0.1f, 0.8f));
+            yield return null;
+
+            // Two Handed
+            manipHandler.ManipulationType = ManipulationHandFlags.TwoHanded;
+
+            // Only testing move/rotate centroid position
+            manipHandler.TwoHandedManipulationType = TransformFlags.Move | TransformFlags.Rotate;
+
+            // Only testing near manipulation
+            manipHandler.AllowFarManipulation = false;
+
+            int manipulationStartedCount = 0;
+            int manipulationEndedCount = 0;
+            manipHandler.OnManipulationStarted.AddListener((med) => manipulationStartedCount++);
+            manipHandler.OnManipulationEnded.AddListener((med) => manipulationEndedCount++);
+
+            // Grab the box.
+            yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            // Should not have moved (yet!)
+            TestUtilities.AssertAboutEqual(testObject.transform.position, initialObjectPosition, $"Object moved when it shouldn't have! Position: {testObject.transform.position:F5}", 0.00001f);
+
+            // The ObjectManipulator should recognize that we've begun manipulation.
+            Assert.IsTrue(manipulationStartedCount == 1);
+
+            // Move both hands outwards; the object may be scaled but the position should remain the same.
+            yield return rightHand.MoveTo(new Vector3(0.2f, -0.1f, 0.8f));
+            yield return leftHand.MoveTo(new Vector3(-0.2f, -0.1f, 0.8f));
+
+            // Should *still* not have moved!
+            TestUtilities.AssertAboutEqual(testObject.transform.position, initialObjectPosition, $"Object moved when it shouldn't have! Position: {testObject.transform.position:F5}", 0.00001f);
+
+            // Manipulation should not yet have ended.
+            Assert.IsTrue(manipulationEndedCount == 0);
+
+            // Get the grab points before we rotate the hands.
+            var leftGrabPoint = manipHandler.GetPointerGrabPoint(leftHand.GetPointer<SpherePointer>().PointerId);
+            var rightGrabPoint = manipHandler.GetPointerGrabPoint(rightHand.GetPointer<SpherePointer>().PointerId);
+            var originalCentroid = (leftGrabPoint + rightGrabPoint) / 2.0f;
+
+            // List of test conditions for test fuzzing.
+            // Uses ValueTuple with layout (position, rotation)
+            List<(Vector3, Vector3)> testConditions = new List<(Vector3, Vector3)>
+            {
+                (new Vector3(0, 90, 0), new Vector3(0.2f, -0.1f, 0.8f)),
+                (new Vector3(25, 30, 45), new Vector3(0.3f, -0.2f, 0.7f)),
+                (new Vector3(75, 140, 0), new Vector3(0.1f, -0.1f, 0.8f)),
+                (new Vector3(10, 90, 20), new Vector3(0.5f, -0.2f, 0.5f)),
+                (new Vector3(45, 110, 0), new Vector3(0.3f, -0.1f, 0.8f))
+            };
+
+            // Fuzz test.
+            foreach (var testCondition in testConditions)
+            {
+                yield return MoveHandsAndCheckCentroid(testCondition.Item1, testCondition.Item2, leftHand, rightHand, manipHandler, initialObjectPosition, originalCentroid, testObject.transform);
+            }
+
+            yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+        }
+
+        /// <summary>
+        /// Helper function for ObjectManipulatorTwoHandedCentroid. Will mirror desired handRotation
+        /// and handPosition across the two hands, and verify that the centroid was still respected
+        /// by the manipulated object.
+        /// </summary>
+        private IEnumerator MoveHandsAndCheckCentroid(Vector3 handRotationEuler, Vector3 handPosition,
+                                                      TestHand leftHand, TestHand rightHand,
+                                                      ObjectManipulator om,
+                                                      Vector3 originalObjectPosition, Vector3 originalGrabCentroid,
+                                                      Transform testObject)
+        {
+            // Rotate the hands.
+            yield return rightHand.SetRotation(Quaternion.Euler(handRotationEuler.x, handRotationEuler.y, handRotationEuler.z));
+            yield return leftHand.SetRotation(Quaternion.Euler(handRotationEuler.x, -handRotationEuler.y, -handRotationEuler.z));
+
+            // Move the hands.
+            yield return rightHand.MoveTo(new Vector3(handPosition.x, handPosition.y, handPosition.z));
+            yield return leftHand.MoveTo(new Vector3(-handPosition.x, handPosition.y, handPosition.z));
+
+            // Recalculate the new grab centroid.
+            var leftGrabPoint = om.GetPointerGrabPoint(leftHand.GetPointer<SpherePointer>().PointerId);
+            var rightGrabPoint = om.GetPointerGrabPoint(rightHand.GetPointer<SpherePointer>().PointerId);
+            var centroid = (leftGrabPoint + rightGrabPoint) / 2.0f;
+
+            // Compute delta between original grab centroid and the new centroid.
+            var centroidDelta = centroid - originalGrabCentroid;
+
+            // Ensure grab consistency.
+            TestUtilities.AssertAboutEqual(testObject.transform.position, originalObjectPosition + centroidDelta,
+                                           $"Object moved did not move according to the delta! Actual position: {testObject.transform.position:F5}, should be {originalObjectPosition + centroidDelta}", 0.00001f);
+        }
+
+        /// <summary>
         /// Ensure that a manipulated object has the same rotation as the hand
         /// when RotateAboutObjectCenter is used
         /// </summary>


### PR DESCRIPTION
## Overview
As detailed in #8187, two-handed near interaction has a serious issue where the grab centroid is incorrectly calculated, resulting in erratic, incorrect grab behavior.

<img src="https://user-images.githubusercontent.com/5544935/87841699-c0c1f980-c853-11ea-9fa2-1e84e7a5d195.gif" width=340px>   <img src="https://user-images.githubusercontent.com/5544935/87841702-c3bcea00-c853-11ea-83b5-fa8a9dc997f3.gif" width=340px>

The root cause of this issue was that the code that is typically used for calculating hand-ray poses was also being used to compute the near-interaction grab point. This resulted in very wiggly and erratic grab poses being generated (because near interactions use fundamentally different principles than hand rays.) The main fix is to simply use the grab-centroid instead of the rotation-aware pose for two-handed interactions when `IsNearManipulation()` returns true.

This root cause is present in both the new `ObjectManipulator` and the legacy `ManipulationHandler`. **This PR fixes both of these components.**

However, another concerning point was that we had no test coverage for verifying the behavior of two-handed near grab interactions. Thus, a comprehensive unit test has been added to verify the grab position behavior when using two-handed near interaction. **This unit test has been added and verified for both `ObjectManipulator` and the legacy `ManipulationHandler`**.

The unit tests have been backwards-verified (i.e. they have been run with the _old, unfixed_ versions of both `ObjectManipulator` and `ManipulationHandler`, and they have been confirmed to fail with the old behavior, and succeed with the fixed behavior.)

## Changes
- Fixes: #8187 for **both** `ObjectManipulator` and `ManipulationHandler` by adding checks for `IsNearManipulation()` and calculating two-hand poses differently depending on manipulation type
- Adds _explicit comments_ and _function signatures_ around the previously misused functions; their purpose and behavior are now explicitly documented for future code adventurers (i.e. the difference between the calculation of two-hand interaction when far and near)
- Adds extensive testing for `ObjectManipulator` and `ManipulationHandler` which fuzzes hand position and rotation and continually verifies the correctness of the object/grab centroid calculation.
