### PR TITLE
Fixing broken TMPro material references when using Material Instance on same object

### DIFF
--- a/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
@@ -321,14 +321,18 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
                 else
                 {
 #if UNITY_EDITOR
-                    // Defer the destructing in case the object is in the act of being destroyed.
-                    EditorApplication.delayCall += () =>
+                    // Let Unity handle unload of unused assets if lifecycle is transitioning from editor to play mode
+                    // Defering the call during this transition would destroy reference only after play mode Awake, leading to possible broken material references on TMPro objects
+                    if (!EditorApplication.isPlayingOrWillChangePlaymode)
                     {
-                        if (toDestroy != null)
+                        EditorApplication.delayCall += () =>
                         {
-                            DestroyImmediate(toDestroy);
-                        }
-                    };
+                            if (toDestroy != null)
+                            {
+                                DestroyImmediate(toDestroy);
+                            }
+                        };
+                    }
 #endif
                 }
             }


### PR DESCRIPTION
## Overview 
This PR is part of Scroll View graduation.

 **1. Scrolling Object Collection causes TextMeshPro MissingReferenceExceptions .**
- Using material instance component on game objects that are using TMPro renderers throws error messages when transitioning from editor mode to playmode.

TMPro also does material life management and caches the renderer shared material during editor mode. When transitioning from editor mode to playmode the MaterialInstance class defers the destruction of the material instanced during editor mode. This destruction only happens after Awake in playmode, breaking TMPro reference. 

This PR suggests letting Unity handle the unloading of unused assets only when transitioning from editor mode to playmode. Profiling this approach shows no extra memory leaking. The error messages do not appear on test mode.

```
MissingReferenceException: The object of type 'Material' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
TMPro.TextMeshPro.GenerateTextMesh () (at Library/PackageCache/com.unity.textmeshpro@2.0.1/Scripts/Runtime/TMPro_Private.cs:1969)
TMPro.TextMeshPro.OnPreRenderObject () (at Library/PackageCache/com.unity.textmeshpro@2.0.1/Scripts/Runtime/TMPro_Private.cs:1549)
TMPro.TextMeshPro.Rebuild (UnityEngine.UI.CanvasUpdate update) (at Library/PackageCache/com.unity.textmeshpro@2.0.1/Scripts/Runtime/TextMeshPro.cs:241)
```
## Changes
- Fixes: #7963 
- Fixes: #6665
