### PR TITLE
Refactor out DeviceUtility.IsPresent to wrap legacy + XR SDK code

### DIFF
--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using UnityEngine;
-using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -305,7 +304,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // This was causing issues while simulating in editor for VR, as the UpDown
             // camera movement is mapped to controller AXIS_3, which happens to be the 
             // select trigger for WMR controllers.
-            if (profile.IsCameraControlEnabled && !XRDevice.isPresent)
+            if (profile.IsCameraControlEnabled && !DeviceUtility.IsPresent)
             {
                 EnableCameraControl();
             }

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using UnityEngine;
-using UnityEngine.XR;
 
 /// <summary>
 /// Provides per-frame data access to simulated hand data
@@ -182,7 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         // If true then hands are controlled by user input
         private bool isSimulatingLeft = false;
         private bool isSimulatingRight = false;
-        private bool isSimulatingGaze => !isSimulatingLeft && !isSimulatingRight && !IsAlwaysVisibleLeft && !IsAlwaysVisibleRight && !XRDevice.isPresent;
+        private bool isSimulatingGaze => !isSimulatingLeft && !isSimulatingRight && !IsAlwaysVisibleLeft && !IsAlwaysVisibleRight && !DeviceUtility.IsPresent;
         /// <summary>
         /// Left hand is controlled by user input.
         /// </summary>

--- a/Assets/MRTK/Core/Utilities/DeviceUtility.cs
+++ b/Assets/MRTK/Core/Utilities/DeviceUtility.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using UnityEngine.XR;
+
+#if UNITY_2019_3_OR_NEWER
+using System.Collections.Generic;
+#endif // UNITY_2019_3_OR_NEWER
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    /// <summary>
+    /// Helps with getting data from or about the current HMD or other XR device.
+    /// </summary>
+    public static class DeviceUtility
+    {
+#if UNITY_2019_3_OR_NEWER
+        private static readonly List<XRDisplaySubsystem> XRDisplaySubsystems = new List<XRDisplaySubsystem>();
+#endif // UNITY_2019_3_OR_NEWER
+
+        /// <summary>
+        /// If an HMD is present and running.
+        /// </summary>
+        public static bool IsPresent
+        {
+            get
+            {
+#if UNITY_2019_3_OR_NEWER
+                SubsystemManager.GetInstances(XRDisplaySubsystems);
+                foreach (XRDisplaySubsystem xrDisplaySubsystem in XRDisplaySubsystems)
+                {
+                    if (xrDisplaySubsystem.running)
+                    {
+                        return true;
+                    }
+                }
+#endif // UNITY_2019_3_OR_NEWER
+
+#if UNITY_2020_1_OR_NEWER
+                return false;
+#else
+                return XRDevice.isPresent;
+#endif // UNITY_2020_1_OR_NEWER
+            }
+        }
+    }
+}

--- a/Assets/MRTK/Core/Utilities/DeviceUtility.cs
+++ b/Assets/MRTK/Core/Utilities/DeviceUtility.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using UnityEngine;
+#if !UNITY_2020_1_OR_NEWER
 using UnityEngine.XR;
-
-#if UNITY_2019_3_OR_NEWER
-using System.Collections.Generic;
 #endif // UNITY_2019_3_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.Utilities
@@ -15,10 +12,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     /// </summary>
     public static class DeviceUtility
     {
-#if UNITY_2019_3_OR_NEWER
-        private static readonly List<XRDisplaySubsystem> XRDisplaySubsystems = new List<XRDisplaySubsystem>();
-#endif // UNITY_2019_3_OR_NEWER
-
         /// <summary>
         /// If an HMD is present and running.
         /// </summary>
@@ -27,13 +20,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             get
             {
 #if UNITY_2019_3_OR_NEWER
-                SubsystemManager.GetInstances(XRDisplaySubsystems);
-                foreach (XRDisplaySubsystem xrDisplaySubsystem in XRDisplaySubsystems)
+                if (XRSubsystemHelpers.DisplaySubsystem != null)
                 {
-                    if (xrDisplaySubsystem.running)
-                    {
-                        return true;
-                    }
+                    return true;
                 }
 #endif // UNITY_2019_3_OR_NEWER
 

--- a/Assets/MRTK/Core/Utilities/DeviceUtility.cs.meta
+++ b/Assets/MRTK/Core/Utilities/DeviceUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef69526e250d5f54ebaf4b703b6602bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

`XRDevice.isPresent` doesn't work with XR SDK (see #7904 for another example of this). Following Unity's [recommendation to check the running status of the XRDisplaySubsystems instead](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/XR.XRDevice-isPresent.html), I added a helper function to wrap both the legacy and XR SDK APIs for getting this data.

## Changes
- Part of #8269 