### PR TITLE
Updated link to IMixedRealityTouchHandler

### DIFF
--- a/Documentation/Architecture/InputSystem/CoreSystem.md
+++ b/Documentation/Architecture/InputSystem/CoreSystem.md
@@ -25,7 +25,7 @@ Input events are generally fired on two different channels:
 ### Objects in focus
 
 Events can be sent directly to a GameObject that has focus. For example, an object might
-have a script that implements [`IMixedRealityTouchHandler`](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityHandTrackHandler.cs).
+have a script that implements [`IMixedRealityTouchHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityTouchHandler).
 This object would get touch events when focused by a hand that is near it. These types of
 events go "up" the GameObject hierarchy until it finds a GameObject that is capable of handling
 the event.


### PR DESCRIPTION

## Overview
The link to Microsoft.MixedReality.Toolkit.Input.IMixedRealityTouchHandler was leading to a 404 page. 

## Changes
I updated the link to use xref like IMixedRealityEventSystem.


## Verification
I couldn't test it because github won't generate that link for me to click. Can someone test that it's leading to the right page ? 
The correct link should lead to https://microsoft.github.io/MixedRealityToolkit-Unity/api/Microsoft.MixedReality.Toolkit.Input.IMixedRealityTouchHandler.html\
