### PR TITLE
Update a subset of the XRSDK configuration checkers to only run on editor startup

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/Editor/OculusXRSDKConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Editor/OculusXRSDKConfigurationChecker.cs
@@ -17,6 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus
     {
         private const string AsmDefFileName = "Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.asmdef";
         private const string OculusReference = "Unity.XR.Oculus";
+        private const string SessionStateKey = "OculusXRSDKConfigurationCheckerSessionStateKey";
 
 #if UNITY_2019_3_OR_NEWER
         private static readonly VersionDefine OculusDefine = new VersionDefine("com.unity.xr.oculus", "", "OCULUS_ENABLED");
@@ -24,7 +25,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus
 
         static OculusXRSDKConfigurationChecker()
         {
-            UpdateAsmDef();
+            // This InitializeOnLoad handler only runs once at editor launch in order to adjust for Unity version
+            // differences. These don't need to (and should not be) run on an ongoing basis. This uses the
+            // volatile SessionState which is clear when Unity launches to ensure that this only runs the
+            // expensive work (UpdateAsmDef) once.
+            if (!SessionState.GetBool(SessionStateKey, false))
+            {
+                SessionState.SetBool(SessionStateKey, true);
+                UpdateAsmDef();
+            }
         }
 
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Editor/WindowsMixedRealityXRSDKConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Editor/WindowsMixedRealityXRSDKConfigurationChecker.cs
@@ -17,6 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
     {
         private const string AsmDefFileName = "Microsoft.MixedReality.Toolkit.Providers.XRSDK.WMR.asmdef";
         private const string WindowsMixedRealityReference = "Unity.XR.WindowsMixedReality";
+        private const string SessionStateKey = "WindowsMixedRealityXRSDKConfigurationCheckerSessionStateKey";
 
 #if UNITY_2019_3_OR_NEWER
         private static readonly VersionDefine WindowsMixedRealityDefine = new VersionDefine("com.unity.xr.windowsmr", "", "WMR_ENABLED");
@@ -24,7 +25,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
         static WindowsMixedRealityXRSDKConfigurationChecker()
         {
-            UpdateAsmDef();
+            // This InitializeOnLoad handler only runs once at editor launch in order to adjust for Unity version
+            // differences. These don't need to (and should not be) run on an ongoing basis. This uses the
+            // volatile SessionState which is clear when Unity launches to ensure that this only runs the
+            // expensive work (UpdateAsmDef) once.
+            if (!SessionState.GetBool(SessionStateKey, false))
+            {
+                SessionState.SetBool(SessionStateKey, true);
+                UpdateAsmDef();
+            }
         }
 
         /// <summary>

--- a/Assets/MRTK/Providers/XRSDK/Editor/XRSDKConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/XRSDK/Editor/XRSDKConfigurationChecker.cs
@@ -18,6 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         private const string AsmDefFileName = "Microsoft.MixedReality.Toolkit.Providers.XRSDK.asmdef";
         private const string XRManagementReference = "Unity.XR.Management";
         private const string SpatialTrackingReference = "UnityEngine.SpatialTracking";
+        private const string SessionStateKey = "XRSDKConfigurationCheckerSessionStateKey";
 
 #if UNITY_2019_3_OR_NEWER
         private static readonly VersionDefine XRManagementDefine = new VersionDefine("com.unity.xr.management", "", "XR_MANAGEMENT_ENABLED");
@@ -26,7 +27,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
 
         static XRSDKConfigurationChecker()
         {
-            UpdateAsmDef();
+            // This InitializeOnLoad handler only runs once at editor launch in order to adjust for Unity version
+            // differences. These don't need to (and should not be) run on an ongoing basis. This uses the
+            // volatile SessionState which is clear when Unity launches to ensure that this only runs the
+            // expensive work (UpdateAsmDef) once.
+            if (!SessionState.GetBool(SessionStateKey, false))
+            {
+                SessionState.SetBool(SessionStateKey, true);
+                UpdateAsmDef();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Per https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8188, we're working on cleaning up a lot of our InitializeOnLoad handlers.

Some of them only need to be run at Unity editor startup time (because they need to do diverging behavior based on whether or not it's being launched in Unity 2019 vs Unity 2018). These ones don't need to run after each compile and prior to entering play mode (which they do right now) - i.e. prior to this change these three things would run their asmdef checkers (which would do file I/O, which can be expensive and is unnecessary). Obviously the Unity editor version is not going to change as the Unity editor is running.

This change uses the volatile SessionState storage space to store whether or not these particular handlers have run in this editor lifetime. I opted not to make some base class because I didn't want to add some other dependency chain for this particular thing (i.e. these will likely get split out and the value of sharing this isn't tooooooo high).