### PR TITLE
Fix the switching of AutoFollowAtDistance

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
@@ -52,6 +52,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 autoFollowAtDistance = value;
 
+                if (!enabled || !gameObject.activeInHierarchy)
+                {
+                    return;
+                }
+
                 if (autoFollowAtDistance)
                 {
                     if (autoFollowDistanceCheck == null)
@@ -65,6 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     {
                         StopCoroutine(autoFollowDistanceCheck);
                         autoFollowDistanceCheck = null;
+                        SetFollowMeBehavior(false);
                     }
                 }
             }
@@ -133,6 +139,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 AutoFollowAtDistance = autoFollowAtDistance;
             }
+        }
+
+        private void OnEnable()
+        {
+            // Begin the follow coroutine when enabled.
+            AutoFollowAtDistance = autoFollowAtDistance;
         }
 
         #endregion MonoBehaviour Implementation


### PR DESCRIPTION
## Overview
Currently the the setter of AutoFollowAtDistance doesn't check whether the script is enabled or the GameObject it is attached to is active before calling StartCoroutine(), which causes an error under certain circumstances. Besides, the auto follow behavior cannot be disabled by changing the AutoFollowAtDistance property as SetFollowMeBehavior(false) is never called.

## Changes
- Fixes: #8028 and call SetFollowMeBehavior(false) when AutoFollowAtDistance is set to false.