### PR TITLE
changed initial worldpose data type and removed ununsed target transform in constraints

### DIFF
--- a/Assets/MRTK/Core/Definitions/Utilities/MixedRealityTransform.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/MixedRealityTransform.cs
@@ -10,6 +10,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     [Serializable]
     public struct MixedRealityTransform : IEqualityComparer
     {
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public MixedRealityTransform(Transform transform)
+        {
+            this.pose = new MixedRealityPose(transform.position, transform.rotation);
+            this.scale = transform.localScale;
+        }
+
         /// <summary>
         /// Constructor.
         /// </summary>

--- a/Assets/MRTK/SDK/Editor/Migration/ObjectManipulatorMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Editor/Migration/ObjectManipulatorMigrationHandler.cs
@@ -86,14 +86,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             if (manipHandler.ConstraintOnRotation != RotationConstraintType.None)
             {
                 var rotateConstraint = objManip.EnsureComponent<RotationAxisConstraint>();
-                rotateConstraint.TargetTransform = manipHandler.HostTransform;
                 rotateConstraint.ConstraintOnRotation = RotationConstraintHelper.ConvertToAxisFlags(manipHandler.ConstraintOnRotation);
             }
 
             if (manipHandler.ConstraintOnMovement == MovementConstraintType.FixDistanceFromHead)
             {
                 var moveConstraint = objManip.EnsureComponent<FixedDistanceConstraint>();
-                moveConstraint.TargetTransform = manipHandler.HostTransform;
                 moveConstraint.ConstraintTransform = CameraCache.Main.transform;
             }
 
@@ -129,7 +127,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                         newMode = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
                         var constraint = objManip.EnsureComponent<FixedRotationToUserConstraint>();
-                        constraint.TargetTransform = objManip.HostTransform;
                         constraint.HandType = ManipulationHandFlags.OneHanded;
                         constraint.ProximityType = proximity;
                         break;
@@ -139,12 +136,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                         newMode = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
                         var rotConstraint = objManip.EnsureComponent<FixedRotationToUserConstraint>();
-                        rotConstraint.TargetTransform = objManip.HostTransform;
                         rotConstraint.HandType = ManipulationHandFlags.OneHanded;
                         rotConstraint.ProximityType = proximity;
 
                         var axisConstraint = objManip.EnsureComponent<RotationAxisConstraint>();
-                        axisConstraint.TargetTransform = objManip.HostTransform;
                         axisConstraint.HandType = ManipulationHandFlags.OneHanded;
                         axisConstraint.ProximityType = proximity;
                         axisConstraint.ConstraintOnRotation = AxisFlags.XAxis | AxisFlags.ZAxis;
@@ -155,7 +150,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                         newMode = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
                         var rotConstraint = objManip.EnsureComponent<FaceUserConstraint>();
-                        rotConstraint.TargetTransform = objManip.HostTransform;
                         rotConstraint.HandType = ManipulationHandFlags.OneHanded;
                         rotConstraint.ProximityType = proximity;
                         rotConstraint.FaceAway = false;
@@ -166,7 +160,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                         newMode = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
                         var rotConstraint = objManip.EnsureComponent<FaceUserConstraint>();
-                        rotConstraint.TargetTransform = objManip.HostTransform;
                         rotConstraint.HandType = ManipulationHandFlags.OneHanded;
                         rotConstraint.ProximityType = proximity;
                         rotConstraint.FaceAway = true;
@@ -177,7 +170,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                         newMode = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
                         var rotConstraint = objManip.EnsureComponent<FixedRotationToWorldConstraint>();
-                        rotConstraint.TargetTransform = objManip.HostTransform;
                         rotConstraint.HandType = ManipulationHandFlags.OneHanded;
                         rotConstraint.ProximityType = proximity;
                         break;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -536,6 +536,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         public void RegisterTransformScaleHandler(MinMaxScaleConstraint transformScaleHandler)
         {
             scaleConstraint = transformScaleHandler;
+            if (scaleConstraint)
+            {
+                scaleConstraint.Initialize(new MixedRealityTransform(transform));
+            }
         }
 
         #endregion

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             ApplyConstraintsForType(ref transform, isOneHanded, isNear, TransformFlags.Move);
         }
 
