### PR TITLE
Scroll graduation - Part 4

### DIFF
--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -571,9 +571,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         // Hand position previous frame
         private Vector3 lastPointerPos;
 
-        // Current time at initial press
-        private float initialPressTime;
-
         #endregion drag position calculation variables
 
         #region velocity calculation variables

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -1523,14 +1523,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <summary>
-        /// Checksif the engaged joint has released the scrollable list
+        /// Checks if the engaged joint has released the scrollable list
         /// </summary>
         private bool DetectScrollRelease(Vector3 pointerPos)
         {
             Vector3 scrollToPointerVector = pointerPos - clipBox.transform.position;
 
-            // Projecting vector onto every clip box space coordinated and using clip box lossy scale as refrence to dimensions to scroll visible bounds
-            // Using dot product to check if pointer is in the front or behind the scroll view plane
+            // Projecting vector onto every clip box space coordinate and using clip box lossy scale as reference to dimensions to scroll view visible bounds
+            // Using dot product to check if pointer is in front or behind the scroll view plane
             bool isScrollRelease = Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBox.transform.up)) > clipBox.transform.lossyScale.y / 2 + releaseThresholdTopBottom
                                 || Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBox.transform.right)) > clipBox.transform.lossyScale.x / 2 + releaseThresholdLeftRight
                               

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -514,12 +514,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(pastButtonPressPos);
             yield return hand.MoveTo(scrollEngagedInsideTopBound);
 
-            Assert.IsTrue(scrollView.isDragging, "Scroll view is not being dragged.");
+            Assert.IsTrue(scrollView.IsDragging, "Scroll view is not being dragged.");
             Assert.IsTrue(scrollView.IsEngaged, "Scroll view is not engaged.");
 
             yield return hand.MoveTo(scrollEngagedOutsideTopBound);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand outside bottom boundary should halt scroll drag engagement            
@@ -528,12 +528,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(pastButtonPressPos);
             yield return hand.MoveTo(scrollEngagedInsideBottomBound);
 
-            Assert.IsTrue(scrollView.isDragging, "Scroll view is not being dragged.");
+            Assert.IsTrue(scrollView.IsDragging, "Scroll view is not being dragged.");
             Assert.IsTrue(scrollView.IsEngaged, "Scroll view is not engaged.");
 
             yield return hand.MoveTo(scrollEngagedOutsideBottomBound);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand outside left boundary should halt scroll drag engagement
@@ -543,12 +543,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(scrollEngagedHalfPageUpPos);
             yield return hand.MoveTo(scrollEngagedInsideLeftBound);
 
-            Assert.IsTrue(scrollView.isDragging, "Scroll view is not being dragged.");
+            Assert.IsTrue(scrollView.IsDragging, "Scroll view is not being dragged.");
             Assert.IsTrue(scrollView.IsEngaged, "Scroll view is not engaged.");
 
             yield return hand.MoveTo(scrollEngagedOutsideLeftBound);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand outside right boundary should halt scroll drag engagement
@@ -558,12 +558,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(scrollEngagedHalfPageUpPos);
             yield return hand.MoveTo(scrollEngagedInsideRightBound);
 
-            Assert.IsTrue(scrollView.isDragging, "Scroll view is not being dragged.");
+            Assert.IsTrue(scrollView.IsDragging, "Scroll view is not being dragged.");
             Assert.IsTrue(scrollView.IsEngaged, "Scroll view is not engaged.");
 
             yield return hand.MoveTo(scrollEngagedOutsideRightBound);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand outside front boundary should halt scroll drag engagement
@@ -573,12 +573,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(scrollEngagedHalfPageUpPos);
             yield return hand.MoveTo(scrollEngagedInsideFrontBound);
 
-            Assert.IsTrue(scrollView.isDragging, "Scroll view is not being dragged.");
+            Assert.IsTrue(scrollView.IsDragging, "Scroll view is not being dragged.");
             Assert.IsTrue(scrollView.IsEngaged, "Scroll view is not engaged.");
 
             yield return hand.MoveTo(scrollEngagedOutsideFrontBound);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand outside back boundary should halt scroll drag engagement
@@ -588,12 +588,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(scrollEngagedHalfPageUpPos);
             yield return hand.MoveTo(scrollEngagedInsideBackBound);
 
-            Assert.IsTrue(scrollView.isDragging, "Scroll view is not being dragged.");
+            Assert.IsTrue(scrollView.IsDragging, "Scroll view is not being dragged.");
             Assert.IsTrue(scrollView.IsEngaged, "Scroll view is not engaged.");
 
             yield return hand.MoveTo(scrollEngagedOutsideBackBound);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             yield return hand.Hide();
