### PR TITLE
Enabling runtime profile switching

### DIFF
--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -80,6 +80,13 @@ namespace Microsoft.MixedReality.Toolkit
         /// <summary>
         /// The public property of the Active Profile, ensuring events are raised on the change of the configuration
         /// </summary>
+        /// <remarks>
+        /// When setting the ActiveProfile during runtime, the destroy of the currently running services will happen after the last LateUpdate()
+        /// of all services, and the instantiation and initialization of the services associated with the new profile will happen before the
+        /// first Update() of all services.
+        /// A noticable application hesitation may occur during this process. Also any scripts with high priority than this can enter its Update
+        /// before the new profiles are properly setup.
+        /// </remarks>
         public MixedRealityToolkitConfigurationProfile ActiveProfile
         {
             get
@@ -88,7 +95,17 @@ namespace Microsoft.MixedReality.Toolkit
             }
             set
             {
-                ResetConfiguration(value);
+                // Behavior during a valid runtime profile switch
+                if (Application.isPlaying && activeProfile != null && value != null)
+                {
+                    newProfile = value;
+                }
+                // Behavior in other scenarios (e.g. when profile switch is being requested by editor code)
+                else
+                {
+                    ResetConfiguration(value);
+                }
+
             }
         }
 
@@ -96,6 +113,22 @@ namespace Microsoft.MixedReality.Toolkit
         /// When a configuration Profile is replaced with a new configuration, force all services to reset and read the new values
         /// </summary>
         public void ResetConfiguration(MixedRealityToolkitConfigurationProfile profile)
+        {
+            RemoveCurrentProfile(profile);
+            InitializeNewProfile(profile);
+        }
+
+        private void InitializeNewProfile(MixedRealityToolkitConfigurationProfile profile)
+        {
+            InitializeServiceLocator();
+
+            if (profile != null && Application.IsPlaying(profile))
+            {
+                EnableAllServices();
+            }
+        }
+
+        private void RemoveCurrentProfile(MixedRealityToolkitConfigurationProfile profile)
         {
             if (activeProfile != null)
             {
@@ -117,14 +150,9 @@ namespace Microsoft.MixedReality.Toolkit
                 }
                 DestroyAllServices();
             }
-
-            InitializeServiceLocator();
-
-            if (profile != null && Application.IsPlaying(profile))
-            {
-                EnableAllServices();
-            }
         }
+
+        private MixedRealityToolkitConfigurationProfile newProfile;
 
         #endregion Mixed Reality Toolkit Profile configuration
 
@@ -654,6 +682,13 @@ namespace Microsoft.MixedReality.Toolkit
         {
             if (IsActiveInstance)
             {
+                // Before any Update() of a service is performed check to see if we need to switch profile
+                // If so we instantiate and initialize the services associated with the new profile.
+                if (newProfile != null)
+                {
+                    InitializeNewProfile(newProfile);
+                    newProfile = null;
+                }
                 UpdateAllServices();
             }
         }
