### PR TITLE
Update and move XRSubsystem helpers into core

### DIFF
--- a/Assets/MRTK/Core/Utilities/XRSubsystemHelpers.cs
+++ b/Assets/MRTK/Core/Utilities/XRSubsystemHelpers.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-
 #if UNITY_2019_3_OR_NEWER
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
 #else
@@ -15,10 +14,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     /// <summary>
     /// A helper class to provide easier access to active Unity XR SDK subsystems.
     /// </summary>
+    /// <remarks>These properties are only valid for the XR SDK pipeline.</remarks>
     public static class XRSubsystemHelpers
     {
         private static XRInputSubsystem inputSubsystem = null;
+#if UNITY_2019_3_OR_NEWER
         private static readonly List<XRInputSubsystem> XRInputSubsystems = new List<XRInputSubsystem>();
+#endif // UNITY_2019_3_OR_NEWER
 
         /// <summary>
         /// The XR SDK input subsystem for the currently loaded XR plug-in.
@@ -47,7 +49,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         private static XRMeshSubsystem meshSubsystem = null;
+#if UNITY_2019_3_OR_NEWER
         private static readonly List<XRMeshSubsystem> XRMeshSubsystems = new List<XRMeshSubsystem>();
+#endif // UNITY_2019_3_OR_NEWER
 
         /// <summary>
         /// The XR SDK mesh subsystem for the currently loaded XR plug-in.
@@ -76,7 +80,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         private static XRDisplaySubsystem displaySubsystem = null;
+#if UNITY_2019_3_OR_NEWER
         private static readonly List<XRDisplaySubsystem> XRDisplaySubsystems = new List<XRDisplaySubsystem>();
+#endif // UNITY_2019_3_OR_NEWER
 
         /// <summary>
         /// The XR SDK display subsystem for the currently loaded XR plug-in.

--- a/Assets/MRTK/Core/Utilities/XRSubsystemHelpers.cs
+++ b/Assets/MRTK/Core/Utilities/XRSubsystemHelpers.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+#if UNITY_2019_3_OR_NEWER
+using UnityEngine;
+using UnityEngine.XR;
+#else
+using UnityEngine.Experimental.XR;
+#endif
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    /// <summary>
+    /// A helper class to provide easier access to active Unity XR SDK subsystems.
+    /// </summary>
+    public static class XRSubsystemHelpers
+    {
+        private static XRInputSubsystem inputSubsystem = null;
+        private static readonly List<XRInputSubsystem> XRInputSubsystems = new List<XRInputSubsystem>();
+
+        /// <summary>
+        /// The XR SDK input subsystem for the currently loaded XR plug-in.
+        /// </summary>
+        public static XRInputSubsystem InputSubsystem
+        {
+            get
+            {
+#if UNITY_2019_3_OR_NEWER
+                if (inputSubsystem == null || !inputSubsystem.running)
+                {
+                    inputSubsystem = null;
+                    SubsystemManager.GetInstances(XRInputSubsystems);
+                    foreach (XRInputSubsystem xrInputSubsystem in XRInputSubsystems)
+                    {
+                        if (xrInputSubsystem.running)
+                        {
+                            inputSubsystem = xrInputSubsystem;
+                            break;
+                        }
+                    }
+                }
+#endif // UNITY_2019_3_OR_NEWER
+                return inputSubsystem;
+            }
+        }
+
+        private static XRMeshSubsystem meshSubsystem = null;
+        private static readonly List<XRMeshSubsystem> XRMeshSubsystems = new List<XRMeshSubsystem>();
+
+        /// <summary>
+        /// The XR SDK mesh subsystem for the currently loaded XR plug-in.
+        /// </summary>
+        public static XRMeshSubsystem MeshSubsystem
+        {
+            get
+            {
+#if UNITY_2019_3_OR_NEWER
+                if (meshSubsystem == null || !meshSubsystem.running)
+                {
+                    meshSubsystem = null;
+                    SubsystemManager.GetInstances(XRMeshSubsystems);
+                    foreach (XRMeshSubsystem xrMeshSubsystem in XRMeshSubsystems)
+                    {
+                        if (xrMeshSubsystem.running)
+                        {
+                            meshSubsystem = xrMeshSubsystem;
+                            break;
+                        }
+                    }
+                }
+#endif // UNITY_2019_3_OR_NEWER
+                return meshSubsystem;
+            }
+        }
+
+        private static XRDisplaySubsystem displaySubsystem = null;
+        private static readonly List<XRDisplaySubsystem> XRDisplaySubsystems = new List<XRDisplaySubsystem>();
+
+        /// <summary>
+        /// The XR SDK display subsystem for the currently loaded XR plug-in.
+        /// </summary>
+        public static XRDisplaySubsystem DisplaySubsystem
+        {
+            get
+            {
+#if UNITY_2019_3_OR_NEWER
+                if (displaySubsystem == null || !displaySubsystem.running)
+                {
+                    displaySubsystem = null;
+                    SubsystemManager.GetInstances(XRDisplaySubsystems);
+                    foreach (XRDisplaySubsystem xrDisplaySubsystem in XRDisplaySubsystems)
+                    {
+                        if (xrDisplaySubsystem.running)
+                        {
+                            displaySubsystem = xrDisplaySubsystem;
+                            break;
+                        }
+                    }
+                }
+#endif // UNITY_2019_3_OR_NEWER
+                return displaySubsystem;
+            }
+        }
+    }
+}

