### PR TITLE
Dispose the dictationRecognizer in Disable()

### DIFF
--- a/Assets/MRTK/Providers/Windows/WindowsDictationInputProvider.cs
+++ b/Assets/MRTK/Providers/Windows/WindowsDictationInputProvider.cs
@@ -320,6 +320,8 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 dictationRecognizer.DictationResult -= DictationRecognizer_DictationResult;
                 dictationRecognizer.DictationComplete -= DictationRecognizer_DictationComplete;
                 dictationRecognizer.DictationError -= DictationRecognizer_DictationError;
+
+                dictationRecognizer.Dispose();
             }
         }
 


### PR DESCRIPTION
## Overview
Currently in WindowsDictationInputProvider the dictationRecognizer is not disposed when Disable() is called (unlike the behavior of the same function of WindowsSpeechInputProvider). This can cause the Garbage Collector to try to clean up the object, which can lead to Destroy() being called on a non-main thread generating exceptions.


## Changes
- Fixes: Dispose the dictationRecognizer when Disable() is called.