### PR TITLE
Update XRSDKWindowsMixedRealityUtilitiesProvider.cs to provide HolographicFrame access

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/XRSDKWindowsMixedRealityUtilitiesProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/XRSDKWindowsMixedRealityUtilitiesProvider.cs
@@ -23,9 +23,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             IntPtr.Zero;
 #endif
 
-        /// <summary>
-        /// Currently unable to access HolographicFrame in XR SDK. Always returns IntPtr.Zero.
-        /// </summary>
-        IntPtr IWindowsMixedRealityUtilitiesProvider.IHolographicFramePtr => IntPtr.Zero;
+        /// <inheritdoc />
+        IntPtr IWindowsMixedRealityUtilitiesProvider.IHolographicFramePtr =>
+#if WMR_ENABLED
+            WindowsMREnvironment.CurrentHolographicRenderFrame;
+#else
+            IntPtr.Zero;
+#endif
     }
 }


### PR DESCRIPTION
## Overview

Now that Windows XR Plugin 2.2.0 is the Unity 2019.4 verified / recommended / installed by default version, we can include this feature that was added in that package (`WindowsMREnvironment.CurrentHolographicRenderFrame`).

This allows the `WindowsMixedRealityReprojectionUpdater` to work and allows apps to switch between depth reprojection and autoplanar on XR SDK.