@@ -637,13 +637,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(offTopPos);
             yield return hand.MoveTo(offBottomPos);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand from outside bottom boundary should not trigger drag engagement
             yield return hand.MoveTo(offTopPos);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand from outside right boundary should not trigger drag engagement
@@ -652,7 +652,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(pastButtonPressPos);
             yield return hand.MoveTo(offTopPos);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand from outside left boundary should not trigger drag engagement
@@ -661,7 +661,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(pastButtonPressPos);
             yield return hand.MoveTo(offTopPos);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand from outside back boundary should not trigger drag engagement
@@ -669,7 +669,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(pastButtonPressPos);
             yield return hand.MoveTo(offTopPos);
 
-            Assert.IsFalse(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
 
             // Moving hand from outside front boundary should trigger drag engagement
@@ -678,7 +678,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(pastButtonPressPos);
             yield return hand.MoveTo(offTopPos);
 
-            Assert.IsTrue(scrollView.isDragging, "Scroll view is being dragged.");
+            Assert.IsTrue(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsTrue(scrollView.IsEngaged, "Scroll view is engaged.");
 
             yield return hand.Hide();
@@ -758,7 +758,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(pastButtonPressPos);
             yield return hand.MoveTo(scrollEngagedPos);
 
-            Assert.IsTrue(scrollView.isDragging, "Scroll view is not being dragged.");
+            Assert.IsTrue(scrollView.IsDragging, "Scroll view is not being dragged.");
 
             yield return hand.Hide();
         }
@@ -862,6 +862,104 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.AreEqual(0, scrollView.FirstVisibleItemIndex, "First visible item is different from the expected");
             Assert.AreEqual(4, scrollView.FirstHiddenItemIndex, "First hidden item is different from the expected");
+        }
+
+        /// <summary>
+        /// Tests if far interaction with GGV pointer can engage the scroll drag.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator GGVScroll()
+        {
+            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+
+            // Setting up a horizontal 1x1 scroll view with two pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                2,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                1,
+                                                                                1,
+                                                                                ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
+            float scale = 10f;
+            scrollView.transform.localScale *= scale;
+
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Hand positions
+            float offset = 0.001f;
+            Vector3 initialPos = new Vector3(0.13f, -0.17f, 0.5f); // Far pointer focus is on button       
+            Vector3 scrollEngagedPos = initialPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight * scale + offset);
+
+            // Interaction with child button should behave normally if scroll drag not yet engaged
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(initialPos);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return hand.MoveTo(scrollEngagedPos);
+
+            Assert.IsTrue(scrollView.IsDragging, "Scroll drag was not triggered.");
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.Hide();
+
+            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Articulated);
+        }
+
+        /// <summary>
+        /// Tests if it is possible to ensure that children click only happens on touch up by changing children configuration.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ContentClickHappensOnTouchUp()
+        {
+            // Setting up a horizontal 1x1 scroll view with two pressable buttons items
+            ScrollingObjectCollection scrollView = InstantiateScrollAndChildren(out GameObject[] scrollItems,
+                                                                                2,
+                                                                                ScrollingObjectCollection.ScrollDirectionType.UpAndDown,
+                                                                                1,
+                                                                                1,
+                                                                                ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity);
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            PressableButton button1Component = scrollItems[0].GetComponentInChildren<PressableButton>();
+            button1Component.ReleaseOnTouchEnd = false;
+
+            bool button1PressCompleted = false;
+            button1Component.ButtonReleased.AddListener(() =>
+            {
+                button1PressCompleted = true;
+            });
+
+            // Hand positions
+            float offset = 0.001f;
+            Vector3 initialPos = Vector3.zero;
+            Vector3 preButtonTouchPos = button1Component.transform.position + new Vector3(0, 0, button1Component.StartPushDistance - offset);
+            Vector3 pastButtonPressPos = button1Component.transform.position + new Vector3(0, 0, button1Component.PressDistance + offset);
+            Vector3 pastButtonReleasePos = button1Component.transform.position + new Vector3(0, 0, button1Component.PressDistance - button1Component.ReleaseDistanceDelta - offset);
+            Vector3 scrollEngagedPos = pastButtonPressPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset);
+
+            // Button click is not completed without passing release plane or if scroll view is engaged in a drag
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(initialPos);
+            yield return hand.MoveTo(preButtonTouchPos);
+            yield return hand.MoveTo(pastButtonPressPos);
+            yield return hand.MoveTo(scrollEngagedPos);
+            yield return hand.MoveTo(pastButtonReleasePos);
+
+            Assert.IsTrue(scrollView.IsDragging, "Scroll drag begin was not triggered.");
+            Assert.IsFalse(button1PressCompleted, "Button1 press release was triggered.");
+
+            // Button click is only completed if passing release plane or if scroll view is not engaged in a drag
+            yield return hand.Show(initialPos);
+            yield return hand.MoveTo(preButtonTouchPos);
+            yield return hand.MoveTo(pastButtonPressPos);
+            yield return hand.MoveTo(pastButtonReleasePos);
+
+            Assert.IsFalse(scrollView.IsDragging, "Scroll drag was triggered.");
+            Assert.IsTrue(button1PressCompleted, "Button1 press release was not triggered.");
+
+            yield return hand.Hide();
         }
 
         #endregion Tests

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -147,8 +147,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsTrue(button2PressBegin, "Button2 press begin did not trigger.");
             Assert.IsTrue(button2PressCompleted, "Button2 press release did not trigger.");
             Assert.IsTrue(button2TouchEnd, "Button2 touch end did not trigger.");
