### PR TITLE
Improve XRSettingsUtilities.IsLegacyXRActive check

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
@@ -66,18 +66,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 {
                     isLegacyXRActive = true;
 
-                    List<ISubsystemDescriptor> descriptors = new List<ISubsystemDescriptor>();
-                    SubsystemManager.GetAllSubsystemDescriptors(descriptors);
+                    List<XRDisplaySubsystemDescriptor> descriptors = new List<XRDisplaySubsystemDescriptor>();
+                    SubsystemManager.GetSubsystemDescriptors(descriptors);
 
-                    foreach (ISubsystemDescriptor descriptor in descriptors)
+                    foreach (XRDisplaySubsystemDescriptor displayDescriptor in descriptors)
                     {
-                        if (descriptor is XRDisplaySubsystemDescriptor displayDescriptor)
+                        if (displayDescriptor.disablesLegacyVr)
                         {
-                            if (displayDescriptor.disablesLegacyVr)
-                            {
-                                isLegacyXRActive = false;
-                                break;
-                            }
+                            isLegacyXRActive = false;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
## Overview

Currently, this property iterates through all subsystem descriptors and checks which ones are `XRDisplaySubsystemDescriptor`s. I missed the fact that I could ask for specific descriptor types in the original implementation...this PR fixes that, to save some iterations and casts.