### PR TITLE
fixed reset of handles when all rotation axis flags are disabled

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -300,7 +300,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
             else
             {
-
                 CardinalAxisType axisType = GetAxisType(handle);
                 switch (axisType)
                 {

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -156,9 +156,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             IsActive = areHandlesActive;
             cachedFlattenAxis = flattenAxis;
+            ResetHandles();
             if (IsActive)
             {
-                ResetHandles();
                 int[] flattenedHandles = VisualUtils.GetFlattenedIndices(flattenAxis);
                 if (flattenedHandles != null)
                 {
@@ -294,11 +294,26 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         #region BoundsControlHandlerBase 
         internal override bool IsVisible(Transform handle)
         {
-            CardinalAxisType axisType = GetAxisType(handle);
-            return IsActive &&
-                ((axisType == CardinalAxisType.X && config.ShowRotationHandleForX) ||
-                (axisType == CardinalAxisType.Y && config.ShowRotationHandleForY) ||
-                (axisType == CardinalAxisType.Z && config.ShowRotationHandleForZ));
+            if (!IsActive)
+            {
+                return false;
+            }
+            else
+            {
+
+                CardinalAxisType axisType = GetAxisType(handle);
+                switch (axisType)
+                {
+                    case CardinalAxisType.X:
+                        return config.ShowRotationHandleForX;
+                    case CardinalAxisType.Y:
+                        return config.ShowRotationHandleForY;
+                    case CardinalAxisType.Z:
+                        return config.ShowRotationHandleForZ;
+                }
+
+                return false;
+            }
         }
 
         internal override HandleType GetHandleType()

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -1042,6 +1042,31 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsTrue(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y not active");
             Assert.IsTrue(rotationHandleAxisZ.gameObject.activeSelf, "rotation handle z not active");
 
+            // test disabling all rotation handles before activating the gameobject
+            // verifies bug https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8239
+            boundsControl.gameObject.SetActive(false);
+            yield return null;
+            rotationHandlesConfig.ShowRotationHandleForX = false;
+            rotationHandlesConfig.ShowRotationHandleForY = false;
+            rotationHandlesConfig.ShowRotationHandleForZ = false;
+            boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateOnStart;
+            boundsControl.gameObject.SetActive(true);
+            yield return null;
+            // refetch transforms
+            rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+            rotationHandleAxisX = rigRoot.transform.Find("midpoint_0");
+            Assert.IsNotNull(rotationHandleAxisX, "rotation handle couldn't be found");
+            rotationHandleAxisY = rigRoot.transform.Find("midpoint_1");
+            Assert.IsNotNull(rotationHandleAxisY, "rotation handle couldn't be found");
+            rotationHandleAxisZ = rigRoot.transform.Find("midpoint_8");
+            Assert.IsNotNull(rotationHandleAxisZ, "rotation handle couldn't be found");
+            // check handle visibility
+            Assert.IsFalse(rotationHandleAxisX.gameObject.activeSelf, "rotation handle x active");
+            Assert.IsFalse(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y active");
+            Assert.IsFalse(rotationHandleAxisZ.gameObject.activeSelf, "rotation handle z active");
+
+
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -1052,6 +1052,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateOnStart;
             boundsControl.gameObject.SetActive(true);
             yield return null;
+            
             // refetch transforms
             rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
             Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -1061,6 +1061,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsNotNull(rotationHandleAxisY, "rotation handle couldn't be found");
             rotationHandleAxisZ = rigRoot.transform.Find("midpoint_8");
             Assert.IsNotNull(rotationHandleAxisZ, "rotation handle couldn't be found");
+            
             // check handle visibility
             Assert.IsFalse(rotationHandleAxisX.gameObject.activeSelf, "rotation handle x active");
             Assert.IsFalse(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y active");


### PR DESCRIPTION
- changed reset condition (early out) to allow hiding rotation handles when all axis are disabled 
- made visibility check more readable in rotation handles
- added test condition for rotation handle visibility test to cover bug scenario

## Overview


## Changes
- Fixes: #8239 


## Verification
added test scenario to existing handle visibility test
verified behavior in bounds control example scene