### PR TITLE
Add an asmdef checker roadblock to PR/CI validation

### DIFF
--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -435,6 +435,117 @@ function CheckUnityScene {
     }
 }
 
+<#
+.SYNOPSIS
+    Given a full filename path, this returns the MRTK project relative path
+    of the file and normalizes the separators to /.
+    For example, given D:\src\MixedRealityToolkit-Unity\Assets\MRTK\Services\DiagnosticsSystem\File.cs,
+    this would return Assets/MRTK/Services/DiagnosticsSystem/File.cs.
+    Note that this function asssumes the Assets/MRTK prefix for all of the MRTK code,
+    and if this ever changes this function would need to be updated to accomodate that.
+#>
+function GetProjectRelativePath {
+    [CmdletBinding()]
+    param(
+        [string]$Filename
+    )
+    process {
+        $normalizedFileName = $FileName.Replace("\", "/")
+        $assetPathStartIndex = $normalizedFileName.IndexOf("Assets/MRTK")
+        $assetFileName = $normalizedFileName.SubString($assetPathStartIndex)
+        $assetFileName
+    }
+}
+
+# This set contains all of the currently allowed asmdefs in the MRTK
+# If you're reading this, it's probably because you've added a new asmdef
+# and you're seeing a CI build/PR validation failure. This is because we've
+# added a roadblock to force discussion of new asmdef creation to ensure that we're
+# not creating a lot of tiny ones.
+# There's non-trivial overhead to the addition of each asmdef (i.e. each asmdef will
+# create build overhead associated with all of the stuff that happens before the actual code
+# inside gets compiled.)
+# In certain cases (especially lighting up a new platform/provider) this will be a necessary
+# addition, but in others it may make more sense to put group the code with another existing
+# binary that has a lot of overlap.
+# Either way, this is an explicit speed bump being added to force discussion at future times.
+$AsmDefExceptions = [System.Collections.Generic.HashSet[String]]@(
+    "Assets/MRTK/Core/Microsoft.MixedReality.Toolkit.asmdef",
+    "Assets/MRTK/Core/Extensions/EditorClassExtensions/Microsoft.MixedReality.Toolkit.Editor.ClassExtensions.asmdef",
+    "Assets/MRTK/Core/Inspectors/Microsoft.MixedReality.Toolkit.Editor.Inspectors.asmdef",
+    "Assets/MRTK/Core/Inspectors/ServiceInspectors/Microsoft.MixedReality.Toolkit.Editor.ServiceInspectors.asmdef",
+    "Assets/MRTK/Core/Providers/InputAnimation/MixedRealityToolkit.Services.InputAnimation.asmdef",
+    "Assets/MRTK/Core/Providers/InputSimulation/Microsoft.MixedReality.Toolkit.Services.InputSimulation.asmdef",
+    "Assets/MRTK/Core/Providers/InputSimulation/Editor/Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor.asmdef",
+    "Assets/MRTK/Core/Providers/ObjectMeshObserver/Microsoft.MixedReality.Toolkit.Providers.ObjectMeshObserver.asmdef",
+    "Assets/MRTK/Core/Utilities/Async/Microsoft.MixedReality.Toolkit.Async.asmdef",
+    "Assets/MRTK/Core/Utilities/BuildAndDeploy/Microsoft.MixedReality.Toolkit.Editor.BuildAndDeploy.asmdef",
+    "Assets/MRTK/Core/Utilities/Editor/Microsoft.MixedReality.Toolkit.Editor.Utilities.asmdef",
+    "Assets/MRTK/Core/Utilities/Gltf/Microsoft.MixedReality.Toolkit.Gltf.asmdef",
+    "Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/Microsoft.MixedReality.Toolkit.Gltf.Importers.asmdef",
+    "Assets/MRTK/Examples/Microsoft.MixedReality.Toolkit.Examples.asmdef",
+    "Assets/MRTK/Examples/Demos/Gltf/Microsoft.MixedReality.Toolkit.Demos.Gltf.asmdef",
+    "Assets/MRTK/Examples/Demos/Gltf/Scripts/Editor/Microsoft.MixedReality.Toolkit.Demos.Gltf.Inspectors.asmdef",
+    "Assets/MRTK/Examples/Demos/StandardShader/Scripts/Editor/Demos.StandardShader.Inspectors.asmdef",
+    "Assets/MRTK/Examples/Demos/Utilities/InspectorFields/Microsoft.MixedReality.Toolkit.Demos.InspectorFields.asmdef",
+    "Assets/MRTK/Examples/Demos/Utilities/InspectorFields/Inspectors/Demos.InspectorFields.Inspectors.asmdef",
+    "Assets/MRTK/Examples/Demos/UX/Interactables/Microsoft.MixedReality.Toolkit.Demos.UX.Interactables.asmdef",
+    "Assets/MRTK/Examples/Experimental/Dwell/Editor/Microsoft.MixedReality.Examples.Editor.Dwell.asmdef",
+    "Assets/MRTK/Extensions/HandPhysicsService/Microsoft.MixedReality.Toolkit.Extensions.HandPhysics.asmdef",
+    "Assets/MRTK/Extensions/LostTrackingService/Microsoft.MixedReality.Toolkit.Extensions.Tracking.asmdef",
+    "Assets/MRTK/Extensions/LostTrackingService/Editor/Microsoft.MixedReality.Toolkit.Extensions.Tracking.Editor.asmdef",
+    "Assets/MRTK/Extensions/SceneTransitionService/Microsoft.MixedReality.Toolkit.Extensions.SceneTransitionService.asmdef",
+    "Assets/MRTK/Providers/LeapMotion/Microsoft.MixedReality.Toolkit.Providers.LeapMotion.asmdef",
+    "Assets/MRTK/Providers/LeapMotion/Editor/Microsoft.MixedReality.Toolkit.LeapMotion.Editor.asmdef",
+    "Assets/MRTK/Providers/Oculus/XRSDK/Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.asmdef",
+    "Assets/MRTK/Providers/Oculus/XRSDK/Editor/Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor.asmdef",
+    "Assets/MRTK/Providers/OpenVR/Microsoft.MixedReality.Toolkit.Providers.OpenVR.asmdef",
+    "Assets/MRTK/Providers/UnityAR/Microsoft.MixedReality.Toolkit.Providers.UnityAR.asmdef",
+    "Assets/MRTK/Providers/UnityAR/Editor/Microsoft.MixedReality.Toolkit.UnityAR.Editor.asmdef",
+    "Assets/MRTK/Providers/Windows/Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput.asmdef",
+    "Assets/MRTK/Providers/WindowsMixedReality/Shared/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared.asmdef",
+    "Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/Microsoft.MixedReality.Toolkit.WMR.Editor.asmdef",
+    "Assets/MRTK/Providers/WindowsMixedReality/XR2018/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.asmdef",
+    "Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Microsoft.MixedReality.Toolkit.Providers.XRSDK.WMR.asmdef",
+    "Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Editor/Microsoft.MixedReality.Toolkit.XRSDK.WMR.Editor.asmdef",
+    "Assets/MRTK/Providers/XRSDK/Microsoft.MixedReality.Toolkit.Providers.XRSDK.asmdef",
+    "Assets/MRTK/Providers/XRSDK/Editor/Microsoft.MixedReality.Toolkit.XRSDK.Editor.asmdef",
+    "Assets/MRTK/SDK/Microsoft.MixedReality.Toolkit.SDK.asmdef",
+    "Assets/MRTK/SDK/Editor/Microsoft.MixedReality.Toolkit.SDK.Editor.asmdef",
+    "Assets/MRTK/SDK/Experimental/Editor/Microsoft.MixedReality.Toolkit.SDK.Experimental.Editor.asmdef",
+    "Assets/MRTK/Services/BoundarySystem/XR2018/Microsoft.MixedReality.Toolkit.Services.BoundarySystem.asmdef",
+    "Assets/MRTK/Services/CameraSystem/Microsoft.MixedReality.Toolkit.Services.CameraSystem.asmdef",
+    "Assets/MRTK/Services/DiagnosticsSystem/Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem.asmdef",
+    "Assets/MRTK/Services/InputSystem/Microsoft.MixedReality.Toolkit.Services.InputSystem.asmdef",
+    "Assets/MRTK/Services/InputSystem/Editor/Microsoft.MixedReality.Toolkit.Services.InputSystem.Editor.asmdef",
+    "Assets/MRTK/Services/SceneSystem/Microsoft.MixedReality.Toolkit.Services.SceneSystem.asmdef",
+    "Assets/MRTK/Services/SpatialAwarenessSystem/Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem.asmdef",
+    "Assets/MRTK/Services/TeleportSystem/Microsoft.MixedReality.Toolkit.Services.TeleportSystem.asmdef",
+    "Assets/MRTK/Tests/EditModeTests/Microsoft.MixedReality.Toolkit.Tests.EditModeTests.asmdef",
+    "Assets/MRTK/Tests/PlayModeTests/Microsoft.MixedReality.Toolkit.Tests.PlayModeTests.asmdef",
+    "Assets/MRTK/Tests/TestUtilities/Microsoft.MixedReality.Toolkit.Tests.Utilities.asmdef",
+    "Assets/MRTK/Tools/Microsoft.MixedReality.Toolkit.Tools.asmdef",
+    "Assets/MRTK/Tools/MSBuild/Microsoft.MixedReality.Toolkit.MSBuild.asmdef",
+    "Assets/MRTK/Tools/RuntimeTools/Tools/Microsoft.MixedReality.Toolkit.Tools.Runtime.asmdef"
+)
+
+function CheckAsmDef {
+    [CmdletBinding()]
+    param(
+        [string]$FileName
+    )
+    process {
+        $containsIssue = $false
+        $assetFileName = GetProjectRelativePath($FileName)
+        if (-Not $AsmDefExceptions.Contains($assetFileName)) {
+            Write-Warning "New Asmdef was added but is not on the allowed list: $assetFileName. An exception can be added to $AsmDefExceptions "
+            Write-Warning "after a dicussion with the rest of the team determining if the asmdef is necessary."
+            $containsIssue = $true
+        }
+        $containsIssue
+    }
+}
+
 # If the file containing the list of changes was provided and actually exists,
 # this validation should scope to only those changed files.
 if ($ChangesFile -and (Test-Path $ChangesFile -PathType leaf)) {
@@ -449,7 +560,8 @@ if ($ChangesFile -and (Test-Path $ChangesFile -PathType leaf)) {
         if (((IsCSharpFile -Filename $changedFile) -and (CheckScript $changedFile)) -or
             ((IsAssetFile -Filename $changedFile) -and (CheckAsset $changedFile)) -or
             ((IsUnityScene -Filename $changedFile) -and (CheckUnityScene $changedFile)) -or
-            ((IsMetaFile -Filename $changedFile) -and (CheckForActualFile $changedFile))) {
+            ((IsMetaFile -Filename $changedFile) -and (CheckForActualFile $changedFile)) -or
+            ((IsAsmDef -Filename $changedFile) -and (CheckAsmDef $changedFile))) {
             $containsIssue = $true;
         }
     }
@@ -472,17 +584,24 @@ else {
         }
     }
 
-    # Check all Unity scenes for extra MixedRealityPlayspace objects 
+    # Check all Unity scenes for extra MixedRealityPlayspace objects
     $codeFiles = Get-ChildItem $Directory *.unity -Recurse | Select-Object FullName
     foreach ($codeFile in $codeFiles) {
         if (CheckUnityScene $codeFile.FullName) {
             $containsIssue = $true
         }
     }
-    
+
     $metas = Get-ChildItem $Directory *.meta -File -Recurse | Select-Object FullName
     foreach ($meta in $metas) {
         if (CheckForActualFile $meta.FullName) {
+            $containsIssue = $true
+        }
+    }
+
+    $asmdefs = Get-ChildItem $Directory *.asmdef -File -Recurse | Select-Object FullName
+    foreach ($asmdef in $asmdefs) {
+        if (CheckAsmDef $asmdef.FullName) {
             $containsIssue = $true
         }
     }


### PR DESCRIPTION
I've been doing a little bit of digging into some of the non-runtime perf aspects of our setup, and one thing that I've looked into is the overhead associated with the split up of the asmdefs that we have today. Here's a rough wall of text of some thoughts/findings:

Amsdefs can be a useful tool in grouping code to reduce overall compilation times in the context of very large projects. About a year ago we went through the process of putting all our code into smaller asmdefs, in the goals of optimizing compile time. 

There are tradeoffs, however, beyond just the project window bloat that occurs in Visual Studio when you have a large amount of asmdefs (this document doesn’t go into this, but note that this specific issue will be addressed with some of the UPM work that we're doing now).

Every single asmdef, even one that contains only a single, empty MonoBehaviour (i.e. one that has zero dependencies and has a MonoBehaviour with an empty Start() and Update() function that isn’t being used in any scene), adds build overhead. With this single empty asmdef example, it takes on average ~.5 seconds to compile this assembly. 

As of the time of writing this document, MRTK currently has ~58 assembly definitions. In a “typical” MRTK compile (in this case, a change in a file in the Microsoft.MixedReality.Toolkit.dll assembly), each assembly tends to take an average of 0.56477 seconds.
Average	0.564774
StdDev	0.114018
Max	0.807838
Min	0.370333

(Note that these numbers are in seconds, taken from a [Z4](https://store.hp.com/us/en/mdp/desktops/hp-z4-workstation-3074457345617221670-1) with 64gb ram and a i9-7920X).

In this case, even the essentially empty asmdef takes 0.530214 seconds – there’s clear overhead with just processing an asmdef. Note that the larger ones (such as Microsoft.MixedReality.Toolkit.SDK.dll  0.807838), the overhead of processing a new asmdef largely outweighs the additional code that needs to be compiled within that. This seems to suggest that we could possibly save compile time by consolidating a lot our asmdefs into a smaller set. (i.e. much of the compile time that we’re using now is actually just in the asmdef overhead).

Note that assemblies are compiled in parallel, so adding a new asmdef doesn’t linearly increase the build time (however, adding more asmdefs by a scale factor of the average number of cores does appear to a linearly increase build times).

One of the advantages of asmdefs is that it reduces the number of things that have to get recompiled when a single source file changes – for example, when changing a file that is at the leaf of the dependency tree, only that assembly will get recompiled. However, for files closer to the root (for example, Microsoft.MixedReality.Toolkit.dll), it along with all of its dependencies will get recompiled. This means that changes to things like Microsoft.MixedReality.Toolkit.dll will tend to have worse compile performance compared to a single massive asmdef (i.e. Assembly-CSharp) because roughly the same amount of code ends up having to get compiled but there’s a ton of asmdef container overhead.

The main purpose for adding this PR validation/CI check is to have an explicit roadblock to force discussion in the future for when it happens. It's fairly easy to add a new asmdef and have that slip under the radar - many new additions will probably make sense (i.e. new platforms, new providers), but having the explicit conversation and then updating the allow list will force the conversation to happen on PR.
