### PR TITLE
Unity 2019 tests: Slate/Pan/Zoom test fix

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -170,6 +170,29 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private List<Vector2> uvsOrig = new List<Vector2>();
         private bool oldIsTargetPositionLockedOnFocusLock;
 
+#if UNITY_2019_4_OR_NEWER
+        // Quad meshes by default (in 2019 and higher) appear to follow the vertex order
+        // specified here: https://docs.unity3d.com/Manual/Example-CreatingaBillboardPlane.html
+        // That is, LowerLeft->LowerRight->UpperLeft->UpperRight
+        // Note that even though the example on that page is one that creates a quad manually
+        // using a specific order of vertices, this order seems to be what a quad mesh defaults to.
+        // This was discovered when looking into an issue on the SlateTests, which depend on the
+        // projection math within this to be using the correct right and up vectors.
+        private const int UpperLeftQuadIndex = 2;
+        private const int UpperRightQuadIndex = 3;
+        private const int LowerLeftQuadIndex = 0;
+#else // !UNITY_2019_4_OR_NEWER
+        // Quad meshes in 2018 and lower appear to follow a vertex order that looks like this:
+        // [0] "(-0.5, -0.5, 0.0)"
+        // [1] "(0.5, 0.5, 0.0)"
+        // [2] "(0.5, -0.5, 0.0)"
+        // [3] "(-0.5, 0.5, 0.0)"
+        // That is, LowerLeft->UpperRight->LowerRight->UpperLeft
+        private const int UpperLeftQuadIndex = 3;
+        private const int UpperRightQuadIndex = 1;
+        private const int LowerLeftQuadIndex = 0;
+#endif
+
         #endregion Private Properties
 
         /// <summary>
@@ -611,9 +634,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Vector2 uvCoord = Vector2.zero;
             Vector2[] uvs = mesh.uv;
-            Vector2 upperLeft = uvs[3];
-            Vector2 upperRight = uvs[1];
-            Vector2 lowerLeft = uvs[0];
+            Vector2 upperLeft = uvs[UpperLeftQuadIndex];
+            Vector2 upperRight = uvs[UpperRightQuadIndex];
+            Vector2 lowerLeft = uvs[LowerLeftQuadIndex];
 
             float magVertical = (lowerLeft - upperLeft).magnitude;
             float magHorizontal = (upperRight - upperLeft).magnitude;
@@ -638,9 +661,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Vector2 quadCoord = Vector2.zero;
             Vector3[] vertices = mesh.vertices;
-            Vector3 upperLeft = transform.TransformPoint(vertices[3]);
-            Vector3 upperRight = transform.TransformPoint(vertices[1]);
-            Vector3 lowerLeft = transform.TransformPoint(vertices[0]);
+            Vector3 upperLeft = transform.TransformPoint(vertices[UpperLeftQuadIndex]);
+            Vector3 upperRight = transform.TransformPoint(vertices[UpperRightQuadIndex]);
+            Vector3 lowerLeft = transform.TransformPoint(vertices[LowerLeftQuadIndex]);
 
             float magVertical = (lowerLeft - upperLeft).magnitude;
             float magHorizontal = (upperRight - upperLeft).magnitude;


### PR DESCRIPTION
So this one was... really interesting.

The last stragglers in our 2019 play mode tests was actually a real issue that's only present in 2019 and not in 2018. If you try using the HandInteractionExample scene and use a ray (or GGV) on the slate and try to scroll, you'll notice that today, when you try to scroll from side to side, it actually moves things vertically.

This is because on 2019, the default quad mesh vertices appear to be different:

If you call mesh.vertices on 2019, here's the order you get:
```
+        [0]    "(-0.5, -0.5, 0.0)"    UnityEngine.Vector3
+        [1]    "(0.5, -0.5, 0.0)"    UnityEngine.Vector3
+        [2]    "(-0.5, 0.5, 0.0)"    UnityEngine.Vector3
+        [3]    "(0.5, 0.5, 0.0)"    UnityEngine.Vector3
```
The same call on 2018 gets this:
```
+        [0]    "(-0.5, -0.5, 0.0)"    UnityEngine.Vector3
+        [1]    "(0.5, 0.5, 0.0)"    UnityEngine.Vector3
+        [2]    "(0.5, -0.5, 0.0)"    UnityEngine.Vector3
+        [3]    "(-0.5, 0.5, 0.0)"    UnityEngine.Vector3
```
I've been looking through Unity docs/announce and I didn't see anything specific about this, though I did see one note on Unity's 2019 release notes around various mesh optimizations (saying not to assume specific mesh vertex ordering). This change still does... rely on ordering, though it does so in a way that appears to be aligned with Unity's quad docs.

What actually happens here is because the wrong vertices are chosen, the up/right vectors which are used to "project onto the slate" are wrong - so you end up getting garbage data used for scrolling. This shows up when you try to scroll left and right (it ends up scrolling up and down instead).

I thought about doing a version agnostic approach (i.e. look for the various quadrants using number compares) but this wouldn't handle cases where quads aren't perfectly axis aligned... (though also I don't know if this is a legit use case).

