### PR TITLE
Revert "Updates the LeapMotion and UnityAR configuration checkers to be manually triggered"

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -13,11 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
     /// <summary>
     /// Class that checks if the Leap Motion Core assets are present and configures the project if they are.
     /// </summary>
-    /// <remarks>
-    /// Note that the checks that this class runs are fairly expensive and are only done manually by the user
-    /// as part of their setup steps described here:
-    /// https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/CrossPlatform/LeapMotionMRTK.html
-    /// </remarks>
+    [InitializeOnLoad]
     static class LeapMotionConfigurationChecker
     {
         // The presence of the LeapXRServiceProvider.cs is used to determine if the Leap Motion Core Assets are in the project.
@@ -66,6 +62,14 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             { "LeapMotion.Core.Scripts.XR.Editor", new string[] { "LeapMotion", "LeapMotion.Core.Editor" } },
             { "LeapMotion.Core.Tests.Editor", new string[] { "LeapMotion" } }
         };
+
+        static LeapMotionConfigurationChecker()
+        {
+            // Check if leap core is in the project
+            isLeapInProject = ReconcileLeapMotionDefine();
+
+            ConfigureLeapMotion(isLeapInProject);
+        }
 
         /// <summary>
         /// Ensures that the appropriate symbolic constant is defined based on the presence of the Leap Motion Core Assets.
@@ -399,6 +403,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             Debug.Log($"Saving {cscFilePath}");
         }
 
+#if UNITY_2018       
         /// <summary>
         /// Force Leap Motion integration after the Leap Motion Core Assets import.  In Unity 2018.4, the configuration checker sometimes does not update after the 
         /// Leap Motion Core Assets import, this case only occurs if the MRTK source is from the unity packages. If the integration of leap and MRTK has not occurred, users can 
@@ -412,5 +417,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
 
             ConfigureLeapMotion(isLeapInProject);
         }
+#endif
     }
 }
+

--- a/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
@@ -12,20 +12,22 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
     /// <summary>
     /// Class to perform checks for configuration checks for the UnityAR provider.
     /// </summary>
-    /// <remarks>
-    /// Note that the checks that this class runs are fairly expensive and are only done manually by the user
-    /// as part of their setup steps described here:
-    /// https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/CrossPlatform/UsingARFoundation.html
-    /// </remarks>
+    [InitializeOnLoad]
     static class UnityARConfigurationChecker
     {
         private const string FileName = "Unity.XR.ARFoundation.asmdef";
         private static readonly string[] definitions = { "ARFOUNDATION_PRESENT" };
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/UnityAR/Update Assembly Definitions")]
-        private static void UpdateAssemblyDefinitions()
+        static UnityARConfigurationChecker()
         {
-            UpdateAsmDef(ReconcileArFoundationDefine());
+            // TODO(https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8188)
+            // This should be updated to only run on editor launch and on large asset changes
+            // (i.e. post import of asset packages). This should remove this from the inner compile
+            // loop.
+            if (!EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                UpdateAsmDef(ReconcileArFoundationDefine());
+            }
         }
 
         /// <summary>

--- a/Documentation/CrossPlatform/LeapMotionMRTK.md
+++ b/Documentation/CrossPlatform/LeapMotionMRTK.md
@@ -26,10 +26,10 @@ This provider can be used in editor and on device while on the Standalone platfo
         - If using Core Assets from Leap Motion Unity Modules version 4.5.0, import the **Core** package into the Unity project.
     > [!NOTE]
     > On import of the Core Assets, test directories are removed and 10 assembly definitions are added to the project. Make sure Visual Studio is closed.
+    - If using Unity 2018.4.x
+        - After the Core Assets import, navigate to **Assets/LeapMotion/**, there should be a LeapMotion.asmdef file next to the Core directory.  If the asmdef file is not present, go to the [Leap Motion Common Errors](#leap-motion-has-not-integrated-with-mrtk). If the file is present, go to the next step.
 
-1. Update the MRTK assembly definition files to reference LeapMotion assembly definitions
-
-    This can be done by invoking the menu item: **Mixed Reality Toolkit > Utilities > Leap Motion > Configure Leap Motion**
+    - If using Unity 2019.3.x, go to the next step
 
 1. Adding the Leap Motion Data Provider
     - Create a new Unity scene
@@ -172,7 +172,7 @@ These errors appear if **Mixed Reality Toolkit > Utilities > Leap Motion > Confi
 
 ### Leap Motion has not integrated with MRTK
 
-This error can occur after the import of the Leap Motion Unity Core Assets if the "Configure Leap Motion" step is not followed.
+This error can occur if the Unity version is 2018.4.x, the MRTK source is from the Unity packages and after the import of the Leap Motion Unity Core Assets.
 
 To test if MRTK recognizes the presence of the Leap Motion Unity Core Assets, open the LeapMotionHandTrackingExample scene located in MRTK/Examples/Demos/HandTracking/ and press play.  If the Leap Motion Unity Core Assets are recognized a green message on the informational panel in the scene will appear.  If the Leap Motion Unity Core Assets are not recognized a red message will appear.
 

--- a/Documentation/CrossPlatform/UsingARFoundation.md
+++ b/Documentation/CrossPlatform/UsingARFoundation.md
@@ -27,8 +27,6 @@
     | AR Foundation  <br/> Version: 3.1.3 |  AR Foundation  <br/> Version: 3.1.3 |
     | ARCore XR Plugin <br/> Version: 3.1.4 | ARKit XR Plugin <br/> Version: 3.1.3 |
 
-1. Update the MRTK UnityAR assembly definitions by invoking the menu item: **Mixed Reality Toolkit > Utilities > UnityAR > Update Assembly Definitions**
-
 ## Enabling the Unity AR camera settings provider
 
 The following steps presume use of the MixedRealityToolkit object. Steps required for other service registrars may be different.

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -69,18 +69,6 @@ There is a confirmation dialog that will be displayed when selecting `Use MSBuil
 
 ![MSBuild for Unity confirmation](Images/ConfigurationDialog/EnableMSB4UPrompt.png)
 
-**Reduction in InitializeOnLoad overhead**
-
-We've been doing work to reduce the amount of work that runs in InitializeOnLoad handlers, which should lead to
-improvements in inner loop development speed. InitializeOnLoad handlers run every time a script is compiled, prior
-to entering play mode, and also at editor launch. These handlers now run in far fewer cases, resulting in general
-Unity responsiveness improvements.
-
-In some cases there was a tradeoff that had to be made:
-For those who are using Leap Motion or ARFoundation, there's now an additional manual step in their respective getting
-started steps. See [Leap Motion](CrossPlatform/LeapMotionMRTK.md#using-leap-motion-by-ultraleap-hand-tracking-in-mrtk) and [ARFoundation]
-(CrossPlatform/UsingARFoundation.md#install-required-packages) for the new steps.
-
 ### Breaking changes
 
 **IMixedRealityPointerMediator**


### PR DESCRIPTION
Reverts microsoft/MixedRealityToolkit-Unity#8287

This is causing a build break because our build machines are still using an older version of Unity 2018 (where missing assemblies leads to an error rather than a warning).

Temporarily reverting this while I get the Unity version updated on the build machines.