@@ -663,6 +698,12 @@ namespace Microsoft.MixedReality.Toolkit
             if (IsActiveInstance)
             {
                 LateUpdateAllServices();
+                // After LateUpdate()s of all services are finished check to see if we need to switch profile
+                // If so we destroy currently running services.
+                if (newProfile != null)
+                {
+                    RemoveCurrentProfile(newProfile);
+                }
             }
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -361,6 +361,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void Update()
         {
+            // Skip Update if the input system is missing during a runtime profile switch
+            if ((CoreServices.InputSystem == null) ||
+                (CoreServices.InputSystem.FocusProvider == null))
+            {
+                return;
+            }
             if (!CoreServices.InputSystem.FocusProvider.TryGetFocusDetails(Pointer, out focusDetails))
             {
                 if (CoreServices.InputSystem.FocusProvider.IsPointerRegistered(Pointer))

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -440,6 +440,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
+        private void OnDestroy()
+        {
+            // Because GazeCursor is not derived from UnityEngine.Object, we need to manually perform null check against Unity's null
+            if (GazeCursor != null && !GazeCursor.Equals(null))
+            {
+                Destroy(GazeCursor.GameObjectReference);
+            }
+        }
+
         #endregion MonoBehaviour Implementation
 
         #region InputSystemGlobalHandlerListener Implementation

--- a/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using Microsoft.MixedReality.Toolkit.Boundary;
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    // Tests to verify that changing the active profile at runtime results in
+    // the MRTK being correctly reconfigured.
+    public class ChangeActiveProfileTests : BasePlayModeTests
+    {
+        
+        #region Utility methods
+
+        private void InitializeTest(MixedRealityToolkitConfigurationProfile profile)
+        {
+            TestUtilities.InitializeMixedRealityToolkit(profile);
+            TestUtilities.PlayspaceToOriginLookingForward();
+        }
+
+        private void ChangeProfile(MixedRealityToolkitConfigurationProfile newProfile)
+        {
+            MixedRealityToolkitConfigurationProfile oldProfile = MixedRealityToolkit.Instance.ActiveProfile;
+            Debug.Log($"Switching active profile from {oldProfile.name} to {newProfile.name}");
+            MixedRealityToolkit.Instance.ActiveProfile = newProfile;
+        }
+
+        private MixedRealityToolkitConfigurationProfile LoadTestProfile(string assetPath)
+        {
+            return AssetDatabase.LoadAssetAtPath<MixedRealityToolkitConfigurationProfile>(assetPath);
+        }
+
+        #endregion // Utility methods
+
+        #region Test cases
+
+        private const string DefaultHoloLens2ProfileGuid = "7e7c962b9eb9dfa44993d5b2f2576752";
+        private static readonly string DefaultHoloLens2ProfilePath = AssetDatabase.GUIDToAssetPath(DefaultHoloLens2ProfileGuid);
+
+        private const string BoundaryOnlyProfileGuid = "1945e1d0f0513ea4da45f9296a206ab3";
+        private static readonly string BoundaryOnlyProfilePath = AssetDatabase.GUIDToAssetPath(BoundaryOnlyProfileGuid);
+
+        /// <summary>
+        /// Test to verify that switching profiles results in appropriate service counts.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator VerifyServiceCount()
+        {
+            MixedRealityToolkitConfigurationProfile profile1 = LoadTestProfile(BoundaryOnlyProfilePath);
+            yield return null;
+
+            // Initialize the test case with profile 1
+            InitializeTest(profile1);
+
+            // Get count of registered services
+            IReadOnlyList<IMixedRealityService> services = MixedRealityServiceRegistry.GetAllServices();
+            int count1 = services.Count;
+            yield return null;
+
+            // Switch to profile 2
+            MixedRealityToolkitConfigurationProfile profile2 = LoadTestProfile(DefaultHoloLens2ProfilePath);
+            ChangeProfile(profile2);
+            yield return null;
+
+            // Get count of registered services
+            services = MixedRealityServiceRegistry.GetAllServices();
+            int count2 = services.Count;
+
+            // We specifically selected the test profiles to ensure that they load a different number of services.
+            Assert.IsTrue(count1 != count2);
+        }
+
+        /// <summary>
+        /// Test to verify that switching profiles results the expected service state.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator VerifyServiceState()
+        {
+            MixedRealityToolkitConfigurationProfile profile1 = TestUtilities.GetDefaultMixedRealityProfile<MixedRealityToolkitConfigurationProfile>();
+            yield return null;
+
+            // Initialize the test case with profile 1
+            InitializeTest(profile1);
+
+            // Cache the interesting settings read from the initial boundary system instance
+            IMixedRealityBoundarySystem boundarySystem1 = CoreServices.BoundarySystem;
+            yield return null;
+
+            float height1 = boundarySystem1.BoundaryHeight;
+            int floorPhysics1 = boundarySystem1.FloorPhysicsLayer;
+            bool showTracked1 = boundarySystem1.ShowTrackedArea;
+            bool showCeiling1 = boundarySystem1.ShowBoundaryCeiling;
+
+            MixedRealityToolkitConfigurationProfile profile2 = LoadTestProfile(BoundaryOnlyProfilePath);
+
+            // Switch to profile 2
+            ChangeProfile(profile2);
+            yield return null;
+
+            // The custom boundary profile has been configured to match the default with the following fields being different
+            // * Boundary height
+            // * Floor plane physics layer
+            // * Show tracked area
+            // * Show boundary ceiling
+            IMixedRealityBoundarySystem boundarySystem2 = CoreServices.BoundarySystem;
+            yield return null;
+
+            // Check service settings to ensure it has properly reset
+            Assert.IsTrue(height1 != boundarySystem2.BoundaryHeight);
+            Assert.IsTrue(floorPhysics1 != boundarySystem2.FloorPhysicsLayer);
+            Assert.IsTrue(showTracked1 != boundarySystem2.ShowTrackedArea);
+            Assert.IsTrue(showCeiling1 != boundarySystem2.ShowBoundaryCeiling);
+        }
+
+        /// <summary>
+        /// Test to verify that switching profiles results in the expected playspace children.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator VerifyPlayspaceChildren()
+        {
+            MixedRealityToolkitConfigurationProfile profile1 = TestUtilities.GetDefaultMixedRealityProfile<MixedRealityToolkitConfigurationProfile>();
+            yield return null;
+
+            // Initialize the test case with profile 1
+            InitializeTest(profile1);
+
+            // Switch between the profiles a few times.
+            MixedRealityToolkitConfigurationProfile profile2 = LoadTestProfile(DefaultHoloLens2ProfilePath);
+            ChangeProfile(profile2);
+            yield return null;
+            ChangeProfile(profile1);
+            yield return null;
+            ChangeProfile(profile2);
+            yield return null;
+
+            int uiRaycastCameraCount = 0;
+            // Confirm that we have one UIRaycastCamera.
+            Debug.Log("Validating UIRaycastCamera count.");
+            Camera[] cameras = GameObject.FindObjectsOfType<Camera>();
+            foreach (Camera camera in cameras)
+            {
+                if ("UIRaycastCamera" == camera.name)
+                {
+                    uiRaycastCameraCount++;
+                }
+            }
+            Assert.AreEqual(1, uiRaycastCameraCount);
+
+            // Confirm that we have only one instance of the default cursor.
+            int defaultCursorCount = 0;
+            Debug.Log("Validating DefaultCursor count.");
+            foreach (Transform child in MixedRealityPlayspace.Transform.GetComponentsInChildren<Transform>())
+            {
+                if ("DefaultCursor(Clone)" == child.name)
+                {
+                    defaultCursorCount++;
+                }
+            }
+            Assert.AreEqual(1, defaultCursorCount);
+        }
+
+        #endregion // Test cases
+    }
+}
+
+#endif // !WINDOWS_UWP

--- a/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 192db538ccadb81459eee451bb027d70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/PlayModeTests/SpatialObserverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpatialObserverTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// <summary>
     /// Test class that validates observers start and stop based on right configuration in editor. 
     /// </summary>
-    public class SpatialObserverTests
+    public class SpatialObserverTests : BasePlayModeTests
     {
         // Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset
         private const string TestSpatialAwarenessSystemProfileGuid = "c992bdb3ac45cd44d856b0198a3ee85d";

--- a/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestBoundaryOnly.asset
+++ b/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestBoundaryOnly.asset
@@ -1,0 +1,52 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7612acbc1a4a4ed0afa5f4ccbe42bee4, type: 3}
+  m_Name: TestBoundaryOnly
+  m_EditorClassIdentifier: 
+  isCustomProfile: 0
+  targetExperienceScale: 3
+  enableCameraSystem: 0
+  cameraProfile: {fileID: 11400000, guid: 8089ccfdd4494cd38f676f9fc1f46a04, type: 2}
+  cameraSystemType:
+    reference: Microsoft.MixedReality.Toolkit.CameraSystem.MixedRealityCameraSystem,
+      Microsoft.MixedReality.Toolkit.Services.CameraSystem
+  enableInputSystem: 0
+  inputSystemProfile: {fileID: 11400000, guid: ad2080e8e71c35f4e8bcde94fa68f098, type: 2}
+  inputSystemType:
+    reference: Microsoft.MixedReality.Toolkit.Input.MixedRealityInputSystem, Microsoft.MixedReality.Toolkit.Services.InputSystem
+  enableBoundarySystem: 1
+  boundarySystemType:
+    reference: Microsoft.MixedReality.Toolkit.Boundary.MixedRealityBoundarySystem,
+      Microsoft.MixedReality.Toolkit.Services.BoundarySystem
+  boundaryVisualizationProfile: {fileID: 11400000, guid: 76348156fa93fec48b20a487b75b1e96,
+    type: 2}
+  enableTeleportSystem: 0
+  teleportSystemType:
+    reference: 
+  enableSpatialAwarenessSystem: 0
+  spatialAwarenessSystemType:
+    reference: 
+  spatialAwarenessSystemProfile: {fileID: 0}
+  diagnosticsSystemProfile: {fileID: 11400000, guid: 478436bd1083882479a52d067e98e537,
+    type: 2}
+  enableDiagnosticsSystem: 0
+  diagnosticsSystemType:
+    reference: Microsoft.MixedReality.Toolkit.Diagnostics.MixedRealityDiagnosticsSystem,
+      Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem
+  sceneSystemProfile: {fileID: 0}
+  enableSceneSystem: 0
+  sceneSystemType:
+    reference: 
+  registeredServiceProvidersProfile: {fileID: 0}
+  useServiceInspectors: 0
+  renderDepthBuffer: 0
+  enableVerboseLogging: 0

--- a/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestBoundaryOnly.asset.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestBoundaryOnly.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1945e1d0f0513ea4da45f9296a206ab3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestBoundaryVisualization.asset
+++ b/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestBoundaryVisualization.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9fd6338e77774badb73a2b1320b41caf, type: 3}
+  m_Name: TestBoundaryVisualization
+  m_EditorClassIdentifier: 
+  isCustomProfile: 0
+  boundaryHeight: 10
+  showFloor: 1
+  floorMaterial: {fileID: 2100000, guid: 47f3c5e1cb6142ba9697cd4c86d74321, type: 2}
+  floorPhysicsLayer: 31
+  floorScale: {x: 10, y: 10}
+  showPlayArea: 1
+  playAreaMaterial: {fileID: 2100000, guid: 3c55769e893c4f4c8c51b7fa69bee2b9, type: 2}
+  playAreaPhysicsLayer: 2
+  showTrackedArea: 1
+  trackedAreaMaterial: {fileID: 2100000, guid: cb74390ea57642f8b5ca0aa8f5fb38c1, type: 2}
+  trackedAreaPhysicsLayer: 2
+  showBoundaryWalls: 0
+  boundaryWallMaterial: {fileID: 2100000, guid: c6bd404f506e1894289fde7b1689f901,
+    type: 2}
+  boundaryWallsPhysicsLayer: 2
+  showBoundaryCeiling: 1
+  boundaryCeilingMaterial: {fileID: 2100000, guid: c6bd404f506e1894289fde7b1689f901,
+    type: 2}
+  ceilingPhysicsLayer: 2