-        public void Initialize(MixedRealityPose worldPose)
+        public void Initialize(MixedRealityTransform worldPose)
         {
             foreach (var constraint in constraints)
             {

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/FixedDistanceConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/FixedDistanceConstraint.cs
@@ -35,10 +35,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #region MonoBehaviour Methods
 
-        public override void Start()
+        public void Start()
         {
-            base.Start();
-
             if (ConstraintTransform == null)
             {
                 ConstraintTransform = CameraCache.Main.transform;
@@ -50,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #region Public Methods
 
         /// <inheritdoc />
-        public override void Initialize(MixedRealityPose worldPose)
+        public override void Initialize(MixedRealityTransform worldPose)
         {
             base.Initialize(worldPose);
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/FixedRotationToUserConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/FixedRotationToUserConstraint.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #region Public Methods
 
         /// <inheritdoc />
-        public override void Initialize(MixedRealityPose worldPose)
+        public override void Initialize(MixedRealityTransform worldPose)
         {
             base.Initialize(worldPose);
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/MaintainApparentSizeConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/MaintainApparentSizeConstraint.cs
@@ -15,7 +15,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #region Properties
 
         private float initialDist;
-        private Vector3 initialScale;
 
         public override TransformFlags ConstraintType => TransformFlags.Scale;
 
@@ -24,12 +23,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #region Public Methods
 
         /// <inheritdoc />
-        public override void Initialize(MixedRealityPose worldPose)
+        public override void Initialize(MixedRealityTransform worldPose)
         {
             base.Initialize(worldPose);
 
             initialDist = (worldPose.Position - CameraCache.Main.transform.position).magnitude;
-            initialScale = TargetTransform.localScale;
         }
 
         /// <summary>
@@ -40,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public override void ApplyConstraint(ref MixedRealityTransform transform)
         {
             float dist = (transform.Position - CameraCache.Main.transform.position).magnitude;
-            transform.Scale = (dist / initialDist) * initialScale;
+            transform.Scale = (dist / initialDist) * worldPoseOnManipulationStart.Scale;
         }
 
         #endregion Public Methods

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/TransformConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/TransformConstraint.cs
@@ -63,5 +63,25 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public abstract void ApplyConstraint(ref MixedRealityTransform transform);
 
         #endregion Public Methods
+
+
+        #region Deprecated
+
+        /// <summary>
+        /// Intended to be called on manipulation started
+        /// </summary>
+        [System.Obsolete("Deprecated: Pass MixedRealityTransform instead of MixedRealityPose.")]
+        public virtual void Initialize(MixedRealityPose worldPose)
+        {
+            Initialize(new MixedRealityTransform(worldPose.Position, worldPose.Rotation, Vector3.one));
+        }
+
+        /// <summary>	
+        /// Transform that we intend to apply constraints to	
+        /// </summary>	
+        [System.Obsolete("Deprecated: Get component transform instead.")]
+        public Transform TargetTransform { get; set; } = null;
+
+        #endregion
     }
 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/TransformConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/TransformConstraint.cs
@@ -14,19 +14,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #region Properties
 
         [SerializeField]
-        [Tooltip("Transform being constrained. Defaults to the object of the component.")]
-        private Transform targetTransform = null;
-
-        /// <summary>
-        /// Transform that we intend to apply constraints to
-        /// </summary>
-        public Transform TargetTransform
-        {
-            get => targetTransform;
-            set => targetTransform = value;
-        }
-
-        [SerializeField]
         [EnumFlags]
         [Tooltip("What type of manipulation this constraint applies to. Defaults to One Handed and Two Handed.")]
         private ManipulationHandFlags handType = ManipulationHandFlags.OneHanded | ManipulationHandFlags.TwoHanded;
@@ -54,30 +41,18 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set => proximityType = value;
         }
 
-        protected MixedRealityPose worldPoseOnManipulationStart;
+        protected MixedRealityTransform worldPoseOnManipulationStart;
 
         public abstract TransformFlags ConstraintType { get; }
 
         #endregion Properties
-
-        #region MonoBehaviour Methods
-
-        public virtual void Start()
-        {
-            if (TargetTransform == null)
-            {
-                TargetTransform = transform;
-            }
-        }
-
-        #endregion MonoBehaviour Methods
 
         #region Public Methods
 
         /// <summary>
         /// Intended to be called on manipulation started
         /// </summary>
-        public virtual void Initialize(MixedRealityPose worldPose)
+        public virtual void Initialize(MixedRealityTransform worldPose)
         {
             worldPoseOnManipulationStart = worldPose;
         }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
@@ -315,11 +315,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             moveConstraint = this.EnsureComponent<FixedDistanceConstraint>();
-            moveConstraint.TargetTransform = hostTransform;
             moveConstraint.ConstraintTransform = CameraCache.Main.transform;
 
             rotateConstraint = this.EnsureComponent<RotationAxisConstraint>();
-            rotateConstraint.TargetTransform = hostTransform;
             rotateConstraint.ConstraintOnRotation = RotationConstraintHelper.ConvertToAxisFlags(constraintOnRotation);
             rotateConstraint.UseLocalSpaceForConstraint = useLocalSpaceForConstraint;
 
@@ -841,7 +839,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
             }
 
-            var pose = new MixedRealityPose(hostTransform.position, hostTransform.rotation);
+            var pose = new MixedRealityTransform(hostTransform);
             if (constraintOnMovement == MovementConstraintType.FixDistanceFromHead && moveConstraint != null)
             {
                 moveConstraint.Initialize(pose);

--- a/Assets/MRTK/SDK/Features/Input/Handlers/MinMaxScaleConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/MinMaxScaleConstraint.cs
@@ -15,8 +15,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
     {
         #region Properties
 
-        private Vector3 initialScale;
-
         [SerializeField]
         [Tooltip("Minimum scaling allowed")]
         private float scaleMinimum = 0.2f;
@@ -76,19 +74,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #endregion Properties
 
-        #region MonoBehaviour Methods
-
-        public override void Start()
+        #region Public Methods
+        public override void Initialize(MixedRealityTransform worldPose)
         {
-            base.Start();
-
-            initialScale = TargetTransform.localScale;
+            base.Initialize(worldPose);
             SetScaleLimits();
         }
-
-        #endregion MonoBehaviour Methods
-
-        #region Public Methods
 
         /// <summary>
         /// Clamps the transform scale to the scale limits set by <see cref="SetScaleLimits"/> such that:
@@ -157,8 +148,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (relativeToInitialState)
             {
-                minimumScale = initialScale * scaleMinimum;
-                maximumScale = initialScale * scaleMaximum;
+                minimumScale = worldPoseOnManipulationStart.Scale * scaleMinimum;
+                maximumScale = worldPoseOnManipulationStart.Scale * scaleMaximum;
             }
             else
             {

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -669,7 +669,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 rigidBody.isKinematic = false;
             }
 
-            constraints.Initialize(new MixedRealityPose(HostTransform.position, HostTransform.rotation));
+            constraints.Initialize(new MixedRealityTransform(HostTransform));
         }
 
         private void HandleManipulationEnded(Vector3 pointerGrabPoint, Vector3 pointerVelocity, Vector3 pointerAnglularVelocity)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -2035,13 +2035,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 if (scaleConstraint == null)
                 {
                     scaleConstraint = gameObject.AddComponent<MinMaxScaleConstraint>();
-
-                    scaleConstraint.TargetTransform = Target.transform;
 #pragma warning disable 0618
                     scaleConstraint.ScaleMinimum = scaleMinimum;
                     scaleConstraint.ScaleMaximum = scaleMaximum;
 #pragma warning restore 0618
                 }
+
+                scaleConstraint.Initialize(new MixedRealityTransform(transform));
             }
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
@@ -564,8 +564,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             manipHandler.ManipulationType = ManipulationHandFlags.OneHanded;
             manipHandler.OneHandRotationModeNear = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
-            var rotConstraint = manipHandler.EnsureComponent<FixedRotationToUserConstraint>();
-            rotConstraint.TargetTransform = manipHandler.HostTransform;
+            manipHandler.EnsureComponent<FixedRotationToUserConstraint>();
 
             // add near interaction grabbable to be able to grab the cube with the simulated articulated hand
             testObject.AddComponent<NearInteractionGrabbable>();
@@ -773,7 +772,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             manipHandler.OneHandRotationModeNear = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
             var rotConstraint = manipHandler.EnsureComponent<FaceUserConstraint>();
-            rotConstraint.TargetTransform = manipHandler.HostTransform;
             rotConstraint.FaceAway = false;
 
             // Face user first
@@ -833,8 +831,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             manipHandler.ManipulationType = ManipulationHandFlags.OneHanded;
             manipHandler.OneHandRotationModeNear = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
-            var rotConstraint = manipHandler.EnsureComponent<FixedRotationToWorldConstraint>();
-            rotConstraint.TargetTransform = manipHandler.HostTransform;
+            manipHandler.EnsureComponent<FixedRotationToWorldConstraint>();
 
             // Face user first
             const int numHandSteps = 1;

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -461,7 +461,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             manipHandler.AllowFarManipulation = false;
 
             var rotateConstraint = manipHandler.EnsureComponent<RotationAxisConstraint>();
-            rotateConstraint.TargetTransform = testObject.transform;
             rotateConstraint.ConstraintOnRotation = 0; // No constraint
 
             // add near interaction grabbable to be able to grab the cube with the simulated articulated hand

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -91,4 +91,10 @@ DevicePortal.UseSSL = true
 
 If an application was previously using the NuGet distribution of the MRTK, the `link.xml` file has been removed from the Foundation package. To restore code preservation rules, opening the project in Unity once will create a default `link.xml` file in `Assets/MixedRealityToolkit.Generated`. It is recommended that this file (and `link.xml.meta`) be added to source control.
 
+** Transform Constraint Changes **
+TargetTransform property has been removed as it wasn't used by constraint system. Constraint logic is based on the transform passed into Initialize and Apply methods. Derived user constraints that rely on this property can cache the TargetTransform in their implementation by storing the transform of the constraint component to achieve the same behavior.
+
+The stored initial world pose `worldPoseOnManipulationStart` data type has been changed from MixedRealityPose to MixedRealityTransform, which includes the local scale value of the manipulated object. With this change it's not necessary to separately cache any initial scale values anymore.
+
+
 ### Known issues

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -92,7 +92,7 @@ DevicePortal.UseSSL = true
 If an application was previously using the NuGet distribution of the MRTK, the `link.xml` file has been removed from the Foundation package. To restore code preservation rules, opening the project in Unity once will create a default `link.xml` file in `Assets/MixedRealityToolkit.Generated`. It is recommended that this file (and `link.xml.meta`) be added to source control.
 
 **Transform Constraint Changes**
-TargetTransform property has been removed as it wasn't used by constraint system. Constraint logic is based on the transform passed into Initialize and Apply methods. Derived user constraints that rely on this property can cache the TargetTransform in their implementation by storing the transform of the constraint component to achieve the same behavior.
+TargetTransform property has been marked as obsolete as it wasn't used by constraint system. Constraint logic is based on the transform passed into Initialize and Apply methods. Derived user constraints that rely on this property can cache the TargetTransform in their implementation by storing the transform of the constraint component to achieve the same behavior.
 
 The stored initial world pose `worldPoseOnManipulationStart` data type has been changed from MixedRealityPose to MixedRealityTransform, which includes the local scale value of the manipulated object. With this change it's not necessary to separately cache any initial scale values anymore.
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -91,7 +91,7 @@ DevicePortal.UseSSL = true
 
 If an application was previously using the NuGet distribution of the MRTK, the `link.xml` file has been removed from the Foundation package. To restore code preservation rules, opening the project in Unity once will create a default `link.xml` file in `Assets/MixedRealityToolkit.Generated`. It is recommended that this file (and `link.xml.meta`) be added to source control.
 
-** Transform Constraint Changes **
+**Transform Constraint Changes**
 TargetTransform property has been removed as it wasn't used by constraint system. Constraint logic is based on the transform passed into Initialize and Apply methods. Derived user constraints that rely on this property can cache the TargetTransform in their implementation by storing the transform of the constraint component to achieve the same behavior.
 
 The stored initial world pose `worldPoseOnManipulationStart` data type has been changed from MixedRealityPose to MixedRealityTransform, which includes the local scale value of the manipulated object. With this change it's not necessary to separately cache any initial scale values anymore.


### PR DESCRIPTION
## Overview

- removed transform target from transform constraint - wasn't used by constraints as the transforms we're operating on are passed into initialize and apply functions.
- changed initial world pose storage to be full transform (including scale) instead of just translation / rotation, so scaling based constraints don't have to manually store the initial scaling value.
- added breaking changes entry for both changes and directions for users that might have used transform target for their own constraints

Misc:
- added ctor for MixedRealityTransform to allow create from Unity Transform

## Changes
- Fixes: #8040 & #7841 
