### PR TITLE
surfaced which controllers are affected when tweaking a controller mapping

### DIFF
--- a/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
@@ -80,6 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static Vector2 horizontalScrollPosition;
 
         private SerializedProperty currentInteractionList;
+        private static List<string> mappedControllerList;
 
         private ControllerPopupWindow thisWindow;
 
@@ -186,12 +187,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             #endregion  Interaction Constraint Setup
         }
 
-        public static void Show(MixedRealityControllerMapping controllerMapping, SerializedProperty interactionsList, Handedness handedness = Handedness.None)
+        public static void Show(MixedRealityControllerMapping controllerMapping, SerializedProperty interactionsList, Handedness handedness = Handedness.None, List<string> mappedControllers = null)
         {
             if (window != null)
             {
                 window.Close();
             }
+            
+            if (mappedControllers != null)
+                mappedControllerList = mappedControllers;
 
             window = null;
 
@@ -276,10 +280,51 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             try
             {
                 RenderInteractionList(currentInteractionList, currentControllerMapping.HasCustomInteractionMappings);
+                RenderMappingList(mappedControllerList);
             }
             catch (Exception)
             {
                 thisWindow.Close();
+            }
+        }
+
+        private void RenderMappingList(List<string> controllerList)
+        {
+            GUIStyle headerStyle = new GUIStyle();
+            headerStyle.richText = true;
+
+            if (currentControllerOption == null || currentControllerTexture == null)
+            {
+                GUILayout.BeginVertical();
+                using (new EditorGUILayout.VerticalScope())
+                {
+                    GUILayout.FlexibleSpace();
+                    EditorGUILayout.LabelField("<b>Controllers affected by this mapping</b>", headerStyle);
+                    for (int i = 0; i < controllerList.Count; i++)
+                    {
+                        EditorGUILayout.LabelField(controllerList[i]);
+                    }
+                }
+                GUILayout.EndVertical();
+            }
+            else
+            {
+                float max_y = currentControllerOption.InputLabelPositions.Max(x => x.y);
+
+                var titleRectPosition = Vector2.up * (max_y + 4 * EditorGUIUtility.singleLineHeight);
+                var titleRectSize = new Vector2(500, EditorGUIUtility.singleLineHeight);
+
+                var titleRect = new Rect(titleRectPosition, titleRectSize);
+                EditorGUI.LabelField(titleRect, "<b>Controllers affected by this mapping</b>", headerStyle);
+
+                for (int i = 0; i < controllerList.Count; i++)
+                {
+                    var rectPosition = Vector2.up * (max_y + (i+5) * EditorGUIUtility.singleLineHeight);
+                    var rectSize = new Vector2(1000, EditorGUIUtility.singleLineHeight);
+
+                    var labelRect = new Rect(rectPosition, rectSize);
+                    EditorGUI.LabelField(labelRect, controllerList[i]);
+                }
             }
         }
 
@@ -697,7 +742,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 EditorGUILayout.EndScrollView();
                 interactionList.serializedObject.ApplyModifiedProperties();
-            }
+            } 
 
             GUILayout.EndVertical();
         }

--- a/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
@@ -80,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static Vector2 horizontalScrollPosition;
 
         private SerializedProperty currentInteractionList;
-        private static List<string> mappedControllerList;
+        private List<string> mappedControllerList = new List<string>();
 
         private ControllerPopupWindow thisWindow;
 
@@ -193,17 +193,19 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 window.Close();
             }
-            
-            if (mappedControllers != null)
-            {
-                mappedControllerList = mappedControllers;
-            }
 
             window = null;
+
+            if (mappedControllers == null)
+            {
+                mappedControllers = new List<string>();
+            }
+
 
             window = CreateInstance<ControllerPopupWindow>();
             window.thisWindow = window;
             window.titleContent = new GUIContent($"{controllerMapping.Description} - Input Action Assignment");
