### PR TITLE
Remove incorrect prefab from ET pointer profile

### DIFF
--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -305,7 +305,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var pointer = pointerObject.GetComponent<IMixedRealityPointer>();
                 if (pointer == null)
                 {
-                    Debug.LogError($"{option.PointerPrefab} does not have {typeof(IMixedRealityPointer).Name} component. Cannot create and utilize pointer");
+                    Debug.LogError($"Ensure that the prefab '{option.PointerPrefab.name}' listed under Input -> Pointers -> Pointer Options has an {typeof(IMixedRealityPointer).Name} component.\nThis prefab can't be used as a pointer as configured and won't be instantiated.");
 
                     GameObjectExtensions.DestroyGameObject(pointerObject);
                 }

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoPointerProfile.asset
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoPointerProfile.asset
@@ -47,10 +47,6 @@ MonoBehaviour:
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
       type: 3}
-  - controllerType: 2048
-    handedness: 7
-    pointerPrefab: {fileID: 1000012072213228, guid: 5b3e2856904e43c680f84f326861032a,
-      type: 3}
   pointerMediator:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator, Microsoft.MixedReality.Toolkit.SDK
   primaryPointerSelector:


### PR DESCRIPTION
# Overview
The pointer profile list had a cursor prefab in one of the slots, instead of the correct pointer prefab:

![image](https://user-images.githubusercontent.com/3580640/89204884-ae420280-d56b-11ea-89ce-a09041c98397.png)

This was leading to an error on start-up.

>DefaultCursor (UnityEngine.GameObject) does not have IMixedRealityPointer component. Cannot create and utilize pointer

Since this input type is covered by a different (correctly assigned) pointer rule, I removed the entry.

## Changes
- Part of fixing: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8125
