### PR TITLE
Update LostTrackingService for Unity 2020 and XRSDK/WMR

### DIFF
--- a/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
+++ b/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 #if ARFOUNDATION_PRESENT
 using System.Collections.Generic;
 using UnityEngine.XR.ARSubsystems;
+
+#if UNITY_2018
+using UnityEngine.Experimental;
+#endif // UNITY_2018
 #endif // ARFOUNDATION_PRESENT
 
 #if UNITY_WSA && !UNITY_2020_1_OR_NEWER

--- a/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
+++ b/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
@@ -6,14 +6,14 @@ using System;
 using Unity.Profiling;
 using UnityEngine;
 
-#if ARFOUNDATION_PRESENT
+#if ARSUBSYSTEMS_ENABLED
 using System.Collections.Generic;
 using UnityEngine.XR.ARSubsystems;
 
 #if UNITY_2018
 using UnityEngine.Experimental;
 #endif // UNITY_2018
-#endif // ARFOUNDATION_PRESENT
+#endif // ARSUBSYSTEMS_ENABLED
 
 #if UNITY_WSA && !UNITY_2020_1_OR_NEWER
 using UnityEngine.XR.WSA;
@@ -83,12 +83,12 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
         {
 #if UNITY_WSA && !UNITY_2020_1_OR_NEWER
             WorldManager.OnPositionalLocatorStateChanged += OnPositionalLocatorStateChanged;
-#elif !ARFOUNDATION_PRESENT
+#elif !ARSUBSYSTEMS_ENABLED
             Debug.LogWarning("This service is not supported on this platform.");
 #endif
         }
 
-#if ARFOUNDATION_PRESENT
+#if ARSUBSYSTEMS_ENABLED
         private UnityEngine.XR.ARSubsystems.TrackingState lastTrackingState = UnityEngine.XR.ARSubsystems.TrackingState.None;
         private NotTrackingReason lastNotTrackingReason = NotTrackingReason.None;
 
@@ -124,7 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
                 lastNotTrackingReason = sessionSubsystem.notTrackingReason;
             }
         }
-#endif // ARFOUNDATION_PRESENT
+#endif // ARSUBSYSTEMS_ENABLED
 
 #if UNITY_EDITOR
         /// <inheritdoc />
@@ -248,7 +248,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
         }
 #endif // UNITY_WSA && !UNITY_2020_1_OR_NEWER
 
-#if ARFOUNDATION_PRESENT
+#if ARSUBSYSTEMS_ENABLED
         private static XRSessionSubsystem sessionSubsystem = null;
         private static readonly List<XRSessionSubsystem> XRSessionSubsystems = new List<XRSessionSubsystem>();
 
@@ -275,6 +275,6 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
                 return sessionSubsystem;
             }
         }
-#endif // ARFOUNDATION_PRESENT
+#endif // ARSUBSYSTEMS_ENABLED
     }
 }

--- a/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
+++ b/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
@@ -1,14 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using Unity.Profiling;
 using UnityEngine;
-using Microsoft.MixedReality.Toolkit.Utilities;
 
-#if UNITY_WSA
+#if ARFOUNDATION_PRESENT
+using System.Collections.Generic;
+using UnityEngine.XR.ARSubsystems;
+#endif // ARFOUNDATION_PRESENT
+
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
 using UnityEngine.XR.WSA;
-#endif
+#endif // UNITY_WSA && !UNITY_2020_1_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
 {
@@ -72,20 +77,55 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
         /// <inheritdoc />
         public override void Initialize()
         {
-#if UNITY_WSA
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
             WorldManager.OnPositionalLocatorStateChanged += OnPositionalLocatorStateChanged;
-#else
+#elif !ARFOUNDATION_PRESENT
             Debug.LogWarning("This service is not supported on this platform.");
 #endif
         }
 
+#if ARFOUNDATION_PRESENT
+        private UnityEngine.XR.ARSubsystems.TrackingState lastTrackingState = UnityEngine.XR.ARSubsystems.TrackingState.None;
+        private NotTrackingReason lastNotTrackingReason = NotTrackingReason.None;
+
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] LostTrackingService.Update");
+
+        /// <inheritdoc />
+        public override void Update()
+        {
+            using (UpdatePerfMarker.Auto())
+            {
+                XRSessionSubsystem sessionSubsystem = SessionSubsystem;
+                if (sessionSubsystem == null)
+                {
+                    return;
+                }
+
+                if (sessionSubsystem.trackingState == lastTrackingState && sessionSubsystem.notTrackingReason == lastNotTrackingReason)
+                {
+                    return;
+                }
+
+                // This combination of states is from the Windows XR Plugin docs, describing the combination when positional tracking is inhibited.
+                if (sessionSubsystem.trackingState == UnityEngine.XR.ARSubsystems.TrackingState.None && sessionSubsystem.notTrackingReason == NotTrackingReason.Relocalizing)
+                {
+                    SetTrackingLost(true);
+                }
+                else
+                {
+                    SetTrackingLost(false);
+                }
+
+                lastTrackingState = sessionSubsystem.trackingState;
+                lastNotTrackingReason = sessionSubsystem.notTrackingReason;
+            }
+        }
+#endif // ARFOUNDATION_PRESENT
+
 #if UNITY_EDITOR
         /// <inheritdoc />