--- a/Assets/MRTK/Core/Utilities/XRSubsystemHelpers.cs.meta
+++ b/Assets/MRTK/Core/Utilities/XRSubsystemHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98b7e5fbc3c5d9d4cb5811501c141f4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -104,7 +104,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             using (UpdateHandDataPerfMarker.Auto())
             {
 #if WINDOWS_UWP && WMR_ENABLED
-                XRSDKSubsystemHelpers.InputSubsystem?.GetCurrentSourceStates(states);
+                XRSubsystemHelpers.InputSubsystem?.GetCurrentSourceStates(states);
 
                 foreach (SpatialInteractionSourceState sourceState in states)
                 {

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         #region IMixedRealityCameraSettings
 
         /// <inheritdoc/>
-        public override bool IsOpaque => XRSDKSubsystemHelpers.DisplaySubsystem?.displayOpaque ?? true;
+        public override bool IsOpaque => XRSubsystemHelpers.DisplaySubsystem?.displayOpaque ?? true;
 
         #endregion IMixedRealityCameraSettings
     }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -111,7 +111,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             }
             else // Pre-Windows 10 1903.
             {
-                if (XRSDKSubsystemHelpers.DisplaySubsystem != null && !XRSDKSubsystemHelpers.DisplaySubsystem.displayOpaque)
+                if (XRSubsystemHelpers.DisplaySubsystem != null && !XRSubsystemHelpers.DisplaySubsystem.displayOpaque)
                 {
                     // HoloLens supports GGV hands
                     return capability == MixedRealityCapability.GGVHand;

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc/>
         protected override void ConfigureObserverVolume()
         {
-            if (SpatialAwarenessSystem == null || XRSDKSubsystemHelpers.MeshSubsystem == null)
+            if (SpatialAwarenessSystem == null || XRSubsystemHelpers.MeshSubsystem == null)
             {
                 return;
             }
@@ -53,16 +53,16 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 switch (ObserverVolumeType)
                 {
                     case VolumeType.AxisAlignedCube:
-                        XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
+                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
                         break;
 #if WMR_ENABLED
                     case VolumeType.Sphere:
                         // We use the x value of the extents as the sphere radius
-                        XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolumeSphere(ObserverOrigin, ObservationExtents.x);
+                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolumeSphere(ObserverOrigin, ObservationExtents.x);
                         break;
 
                     case VolumeType.UserAlignedCube:
-                        XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolumeOrientedBox(ObserverOrigin, ObservationExtents, ObserverRotation);
+                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolumeOrientedBox(ObserverOrigin, ObservationExtents, ObserverRotation);
                         break;
 #endif // WMR_ENABLED
                     default:

--- a/Assets/MRTK/Providers/XRSDK/Editor/XRSDKConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/XRSDK/Editor/XRSDKConfigurationChecker.cs
@@ -16,11 +16,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
     static class XRSDKConfigurationChecker
     {
         private const string AsmDefFileName = "Microsoft.MixedReality.Toolkit.Providers.XRSDK.asmdef";
-        private const string XRManagementReference = "Unity.XR.Management";
         private const string SpatialTrackingReference = "UnityEngine.SpatialTracking";
 
 #if UNITY_2019_3_OR_NEWER
-        private static readonly VersionDefine XRManagementDefine = new VersionDefine("com.unity.xr.management", "", "XR_MANAGEMENT_ENABLED");
         private static readonly VersionDefine SpatialTrackingDefine = new VersionDefine("com.unity.xr.legacyinputhelpers", "", "SPATIALTRACKING_ENABLED");
 #endif // UNITY_2019_3_OR_NEWER
 
@@ -78,12 +76,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                 versionDefines.AddRange(asmDef.VersionDefines);
             }
 
-            if (!references.Contains(XRManagementReference))
-            {
-                // Add a reference to the ARFoundation assembly
-                references.Add(XRManagementReference);
-                changed = true; 
-            }
             if (!references.Contains(SpatialTrackingReference))
             {
                 // Add a reference to the spatial tracking assembly
@@ -91,12 +83,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                 changed = true;
             }
 
-            if (!versionDefines.Contains(XRManagementDefine))
-            {
-                // Add the XRManagement #define
-                versionDefines.Add(XRManagementDefine);
-                changed = true;
-            }
             if (!versionDefines.Contains(SpatialTrackingDefine))
             {
                 // Add the spatial tracking #define
@@ -104,12 +90,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                 changed = true;
             }
 #else
-            if (references.Contains(XRManagementReference))
-            {
-                // Remove the reference to the XRManagement assembly
-                references.Remove(XRManagementReference);
-                changed = true;
-            }
             if (references.Contains(SpatialTrackingReference))
             {
                 // Remove the reference to the spatial tracking assembly

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         #region IMixedRealityCameraSettings
 
         /// <inheritdoc/>
-        public override bool IsOpaque => XRSDKSubsystemHelpers.DisplaySubsystem?.displayOpaque ?? true;
+        public override bool IsOpaque => XRSubsystemHelpers.DisplaySubsystem?.displayOpaque ?? true;
 
 #if SPATIALTRACKING_ENABLED
         /// <inheritdoc/>

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             if (SpatialAwarenessSystem == null) { return; }
 
-            if (XRSDKSubsystemHelpers.MeshSubsystem != null)
+            if (XRSubsystemHelpers.MeshSubsystem != null)
             {
                 ConfigureObserverVolume();
 
@@ -77,9 +77,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             // For non-custom levels, the enum value is the appropriate triangles per cubic meter.
             int level = (int)levelOfDetail;
-            if (XRSDKSubsystemHelpers.MeshSubsystem != null)
+            if (XRSubsystemHelpers.MeshSubsystem != null)
             {
-                XRSDKSubsystemHelpers.MeshSubsystem.meshDensity = level / (float)SpatialAwarenessMeshLevelOfDetail.Fine; // For now, map Coarse to 0.0 and Fine to 1.0
+                XRSubsystemHelpers.MeshSubsystem.meshDensity = level / (float)SpatialAwarenessMeshLevelOfDetail.Fine; // For now, map Coarse to 0.0 and Fine to 1.0
             }
             return level;
         }
@@ -228,7 +228,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         /// </summary>
         private void UpdateObserver()
         {
-            if (SpatialAwarenessSystem == null || XRSDKSubsystemHelpers.MeshSubsystem == null) { return; }
+            if (SpatialAwarenessSystem == null || XRSubsystemHelpers.MeshSubsystem == null) { return; }
 
             using (UpdateObserverPerfMarker.Auto())
             {
@@ -260,7 +260,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                         // The application can update the observer volume at any time, make sure we are using the latest.
                         ConfigureObserverVolume();
 
-                        if (XRSDKSubsystemHelpers.MeshSubsystem.TryGetMeshInfos(meshInfos))
+                        if (XRSubsystemHelpers.MeshSubsystem.TryGetMeshInfos(meshInfos))
                         {
                             UpdateMeshes(meshInfos);
                         }
@@ -342,7 +342,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                     newMesh.GameObject.SetActive(true);
                 }
 
-                XRSDKSubsystemHelpers.MeshSubsystem.GenerateMeshAsync(meshId, newMesh.Filter.mesh, newMesh.Collider, MeshVertexAttributes.Normals, (MeshGenerationResult meshGenerationResult) => MeshGenerationAction(meshGenerationResult));
+                XRSubsystemHelpers.MeshSubsystem.GenerateMeshAsync(meshId, newMesh.Filter.mesh, newMesh.Collider, MeshVertexAttributes.Normals, (MeshGenerationResult meshGenerationResult) => MeshGenerationAction(meshGenerationResult));
                 outstandingMeshObject = newMesh;
             }
         }
@@ -409,7 +409,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         /// </summary>
         protected virtual void ConfigureObserverVolume()
         {
-            if (SpatialAwarenessSystem == null || XRSDKSubsystemHelpers.MeshSubsystem == null)
+            if (SpatialAwarenessSystem == null || XRSubsystemHelpers.MeshSubsystem == null)
             {
                 return;
             }
@@ -420,7 +420,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                 switch (ObserverVolumeType)
                 {
                     case VolumeType.AxisAlignedCube:
-                        XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
+                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
                         break;
 
                     default:

--- a/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         protected override List<Vector3> GetBoundaryGeometry()
         {
             // Boundaries are supported for Room Scale experiences only.
-            if (XRSDKSubsystemHelpers.InputSubsystem.GetTrackingOriginMode() != TrackingOriginModeFlags.Floor)
+            if (XRSubsystemHelpers.InputSubsystem.GetTrackingOriginMode() != TrackingOriginModeFlags.Floor)
             {
                 return null;
             }
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             // Get the boundary geometry.
             var boundaryGeometry = new List<Vector3>(0);
 
-            if (!XRSDKSubsystemHelpers.InputSubsystem.TryGetBoundaryPoints(boundaryGeometry) || boundaryGeometry.Count == 0)
+            if (!XRSubsystemHelpers.InputSubsystem.TryGetBoundaryPoints(boundaryGeometry) || boundaryGeometry.Count == 0)
             {
                 return null;
             }
@@ -94,7 +94,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                     break;
             }
 
-            if (!XRSDKSubsystemHelpers.InputSubsystem.TrySetTrackingOriginMode(trackingOriginMode))
+            if (!XRSubsystemHelpers.InputSubsystem.TrySetTrackingOriginMode(trackingOriginMode))
             {
                 Debug.LogWarning("Tracking origin unable to be set.");
             }

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
             {
                 base.Update();
 
-                if (XRSDKSubsystemHelpers.InputSubsystem == null || !XRSDKSubsystemHelpers.InputSubsystem.running)
+                if (XRSubsystemHelpers.InputSubsystem == null || !XRSubsystemHelpers.InputSubsystem.running)
                 {
                     return;
                 }

--- a/Assets/MRTK/Providers/XRSDK/XRSDKSubsystemHelpers.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKSubsystemHelpers.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using UnityEngine;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
 using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK
@@ -10,90 +10,22 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
     /// <summary>
     /// A helper class to provide easier access to active Unity XR SDK subsystems.
     /// </summary>
+    [Obsolete("Use Microsoft.MixedReality.Toolkit.Utilities.XRSubsystemHelpers instead.")]
     public static class XRSDKSubsystemHelpers
     {
-        private static XRInputSubsystem inputSubsystem = null;
-        private static readonly List<XRInputSubsystem> XRInputSubsystems = new List<XRInputSubsystem>();
-
         /// <summary>
         /// The XR SDK input subsystem for the currently loaded XR plug-in.
         /// </summary>
-        public static XRInputSubsystem InputSubsystem
-        {
-            get
-            {
-                if (inputSubsystem == null || !inputSubsystem.running)
-                {
-                    inputSubsystem = null;
-                    SubsystemManager.GetInstances(XRInputSubsystems);
-                    foreach (XRInputSubsystem xrInputSubsystem in XRInputSubsystems)
-                    {
-                        if (xrInputSubsystem.running)
-                        {
-                            inputSubsystem = xrInputSubsystem;
-                            break;
-                        }
-                    }
-                }
-
-                return inputSubsystem;
-            }
-        }
-
-        private static XRMeshSubsystem meshSubsystem = null;
-        private static readonly List<XRMeshSubsystem> XRMeshSubsystems = new List<XRMeshSubsystem>();
+        public static XRInputSubsystem InputSubsystem => XRSubsystemHelpers.InputSubsystem;
 
         /// <summary>
         /// The XR SDK mesh subsystem for the currently loaded XR plug-in.
         /// </summary>
-        public static XRMeshSubsystem MeshSubsystem
-        {
-            get
-            {
-                if (meshSubsystem == null || !meshSubsystem.running)
-                {
-                    meshSubsystem = null;
-                    SubsystemManager.GetInstances(XRMeshSubsystems);
-                    foreach (XRMeshSubsystem xrMeshSubsystem in XRMeshSubsystems)
-                    {
-                        if (xrMeshSubsystem.running)
-                        {
-                            meshSubsystem = xrMeshSubsystem;
-                            break;
-                        }
-                    }
-                }
-
-                return meshSubsystem;
-            }
-        }
-
-        private static XRDisplaySubsystem displaySubsystem = null;
-        private static readonly List<XRDisplaySubsystem> XRDisplaySubsystems = new List<XRDisplaySubsystem>();
+        public static XRMeshSubsystem MeshSubsystem => XRSubsystemHelpers.MeshSubsystem;
 
         /// <summary>
         /// The XR SDK display subsystem for the currently loaded XR plug-in.
         /// </summary>
-        public static XRDisplaySubsystem DisplaySubsystem
-        {
-            get
-            {
-                if (displaySubsystem == null || !displaySubsystem.running)
-                {
-                    displaySubsystem = null;
-                    SubsystemManager.GetInstances(XRDisplaySubsystems);
-                    foreach (XRDisplaySubsystem xrDisplaySubsystem in XRDisplaySubsystems)
-                    {
-                        if (xrDisplaySubsystem.running)
-                        {
-                            displaySubsystem = xrDisplaySubsystem;
-                            break;
-                        }
-                    }
-                }
-
-                return displaySubsystem;
-            }
-        }
+        public static XRDisplaySubsystem DisplaySubsystem => XRSubsystemHelpers.DisplaySubsystem;
     }
 }

--- a/Assets/MRTK/Providers/XRSDK/XRSDKSubsystemHelpers.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKSubsystemHelpers.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using UnityEngine;
 using UnityEngine.XR;
-
-#if XR_MANAGEMENT_ENABLED
-using UnityEngine.XR.Management;
-#endif // XR_MANAGEMENT_ENABLED
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK
 {
@@ -15,6 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
     public static class XRSDKSubsystemHelpers
     {
         private static XRInputSubsystem inputSubsystem = null;
+        private static readonly List<XRInputSubsystem> XRInputSubsystems = new List<XRInputSubsystem>();
 
         /// <summary>
         /// The XR SDK input subsystem for the currently loaded XR plug-in.
@@ -23,19 +22,26 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             get
             {
-#if XR_MANAGEMENT_ENABLED
-                if (inputSubsystem == null &&
-                    ActiveLoader != null)
+                if (inputSubsystem == null || !inputSubsystem.running)
                 {
-                    inputSubsystem = ActiveLoader.GetLoadedSubsystem<XRInputSubsystem>();
+                    inputSubsystem = null;
+                    SubsystemManager.GetInstances(XRInputSubsystems);
+                    foreach (XRInputSubsystem xrInputSubsystem in XRInputSubsystems)
+                    {
+                        if (xrInputSubsystem.running)
+                        {
+                            inputSubsystem = xrInputSubsystem;
+                            break;
+                        }
+                    }
                 }
-#endif // XR_MANAGEMENT_ENABLED
 
                 return inputSubsystem;
             }
         }
 
         private static XRMeshSubsystem meshSubsystem = null;
+        private static readonly List<XRMeshSubsystem> XRMeshSubsystems = new List<XRMeshSubsystem>();
 
         /// <summary>
         /// The XR SDK mesh subsystem for the currently loaded XR plug-in.
@@ -44,19 +50,26 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             get
             {
-#if XR_MANAGEMENT_ENABLED
-                if (meshSubsystem == null &&
-                    ActiveLoader != null)
+                if (meshSubsystem == null || !meshSubsystem.running)
                 {
-                    meshSubsystem = ActiveLoader.GetLoadedSubsystem<XRMeshSubsystem>();
+                    meshSubsystem = null;
+                    SubsystemManager.GetInstances(XRMeshSubsystems);
+                    foreach (XRMeshSubsystem xrMeshSubsystem in XRMeshSubsystems)
+                    {
+                        if (xrMeshSubsystem.running)
+                        {
+                            meshSubsystem = xrMeshSubsystem;
+                            break;
+                        }
+                    }
                 }
-#endif // XR_MANAGEMENT_ENABLED
 
                 return meshSubsystem;
             }
         }
 
         private static XRDisplaySubsystem displaySubsystem = null;
+        private static readonly List<XRDisplaySubsystem> XRDisplaySubsystems = new List<XRDisplaySubsystem>();
 
         /// <summary>
         /// The XR SDK display subsystem for the currently loaded XR plug-in.
@@ -65,33 +78,22 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             get
             {
-#if XR_MANAGEMENT_ENABLED
-                if (displaySubsystem == null &&
-                    ActiveLoader != null)
+                if (displaySubsystem == null || !displaySubsystem.running)
                 {
-                    displaySubsystem = ActiveLoader.GetLoadedSubsystem<XRDisplaySubsystem>();
+                    displaySubsystem = null;
+                    SubsystemManager.GetInstances(XRDisplaySubsystems);
+                    foreach (XRDisplaySubsystem xrDisplaySubsystem in XRDisplaySubsystems)
+                    {
+                        if (xrDisplaySubsystem.running)
+                        {
+                            displaySubsystem = xrDisplaySubsystem;
+                            break;
+                        }
+                    }
                 }
-#endif // XR_MANAGEMENT_ENABLED
 
                 return displaySubsystem;
             }
         }
-
-#if XR_MANAGEMENT_ENABLED
-        private static XRLoader ActiveLoader
-        {
-            get
-            {
-                if (XRGeneralSettings.Instance != null &&
-                    XRGeneralSettings.Instance.Manager != null &&
-                    XRGeneralSettings.Instance.Manager.activeLoader != null)
-                {
-                    return XRGeneralSettings.Instance.Manager.activeLoader;
-                }
-
-                return null;
-            }
-        }
-#endif // XR_MANAGEMENT_ENABLED
     }
 }


### PR DESCRIPTION
## Overview

Rewrote the helpers to no longer have a dependency on the Unity XR Management package. Now that it only has a dependency on the engine, I've moved it to the MRTK core, to allow other components to use it without needing to take a dependency on the XRSDK provider package.

This was done for a similar reason as #8270, to allow components to call methods on these subsystems without taking a dependency on the XRSDK package.