### PR TITLE
Update play mode tests to work in Unity 2019

### DIFF
--- a/Assets/MRTK/Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
@@ -51,19 +51,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.SpatialAwarenessSystem
         }
 
         [Test]
-        public void TestEmptyDataProvider()
-        {
-            TestUtilities.InitializeMixedRealityToolkitAndCreateScenes(true);
-
-            // Check for Spatial Awareness System
-            var spatialAwarenessSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySpatialAwarenessSystem>();
-            var dataProviderAccess = spatialAwarenessSystem as IMixedRealityDataProviderAccess;
-
-            Assert.IsNotNull(dataProviderAccess);
-            Assert.IsEmpty(dataProviderAccess.GetDataProviders());
-        }
-
-        [Test]
         public void TestDataProviderRegistration()
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();

--- a/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
@@ -30,8 +30,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private GameObject cube;
 
         // Initializes MRTK, instantiates the test content prefab 
-        [SetUp]
-        public void SetUp()
+        [UnitySetUp]
+        public IEnumerator SetUp()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
@@ -53,13 +53,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             var collider = cube.GetComponentInChildren<Collider>();
             Assert.IsNotNull(collider);
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             Object.Destroy(cube);
             TestUtilities.ShutdownMixedRealityToolkit();
+            yield return null;
         }
 
         private void VerifyCursorStateFromPointers(IEnumerable<IMixedRealityPointer> pointers, CursorStateEnum state)

--- a/Assets/MRTK/Tests/PlayModeTests/BaseEventSystemTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseEventSystemTests.cs
@@ -33,16 +33,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// </remarks>
     class BaseEventSystemTests
     {
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/BasePlayModeTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BasePlayModeTests.cs
@@ -10,7 +10,8 @@
 // issue will likely persist for 2018, this issue is worked around by wrapping all
 // play mode tests in this check.
 
-using NUnit.Framework;
+using System.Collections;
+using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
@@ -19,16 +20,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// </summary>
     public abstract class BasePlayModeTests
     {
-        [SetUp]
-        public virtual void Setup()
+        [UnitySetUp]
+        public virtual IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public virtual void TearDown()
+        [UnityTearDown]
+        public virtual IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -25,16 +25,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     public class BoundingBoxTests
     {
         #region Utilities
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator SetUp()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void ShutdownMrtk()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         private readonly Vector3 boundingBoxStartCenter = Vector3.forward * 1.5f;

--- a/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
@@ -23,16 +23,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class ConstraintTests
     {
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator SetUp()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
@@ -71,16 +71,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             public bool IsInPointingPose => throw new System.NotImplementedException();
         }
 
-        [SetUp]
-        public void Init()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void Shutdown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             TestUtilities.ShutdownMixedRealityToolkit();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -33,8 +33,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         private Material testMaterialGrabbed;
 
         #region Utilities
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
 
@@ -45,12 +45,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
             testMaterialGrabbed = new Material(shader);
             testMaterialGrabbed.color = Color.green;
+            yield return null;
         }
 
-        [TearDown]
-        public void ShutdownMrtk()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         private readonly Vector3 boundsControlStartCenter = Vector3.forward * 1.5f;

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/ElasticTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/ElasticTests.cs
@@ -46,16 +46,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Drag = 0.2f
         };
 
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void ShutdownMrtk()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
-            PlayModeTestUtilities.TearDown();
+            TestUtilities.ShutdownMixedRealityToolkit();
+            yield return null;
         }
         #endregion
 

--- a/Assets/MRTK/Tests/PlayModeTests/FocusProviderRaycastTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/FocusProviderRaycastTests.cs
@@ -47,8 +47,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
         }
 
-        [SetUp]
-        public void SetupFocusProviderRaycastTests()
+        [UnitySetUp]
+        public IEnumerator SetupFocusProviderRaycastTests()
         {
             PlayModeTestUtilities.Setup();
 
@@ -59,10 +59,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             GameObject raycastTestPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath("dc3b0cf66c0615e4c81d979f35d51eaa"));
             raycastTestPrefabInstance = Object.Instantiate(raycastTestPrefab);
+            yield return null;
         }
 
