### PR TITLE
Scroll View Graduation - Part 3

### DIFF
--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
@@ -115,7 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
                 scrollCollection.SetupAtRuntime = false;
                 scrollCollection.CellHeight = 0.032f;
                 scrollCollection.CellWidth = 0.032f;
-                scrollCollection.Tiers = 3;
+                scrollCollection.ItemsPerTier = 3;
                 scrollCollection.ViewableArea = 5;
                 scrollCollection.HandDeltaMagThreshold = 0.02f;
                 scrollCollection.TypeOfVelocity = ScrollingObjectCollection.VelocityType.FalloffPerItem;

--- a/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
@@ -222,16 +222,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
             if (showDebugOptions)
             {
-                using (new EditorGUI.DisabledGroupScope(EditorApplication.isPlaying))
+                using (new EditorGUI.IndentLevelScope())
                 {
-                    visibleDebugPlanes = EditorGUILayout.Toggle("Show Event Planes", visibleDebugPlanes);
+                    using (new EditorGUI.DisabledGroupScope(EditorApplication.isPlaying))
+                    {
+                        visibleDebugPlanes = EditorGUILayout.Toggle("Show Event Planes", visibleDebugPlanes);
+                    }
                 }
-
-                EditorGUILayout.Space();
 
                 using (new EditorGUI.DisabledGroupScope(!EditorApplication.isPlaying))
                 {
-
                     using (new EditorGUI.IndentLevelScope())
                     {
                         animateTransition = EditorGUILayout.Toggle("Animate", animateTransition);

--- a/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
@@ -442,6 +442,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
             float mouseHandleDistance = Vector2.Distance(mouseScreenPosition, handleViewportPosition);
 
+            // Check if mouse is hovering circle centered on plane center. Keep circle ratio as a multiple of the current unity handle size.
             if (mouseHandleDistance < handleSize * 10.0f && mouseHandleDistance < smallestMouseHandleDistance)
             {
                 smallestMouseHandleDistance = mouseHandleDistance;

--- a/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Experimental.UI;
-using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEditor;
 using UnityEngine;
@@ -13,8 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
     public class ScrollingObjectCollectionInspector : UnityEditor.Editor
     {
         private bool animateTransition = true;
-        private int amountOfItemsToMoveBy = 1;
-        private int amountOfLinesToMoveTo = 1;
+        private int amountOfTiersToMove = 1;
+        private int amountOfPagesToMove = 1;
         private int indexToMoveTo = 1;
 
         private SerializedProperty sorting;
@@ -23,16 +22,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
         private SerializedProperty canScroll;
         private SerializedProperty scrollDirection;
-        private SerializedProperty useNearScrollBoundary;
         private SerializedProperty viewableArea;
-        private SerializedProperty tiers;
+        private SerializedProperty itemsPerTier;
         private SerializedProperty useCameraPreRender;
 
         private SerializedProperty setupAtRuntime;
         private SerializedProperty occlusionPositionPadding;
         private SerializedProperty occlusionScalePadding;
         private SerializedProperty handDeltaMagThreshold;
-        private SerializedProperty snapListItems;
 
         private SerializedProperty velocityType;
         private SerializedProperty velocityMultiplier;
@@ -47,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private SerializedProperty momentumEvent;
         private SerializedProperty disableClippedItems;
 
-        private bool showOverrideButtons = true;
+        private bool showDebugOptions = true;
         private bool showUnityEvents = false;
 
         // Serialized properties purely for inspector visualization
@@ -59,13 +56,31 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private SerializedProperty frontPlaneDistance;
         private Shader MRTKtmp;
 
+        private ScrollingObjectCollection scrollView;
+
+        private static bool visibleDebugPlanes = false;
+
+        private Color touchPlaneColor = Color.cyan;
+        private Color releasePlaneColor = Color.magenta;
+        private static GUIStyle labelStyle;
+        private Vector3 mouseScreenPosition;
+        private float smallestMouseHandleDistance;
+
+        private const string TouchPlaneDescription = "Touch plane";
+        private const string LeftReleasePlaneDescription = "Left Release Plane";
+        private const string RightReleasePlaneDescription = "Right Release Plane";
+        private const string TopReleasePlaneDescription = "Top release Plane";
+        private const string BottomReleasePlaneDescription = "Bottom Release Plane";
+        private const string BackReleasePlaneDescription = "Back release Plane";
+        private const string FrontReleasePlaneDescription = "Front Release Plane";
+
         private void OnEnable()
         {
             sorting = serializedObject.FindProperty("sortType");
             cellHeight = serializedObject.FindProperty("cellHeight");
             cellWidth = serializedObject.FindProperty("cellWidth");
 
-            tiers = serializedObject.FindProperty("tiers");
+            itemsPerTier = serializedObject.FindProperty("itemsPerTier");
             canScroll = serializedObject.FindProperty("canScroll");
             scrollDirection = serializedObject.FindProperty("scrollDirection");
             viewableArea = serializedObject.FindProperty("viewableArea");
@@ -77,7 +92,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
             handDeltaMagThreshold = serializedObject.FindProperty("handDeltaMagThreshold");
 
-            snapListItems = serializedObject.FindProperty("snapListItems");
             velocityType = serializedObject.FindProperty("typeOfVelocity");
             velocityMultiplier = serializedObject.FindProperty("velocityMultiplier");
             velocityDampen = serializedObject.FindProperty("velocityDampen");
@@ -97,6 +111,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             releaseThresholdLeftRight = serializedObject.FindProperty("releaseThresholdLeftRight");
             releaseThresholdTopBottom = serializedObject.FindProperty("releaseThresholdTopBottom");
             frontPlaneDistance = serializedObject.FindProperty("frontPlaneDistance");
+
+            scrollView = (ScrollingObjectCollection)target;
+
+            if (labelStyle == null)
+            {
+                labelStyle = new GUIStyle();
+                labelStyle.normal.textColor = Color.white;
+            }
         }
 
         public override void OnInspectorGUI()
@@ -106,6 +128,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             EditorGUI.BeginChangeCheck();
 
             ScrollingObjectCollection scrollContainer = (ScrollingObjectCollection)target;
+
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
 
             EditorGUILayout.LabelField("General Properties", EditorStyles.boldLabel);
             using (new EditorGUI.IndentLevelScope())
@@ -124,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
                 EditorGUILayout.PropertyField(sorting);
                 EditorGUILayout.PropertyField(cellWidth);
                 EditorGUILayout.PropertyField(cellHeight);
-                EditorGUILayout.PropertyField(tiers);
+                EditorGUILayout.PropertyField(itemsPerTier);
                 EditorGUILayout.PropertyField(viewableArea);
                 EditorGUILayout.Space();
             }
@@ -138,23 +163,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             }
 
             EditorGUILayout.Space();
-
-            EditorGUILayout.HelpBox("In order for a ScrollableObjectCollection to work properly with PressableButton, ReleaseOnTouchEnd must be inactive.", MessageType.Info);
-
-            if (GUILayout.Button("Set Up PressableButtons"))
-            {
-                PressableButton[] pBs = scrollContainer.transform.GetComponentsInChildren<PressableButton>();
-                foreach (PressableButton p in pBs)
-                {
-                    p.ReleaseOnTouchEnd = false;
-                }
-
-                PhysicalPressEventRouter[] routers = scrollContainer.transform.GetComponentsInChildren<PhysicalPressEventRouter>();
-                foreach (PhysicalPressEventRouter r in routers)
-                {
-                    r.InteractableOnClick = PhysicalPressEventRouter.PhysicalPressEventBehavior.EventOnClickCompletion;
-                }
-            }
 
             EditorGUILayout.LabelField("Scrolling Properties", EditorStyles.boldLabel);
 
@@ -195,7 +203,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
             EditorGUILayout.Space();
 
-            showUnityEvents = EditorGUILayout.Foldout(showUnityEvents, "Unity Events: ", true);
+            showUnityEvents = EditorGUILayout.Foldout(showUnityEvents, "Unity Events", true);
 
             if (showUnityEvents)
             {
@@ -210,55 +218,49 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
             EditorGUILayout.Space();
 
-            showOverrideButtons = EditorGUILayout.Foldout(showOverrideButtons, "Scrolling debug buttons", true);
+            showDebugOptions = EditorGUILayout.Foldout(showDebugOptions, "Debug Options", true);
 
-            EditorGUILayout.Space();
-
-            if (showOverrideButtons)
+            if (showDebugOptions)
             {
-                using (new EditorGUI.IndentLevelScope())
+                using (new EditorGUI.DisabledGroupScope(EditorApplication.isPlaying))
                 {
-                    animateTransition = EditorGUILayout.Toggle("Animate", animateTransition);
+                    visibleDebugPlanes = EditorGUILayout.Toggle("Show Event Planes", visibleDebugPlanes);
+                }
 
-                    using (new EditorGUILayout.HorizontalScope())
+                EditorGUILayout.Space();
+
+                using (new EditorGUI.DisabledGroupScope(!EditorApplication.isPlaying))
+                {
+
+                    using (new EditorGUI.IndentLevelScope())
                     {
-                        if (GUILayout.Button("Page Up"))
+                        animateTransition = EditorGUILayout.Toggle("Animate", animateTransition);
+
+                        using (new EditorGUILayout.HorizontalScope())
                         {
-                            scrollContainer.PageBy(1, animateTransition);
+                            amountOfPagesToMove = EditorGUILayout.IntField(amountOfPagesToMove);
+                            if (GUILayout.Button("Move By Pages"))
+                            {
+                                scrollContainer.MoveByPages(amountOfPagesToMove, animateTransition);
+                            }
                         }
-                        if (GUILayout.Button("Page Down"))
+
+                        using (new EditorGUILayout.HorizontalScope())
                         {
-                            scrollContainer.PageBy(-1, animateTransition);
+                            amountOfTiersToMove = EditorGUILayout.IntField(amountOfTiersToMove);
+                            if (GUILayout.Button("Move By Tiers"))
+                            {
+                                scrollContainer.MoveByTiers(amountOfTiersToMove, animateTransition);
+                            }
                         }
-                    }
 
-                    using (new EditorGUILayout.HorizontalScope())
-                    {
-
-                        amountOfLinesToMoveTo = EditorGUILayout.IntField(amountOfLinesToMoveTo);
-                        if (GUILayout.Button("Move By Tiers"))
+                        using (new EditorGUILayout.HorizontalScope())
                         {
-                            scrollContainer.MoveByLines(amountOfLinesToMoveTo, animateTransition);
-                        }
-                    }
-
-                    using (new EditorGUILayout.HorizontalScope())
-                    {
-
-                        amountOfItemsToMoveBy = EditorGUILayout.IntField(amountOfItemsToMoveBy);
-                        if (GUILayout.Button("Move By Items"))
-                        {
-                            scrollContainer.MoveByItems(amountOfItemsToMoveBy, animateTransition);
-                        }
-                    }
-
-                    using (new EditorGUILayout.HorizontalScope())
-                    {
-
-                        indexToMoveTo = EditorGUILayout.IntField(indexToMoveTo);
-                        if (GUILayout.Button("Move To Index"))
-                        {
-                            scrollContainer.MoveTo(indexToMoveTo, animateTransition);
+                            indexToMoveTo = EditorGUILayout.IntField(indexToMoveTo);
+                            if (GUILayout.Button("Move To Index"))
+                            {
+                                scrollContainer.MoveToIndex(indexToMoveTo, animateTransition);
+                            }
                         }
                     }
                 }
@@ -276,7 +278,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
                     if (!CheckForStandardShader(nodeTransform.GetComponentsInChildren<Renderer>()))
                     {
-                        Debug.LogWarning(nodeTransform.name + " has a renderer that is not using " +  StandardShaderUtility.MrtkStandardShaderName + ". This will result in unexpected results with ScrollingObjectCollection");
+                        Debug.LogWarning(nodeTransform.name + " has a renderer that is not using " + StandardShaderUtility.MrtkStandardShaderName + ". This will result in unexpected results with ScrollingObjectCollection");
                     }
                 }
             }
@@ -286,17 +288,23 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         [DrawGizmo(GizmoType.Selected)]
         private void OnSceneGUI()
         {
-            ScrollingObjectCollection scrollContainer = (ScrollingObjectCollection)target;
             MRTKtmp = Shader.Find("Mixed Reality Toolkit/TextMeshPro");
 
-            if (scrollContainer.ClippingObject == null) { return; }
+            if (scrollView.ClippingObject == null) { return; }
 
             if (Event.current.type == EventType.Repaint)
             {
-                DisplayTouchPlane(scrollContainer);
+                if (visibleDebugPlanes)
+                {
+                    GetMouseViewportPosition();
+
+                    smallestMouseHandleDistance = float.PositiveInfinity;
+
+                    DrawAllDebugPlanes();
+                }
 
                 // Display the item number on the list items
-                for (int i = 0; i <= nodeList.arraySize-1; i++)
+                for (int i = 0; i <= nodeList.arraySize - 1; i++)
                 {
                     var node = nodeList.GetArrayElementAtIndex(i);
                     Transform nodeTransform = node.FindPropertyRelative("Transform").objectReferenceValue as Transform;
@@ -311,43 +319,147 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         }
 
         /// <summary>
-        /// Displays the touch plane used for scrolling (and releasing).
+        /// Draws the touch plane used for scroll engage detection.
         /// </summary>
-        private void DisplayTouchPlane(ScrollingObjectCollection container)
+        private void DrawTouchPlane()
         {
-            Color arrowColor = Color.cyan;
-            Vector3 center;
-            if (container.ClippingObject == null)
-            {
-                return;
-            }
+            Vector3 planeLocalPosition = Vector3.forward * frontPlaneDistance.floatValue * -1.0f;
+            Vector3 widthHalfExtent = scrollView.transform.right * scrollView.ClippingObject.transform.lossyScale.x / 2;
+            Vector3 heightHalfExtent = scrollView.transform.up * scrollView.ClippingObject.transform.lossyScale.y / 2;
 
-            var scrollContainer = (ScrollingObjectCollection)target;
-            // now that its running lets show the press plane so users have feedback about touch
-            center = scrollContainer.transform.TransformPoint(Vector3.forward * -1.0f * releaseThresholdFront.floatValue);
+            Quaternion handleRotation = Quaternion.LookRotation(scrollView.transform.forward * -1.0f);
 
-            UnityEditor.Handles.color = arrowColor;
+            DrawPlaneAndHandle(planeLocalPosition, widthHalfExtent, heightHalfExtent, handleRotation, touchPlaneColor, TouchPlaneDescription);
+        }
 
-            float arrowSize = UnityEditor.HandleUtility.GetHandleSize(center) * 0.75f;
+        /// <summary>
+        /// Draws the front release plane used for scroll engage release detection.
+        /// </summary>
+        private void DrawFrontReleasePlane()
+        {
+            Vector3 planeLocalPosition = Vector3.forward * releaseThresholdFront.floatValue * -1.0f;
+            Vector3 widthHalfExtent = scrollView.transform.right * scrollView.ClippingObject.transform.lossyScale.x / 2;
+            Vector3 heightHalfExtent = scrollView.transform.up * scrollView.ClippingObject.transform.lossyScale.y / 2;
 
-            container.transform.rotation.ToAngleAxis(out float ang, out Vector3 currRotAxis);
+            Quaternion handleRotation = Quaternion.LookRotation(scrollView.transform.forward);
 
-            Vector3 rightDelta = container.transform.right * container.ClippingObject.transform.localScale.x;
-            Vector3 upDelta = container.transform.up * container.ClippingObject.transform.localScale.y;
+            DrawPlaneAndHandle(planeLocalPosition, widthHalfExtent, heightHalfExtent, handleRotation, releasePlaneColor, FrontReleasePlaneDescription);
+        }
 
-            Quaternion rot = Quaternion.LookRotation(container.transform.forward * -1.0f, container.transform.up);
-            UnityEditor.Handles.ArrowHandleCap(0, center + (rightDelta * 0.5f) - (upDelta * 0.5f), rot, arrowSize, EventType.Repaint);
+        /// <summary>
+        /// Draws the back release plane used for scroll engage release detection.
+        /// </summary>
+        private void DrawBackReleasePlane()
+        {
+            Vector3 planeLocalPosition = Vector3.forward * releaseThresholdBack.floatValue;
+            Vector3 widthHalfExtent = scrollView.transform.right * scrollView.ClippingObject.transform.lossyScale.x / 2;
+            Vector3 heightHalfExtent = scrollView.transform.up * scrollView.ClippingObject.transform.lossyScale.y / 2;
+
+            Quaternion handleRotation = Quaternion.LookRotation(scrollView.transform.forward * -1.0f);
+
+            DrawPlaneAndHandle(planeLocalPosition, widthHalfExtent, heightHalfExtent, handleRotation, releasePlaneColor, BackReleasePlaneDescription);
+        }
+
+        /// <summary>
+        /// Draws the right release plane used for scroll engage release detection.
+        /// </summary>
+        private void DrawRightReleasePlane()
+        {
+            Vector3 planeLocalPosition = Vector3.right * releaseThresholdLeftRight.floatValue;
+            Vector3 widthHalfExtent = scrollView.transform.forward * scrollView.ClippingObject.transform.lossyScale.z / 2;
+            Vector3 heightHalfExtent = scrollView.transform.up * scrollView.ClippingObject.transform.lossyScale.y / 2;
+
+            Quaternion handleRotation = Quaternion.LookRotation(scrollView.transform.right * -1.0f);
+
+            DrawPlaneAndHandle(planeLocalPosition, widthHalfExtent, heightHalfExtent, handleRotation, releasePlaneColor, RightReleasePlaneDescription);
+        }
+
+        /// <summary>
+        /// Draws the left release plane used for scroll engage release detection.
+        /// </summary>
+        private void DrawLeftReleasePlane()
+        {
+            Vector3 planeLocalPosition = Vector3.right * releaseThresholdLeftRight.floatValue * -1.0f;
+            Vector3 widthHalfExtent = scrollView.transform.forward * scrollView.ClippingObject.transform.lossyScale.z / 2;
+            Vector3 heightHalfExtent = scrollView.transform.up * scrollView.ClippingObject.transform.lossyScale.y / 2;
+
+            Quaternion handleRotation = Quaternion.LookRotation(scrollView.transform.right);
+
+            DrawPlaneAndHandle(planeLocalPosition, widthHalfExtent, heightHalfExtent, handleRotation, releasePlaneColor, LeftReleasePlaneDescription);
+        }
+
+        /// <summary>
+        /// Draws the top release plane used for scroll engage release detection.
+        /// </summary>
+        private void DrawTopReleasePlane()
+        {
+            Vector3 planeLocalPosition = Vector3.up * releaseThresholdTopBottom.floatValue;
+            Vector3 widthHalfExtent = scrollView.transform.right * scrollView.ClippingObject.transform.lossyScale.x / 2;
+            Vector3 heightHalfExtent = scrollView.transform.forward * scrollView.ClippingObject.transform.lossyScale.z / 2;
+
+            Quaternion handleRotation = Quaternion.LookRotation(scrollView.transform.up * -1.0f);
+
+            DrawPlaneAndHandle(planeLocalPosition, widthHalfExtent, heightHalfExtent, handleRotation, releasePlaneColor, TopReleasePlaneDescription);
+        }
+
+        /// <summary>
+        /// Draws the top release plane used for scroll engage release detection.
+        /// </summary>
+        private void DrawBottomReleasePlane()
+        {
+            Vector3 planeLocalPosition = Vector3.up * releaseThresholdTopBottom.floatValue * -1.0f;
+            Vector3 widthHalfExtent = scrollView.transform.right * scrollView.ClippingObject.transform.lossyScale.x / 2;
+            Vector3 heightHalfExtent = scrollView.transform.forward * scrollView.ClippingObject.transform.lossyScale.z / 2;
+
+            Quaternion handleRotation = Quaternion.LookRotation(scrollView.transform.up);
+
+            DrawPlaneAndHandle(planeLocalPosition, widthHalfExtent, heightHalfExtent, handleRotation, releasePlaneColor, BottomReleasePlaneDescription);
+        }
+
+        /// <summary>
+        /// Draws the scroll interaction debug planes.
+        /// </summary>
+        private void DrawPlaneAndHandle(Vector3 planeLocalPosition, Vector3 widthHalfExtent, Vector3 hightHalfExtent, Quaternion handleRotation, Color color, string labelText)
+        {
+            Vector3 planePosition = scrollView.ClippingObject.transform.position + scrollView.ClippingObject.transform.TransformDirection(planeLocalPosition);
 
             Vector3[] points = new Vector3[4];
-            points[0] = center;
-            points[1] = center + rightDelta;
-            points[2] = center + rightDelta - upDelta;
-            points[3] = center - upDelta;
+            points[0] = planePosition - widthHalfExtent + hightHalfExtent;
+            points[1] = planePosition + widthHalfExtent + hightHalfExtent;
+            points[2] = planePosition + widthHalfExtent - hightHalfExtent;
+            points[3] = planePosition - widthHalfExtent - hightHalfExtent;
 
-            UnityEditor.Handles.DrawSolidRectangleWithOutline(points, new Color(0.85f, 1.0f, 1.0f, 0.1f), arrowColor);
-            GUIStyle labelStyle = new GUIStyle();
-            labelStyle.normal.textColor = Color.white;
-            UnityEditor.Handles.Label(center + (rightDelta * 0.5f) - (upDelta * 0.5f), new GUIContent("touch plane", "The plane which the finger will need to cross in order for the touch to be calculated as a scroll or release."), labelStyle);
+            float handleSize = HandleUtility.GetHandleSize(planePosition) * 0.30f;
+
+            // Draw handle and plane
+            Handles.color = color;
+            Handles.ArrowHandleCap(0, planePosition, handleRotation, handleSize, EventType.Repaint);
+            Handles.DrawSolidRectangleWithOutline(points, Color.Lerp(color, Color.clear, 0.5f), color);
+
+            // Draw label if handle has smallest vieport distance from the mouse pointer
+            Vector3 handleViewportPosition = SceneView.currentDrawingSceneView.camera.WorldToScreenPoint(planePosition);
+            handleViewportPosition = SceneView.currentDrawingSceneView.camera.ScreenToViewportPoint(handleViewportPosition);
+
+            float mouseHandleDistance = Vector2.Distance(mouseScreenPosition, handleViewportPosition);
+
+            if (mouseHandleDistance < handleSize * 10.0f && mouseHandleDistance < smallestMouseHandleDistance)
+            {
+                smallestMouseHandleDistance = mouseHandleDistance;
+
+                Handles.Label(planePosition + (Vector3.up * handleSize * 3.0f), new GUIContent(labelText), labelStyle);
+                Handles.DrawDottedLine(planePosition + (Vector3.up * handleSize * 2.0f) + (Vector3.right * handleSize), planePosition, 5f);
+            }
+        }
+
+        private void DrawAllDebugPlanes()
+        {
+            DrawTouchPlane();
+            DrawFrontReleasePlane();
+            DrawBackReleasePlane();
+            DrawRightReleasePlane();
+            DrawLeftReleasePlane();
+            DrawTopReleasePlane();
+            DrawBottomReleasePlane();
         }
 
         /// <summary>
@@ -358,7 +470,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private bool CheckForStandardShader(Renderer[] rends)
         {
             foreach (Renderer rend in rends)
-            {                
+            {
                 if (!StandardShaderUtility.IsUsingMrtkStandardShader(rend.sharedMaterial) && rend.sharedMaterial.shader != MRTKtmp)
                 {
                     return false;
@@ -367,5 +479,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             return true;
         }
 
+        private void GetMouseViewportPosition()
+        {
+            mouseScreenPosition = HandleUtility.GUIPointToScreenPixelCoordinate(Event.current.mousePosition);
+            mouseScreenPosition = SceneView.currentDrawingSceneView.camera.ScreenToViewportPoint(mouseScreenPosition);
+        }
     }
 }

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -442,7 +442,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 }
                 else
                 {
-                    return -((int)Mathf.Ceil(scrollContainer.transform.localPosition.x / CellWidth) * ItemsPerTier);
+                    return ((int)Mathf.Ceil(Mathf.Abs(scrollContainer.transform.localPosition.x / CellWidth)) * ItemsPerTier);
                 }
             }
         }

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -24,33 +24,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator ScrollEngageResetsNearInteractionWithChildren()
         {
-            // Setting up three pressable buttons as scroll items
-            GameObject scrollObject = new GameObject();
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.parent = scrollObject.transform;
-
-            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button2.transform.parent = scrollObject.transform;
-
-            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button3.transform.parent = scrollObject.transform;
-
-            // Setting up a vertical 2x1 scroll view. The first two items are visible
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.ItemsPerTier = 1;
-            scrollView.ViewableArea = 2;
-            scrollView.UpdateCollection();
-            scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
-            scrollObject.transform.position = Vector3.forward;
-
+            // Setting up a vertical 1x2 scroll view with three pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                3,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                1,
+                                                                                2,
+                                                                                ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
             TestUtilities.PlayspaceToOriginLookingForward();
 
-            PressableButton button1Component = button1.GetComponentInChildren<PressableButton>();
-            PressableButton button2Component = button2.GetComponentInChildren<PressableButton>();
+            PressableButton button1Component = scrollItems[0].GetComponentInChildren<PressableButton>();
+            PressableButton button2Component = scrollItems[1].GetComponentInChildren<PressableButton>();
 
             Assert.IsNotNull(button1Component);
             Assert.IsNotNull(button2Component);
@@ -172,33 +158,22 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator ScrollEngageResetsFarInteractionWithChildren()
         {
-            // Setting up two pressable buttons as scroll items
-            GameObject scrollObject = new GameObject();
+            // Setting up a vertical 1x1 scroll view with two pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                2,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                1,
+                                                                                1,
+                                                                                ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
             float scale = 10f;
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.localScale *= scale;
-            button1.transform.parent = scrollObject.transform;
-
-            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button2.transform.localScale *= scale;
-            button2.transform.parent = scrollObject.transform;
-
-            // Setting up a vertical 1x1 scroll view 
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x * scale;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y * scale;
-            scrollView.ItemsPerTier = 1;
-            scrollView.ViewableArea = 1;
-            scrollView.UpdateCollection();
-            scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
-            scrollObject.transform.position = Vector3.forward;
+            scrollView.transform.localScale *= scale;
 
             TestUtilities.PlayspaceToOriginLookingForward();
 
-            Interactable interactable1 = button1.GetComponent<Interactable>();
-            Interactable interactable2 = button2.GetComponent<Interactable>();
+            Interactable interactable1 = scrollItems[0].GetComponent<Interactable>();
+            Interactable interactable2 = scrollItems[1].GetComponent<Interactable>();
 
             Assert.IsNotNull(interactable1);
             Assert.IsNotNull(interactable2);
@@ -212,7 +187,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Hand positions
             float offset = 0.001f;
             Vector3 initialPos = new Vector3(0.13f, -0.17f, 0.5f); // Far pointer focus is on button       
-            Vector3 scrollEngagedPos = initialPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset);
+            Vector3 scrollEngagedPos = initialPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight * scale + offset);
 
             // Interaction with child button should behave normally if scroll drag not yet engaged
             TestHand hand = new TestHand(Handedness.Right);
@@ -264,32 +239,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator NoJumpsWhenInteractingWithChildren()
         {
-            // Setting up three pressable buttons as scroll items
-            GameObject scrollObject = new GameObject();
+            // Setting up a vertical 1x2 scroll view with three pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                3,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                1,
+                                                                                2,
+                                                                                ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
             float scale = 10f;
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.localScale *= scale;
-            button1.transform.parent = scrollObject.transform;
-
-            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button2.transform.localScale *= scale;
-            button2.transform.parent = scrollObject.transform;
-
-            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button3.transform.localScale *= scale;
-            button3.transform.parent = scrollObject.transform;
-
-            // Setting up a vertical 2x1 scroll view
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x * scale;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y * scale;
-            scrollView.ItemsPerTier = 1;
-            scrollView.ViewableArea = 2;
-            scrollView.UpdateCollection();
-            scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
-            scrollObject.transform.position = new Vector3(0, scrollView.CellHeight, 1.0f);
+            scrollView.transform.localScale *= scale;
+ 
 
             TestUtilities.PlayspaceToOriginLookingForward();
 
@@ -323,29 +284,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator InteractionWithBackgroundEmptySpace()
         {
-            // Setting up three pressable buttons as scroll items
-            GameObject scrollObject = new GameObject();
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.parent = scrollObject.transform;
-
-            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button2.transform.parent = scrollObject.transform;
-
-            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button3.transform.parent = scrollObject.transform;
-
-            // Setting up a vertical 2x1 scroll view where second row has one button and one empty slot
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.ItemsPerTier = 2;
-            scrollView.ViewableArea = 1;
-            scrollView.UpdateCollection();
-            scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
-            scrollObject.transform.position = Vector3.forward;
-
+            // Setting up a vertical 2x1 scroll view with three pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                3,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                2,
+                                                                                1,
+                                                                                ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
             TestUtilities.PlayspaceToOriginLookingForward();
 
             bool scrollDragBegin = false;
@@ -357,7 +304,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Hand positions
             float offset = 0.001f;
             Vector3 initialPos = Vector3.zero;
-            Vector3 scrollTouchPos = button2.transform.position + Vector3.forward * 0.015f; // Touching scroll second colum slot        
+            Vector3 scrollTouchPos = scrollItems[1].transform.position + Vector3.forward * 0.015f; // Touching scroll second colum slot        
             Vector3 scrollEngagedUpPos = scrollTouchPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset); // Scrolls up one row
             Vector3 scrollEngagedDownPos = scrollTouchPos - Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset); // Scrolls down one row
 
@@ -389,34 +336,22 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator ChildrenCanBeAddedAndDeleted()
         {
-            // Setting up three pressable buttons as scroll items
-            GameObject scrollObject = new GameObject();
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.parent = scrollObject.transform;
-
-            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button2.transform.parent = scrollObject.transform;
-
-            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button3.transform.parent = scrollObject.transform;
-
+            // Setting up a vertical 1x1 scroll view with three pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                3,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                1,
+                                                                                1,
+                                                                                ScrollingObjectCollection.VelocityType.FalloffPerItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
+            // This button will be added later to the scroll collection
             GameObject button4 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-
-            // Setting up a vertical 1x1 scroll view
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.ItemsPerTier = 1;
-            scrollView.ViewableArea = 1;
-            scrollView.UpdateCollection();
-            scrollObject.transform.position = Vector3.forward;
 
             TestUtilities.PlayspaceToOriginLookingForward();
 
-            PressableButton button1Component = button1.GetComponentInChildren<PressableButton>();
-            PressableButton button3Component = button3.GetComponentInChildren<PressableButton>();
+            PressableButton button1Component = scrollItems[0].GetComponentInChildren<PressableButton>();
+            PressableButton button3Component = scrollItems[2].GetComponentInChildren<PressableButton>();
             PressableButton button4Component = button4.GetComponentInChildren<PressableButton>();
 
             Assert.IsNotNull(button1Component);
@@ -450,8 +385,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Hand positions
             float offset = 0.001f;
             Vector3 initialPos = Vector3.zero;
-            Vector3 preButtonTouchPos = button1.transform.position + new Vector3(0, 0, button1Component.StartPushDistance - offset);
-            Vector3 pastButtonPressPos = button1.transform.position + new Vector3(0, 0, button1Component.PressDistance + offset);
+            Vector3 preButtonTouchPos = button1Component.transform.position + new Vector3(0, 0, button1Component.StartPushDistance - offset);
+            Vector3 pastButtonPressPos = button1Component.transform.position + new Vector3(0, 0, button1Component.PressDistance + offset);
             Vector3 scrollEngagedHalfPageUpPos = pastButtonPressPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight / 2 + offset);
             Vector3 scrollEngagedOnePageUpPos = pastButtonPressPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset);
             Vector3 scrollEngagedTwoPageUpPos = pastButtonPressPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight * 2 + offset);
@@ -469,8 +404,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(button4TouchBegin, "Button4 touch begin was triggered.");
 
             // Removing scroll item while scroll is engaged
-            scrollView.RemoveItem(button2);
-            GameObject.Destroy(button2);
+            scrollView.RemoveItem(scrollItems[1]);
+            GameObject.Destroy(scrollItems[1]);
 
             // Scrolling to second row
             scrollDragBegin = false;
@@ -538,29 +473,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator ScrollEngageResetsWhenOutOfBoundaryThreshold()
         {
-            // Setting up two pressable buttons as scroll items
-            GameObject scrollObject = new GameObject();
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.parent = scrollObject.transform;
-
-            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button2.transform.parent = scrollObject.transform;
-
-            // Setting up a vertical 1x1 scroll view. 
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.ItemsPerTier = 1;
-            scrollView.ViewableArea = 1;
-            scrollView.UpdateCollection();
-            scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
-            scrollObject.transform.position = Vector3.forward;
-
+            // Setting up a vertical 1x1 scroll view with two pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                2,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                1,
+                                                                                1,
+                                                                                ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
             TestUtilities.PlayspaceToOriginLookingForward();
 
-            PressableButton button1Component = button1.GetComponentInChildren<PressableButton>();
+            PressableButton button1Component = scrollItems[0].GetComponentInChildren<PressableButton>();
 
             Assert.IsNotNull(button1Component);
 
@@ -681,28 +605,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator ScrollEngageOnlyFromFrontInteraction()
         {
-            // Setting up two pressable buttons as scroll items
-            GameObject scrollObject = new GameObject();
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.parent = scrollObject.transform;
-
-            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button2.transform.parent = scrollObject.transform;
-
-            // Setting up a vertical 1x1 scroll view. 
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.ItemsPerTier = 1;
-            scrollView.ViewableArea = 1;
-            scrollView.UpdateCollection();
-            scrollObject.transform.position = Vector3.forward;
-
+            // Setting up a vertical 1x1 scroll view with two pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                2,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                1,
+                                                                                1,
+                                                                                ScrollingObjectCollection.VelocityType.FalloffPerItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
             TestUtilities.PlayspaceToOriginLookingForward();
 
-            PressableButton button1Component = button1.GetComponentInChildren<PressableButton>();
+            PressableButton button1Component = scrollItems[0].GetComponentInChildren<PressableButton>();
 
             Assert.IsNotNull(button1Component);
 
@@ -776,20 +690,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator ScrollViewCanBeScaled()
         {
-            // Setting up one pressable button as scroll item
-            GameObject scrollObject = new GameObject();
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.parent = scrollObject.transform;
-
-            // Setting up a vertical 1x1 scroll view. 
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.ItemsPerTier = 1;
-            scrollView.ViewableArea = 1;
-            scrollView.UpdateCollection();
+            // Setting up a vertical 1x1 scroll view with one single pressable button item
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                1,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                1,
+                                                                                1,
+                                                                                ScrollingObjectCollection.VelocityType.FalloffPerItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
 
             GameObject ClippingObject = scrollView.ClippingObject;
 
@@ -801,7 +710,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Doubling the scroll object scale should not alter the clipping box local scale
             float newScrollScale = 2.0f;
-            scrollObject.transform.localScale *= newScrollScale;
+            scrollView.transform.localScale *= newScrollScale;
 
             yield return null;
             scrollView.UpdateCollection();
@@ -818,31 +727,20 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator ScrollViewCanbeRotated()
         {
-            // Setting up two pressable buttons as scroll items
-            GameObject scrollObject = new GameObject();
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.parent = scrollObject.transform;
-
-            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button2.transform.parent = scrollObject.transform;
-
-            // Setting up a vertical 1x1 scroll view. 
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.ItemsPerTier = 1;
-            scrollView.ViewableArea = 1;
-            scrollView.UpdateCollection();
-            scrollObject.transform.position = - Vector3.up;
-            scrollObject.transform.rotation = Quaternion.LookRotation(-Vector3.up);
-
+            // Setting up a vertical 1x1 scroll view with two pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems, 
+                                                                                2, 
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown, 
+                                                                                1, 
+                                                                                1,
+                                                                                ScrollingObjectCollection.VelocityType.FalloffPerItem,
+                                                                                Vector3.up * -1.0f,
+                                                                                Quaternion.LookRotation(-Vector3.up));
             // Setting up camera to look down
             MixedRealityPlayspace.Position = Vector3.zero;
             MixedRealityPlayspace.Rotation = Quaternion.LookRotation(-Vector3.up);
 
-            PressableButton button1Component = button1.GetComponentInChildren<PressableButton>();
+            PressableButton button1Component = scrollItems[0].GetComponentInChildren<PressableButton>();
 
             Assert.IsNotNull(button1Component);
 
@@ -871,45 +769,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator CanBeScrolledByTierOrIndexOrPage()
         {
-            // Setting up nine pressable buttons as scroll items
-            GameObject scrollObject = new GameObject();
-
-            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button1.transform.parent = scrollObject.transform;
-
-            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button2.transform.parent = scrollObject.transform;
-
-            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button3.transform.parent = scrollObject.transform;
-
-            GameObject button4 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button4.transform.parent = scrollObject.transform;
-
-            GameObject button5 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button5.transform.parent = scrollObject.transform;
-
-            GameObject button6 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button6.transform.parent = scrollObject.transform;
-
-            GameObject button7 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button7.transform.parent = scrollObject.transform;
-
-            GameObject button8 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button8.transform.parent = scrollObject.transform;
-
-            GameObject button9 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
-            button9.transform.parent = scrollObject.transform;
-
-            // Setting up a horizontal 2x2 scroll view 
-            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
-            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.LeftAndRight;
-            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
-            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.ItemsPerTier = 2;
-            scrollView.ViewableArea = 2;
-            scrollView.UpdateCollection();
-            scrollObject.transform.position = Vector3.forward;
+            // Setting up a horizontal 2x2 scroll view with nine pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems, 
+                                                                                9, 
+                                                                                ScrollingObjectCollection.ScrollDirectionType.LeftAndRight, 
+                                                                                2, 
+                                                                                2, 
+                                                                                ScrollingObjectCollection.VelocityType.FalloffPerItem, 
+                                                                                Vector3.forward, 
+                                                                                Quaternion.identity);
             TestUtilities.PlayspaceToOriginLookingForward();
 
             yield return null;
@@ -1006,6 +874,41 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             GameObject button = Object.Instantiate(buttonPrefab) as GameObject;
 
             return button;
+        }
+
+        private ScrollingObjectCollection InstantiateScrollAndChildren(out GameObject[] scrollItems, 
+                                                                       int numberOfItems, 
+                                                                       ScrollingObjectCollection.ScrollDirectionType scrollDirection, 
+                                                                       int itemsPerTier, 
+                                                                       int viewableArea,
+                                                                       ScrollingObjectCollection.VelocityType velocityType,
+                                                                       Vector3 position,
+                                                                       Quaternion rotation)
+        {
+            Debug.Assert(numberOfItems > 0);
+
+            GameObject scrollObject = new GameObject();
+
+            scrollItems = new GameObject[numberOfItems];
+            for (int i = 0; i < numberOfItems; i++)
+            {
+                scrollItems[i] = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+                scrollItems[i].transform.parent = scrollObject.transform;
+            }
+
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = scrollDirection;
+            scrollView.CellWidth = scrollItems[0].GetComponent<NearInteractionTouchable>().Bounds.x;
+            scrollView.CellHeight = scrollItems[0].GetComponent<NearInteractionTouchable>().Bounds.y;
+            scrollView.TypeOfVelocity = velocityType;
+            scrollView.ItemsPerTier = itemsPerTier;
+            scrollView.ViewableArea = viewableArea;
+            scrollView.UpdateCollection();
+
+            scrollObject.transform.position = position;
+            scrollObject.transform.rotation = rotation;
+
+            return scrollView;
         }
 
         #endregion Utilities

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
             scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
             scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.Tiers = 1;
+            scrollView.ItemsPerTier = 1;
             scrollView.ViewableArea = 2;
             scrollView.UpdateCollection();
             scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
@@ -189,7 +189,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
             scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x * scale;
             scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y * scale;
-            scrollView.Tiers = 1;
+            scrollView.ItemsPerTier = 1;
             scrollView.ViewableArea = 1;
             scrollView.UpdateCollection();
             scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
@@ -285,7 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
             scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x * scale;
             scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y * scale;
-            scrollView.Tiers = 1;
+            scrollView.ItemsPerTier = 1;
             scrollView.ViewableArea = 2;
             scrollView.UpdateCollection();
             scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
@@ -340,7 +340,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
             scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
             scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.Tiers = 2;
+            scrollView.ItemsPerTier = 2;
             scrollView.ViewableArea = 1;
             scrollView.UpdateCollection();
             scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
@@ -408,7 +408,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
             scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
             scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.Tiers = 1;
+            scrollView.ItemsPerTier = 1;
             scrollView.ViewableArea = 1;
             scrollView.UpdateCollection();
             scrollObject.transform.position = Vector3.forward;
@@ -552,7 +552,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
             scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
             scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.Tiers = 1;
+            scrollView.ItemsPerTier = 1;
             scrollView.ViewableArea = 1;
             scrollView.UpdateCollection();
             scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
@@ -695,7 +695,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
             scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
             scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
-            scrollView.Tiers = 1;
+            scrollView.ItemsPerTier = 1;
             scrollView.ViewableArea = 1;
             scrollView.UpdateCollection();
             scrollObject.transform.position = Vector3.forward;
@@ -768,6 +768,232 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsTrue(scrollView.IsEngaged, "Scroll view is engaged.");
 
             yield return hand.Hide();
+        }
+
+        /// <summary>
+        /// Tests if updating the collection after scaling the scroll object does not alter clipping box local scale.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScrollViewCanBeScaled()
+        {
+            // Setting up one pressable button as scroll item
+            GameObject scrollObject = new GameObject();
+
+            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button1.transform.parent = scrollObject.transform;
+
+            // Setting up a vertical 1x1 scroll view. 
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
+            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
+            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
+            scrollView.ItemsPerTier = 1;
+            scrollView.ViewableArea = 1;
+            scrollView.UpdateCollection();
+
+            GameObject ClippingObject = scrollView.ClippingObject;
+
+            // Clipping box dimensions should match the unique scroll item dimensions
+            Assert.IsNotNull(ClippingObject);
+            Assert.AreEqual(ClippingObject.transform.localScale.x, scrollView.CellWidth, 0.001, "Clipping box width did not scale as expected");
+            Assert.AreEqual(ClippingObject.transform.localScale.y, scrollView.CellHeight, 0.001, "Clipping box height did not scale as expected");
+            Assert.AreEqual(ClippingObject.transform.localScale.z, scrollView.CellWidth / 2, 0.001, "Clipping box depth did not scale as expected");
+
+            // Doubling the scroll object scale should not alter the clipping box local scale
+            float newScrollScale = 2.0f;
+            scrollObject.transform.localScale *= newScrollScale;
+
+            yield return null;
+            scrollView.UpdateCollection();
+            yield return null;
+
+            Assert.AreEqual(ClippingObject.transform.localScale.x, scrollView.CellWidth, 0.001, "Clipping box width did not scale as expected");
+            Assert.AreEqual(ClippingObject.transform.localScale.y, scrollView.CellHeight, 0.001, "Clipping box height did not scale as expected");
+            Assert.AreEqual(ClippingObject.transform.localScale.z, scrollView.CellWidth / 2, 0.001, "Clipping box depth did not scale as expected");
+        }
+
+        /// <summary>
+        /// Tests if scroll behaves as expected if scroll object is rotated.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScrollViewCanbeRotated()
+        {
+            // Setting up two pressable buttons as scroll items
+            GameObject scrollObject = new GameObject();
+
+            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button1.transform.parent = scrollObject.transform;
+
+            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button2.transform.parent = scrollObject.transform;
+
+            // Setting up a vertical 1x1 scroll view. 
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
+            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
+            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
+            scrollView.ItemsPerTier = 1;
+            scrollView.ViewableArea = 1;
+            scrollView.UpdateCollection();
+            scrollObject.transform.position = - Vector3.up;
+            scrollObject.transform.rotation = Quaternion.LookRotation(-Vector3.up);
+
+            // Setting up camera to look down
+            MixedRealityPlayspace.Position = Vector3.zero;
+            MixedRealityPlayspace.Rotation = Quaternion.LookRotation(-Vector3.up);
+
+            PressableButton button1Component = button1.GetComponentInChildren<PressableButton>();
+
+            Assert.IsNotNull(button1Component);
+
+            // Hand positions
+            float offset = 0.001f;
+            Vector3 initialPos = Vector3.zero;
+            Vector3 preButtonPressPos = button1Component.transform.position - new Vector3(0, button1Component.StartPushDistance - offset, 0);
+            Vector3 pastButtonPressPos = button1Component.transform.position - new Vector3(0, button1Component.PressDistance + 0.03f, 0);
+            Vector3 scrollEngagedPos = pastButtonPressPos + Vector3.forward * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset);
+
+            // Moving hand along z axis should still engage an up-down scroll view rotated 90 degrees around x
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(initialPos);
+            yield return hand.MoveTo(preButtonPressPos);
+            yield return hand.MoveTo(pastButtonPressPos);
+            yield return hand.MoveTo(scrollEngagedPos);
+
+            Assert.IsTrue(scrollView.isDragging, "Scroll view is not being dragged.");
+
+            yield return hand.Hide();
+        }
+
+        /// <summary>
+        /// Tests if scroll can be moved by page, by tier or to make specific element to be presented in the first visible tier.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator CanBeScrolledByTierOrIndexOrPage()
+        {
+            // Setting up nine pressable buttons as scroll items
+            GameObject scrollObject = new GameObject();
+
+            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button1.transform.parent = scrollObject.transform;
+
+            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button2.transform.parent = scrollObject.transform;
+
+            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button3.transform.parent = scrollObject.transform;
+
+            GameObject button4 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button4.transform.parent = scrollObject.transform;
+
+            GameObject button5 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button5.transform.parent = scrollObject.transform;
+
+            GameObject button6 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button6.transform.parent = scrollObject.transform;
+
+            GameObject button7 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button7.transform.parent = scrollObject.transform;
+
+            GameObject button8 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button8.transform.parent = scrollObject.transform;
+
+            GameObject button9 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button9.transform.parent = scrollObject.transform;
+
+            // Setting up a horizontal 2x2 scroll view 
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.LeftAndRight;
+            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
+            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
+            scrollView.ItemsPerTier = 2;
+            scrollView.ViewableArea = 2;
+            scrollView.UpdateCollection();
+            scrollObject.transform.position = Vector3.forward;
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            yield return null;
+
+            // Initial scroll state
+            Assert.AreEqual(0, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(4, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Moving to second tier
+            scrollView.MoveByTiers(1, false);
+            yield return null;
+
+            Assert.AreEqual(2, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(6, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Moving to fourth tier
+            scrollView.MoveByTiers(2, false);
+            yield return null;
+
+            Assert.AreEqual(6, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(10, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Scroll container should not move beyond its min position
+            scrollView.MoveByTiers(1, false);
+            yield return null;
+
+            Assert.AreEqual(6, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(10, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Moving back to first tier
+            scrollView.MoveByTiers(-4, false);
+            yield return null;
+
+            Assert.AreEqual(0, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(4, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Moving one page to third tier
+            scrollView.MoveByPages(1, false);
+            yield return null;
+
+            Assert.AreEqual(4, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(8, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Moving half page to fourth tier as scroll container hits its min position
+            scrollView.MoveByPages(1, false);
+            yield return null;
+
+            Assert.AreEqual(6, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(10, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Moving one page and a half back to first tier
+            scrollView.MoveByPages(-2, false);
+            yield return null;
+
+            Assert.AreEqual(0, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(4, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Second item is already in first visible tier
+            scrollView.MoveToIndex(1, false);
+            yield return null;
+
+            Assert.AreEqual(0, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(4, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Moving to second tier making fourth element to be on first visible tier
+            scrollView.MoveToIndex(3, false);
+            yield return null;
+
+            Assert.AreEqual(2, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(6, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Moving to fourth tier as scroll container hits its min position
+            scrollView.MoveToIndex(8, false); // should move to 6 as max
+            yield return null;
+
+            Assert.AreEqual(6, scrollView.FirstVisibleItemIndex,  "First visible item is different from the expected");
+            Assert.AreEqual(10, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+
+            // Moving to back to first tier. Negative argument should not cause any errors
+            scrollView.MoveToIndex(-1, false); 
+            yield return null;
+
+            Assert.AreEqual(0, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
+            Assert.AreEqual(4, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
         }
 
         #endregion Tests


### PR DESCRIPTION
## Overview
This PR is part of Scroll View graduation and handles the following issues:


 **1. Allow Scroll view to be manipulated / scaled / rotated.**
- Updating the scroll collection when scroll object has scale different than Vector.one gives wrong bounds dimension to the clipping box.
- Adjusted clipping box local scale calculation to account for parents scale. Tests added.

_Clipping box after parent scale is doubled:_
![Screenshot (48)](https://user-images.githubusercontent.com/16922045/88415726-e1033280-cdd6-11ea-8e23-f41281b3838e.png)

**2. Make sure pagination works as expected.** 

- Moving scroll by Tiers or by page gives weird results, causing the scroll container to get stuck or move only a limited amount of tiers when using left-right scroll view. 


_Before change:_
![scroll_pagination_before](https://user-images.githubusercontent.com/16922045/88411843-8cf54f80-cdd0-11ea-82d8-f70a6116f93b.gif)

_After change:_
![scroll_pagination_after](https://user-images.githubusercontent.com/16922045/88414971-a056e980-cdd5-11ea-8f83-972301259593.gif)

**3. Scroll Object Collection inspector should draw the interaction planes.**

_After change:_
![Screenshot (45)](https://user-images.githubusercontent.com/16922045/88410935-f96f4f00-cdce-11ea-8cca-dde2880d29d5.png)

## Changes
- Fixes: #7451
- Fixes: #7450
- Fixes: #8208
