### PR TITLE
Fix examples upm package

### DIFF
--- a/Assets/MRTK/Examples/packagetemplate.json
+++ b/Assets/MRTK/Examples/packagetemplate.json
@@ -28,7 +28,7 @@
     },
     "files": [
         "Samples~*",
-        "StandardAssets~*",
+        "StandardAssets*",
         "MRTK.Examples*",
         "License*",
         "package.json.meta"


### PR DESCRIPTION
The upm version of the examples package was incorrectly marking the StandardAssets folder as hidden in the editor (appended with a ~).

This change fixes this issue and the package contents are shown below. (In the editor, right click on the package and select "Show in Explorer"

![image](https://user-images.githubusercontent.com/13281406/89948813-9c9bd300-dbdb-11ea-8fb9-5440572d1038.png)
