### PR TITLE
PointerUtils doesn't work with custom PointerMediator

### DIFF
--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityPointerMediator.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityPointerMediator.cs
@@ -9,9 +9,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     public interface IMixedRealityPointerMediator
     {
-        void RegisterPointers(IMixedRealityPointer[] pointer);
+        void RegisterPointers(IMixedRealityPointer[] pointers);
         void UnregisterPointers(IMixedRealityPointer[] pointers);
 
         void UpdatePointers();
+
+        /// <summary>
+        /// Called to set the pointer preferences of the current input and focus
+        /// configuration.
+        /// </summary>
+        /// <remarks>
+        /// These preferences can be used by the pointer mediator to determine runtime
+        /// preferences set by the caller (for example, the caller could request to turn
+        /// off all hand rays). It's possible that some of these preferences may not be
+        /// honored (for example, current input system is set up to not have hand rays
+        /// at all, and a request comes in to turn on/off hand rays).
+        /// </remarks>
+        void SetPointerPreferences(IPointerPreferences pointerPreferences);
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -20,14 +20,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected readonly HashSet<IMixedRealityTeleportPointer> teleportPointers = new HashSet<IMixedRealityTeleportPointer>();
         protected readonly HashSet<IMixedRealityPointer> unassignedPointers = new HashSet<IMixedRealityPointer>();
         protected readonly Dictionary<IMixedRealityInputSource, HashSet<IMixedRealityPointer>> pointerByInputSourceParent = new Dictionary<IMixedRealityInputSource, HashSet<IMixedRealityPointer>>();
-
-        private IPointerPreferences pointerPreferences;
+        protected IPointerPreferences pointerPreferences;
 
         public DefaultPointerMediator()
-            : this(null)
         {
+            pointerPreferences = null;
         }
 
+        [Obsolete("Use DefaultPointerMediator() instead, followed by a call to SetPointerPreferences()")]
         public DefaultPointerMediator(IPointerPreferences pointerPrefs)
         {
             pointerPreferences = pointerPrefs;
@@ -203,6 +203,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     unassignedPointer.IsActive = true;
                 }
             }
+        }
+
+        public void SetPointerPreferences(IPointerPreferences pointerPreferences)
+        {
+            this.pointerPreferences = pointerPreferences;
         }
 
         private static readonly ProfilerMarker ApplyCustomPointerBehaviorsPerfMarker = new ProfilerMarker("[MRTK] DefaultPointerMediator.ApplyCustomPointerBehaviors");

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -205,6 +205,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         public void SetPointerPreferences(IPointerPreferences pointerPreferences)
         {
             this.pointerPreferences = pointerPreferences;

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -798,6 +798,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     try
                     {
                         // First, try to use constructor used by DefaultPointerMediator (it takes a IPointePreferences)
+                        // This is a deprecated constructor - the method of passing the pointer preferences through a non
+                        // default constructor is a loose contract that breaks pointer preferences because it becomes extremely
+                        // unclear why the class never gets passed a pointer preferences object.
                         mediator = Activator.CreateInstance(mediatorType, this) as IMixedRealityPointerMediator;
                     }
                     catch (MissingMethodException)
@@ -805,6 +808,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         // We are using custom mediator not provided by MRTK, instantiate with empty constructor
                         mediator = Activator.CreateInstance(mediatorType) as IMixedRealityPointerMediator;
                     }
