### PR TITLE
Split boundary system fixes from #8050

### DIFF
--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -24,6 +24,26 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             BoundaryProfile = profile;
         }
 
+        /// <summary>
+        /// Reads the visualization profile contents and stores the values in class properties.
+        /// </summary>
+        private void ReadProfile()
+        {
+            if (BoundaryProfile == null) { return; }
+
+            BoundaryHeight = BoundaryProfile.BoundaryHeight;
+            ShowFloor = BoundaryProfile.ShowFloor;
+            FloorPhysicsLayer = BoundaryProfile.FloorPhysicsLayer;
+            ShowPlayArea = BoundaryProfile.ShowPlayArea;
+            PlayAreaPhysicsLayer = BoundaryProfile.PlayAreaPhysicsLayer;
+            ShowTrackedArea = BoundaryProfile.ShowTrackedArea;
+            TrackedAreaPhysicsLayer = BoundaryProfile.TrackedAreaPhysicsLayer;
+            ShowBoundaryWalls = BoundaryProfile.ShowBoundaryWalls;
+            BoundaryWallsPhysicsLayer = BoundaryProfile.BoundaryWallsPhysicsLayer;
+            ShowBoundaryCeiling = BoundaryProfile.ShowBoundaryCeiling;
+            CeilingPhysicsLayer = BoundaryProfile.CeilingPhysicsLayer;
+        }
+
         #region IMixedRealityService Implementation
 
         private MixedRealityBoundaryVisualizationProfile BoundaryProfile { get; }
@@ -36,25 +56,16 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// <inheritdoc/>
         public override void Initialize()
         {
-            if (!Application.isPlaying || BoundaryProfile == null) { return; }
+            // The profile needs to be read on initialization to ensure that re-initialization
+            // after profile change reads the correct data.
+            ReadProfile();
+
+            if (!Application.isPlaying) { return; }
 
             boundaryEventData = new BoundaryEventData(EventSystem.current);
 
-            BoundaryHeight = BoundaryProfile.BoundaryHeight;
-
             SetTrackingSpace();
             CalculateBoundaryBounds();
-
-            ShowFloor = BoundaryProfile.ShowFloor;
-            FloorPhysicsLayer = BoundaryProfile.FloorPhysicsLayer;
-            ShowPlayArea = BoundaryProfile.ShowPlayArea;
-            PlayAreaPhysicsLayer = BoundaryProfile.PlayAreaPhysicsLayer;
-            ShowTrackedArea = BoundaryProfile.ShowTrackedArea;
-            TrackedAreaPhysicsLayer = BoundaryProfile.TrackedAreaPhysicsLayer;
-            ShowBoundaryWalls = BoundaryProfile.ShowBoundaryWalls;
-            BoundaryWallsPhysicsLayer = BoundaryProfile.BoundaryWallsPhysicsLayer;
-            ShowBoundaryCeiling = BoundaryProfile.ShowBoundaryCeiling;
-            CeilingPhysicsLayer = BoundaryProfile.CeilingPhysicsLayer;
 
             RaiseBoundaryVisualizationChanged();
         }

--- a/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
+++ b/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
@@ -32,9 +32,11 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// <inheritdoc/>
         public override void Initialize()
         {
-            if (!Application.isPlaying || !XRDevice.isPresent) { return; }
-
+            // The base class initialization should be run every time. This ensures
+            // that profile settings are read at the correct time.
             base.Initialize();
+
+            if (!Application.isPlaying || !XRDevice.isPresent) { return; }
         }
 
         #endregion IMixedRealityService Implementation


### PR DESCRIPTION
This change separates the boundary system fixes from the change profile PR (#8050). The issue that is being fixed is unrelated and was originally included there to allow a profile change test case to run correctly.

The changes made are:

* Add a ReadProfile method to BaseBoundarySystem.cs
  * Check for a null profile in ReadProfile
  * Call ReadProfile at the top of Initialize to ensure that the profile is always read before any decisions are made (THIS was the bug that broke the profile change test)
* Ensure that the base.Initialize() method is always called in MixedRealityBoundarySystem.cs (this was a contributing factor the the bug)