+            window.mappedControllerList = mappedControllers;
             window.currentControllerMapping = controllerMapping;
             window.currentInteractionList = interactionsList;
             isMouseInRects = new bool[interactionsList.arraySize];

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
     [CustomEditor(typeof(MixedRealityControllerMappingProfile))]
     public class MixedRealityControllerMappingProfileInspector : BaseMixedRealityToolkitConfigurationProfileInspector
     {
-        private struct ControllerMappingSignature
+        private readonly struct ControllerMappingSignature
         {
             public SupportedControllerType SupportedControllerType;
             public Handedness Handedness;

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -104,9 +104,9 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
             controllerRenderList.Clear();
 
-            // Generating the set of controllers that belong to each mapping
-            Dictionary<ControllerMappingSignature, List<string>> mappingSignatureDictionary = new Dictionary<ControllerMappingSignature, List<string>>();
-            List<ControllerMappingSignature> mappingSignatureList = new List<ControllerMappingSignature>();
+            // Generating the set of controllers that belong to each Controller Mapping Signature
+            Dictionary<ControllerMappingSignature, List<string>> controllersAffectedByMappingSignatures = new Dictionary<ControllerMappingSignature, List<string>>();
+            List<ControllerMappingSignature> ControllerMappingSignatureList = new List<ControllerMappingSignature>();
             for (int i = 0; i < thisProfile.MixedRealityControllerMappings.Length; i++)
             {
                 MixedRealityControllerMapping controllerMapping = thisProfile.MixedRealityControllerMappings[i];
@@ -121,11 +121,11 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 var handednessProperty = controllerMappingProperty.FindPropertyRelative("handedness");
 
                 ControllerMappingSignature currentSignature = new ControllerMappingSignature(supportedControllerType, handedness);
-                if(!mappingSignatureDictionary.ContainsKey(currentSignature))
+                if(!controllersAffectedByMappingSignatures.ContainsKey(currentSignature))
                 {
-                    mappingSignatureDictionary.Add(currentSignature, new List<string>());
+                    controllersAffectedByMappingSignatures.Add(currentSignature, new List<string>());
                 }
-                mappingSignatureDictionary[currentSignature].Add(controllerType.ToString());
+                controllersAffectedByMappingSignatures[currentSignature].Add(controllerType.ToString());
             }
 
             showControllerDefinitions = EditorGUILayout.Foldout(showControllerDefinitions, "Controller Definitions", true);
@@ -335,7 +335,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                             if (GUILayout.Button(buttonContent, MixedRealityStylesUtility.ControllerButtonStyle, GUILayout.Height(128f), GUILayout.MinWidth(32f), GUILayout.ExpandWidth(true)))
                             {
                                 ControllerMappingSignature buttonSignature = new ControllerMappingSignature(supportedControllerType, handedness);
-                                ControllerPopupWindow.Show(controllerMapping, interactionsProperty, handedness, mappingSignatureDictionary[buttonSignature]);
+                                ControllerPopupWindow.Show(controllerMapping, interactionsProperty, handedness, controllersAffectedByMappingSignatures[buttonSignature]);
                             }
                         }
                     }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -15,6 +15,18 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
     [CustomEditor(typeof(MixedRealityControllerMappingProfile))]
     public class MixedRealityControllerMappingProfileInspector : BaseMixedRealityToolkitConfigurationProfileInspector
     {
+        private struct ControllerMappingSignature
+        {
+            public SupportedControllerType SupportedControllerType;
+            public Handedness Handedness;
+
+            public ControllerMappingSignature(SupportedControllerType supportedControllerType, Handedness handedness)
+            {
+                SupportedControllerType = supportedControllerType;
+                Handedness = handedness;
+            }
+        }
+
         private struct ControllerRenderProfile
         {
             public SupportedControllerType SupportedControllerType;
@@ -91,6 +103,30 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             }
 
             controllerRenderList.Clear();
+
+            // Generating the set of controllers that belong to each mapping
+            Dictionary<ControllerMappingSignature, List<string>> mappingSignatureDictionary = new Dictionary<ControllerMappingSignature, List<string>>();
+            List<ControllerMappingSignature> mappingSignatureList = new List<ControllerMappingSignature>();
+            for (int i = 0; i < thisProfile.MixedRealityControllerMappings.Length; i++)
+            {
+                MixedRealityControllerMapping controllerMapping = thisProfile.MixedRealityControllerMappings[i];
+                Type controllerType = controllerMapping.ControllerType;
+                if (controllerType == null) { continue; }
+
+                Handedness handedness = controllerMapping.Handedness;
+                bool useCustomInteractionMappings = controllerMapping.HasCustomInteractionMappings;
+                SupportedControllerType supportedControllerType = controllerMapping.SupportedControllerType;
+
+                var controllerMappingProperty = controllerList.GetArrayElementAtIndex(i);
+                var handednessProperty = controllerMappingProperty.FindPropertyRelative("handedness");
+
+                ControllerMappingSignature currentSignature = new ControllerMappingSignature(supportedControllerType, handedness);
+                if(!mappingSignatureDictionary.ContainsKey(currentSignature))
+                {
+                    mappingSignatureDictionary.Add(currentSignature, new List<string>());
+                }
+                mappingSignatureDictionary[currentSignature].Add(controllerType.ToString());
+            }
 
             showControllerDefinitions = EditorGUILayout.Foldout(showControllerDefinitions, "Controller Definitions", true);
             if (showControllerDefinitions)
@@ -298,7 +334,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
                             if (GUILayout.Button(buttonContent, MixedRealityStylesUtility.ControllerButtonStyle, GUILayout.Height(128f), GUILayout.MinWidth(32f), GUILayout.ExpandWidth(true)))
                             {
-                                ControllerPopupWindow.Show(controllerMapping, interactionsProperty, handedness);
+                                ControllerMappingSignature buttonSignature = new ControllerMappingSignature(supportedControllerType, handedness);
+                                ControllerPopupWindow.Show(controllerMapping, interactionsProperty, handedness, mappingSignatureDictionary[buttonSignature]);
                             }
                         }
                     }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -17,8 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
     {
         private readonly struct ControllerMappingSignature
         {
-            public SupportedControllerType SupportedControllerType;
-            public Handedness Handedness;
+            public SupportedControllerType SupportedControllerType { get; }
+            public Handedness Handedness { get; }
 
             public ControllerMappingSignature(SupportedControllerType supportedControllerType, Handedness handedness)
             {


### PR DESCRIPTION
## Overview

Currently, the profile inspector doesn't make it very clear to the user which controllers are loaded for the current profile. For example, when a user imports a package for support for a new type of controller, it is not immediately obvious whether the new controller definition they imported is being used, as it may share fit under a different controller definition (ie, Oculus XRSDK controller and Oculus OpenVR controller). This PR adds UI elements to the controller mapping window to make this more transparent (and save headaches when determining if a controller is actually currently being used by the profile)

![image](https://user-images.githubusercontent.com/39840334/88443060-af389e80-cdcb-11ea-8f61-df9bf3cc5751.png)
![image](https://user-images.githubusercontent.com/39840334/88443071-bbbcf700-cdcb-11ea-972c-0969e00536db.png)

All names WIP