### PR TITLE
Update some deprecated APIs in Unity 2020

### DIFF
--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/RoomFileFormat/RoomFileImporter.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/RoomFileFormat/RoomFileImporter.cs
@@ -3,8 +3,13 @@
 
 using System.Collections.Generic;
 using System.IO;
-using UnityEditor.Experimental.AssetImporters;
 using UnityEngine;
+
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters;
+#else
+using UnityEditor.Experimental.AssetImporters;
+#endif // UNITY_2020_2_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver.RoomFile
 {

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -286,7 +286,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         public static bool IsVisibleMetaFiles()
         {
+#if UNITY_2020_2_OR_NEWER
+            return VersionControlSettings.mode.Equals("Visible Meta Files");
+#else
             return EditorSettings.externalVersionControl.Equals("Visible Meta Files");
+#endif // UNITY_2020_2_OR_NEWER
         }
 
         /// <summary>
@@ -294,7 +298,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         public static void SetVisibleMetaFiles()
         {
+#if UNITY_2020_2_OR_NEWER
+            VersionControlSettings.mode = "Visible Meta Files";
+#else
             EditorSettings.externalVersionControl = "Visible Meta Files";
+#endif // UNITY_2020_2_OR_NEWER
         }
 
         /// <summary>
@@ -330,8 +338,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Discover and set the appropriate XR Settings for virtual reality supported for the current build target.
         /// </summary>
+        /// <remarks>Has no effect on Unity 2020 or newer. Will be updated if a replacement API is provided by Unity.</remarks>
         public static void ApplyXRSettings()
         {
+#if !UNITY_2020_1_OR_NEWER
             // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
             // with legacy requirements.
 #pragma warning disable 0618
@@ -352,11 +362,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 PlayerSettings.SetVirtualRealitySupported(targetGroup, true);
             }
 #pragma warning restore 0618
+#endif // !UNITY_2020_1_OR_NEWER
         }
 
         private static bool GetCapability(PlayerSettings.WSACapability capability)
         {
-            return MixedRealityOptimizeUtils.IsBuildTargetUWP() ? PlayerSettings.WSA.GetCapability(capability) : true;
+            return !MixedRealityOptimizeUtils.IsBuildTargetUWP() || PlayerSettings.WSA.GetCapability(capability);
         }
     }
 }

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GlbAssetImporter.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GlbAssetImporter.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters;
+#else
 using UnityEditor.Experimental.AssetImporters;
+#endif // UNITY_2020_2_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization.Editor
 {

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GltfAssetImporter.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GltfAssetImporter.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters;
+#else
 using UnityEditor.Experimental.AssetImporters;
+#endif // UNITY_2020_2_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization.Editor
 {

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GltfEditorImporter.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GltfEditorImporter.cs
@@ -4,8 +4,13 @@
 using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema;
 using System.IO;
 using UnityEditor;
-using UnityEditor.Experimental.AssetImporters;
 using UnityEngine;
+
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters;
+#else
+using UnityEditor.Experimental.AssetImporters;
+#endif // UNITY_2020_2_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization.Editor
 {

--- a/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -61,6 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
                 {
                     Debug.LogWarning("Windows Mixed Reality specific camera code has been moved into Windows Mixed Reality Camera Settings. Please ensure you have this added under your Camera System's Settings Providers, as this deprecated code path may be removed in a future update.");
 
+#if !UNITY_2020_1_OR_NEWER
                     // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
                     // with legacy requirements.
 #pragma warning disable 0618
@@ -69,6 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
                         currentDisplayType = DisplayType.Transparent;
                     }
 #pragma warning restore 0618
+#endif // !UNITY_2020_1_OR_NEWER
                 }
 #endif
 


### PR DESCRIPTION
## Overview

Opening some PRs as I go. This PR:

1. Updates the namespace for Unity's `ScriptedImporter` in Unity 2020.2
1. Uses the new `VersionControlSettings` properties in Unity 2020.2 for setting meta file visibility.
1. Compiles out `ApplyXRSettings`, which references `PlayerSettings.SetVirtualRealitySupported`. I haven't yet found a corresponding API in XR SDK.
1. Compiles out a path in the camera system which talked to WSA APIs for device opaqueness. This was already a deprecated flow in MRTK in favor of our platform-specific camera settings providers.

## Changes
- Part of #8269 
