### PR TITLE
Eye tracking example: OnLoadStartScene improvements

### DIFF
--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
@@ -1,11 +1,17 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 {
+    public enum LoadOptions
+    {
+        LoadOnDeviceAndInEditor,
+        LoadOnlyOnDevice,
+    }
+
     /// <summary>
     /// When the button is selected, it triggers starting the specified scene.
     /// </summary>
@@ -16,9 +22,27 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         [Tooltip("Name of the scene to be loaded when the button is selected.")]
         private string SceneToBeLoaded = "";
 
+        [SerializeField]
+        [Tooltip("Option to only load the scene if running on the HoloLens device.")]
+        private LoadOptions LoadOption = LoadOptions.LoadOnlyOnDevice;
+
         public void Start()
         {
+            if (LoadOption == LoadOptions.LoadOnlyOnDevice)
+            {
+                LoadOnDevice();
+            }
+            else
+            {
+                LoadNewScene();
+            }
+        }
+
+        private void LoadOnDevice()
+        {
+#if WINDOWS_UWP
             LoadNewScene();
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         }
 
         private void LoadNewScene()

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using UnityEngine;
 using UnityEngine.SceneManagement;

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
@@ -6,7 +6,7 @@ using UnityEngine.SceneManagement;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 {
-    public enum LoadOptions
+    private enum LoadOptions
     {
         LoadOnDeviceAndInEditor,
         LoadOnlyOnDevice,

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
@@ -6,11 +6,6 @@ using UnityEngine.SceneManagement;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 {
-    private enum LoadOptions
-    {
-        LoadOnDeviceAndInEditor,
-        LoadOnlyOnDevice,
-    }
 
     /// <summary>
     /// When the button is selected, it triggers starting the specified scene.
@@ -18,6 +13,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
     [AddComponentMenu("Scripts/MRTK/Examples/OnLoadStartScene")]
     public class OnLoadStartScene : MonoBehaviour
     {
+        private enum LoadOptions
+        {
+            LoadOnDeviceAndInEditor,
+            LoadOnlyOnDevice,
+        }
         [SerializeField]
         [Tooltip("Name of the scene to be loaded when the button is selected.")]
         private string SceneToBeLoaded = "";
@@ -40,9 +40,10 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
         private void LoadOnDevice()
         {
-#if WINDOWS_UWP
-            LoadNewScene();
-#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+            if (!Application.isEditor)
+            {
+                LoadNewScene();
+            }
         }
 
         private void LoadNewScene()


### PR DESCRIPTION
## Overview
Add a "load option" in one of the eye tracking example scripts to allow additive scene loading only on device.
![image](https://user-images.githubusercontent.com/168492/88848751-bf6ec600-d19d-11ea-9c57-f70b7777604b.png)


## Changes
- Fixes: #8224