-        public void EditorSetTrackingLost(bool trackingLost)
-        {
-            SetTrackingLost(trackingLost);
-        }
-#endif
+        public void EditorSetTrackingLost(bool trackingLost) => SetTrackingLost(trackingLost);
+#endif // UNITY_EDITOR
 
         private static readonly ProfilerMarker DisableTrackingLostVisualPerfMarker = new ProfilerMarker("[MRTK] LostTrackingService.DisableTrackingLostVisual");
 
@@ -183,7 +223,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
             }
         }
 
-#if UNITY_WSA
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
         private static readonly ProfilerMarker OnPositionLocatorStateChangedPerfMarker = new ProfilerMarker("[MRTK] LostTrackingService.OnPositionalLocatorStateChanged");
 
         private void OnPositionalLocatorStateChanged(PositionalLocatorState oldState, PositionalLocatorState newState)
@@ -202,6 +242,35 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
                 }
             }
         }
-#endif
+#endif // UNITY_WSA && !UNITY_2020_1_OR_NEWER
+
+#if ARFOUNDATION_PRESENT
+        private static XRSessionSubsystem sessionSubsystem = null;
+        private static readonly List<XRSessionSubsystem> XRSessionSubsystems = new List<XRSessionSubsystem>();
+
+        /// <summary>
+        /// The XR SDK display subsystem for the currently loaded XR plug-in.
+        /// </summary>
+        private static XRSessionSubsystem SessionSubsystem
+        {
+            get
+            {
+                if (sessionSubsystem == null || !sessionSubsystem.running)
+                {
+                    sessionSubsystem = null;
+                    SubsystemManager.GetInstances(XRSessionSubsystems);
+                    foreach (XRSessionSubsystem xrSessionSubsystem in XRSessionSubsystems)
+                    {
+                        if (xrSessionSubsystem.running)
+                        {
+                            sessionSubsystem = xrSessionSubsystem;
+                            break;
+                        }
+                    }
+                }
+                return sessionSubsystem;
+            }
+        }
+#endif // ARFOUNDATION_PRESENT
     }
 }

--- a/Assets/MRTK/Extensions/LostTrackingService/Microsoft.MixedReality.Toolkit.Extensions.Tracking.asmdef
+++ b/Assets/MRTK/Extensions/LostTrackingService/Microsoft.MixedReality.Toolkit.Extensions.Tracking.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "Microsoft.MixedReality.Toolkit.Extensions.Tracking",
     "references": [
-        "Microsoft.MixedReality.Toolkit"
+        "Microsoft.MixedReality.Toolkit",
+        "Unity.XR.ARSubsystems"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/Assets/MRTK/Extensions/LostTrackingService/Microsoft.MixedReality.Toolkit.Extensions.Tracking.asmdef
+++ b/Assets/MRTK/Extensions/LostTrackingService/Microsoft.MixedReality.Toolkit.Extensions.Tracking.asmdef
@@ -4,12 +4,19 @@
         "Microsoft.MixedReality.Toolkit",
         "Unity.XR.ARSubsystems"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.xr.arsubsystems",
+            "expression": "",
+            "define": "ARSUBSYSTEMS_ENABLED"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
@@ -41,14 +41,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
             {
                 ScriptUtilities.AppendScriptingDefinitions(BuildTargetGroup.Android, definitions);
                 ScriptUtilities.AppendScriptingDefinitions(BuildTargetGroup.iOS, definitions);
-                ScriptUtilities.AppendScriptingDefinitions(BuildTargetGroup.WSA, definitions);
                 return true;
             }
             else
             {
                 ScriptUtilities.RemoveScriptingDefinitions(BuildTargetGroup.Android, definitions);
                 ScriptUtilities.RemoveScriptingDefinitions(BuildTargetGroup.iOS, definitions);
-                ScriptUtilities.RemoveScriptingDefinitions(BuildTargetGroup.WSA, definitions);
                 return false;
             }
         }
@@ -104,7 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 
             if (arFoundationPresent)
             {
-#if UNITY_2018 || UNITY_2019_1_OR_NEWER
+#if UNITY_2018_1_OR_NEWER
                 if (!references.Contains(arFoundationReference))
                 {
                     // Add a reference to the ARFoundation assembly

--- a/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
@@ -41,12 +41,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
             {
                 ScriptUtilities.AppendScriptingDefinitions(BuildTargetGroup.Android, definitions);
                 ScriptUtilities.AppendScriptingDefinitions(BuildTargetGroup.iOS, definitions);
+                ScriptUtilities.AppendScriptingDefinitions(BuildTargetGroup.WSA, definitions);
                 return true;
             }
             else
             {
                 ScriptUtilities.RemoveScriptingDefinitions(BuildTargetGroup.Android, definitions);
                 ScriptUtilities.RemoveScriptingDefinitions(BuildTargetGroup.iOS, definitions);
+                ScriptUtilities.RemoveScriptingDefinitions(BuildTargetGroup.WSA, definitions);
                 return false;
             }
         }


### PR DESCRIPTION
## Overview

Updates the LostTrackingService to no longer call into removed legacy XR APIs (`WorldManager`) on Unity 2020.
Also adds support for the replacement APIs in ARSubsystems' XRSessionSubsystem. This required a new reference to that assembly, and I reused the existing `ARFOUNDATION_PRESENT` define, since have ARFoundation implies ARSubsystems.

## Changes

- Part of #8269 