+
+                    mediator.SetPointerPreferences(this);
                 }
 
                 if (mediator != null)

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/TestCustomPointerMediator.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/TestCustomPointerMediator.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.MixedReality.Toolkit.Input;
+
+namespace Microsoft.MixedReality.Toolkit.Tests.Input
+{
+    /// <summary>
+    /// A custom pointer mediator used to validate that the common behaviors of DefaultPointerMediator
+    /// carry over even as a subclass.
+    /// </summary>
+    public class TestPointerMediator : DefaultPointerMediator
+    {
+        public override void UpdatePointers()
+        {
+            base.UpdatePointers();
+        }
+    }
+}

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/TestCustomPointerMediator.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/TestCustomPointerMediator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e95f7b04810e5d14caaa46c0bd6a3dc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
@@ -27,6 +27,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// </summary>
     public class PointerBehaviorTests : BasePlayModeTests
     {
+        // Tests/PlayModeTests/TestProfiles/TestCustomPointerMediatorInputProfile.asset
+        private const string ProfileGuid = "f1bb9273769c84743a29dc206e284023";
+        private static readonly string ProfilePath = AssetDatabase.GUIDToAssetPath(ProfileGuid);
+
         /// <summary>
         /// Simple container for comparing expected pointer states to actual.
         /// if a bool? is null, this means pointer is null (doesn't exist)
@@ -225,6 +229,35 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestRays()
         {
+            yield return TestRaysWorker();
+        }
+
+
+        /// <summary>
+        /// Tests that rays can be turned on and off even with a custom mediator.
+        /// </summary>
+        /// <remarks>
+        /// Added to ensure we don't regress https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8243
+        /// </remarks>
+        [UnityTest]
+        public IEnumerator TestRaysCustomMediator()
+        {
+            // MRTK has already been created by SetUp prior to calling this,
+            // we have to shut it down to re-init with the custom input profile which
+            // replaces the default pointer mediator.
+            PlayModeTestUtilities.TearDown();
+            yield return null;
+
+            var profile = TestUtilities.GetDefaultMixedRealityProfile<MixedRealityToolkitConfigurationProfile>();
+            profile.InputSystemProfile.PointerProfile = AssetDatabase.LoadAssetAtPath<MixedRealityPointerProfile>(ProfilePath);
+            PlayModeTestUtilities.Setup(profile);
+            yield return null;
+
+            yield return TestRaysWorker();
+        }
+
+        private IEnumerator TestRaysWorker()
+        {
             PointerStateContainer lineOn = new PointerStateContainer()
             {
                 GazePointerEnabled = false,
@@ -279,7 +312,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             EnsurePointerStates(Handedness.Right, lineOn);
             EnsurePointerStates(Handedness.Left, lineOn);
         }
-
     }
 }
 

--- a/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestCustomPointerMediatorInputProfile.asset
+++ b/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestCustomPointerMediatorInputProfile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db393d206eab4604ab74278cb6cda355, type: 3}
   m_Name: TestCustomPointerMediatorInputProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   pointingExtent: 10
   pointingRaycastLayerMasks:
   - serializedVersion: 2

--- a/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestCustomPointerMediatorInputProfile.asset
+++ b/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestCustomPointerMediatorInputProfile.asset
@@ -1,0 +1,66 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db393d206eab4604ab74278cb6cda355, type: 3}
+  m_Name: TestCustomPointerMediatorInputProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 1
+  pointingExtent: 10
+  pointingRaycastLayerMasks:
+  - serializedVersion: 2
+    m_Bits: 4294967291
+  debugDrawPointingRays: 1
+  debugDrawPointingRayColors:
+  - {r: 1, g: 0.58280706, b: 0, a: 1}
+  - {r: 0.86426115, g: 1, b: 0, a: 1}
+  - {r: 0, g: 1, b: 0.2163105, a: 1}
+  - {r: 0, g: 0.3028021, b: 1, a: 1}
+  - {r: 0.44855833, g: 0, b: 1, a: 1}
+  gazeCursorPrefab: {fileID: 1000012072213228, guid: 5b3e2856904e43c680f84f326861032a,
+    type: 3}
+  gazeProviderType:
+    reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
+  useHeadGazeOverride: 0
+  isEyeTrackingEnabled: 0
+  pointerOptions:
+  - controllerType: 1071
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: d5b94136462644c9873bb3347169ae7e,
+      type: 3}
+  - controllerType: 47
+    handedness: 7
+    pointerPrefab: {fileID: 1196247974088106, guid: c4fd3c6fc7ff484eb434775066e7f327,
+      type: 3}
+  - controllerType: 256
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,
+      type: 3}
+  - controllerType: 512
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: 31d81f88cf3f71d4b8392ded50df3f05,
+      type: 3}
+  - controllerType: 1024
+    handedness: 7
+    pointerPrefab: {fileID: 1507865967819406, guid: 38b548c6a2c270545a383296ad2bc4d5,
+      type: 3}
+  - controllerType: 1024
+    handedness: 7
+    pointerPrefab: {fileID: 1507865967819406, guid: c2fde7a8938065b459cff79b8ed89393,
+      type: 3}
+  - controllerType: 2048
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
+      type: 3}
+  pointerMediator:
+    reference: Microsoft.MixedReality.Toolkit.Tests.Input.TestPointerMediator, Microsoft.MixedReality.Toolkit.Tests.PlayModeTests
+  primaryPointerSelector:
+    reference: Microsoft.MixedReality.Toolkit.Input.DefaultPrimaryPointerSelector,
+      Microsoft.MixedReality.Toolkit.SDK

