### PR TITLE
Added option to set the physical material of the Spatial Mesh

### DIFF
--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
@@ -82,6 +82,14 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// The material to be used when observed meshes should occlude other objects.
         /// </summary>
         public Material OcclusionMaterial => occlusionMaterial;
+        
+        [SerializeField] 
+        [Tooltip("Optional physics material to apply to spatial mesh")]
+        private PhysicMaterial physicsMaterial = null;
+
+        public PhysicMaterial PhysicsMaterial => physicsMaterial;
+
+        
 
         #endregion IMixedRealitySpatialAwarenessMeshObserver settings
     }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.﻿
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -32,6 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor.SpatialAwareness
         private SerializedProperty displayOption;
         private SerializedProperty visibleMaterial;
         private SerializedProperty occlusionMaterial;
+        private SerializedProperty physicsMaterial;
 
         private readonly GUIContent displayOptionContent = new GUIContent("Display Option");
         private readonly GUIContent lodContent = new GUIContent("Level of Detail");
@@ -60,6 +61,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor.SpatialAwareness
             displayOption = serializedObject.FindProperty("displayOption");
             visibleMaterial = serializedObject.FindProperty("visibleMaterial");
             occlusionMaterial = serializedObject.FindProperty("occlusionMaterial");
+            physicsMaterial = serializedObject.FindProperty("physicsMaterial");
+
         }
 
         public override void OnInspectorGUI()
@@ -119,6 +122,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor.SpatialAwareness
                     EditorGUILayout.PropertyField(displayOption, displayOptionContent);
                     EditorGUILayout.PropertyField(visibleMaterial);
                     EditorGUILayout.PropertyField(occlusionMaterial);
+                    EditorGUILayout.PropertyField(physicsMaterial);
                 }
 
                 serializedObject.ApplyModifiedProperties();

--- a/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
@@ -69,6 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             RecalculateNormals = profile.RecalculateNormals;
             TrianglesPerCubicMeter = profile.TrianglesPerCubicMeter;
             VisibleMaterial = profile.VisibleMaterial;
+            PhysicsMaterial = profile.PhysicsMaterial;
         }
 
         private static readonly ProfilerMarker ApplyUpdatedMeshDisplayOptionPerfMarker = new ProfilerMarker("[MRTK] BaseSpatialMeshObserver.ApplyUpdatedMeshDisplayOption");
@@ -280,6 +281,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
                 }
             }
         }
+
+        public PhysicMaterial PhysicsMaterial  { get; private set; }
 
         private Material visibleMaterial = null;
 

--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -248,6 +248,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
                 meshObject.Renderer.sharedMaterial = (DisplayOption == SpatialAwarenessMeshDisplayOptions.Visible) ?
                     VisibleMaterial :
                     OcclusionMaterial;
+
+                if (PhysicsMaterial != null)
+                {
+                    meshObject.Collider.material = PhysicsMaterial;
+                }
             }
 
             meshObject.Renderer.enabled = enable;

--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfileInspector.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfileInspector.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.﻿
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using Microsoft.MixedReality.Toolkit.Editor;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -39,6 +39,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         private SerializedProperty visibleMaterial;
         private SerializedProperty occlusionMaterial;
 
+        private SerializedProperty physicsMaterial;
+
         private readonly GUIContent displayOptionContent = new GUIContent("Display Option");
         private readonly GUIContent lodContent = new GUIContent("Level of Detail");
         private readonly GUIContent volumeTypeContent = new GUIContent("Observer Shape");
@@ -67,6 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
             displayOption = serializedObject.FindProperty("displayOption");
             visibleMaterial = serializedObject.FindProperty("visibleMaterial");
             occlusionMaterial = serializedObject.FindProperty("occlusionMaterial");
+            physicsMaterial = serializedObject.FindProperty("physicsMaterial");
         }
 
         public override void OnInspectorGUI()
@@ -136,6 +139,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
                     EditorGUILayout.PropertyField(displayOption, displayOptionContent);
                     EditorGUILayout.PropertyField(visibleMaterial);
                     EditorGUILayout.PropertyField(occlusionMaterial);
+                    EditorGUILayout.PropertyField(physicsMaterial);
                 }
 
                 serializedObject.ApplyModifiedProperties();

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -661,6 +661,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                     meshObject.Renderer.sharedMaterial = (displayOption == SpatialAwarenessMeshDisplayOptions.Visible) ?
                         VisibleMaterial :
                         OcclusionMaterial;
+
+                    if (PhysicsMaterial != null)
+                    {
+                        meshObject.Collider.material = PhysicsMaterial;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Overview
Added option to set the physical material of the Spatial Mesh at both the WindowsMixedRealitySpatialMeshObserver and the SpatialObjectMeshObserver. This allows to change the physical properties of the Spatial Mesh and make things bounce off it - or not. 

See [here ](https://twitter.com/LocalJoost/status/1291043181509988352)for a demo video

