### PR TITLE
Don't try loading Unity-deprecated assemblies in 2020+

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.asmdef
@@ -15,5 +15,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [
+        "!UNITY_2020_1_OR_NEWER"
+    ]
 }

--- a/Assets/MRTK/Services/BoundarySystem/XR2018/Microsoft.MixedReality.Toolkit.Services.BoundarySystem.asmdef
+++ b/Assets/MRTK/Services/BoundarySystem/XR2018/Microsoft.MixedReality.Toolkit.Services.BoundarySystem.asmdef
@@ -10,5 +10,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [
+        "!UNITY_2020_1_OR_NEWER"
+    ]
 }


### PR DESCRIPTION
## Overview

Adds a constraint to the two XR2018 assemblies we have, preventing them from loading on Unity 2020.1 or newer, where the legacy XR pipeline has been removed from Unity.

## Changes
- Part of #8269 