--- a/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestBoundaryVisualization.asset.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/TestProfiles/TestBoundaryVisualization.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 76348156fa93fec48b20a487b75b1e96
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -195,7 +195,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             BaseEventSystem.enableDanglingHandlerDiagnostics = false;
         }
 
-        private static T GetDefaultMixedRealityProfile<T>() where T : BaseMixedRealityProfile
+        public static T GetDefaultMixedRealityProfile<T>() where T : BaseMixedRealityProfile
         {
 #if UNITY_EDITOR
             return ScriptableObjectExtensions.GetAllInstances<T>().FirstOrDefault(profile => profile.name.Equals($"Default{typeof(T).Name}"));


### PR DESCRIPTION
## Overview
This PR is based on efforts made in #8050, which attempted to address multiple issues at once. Instead, this PR focuses on the specific issues related to allowing developers to change the active profile of MRTK during runtime.

## Changes
- In this PR, the behavior of runtime profile change is modified to first take the request, then destroy current profile services after all LateUpdate()s of current profile services have been called, and finally initialize the new services associated with the new profile in the next frame before any Update() for a service is called. This solves the problem of potentially performing the profile change in the middle of an Update or LateUpdate of a service which causes a variety of problems. Delaying the initialization of new services to the next frame also helps to resolve the problems related to Destroy().

Tests are also added to this PR to help validate the changes achieving the goal mentioned above.