-        [TearDown]
-        public void ShutdownFocusProviderRaycastTests()
+        [UnityTearDown]
+        public IEnumerator ShutdownFocusProviderRaycastTests()
         {
             if (raycastTestPrefabInstance)
             {
@@ -75,6 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             pointer = null;
 
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/FocusProviderTests.cs
@@ -24,16 +24,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class FocusProviderTests
     {
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
@@ -28,18 +28,20 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const string CubeCustomAttrGuid = "f0bb9fb635c69be4e8526b0fb6b48f39";
 
         private AsyncCoroutineRunner asyncCoroutineRunner;
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             asyncCoroutineRunner = new GameObject("AsyncCoroutineRunner").AddComponent<AsyncCoroutineRunner>();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
             GameObject.Destroy(asyncCoroutineRunner.gameObject);
+            yield return null;
         }
 
         private IEnumerator WaitForTask(Task task)

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -33,17 +33,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// </summary>
     internal class GridObjectCollectionTests
     {
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         #region Tests

--- a/Assets/MRTK/Tests/PlayModeTests/InputEventSystemTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputEventSystemTests.cs
@@ -28,16 +28,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
     class InputEventSystemTests
     {
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/InputRayUtilsTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputRayUtilsTests.cs
@@ -23,17 +23,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     // Tests to verify that the ray utilities methods are functioning correctly
     public class InputRayUtilsTests
     {
-        [SetUp]
-        public void SetUp()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/DefaultRaycastProviderTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/DefaultRaycastProviderTest.cs
@@ -32,17 +32,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             yield return null;
         }
 
-        [SetUp]
-        public void SetUp()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             defaultRaycastProvider = new DefaultRaycastProvider(null);
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs
@@ -20,16 +20,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 {
     class DisableEnableInputSystemTest
     {
-        [SetUp]
-        public void SetUp()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
@@ -10,15 +10,11 @@
 // issue will likely persist for 2018, this issue is worked around by wrapping all
 // play mode tests in this check.
 
-using Microsoft.MixedReality.Toolkit.Editor;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
 using System.Collections;
-using System.Linq;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -29,8 +25,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         GameObject cube;
         Interactable interactable;
 
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
@@ -40,13 +36,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             interactable = cube.AddComponent<Interactable>();
             Assert.NotNull(interactable, "Failed to add interactable to cube");
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             GameObject.Destroy(cube);
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
@@ -52,11 +52,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private readonly Color FocusColor = Color.yellow;
         private readonly Color DisabledColor = Color.gray;
 
-        [SetUp]
-        public override void Setup()
+        [UnitySetUp]
+        public override IEnumerator Setup()
         {
-            base.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/JoystickTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/JoystickTests.cs
@@ -22,17 +22,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class JoystickTests
     {
-
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         #region Tests

--- a/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -26,18 +26,20 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         private readonly List<Action> cleanupAction = new List<Action>();
 
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             cleanupAction.ForEach(f => f?.Invoke());
 
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/NearInteractionGrabbableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/NearInteractionGrabbableTests.cs
@@ -21,17 +21,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class NearInteractionGrabbableTests
     {
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             PlayModeTestUtilities.EnsureInputModule();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/NearInteractionTouchableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/NearInteractionTouchableTests.cs
@@ -21,8 +21,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class NearInteractionTouchableTests
     {
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             PlayModeTestUtilities.EnsureInputModule();
@@ -44,12 +44,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             pokeMaterial = new Material(shader);
             pokeMaterial.color = Color.green;
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -26,18 +26,20 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         private readonly List<Action> cleanupAction = new List<Action>();
 
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             cleanupAction.ForEach(f => f?.Invoke());
 
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
@@ -27,17 +27,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const string defaultPinchSliderPrefabGuid = "1093263a89abe47499cccf7dcb08effb";
         private static readonly string defaultPinchSliderPrefabPath = AssetDatabase.GUIDToAssetPath(defaultPinchSliderPrefabGuid);
 
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         #region Tests

--- a/Assets/MRTK/Tests/PlayModeTests/PointerEventsTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerEventsTests.cs
@@ -127,8 +127,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const int numFramesPerMove = 1;
 
         // Initializes MRTK, instantiates the test content prefab and adds a pointer handler to the test collider
-        [SetUp]
-        public void SetUp()
+        [UnitySetUp]
+        public IEnumerator SetUp()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
@@ -147,12 +147,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNotNull(collider);
 
             handler = collider.gameObject.AddComponent<PointerHandler>();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             TestUtilities.ShutdownMixedRealityToolkit();
+            yield return null;
         }
 
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/PointerProfileTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerProfileTests.cs
@@ -3,7 +3,9 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using NUnit.Framework;
+using System.Collections;
 using UnityEditor;
+using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
@@ -14,17 +16,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         private static readonly string eyeTrackingConfigurationProfilePath = AssetDatabase.GUIDToAssetPath(eyeTrackingConfigurationProfileGuid);
 
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         // <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
@@ -37,17 +37,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const string CurvePointerGuid = "c4fd3c6fc7ff484eb434775066e7f327";
         private static readonly string CurvePointerPrefab = AssetDatabase.GUIDToAssetPath(CurvePointerGuid);
 
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         #region Tests

--- a/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
@@ -30,21 +30,23 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private GameObject panObject;
         private HandInteractionPanZoom panZoom;
 
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             PlayModeTestUtilities.PushHandSimulationProfile();
             TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             GameObject.Destroy(panObject);
             GameObject.Destroy(panZoom);
             PlayModeTestUtilities.PopHandSimulationProfile();
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -45,15 +45,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         private List<SetupData> setupDataList = new List<SetupData>();
 
-        [TearDown]
-        public override void TearDown()
+        [UnityTearDown]
+        public override IEnumerator TearDown()
         {
             foreach (var setupData in setupDataList)
             {
                 Object.Destroy(setupData?.target);
             }
 
-            base.TearDown();
+            return base.TearDown();
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/SpeechTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpeechTests.cs
@@ -23,16 +23,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class SpeechTests
     {
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
@@ -35,10 +35,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private GameObject overlapRect;
 
         // Initializes MRTK, instantiates the test content prefab and adds a pointer handler to the test collider
-        [SetUp]
-        public override void Setup()
+        [UnitySetUp]
+        public override IEnumerator Setup()
         {
-            base.Setup();
+            yield return base.Setup();
 
             float centerZ = 2.0f;
             float scale = 0.2f;
@@ -64,13 +64,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             var overlapGrabbable = overlapRect.AddComponent<NearInteractionGrabbable>();
             Assert.IsNotNull(overlapGrabbable);
+            yield return null;
         }
 
-        [TearDown]
-        public override void TearDown()
+        [UnityTearDown]
+        public override IEnumerator TearDown()
         {
             GameObject.Destroy(cube);
-            base.TearDown();
+            return base.TearDown();
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -26,8 +26,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
         GameObject cube;
         Interactable interactable;
 
-        [SetUp]
-        public void SetUp()
+        [UnitySetUp]
+        public IEnumerator SetUp()
         {
             PlayModeTestUtilities.Setup();
 
@@ -43,13 +43,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             interactable = cube.AddComponent<Interactable>();
 
             KeyInputSystem.StartKeyInputStimulation();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             KeyInputSystem.StopKeyInputSimulation();
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
@@ -30,17 +30,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         private const string DefaultColorProperty = "_Color";
 
-        [SetUp]
-        public void Setup()
+        [UnitySetUp]
+        public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         #region Tests

--- a/Documentation/Contributing/UnitTests.md
+++ b/Documentation/Contributing/UnitTests.md
@@ -141,7 +141,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     class ExamplePlayModeTests
     {
-
         // This method is called once before we enter play mode and execute any of the tests
         // do any kind of setup here that can't be done in playmode
         public void Setup()
@@ -152,18 +151,24 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         // Do common setup for each of your tests here - this will be called for each individual test after entering playmode
-        [Setup]
-        public void Init()
+        // Note that this uses UnitySetUp instead of [SetUp] because the init function needs to await a frame passing
+        // to ensure that the MRTK system has had the chance to fully set up before the test runs.
+        [UnitySetUp]
+        public IEnumerator Init()
         {
             // in most play mode test cases you would want to at least create an MRTK GameObject using the default profile
             TestUtilities.InitializeMixedRealityToolkit(true);
+            yield return null;
         }
 
         // Destroy the scene - this method is called after each test listed below has completed
-        [TearDown]
-        public void TearDown()
+        // Note that this uses UnityTearDown instead of [TearDown] because the init function needs to await a frame passing
+        // to ensure that the MRTK system has fully torn down before the next test setup->run cycle starts.
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
             PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         #region Tests


### PR DESCRIPTION
Play mode tests in Unity 2019 has been broken for a bit, and it looks like the reason for the vast majority of them are changes in the mechanics behind setup and teardown.

In particular, it looks like in Unity 2018 there seems to have been a frame that passed after setup and after teardown, which allowed for things to properly get setup (and property torn down) between tests.

However in 2019, it looks like there isn't a frame that passes - so what ends up happening is both:

1. Setup occurs and some tests will try to use state that isn't exactly set up yet.
2. Tear down and setup happens within the same frame (which leads to some issues where things that get torn down and set up in the same frame... well, they don't exactly work out right). In particular there are some things that will destroy Unity objects, and these things require a frame to pass in order for destruction to actually work. Some things in setup then look to see if things already exist and still see them around (i.e. there's still stale state at the time of setup because things haven't been torn down).

This change brings the number of failures from ~98 to around 4 or 5. 

This also updates the contribution guidelines to describe how to write tests that work both in 2019 and 2018 (i.e. using the yield return null in setup/teardown to wait a frame.)