--- a/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestCustomPointerMediatorInputProfile.asset.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestCustomPointerMediatorInputProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1bb9273769c84743a29dc206e284023
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -90,7 +90,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// Creates a play mode test scene, creates an MRTK instance, initializes playspace.
         /// </summary>
-        public static void Setup()
+        /// <remarks>
+        /// Takes an optional MixedRealityToolkitConfigurationProfile used to initialize the MRTK.
+        /// </remarks>
+        public static void Setup(MixedRealityToolkitConfigurationProfile profile = null)
         {
             Assert.True(Application.isPlaying, "This setup method should only be used during play mode tests. Use TestUtilities.");
 
@@ -115,7 +118,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
 
             // Create an MRTK instance and set up playspace
-            TestUtilities.InitializeMixedRealityToolkit(true);
+            if (profile == null)
+            {
+                TestUtilities.InitializeMixedRealityToolkit(true);
+            }
+            else
+            {
+                TestUtilities.InitializeMixedRealityToolkit(profile);
+            }
             TestUtilities.InitializePlayspace();
 
             // Ensure user input is disabled during the tests

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -195,7 +195,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             BaseEventSystem.enableDanglingHandlerDiagnostics = false;
         }
 
-        private static T GetDefaultMixedRealityProfile<T>() where T : BaseMixedRealityProfile
+        public static T GetDefaultMixedRealityProfile<T>() where T : BaseMixedRealityProfile
         {
 #if UNITY_EDITOR
             return ScriptableObjectExtensions.GetAllInstances<T>().FirstOrDefault(profile => profile.name.Equals($"Default{typeof(T).Name}"));

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -71,6 +71,19 @@ There is a confirmation dialog that will be displayed when selecting `Use MSBuil
 
 ### Breaking changes
 
+**IMixedRealityPointerMediator**
+
+This interface has been updated to have a new function:
+
+```csharp
+void SetPointerPreferences(IPointerPreferences pointerPreferences);
+```
+
+If you have a custom pointer mediator that doesn't subclass DefaultPointerMediator, you will need to implement this
+new function. See [this issue](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8243) for more background
+on why this was added. This was added to ensure that pointer preferences would be explicitly passed to the mediator,
+rather than having it be implicitly done based on the presence of a constructor that took a IPointerPreferences.
+
 **Rest / Device Portal API**
 
 The `UseSSL` static property has been moved from `Rest` to `DevicePortal`.


### PR DESCRIPTION
## Overview
Was surprised to see this but then took a look at the code and was not surprised to see this!

Here's what happens:
When you set the pointer preferences (stored on the FocusProvider), the preferences themselves get stored. However, when the FocusProvider is creating the pointer mediator, it only passes the pointer preferences along to the object IF the object has as constructor that takes an IPointerPreferences.

There are a couple of things wrong with this:
1. The DefaultPointerMediator has pointerPreferences marked as private, so even if someone wanted to save the pointer preferences, they couldn't do so in an way that would make the base class (DefaultPointerMediator) be able to functionally retrieve its pointer preferences. (Yes, you could do a bunch of repeat work but that's not helpful).
2. This is an extremely indirect dependency/contract on custom mediators - you don't know you have to handle this (i.e. that writing a constructor that takes a pointer preferences is basically required in order to field the entire set of input). It's literally impossible for you to know that you have to do this.

This change does a few things:
1. Fixes the issue.
2. Updates the test utilities to allow initing the MRTK with a different profile (so avoid copy pasta in the future).
3. Makes the default profile getting of the test utilities public (to reduce copy pasta)
4. Updates the breaking changes section to mention the addition of the function on that interface.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8243