-
-            yield return hand.Hide();
         }
 
         /// <summary>
@@ -228,9 +226,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(interactable2.HasFocus, "Interactable2 does not have far pointer focus.");
             Assert.IsTrue(interactable2.HasPress, "Interactable2 did not get press from far interaction.");
-
-            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return hand.Hide();
         }
 
         /// <summary>
@@ -273,9 +268,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
             Assert.AreEqual(scrollView.ScrollContainerPosition.y, 0, "Scroll container has moved.");
-
-            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return hand.Hide();
         }
 
         /// <summary>
@@ -326,8 +318,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(scrollDragBegin, "Scroll drag begin was triggered.");
             Assert.AreEqual(scrollView.ScrollContainerPosition.y, 0, 0.001, "Scroll container has not moved to first row.");
-
-            yield return hand.Hide();
         }
 
         /// <summary>
@@ -463,8 +453,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(button1TouchBegin, "Button1 touch begin was triggered.");
             Assert.IsFalse(button3TouchBegin, "Button3 touch begin was triggered.");
             Assert.IsTrue(button4TouchBegin, "Button4 touch begin was not triggered.");
-
-            hand.Hide();
         }
 
         /// <summary>
@@ -595,8 +583,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsFalse(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsFalse(scrollView.IsEngaged, "Scroll view is engaged.");
-
-            yield return hand.Hide();
         }
 
         /// <summary>
@@ -680,8 +666,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(scrollView.IsDragging, "Scroll view is being dragged.");
             Assert.IsTrue(scrollView.IsEngaged, "Scroll view is engaged.");
-
-            yield return hand.Hide();
         }
 
         /// <summary>
@@ -759,8 +743,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(scrollEngagedPos);
 
             Assert.IsTrue(scrollView.IsDragging, "Scroll view is not being dragged.");
-
-            yield return hand.Hide();
         }
 
         /// <summary>
@@ -898,11 +880,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(scrollEngagedPos);
 
             Assert.IsTrue(scrollView.IsDragging, "Scroll drag was not triggered.");
-
-            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return hand.Hide();
-
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Articulated);
         }
 
         /// <summary>
@@ -958,8 +935,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsFalse(scrollView.IsDragging, "Scroll drag was triggered.");
             Assert.IsTrue(button1PressCompleted, "Button1 press release was not triggered.");
-
-            yield return hand.Hide();
         }
 
         #endregion Tests


### PR DESCRIPTION
## Overview 
This PR is part of Scroll View graduation and handles the following issues:

 **1. Scroll should work as expected using GGV and HL1 .**
- TryGetPointerPositionOnPlane() method was using pointer.result.point for all far pointers. On GGVPointer this is the point of focus from gaze.
- Changed method to use pointer.position projection instead. Tests added.

**2. Content click should happen on Touch up (Web Browser).** 

- In order to avoid false clicks when user engage on a scroll drag and match HL web browser behavior, child button should be configured to trigger clicks only on touch up. Adding tests to check if configuring buttons with correct settings ensures click on touch up.

_Scroll child button clicking on touch up:_
![scroll_touchup_after](https://user-images.githubusercontent.com/16922045/88874396-e7e6d680-d216-11ea-83ed-bfe5e612669c.gif)


## Changes
- Fixes: #7151
- Fixes: #7455

( _This PR merges into graduation/scroll_view branch_ )
