### PR TITLE
Added non uniform scaling support for bounds control

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Editor/Inspectors/BoundsControl/BoundsControlInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Editor/Inspectors/BoundsControl/BoundsControlInspector.cs
@@ -21,7 +21,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private SerializedProperty activationType;
         private SerializedProperty controlPadding;
         private SerializedProperty flattenAxis;
-        private SerializedProperty scaleMode;
 
         private SerializedProperty smoothingActive;
         private SerializedProperty rotateLerpTime;
@@ -61,7 +60,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             boundsCalculationMethod = serializedObject.FindProperty("boundsCalculationMethod");
             flattenAxis = serializedObject.FindProperty("flattenAxis");
             controlPadding = serializedObject.FindProperty("boxPadding");
-            scaleMode = serializedObject.FindProperty("scaleMode");
 
             smoothingActive = serializedObject.FindProperty("smoothingActive");
             rotateLerpTime = serializedObject.FindProperty("rotateLerpTime");
@@ -104,7 +102,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
                     EditorGUILayout.PropertyField(boundsCalculationMethod);
                     EditorGUILayout.PropertyField(controlPadding);
                     EditorGUILayout.PropertyField(flattenAxis);
-                    EditorGUILayout.PropertyField(scaleMode);
 
                     EditorGUILayout.Space();
                     EditorGUILayout.LabelField(new GUIContent("Smoothing"), EditorStyles.boldLabel);

--- a/Assets/MRTK/SDK/Experimental/Editor/Inspectors/BoundsControl/BoundsControlInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Editor/Inspectors/BoundsControl/BoundsControlInspector.cs
@@ -21,6 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private SerializedProperty activationType;
         private SerializedProperty controlPadding;
         private SerializedProperty flattenAxis;
+        private SerializedProperty scaleMode;
 
         private SerializedProperty smoothingActive;
         private SerializedProperty rotateLerpTime;
@@ -60,6 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             boundsCalculationMethod = serializedObject.FindProperty("boundsCalculationMethod");
             flattenAxis = serializedObject.FindProperty("flattenAxis");
             controlPadding = serializedObject.FindProperty("boxPadding");
+            scaleMode = serializedObject.FindProperty("scaleMode");
 
             smoothingActive = serializedObject.FindProperty("smoothingActive");
             rotateLerpTime = serializedObject.FindProperty("rotateLerpTime");
@@ -102,6 +104,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
                     EditorGUILayout.PropertyField(boundsCalculationMethod);
                     EditorGUILayout.PropertyField(controlPadding);
                     EditorGUILayout.PropertyField(flattenAxis);
+                    EditorGUILayout.PropertyField(scaleMode);
 
                     EditorGUILayout.Space();
                     EditorGUILayout.LabelField(new GUIContent("Smoothing"), EditorStyles.boldLabel);

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -170,6 +170,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
+        public enum ScaleMode
+        {
+            Uniform,
+            Precise
+        }
+
+        public ScaleMode scaleMode;
+
+
         [SerializeField]
         [Tooltip("Bounds control box display configuration section.")]
         private BoxDisplayConfiguration boxDisplayConfiguration;
@@ -1024,25 +1033,56 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 }
                 else if (transformType == HandleType.Scale)
                 {
-                    float initialDist = Vector3.Dot(initialGrabPoint - oppositeCorner, diagonalDir);
-                    float currentDist = Vector3.Dot(currentGrabPoint - oppositeCorner, diagonalDir);
-                    float scaleFactor = 1 + (currentDist - initialDist) / initialDist;
-
-                    Vector3 newScale = initialScaleOnGrabStart * scaleFactor;
-
-                    MixedRealityTransform clampedTransform = MixedRealityTransform.NewScale(newScale);
-                    if (scaleConstraint != null)
+                    if (scaleMode == ScaleMode.Uniform)
                     {
-                        scaleConstraint.ApplyConstraint(ref clampedTransform);
-                        if (clampedTransform.Scale != newScale)
-                        {
-                            scaleFactor = clampedTransform.Scale[0] / initialScaleOnGrabStart[0];
-                        }
-                    }
+                        float initialDist = Vector3.Dot(initialGrabPoint - oppositeCorner, diagonalDir);
+                        float currentDist = Vector3.Dot(currentGrabPoint - oppositeCorner, diagonalDir);
+                        float scaleFactor = 1 + (currentDist - initialDist) / initialDist;
 
-                    var newPosition = initialPositionOnGrabStart * scaleFactor + (1 - scaleFactor) * oppositeCorner;
-                    Target.transform.localScale = smoothingActive ? Smoothing.SmoothTo(Target.transform.localScale, clampedTransform.Scale, scaleLerpTime, Time.deltaTime) : clampedTransform.Scale;
-                    Target.transform.position = smoothingActive ? Smoothing.SmoothTo(Target.transform.position, newPosition, scaleLerpTime, Time.deltaTime) : newPosition;
+                        Vector3 newScale = initialScaleOnGrabStart * scaleFactor;
+
+                        MixedRealityTransform clampedTransform = MixedRealityTransform.NewScale(newScale);
+                        if (scaleConstraint != null)
+                        {
+                            scaleConstraint.ApplyConstraint(ref clampedTransform);
+                            if (clampedTransform.Scale != newScale)
+                            {
+                                scaleFactor = clampedTransform.Scale[0] / initialScaleOnGrabStart[0];
+                            }
+                        }
+
+                        var newPosition = initialPositionOnGrabStart * scaleFactor + (1 - scaleFactor) * oppositeCorner;
+                        Target.transform.localScale = smoothingActive ? Smoothing.SmoothTo(Target.transform.localScale, clampedTransform.Scale, scaleLerpTime, Time.deltaTime) : clampedTransform.Scale;
+                        Target.transform.position = smoothingActive ? Smoothing.SmoothTo(Target.transform.position, newPosition, scaleLerpTime, Time.deltaTime) : newPosition;
+                    }
+                    else
+                    {
+                        // get diff from center point of box
+                        //Vector3 grabDiff = (initialGrabPoint - oppositeCorner / 2) - (currentGrabPoint - oppositeCorner / 2);
+
+                        Vector3 initialDist = (initialGrabPoint - oppositeCorner);
+                        Vector3 currentDist = (currentGrabPoint - oppositeCorner);
+                        Vector3 grabDiff = (currentDist - initialDist);
+                        Vector3 scaleFactor = Vector3.one + new Vector3(grabDiff.x / initialDist.x, grabDiff.y / initialDist.y, grabDiff.z / initialDist.z);
+                        Vector3 newScale = new Vector3(initialScaleOnGrabStart.x * scaleFactor.x, initialScaleOnGrabStart.y * scaleFactor.y, initialScaleOnGrabStart.z * scaleFactor.z);
+
+                        MixedRealityTransform clampedTransform = MixedRealityTransform.NewScale(newScale);
+                        if (scaleConstraint != null)
+                        {
+                            scaleConstraint.ApplyConstraint(ref clampedTransform);
+                            if (clampedTransform.Scale != newScale)
+                            {
+                                scaleFactor = new Vector3(clampedTransform.Scale.x / initialScaleOnGrabStart.x, clampedTransform.Scale.y / initialScaleOnGrabStart.y, clampedTransform.Scale.z / initialScaleOnGrabStart.z);
+                            }
+                        }
+
+
+                       
+                        Target.transform.localScale = smoothingActive ? Smoothing.SmoothTo(Target.transform.localScale, clampedTransform.Scale, scaleLerpTime, Time.deltaTime) : clampedTransform.Scale;
+                       // var newPosition = initialPositionOnGrabStart.Mul(scaleFactor + (Vector3.one - scaleFactor).Mul(oppositeCorner));
+                        //Target.transform.position = smoothingActive ? Smoothing.SmoothTo(Target.transform.position, newPosition, scaleLerpTime, Time.deltaTime) : newPosition;
+                    }
+                    
                 }
             }
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -1031,7 +1031,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                         float scaleFactorUniform = 1 + (currentDist - initialDist) / initialDist;
                         scaleFactor = new Vector3(scaleFactorUniform, scaleFactorUniform, scaleFactorUniform);
                     }
-                    else
+                    else // non-uniform scaling
                     {
                         // get diff from center point of box
                         Vector3 initialDist = (initialGrabPoint - oppositeCorner);

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControlTypes.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControlTypes.cs
@@ -118,8 +118,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControlTypes
         /// </summary>
         Uniform,
         /// <summary>
-        /// Precise scaling scales non uniformly according to movement in 3d space.
+        /// Scales non uniformly according to movement in 3d space.
         /// </summary>
-        Precise
+        NonUniform
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControlTypes.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControlTypes.cs
@@ -107,4 +107,19 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControlTypes
         Y,
         Z
     }
+
+    /// <summary>
+    /// Scale mode that is used for scaling behavior of bounds control.
+    /// </summary>
+    public enum HandleScaleMode
+    {
+        /// <summary>
+        /// Control will be scaled uniformly.
+        /// </summary>
+        Uniform,
+        /// <summary>
+        /// Precise scaling scales non uniformly according to movement in 3d space.
+        /// </summary>
+        Precise
+    }
 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControlTypes;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
@@ -55,6 +56,29 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 }
             }
         }
+
+        [SerializeField]
+        [Tooltip("Scale mode that is applied when interacting with scale handles - default is uniform scaling. Precise mode scales the control non uniformly according to hand / controller movement in space.")]
+        private HandleScaleMode scaleBehavior = HandleScaleMode.Uniform;
+
+        /// <summary>
+        /// Scale behavior that is applied when interacting with scale handles - default is uniform scaling. Precise mode scales the control non uniformly according to hand / controller movement in space.
+        /// </summary>
+        public HandleScaleMode ScaleBehavior
+        {
+            get
+            {
+                return scaleBehavior;
+            }
+            set
+            {
+                if (scaleBehavior != value)
+                {
+                    scaleBehavior = value;
+                }
+            }
+        }
+
 
         #endregion serialized fields
     }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
@@ -58,11 +58,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         [SerializeField]
-        [Tooltip("Scale mode that is applied when interacting with scale handles - default is uniform scaling. Precise mode scales the control non uniformly according to hand / controller movement in space.")]
+        [Tooltip("Scale mode that is applied when interacting with scale handles - default is uniform scaling. Non uniform mode scales the control according to hand / controller movement in space.")]
         private HandleScaleMode scaleBehavior = HandleScaleMode.Uniform;
 
         /// <summary>
-        /// Scale behavior that is applied when interacting with scale handles - default is uniform scaling. Precise mode scales the control non uniformly according to hand / controller movement in space.
+        /// Scale behavior that is applied when interacting with scale handles - default is uniform scaling. Non uniform mode scales the control according to hand / controller movement in space.
         /// </summary>
         public HandleScaleMode ScaleBehavior
         {

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -276,7 +276,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         public IEnumerator ScaleNonUniform()
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
-            boundsControl.ScaleHandlesConfig.ScaleBehavior = HandleScaleMode.Precise;
+            boundsControl.ScaleHandlesConfig.ScaleBehavior = HandleScaleMode.NonUniform;
             yield return VerifyInitialBoundsCorrect(boundsControl);
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
 

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -250,12 +250,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
 
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
-            // This particular test is sensitive to the number of test frames, and is run at a slower pace.
-            int numSteps = 30;
             var delta = new Vector3(0.1f, 0.1f, 0f);
-            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService, ArticulatedHandPose.GestureId.OpenSteadyGrabPoint, initialHandPosition);
-            yield return PlayModeTestUtilities.MoveHand(initialHandPosition, frontRightCornerPos, ArticulatedHandPose.GestureId.OpenSteadyGrabPoint, Handedness.Right, inputSimulationService, numSteps);
-            yield return PlayModeTestUtilities.MoveHand(frontRightCornerPos, frontRightCornerPos + delta, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService, numSteps);
+            TestHand hand = new TestHand(Handedness.Left);
+            yield return hand.Show(initialHandPosition);
+            yield return hand.MoveTo(frontRightCornerPos);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return hand.MoveTo(frontRightCornerPos + delta);
+            yield return null;
 
             var endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
             Vector3 expectedCenter = new Vector3(0.033f, 0.033f, 1.467f);
@@ -275,25 +276,25 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         public IEnumerator ScaleNonUniform()
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
-            boundsControl.scaleMode = BoundsControl.ScaleMode.Precise;
+            boundsControl.ScaleHandlesConfig.ScaleBehavior = HandleScaleMode.Precise;
             yield return VerifyInitialBoundsCorrect(boundsControl);
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
 
             // front right corner is corner 3
             var frontRightCornerPos = boundsControl.gameObject.transform.Find("rigRoot/corner_3").position;
 
-
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
-            // This particular test is sensitive to the number of test frames, and is run at a slower pace.
-            int numSteps = 30;
             var delta = new Vector3(0.1f, 0.1f, 0f);
-            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService, ArticulatedHandPose.GestureId.OpenSteadyGrabPoint, initialHandPosition);
-            yield return PlayModeTestUtilities.MoveHand(initialHandPosition, frontRightCornerPos, ArticulatedHandPose.GestureId.OpenSteadyGrabPoint, Handedness.Right, inputSimulationService, numSteps);
-            yield return PlayModeTestUtilities.MoveHand(frontRightCornerPos, frontRightCornerPos + delta, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService, numSteps);
+            TestHand hand = new TestHand(Handedness.Left);
+            yield return hand.Show(initialHandPosition);
+            yield return hand.MoveTo(frontRightCornerPos);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return hand.MoveTo(frontRightCornerPos + delta);
+            yield return null;
 
             var endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
-            Vector3 expectedCenter = new Vector3(0.0f, 0.0f, 1.5f);
-            Vector3 expectedSize = Vector3.one * .597f;
+            Vector3 expectedCenter = new Vector3(0.05f, 0.05f, 1.5f);
+            Vector3 expectedSize = Vector3.one * .6f;
             expectedSize.z = 0.5f;
             TestUtilities.AssertAboutEqual(endBounds.center, expectedCenter, "endBounds incorrect center");
             TestUtilities.AssertAboutEqual(endBounds.size, expectedSize, "endBounds incorrect size");

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
-        /// Uses near interaction to scale the bounds control by directly grabbing corner
+        /// Uses near interaction to scale the bounds control by directly grabbing corner - uniform scaling
         /// </summary>
         [UnityTest]
         public IEnumerator ScaleViaNearInteraction()
@@ -270,7 +270,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
-        /// Uses near interaction to scale the bounds control by directly grabbing corner
+        /// Uses near interaction to scale the bounds control by directly grabbing corner - precise scaling 
         /// </summary>
         [UnityTest]
         public IEnumerator ScaleNonUniform()

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -243,7 +243,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
 
             // front right corner is corner 3
             var frontRightCornerPos = boundsControl.gameObject.transform.Find("rigRoot/corner_3").position;
@@ -264,8 +263,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             TestUtilities.AssertAboutEqual(endBounds.center, expectedCenter, "endBounds incorrect center");
             TestUtilities.AssertAboutEqual(endBounds.size, expectedSize, "endBounds incorrect size");
 
-            GameObject.Destroy(boundsControl.gameObject);
-            // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
         }
 
@@ -278,7 +275,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
             boundsControl.ScaleHandlesConfig.ScaleBehavior = HandleScaleMode.NonUniform;
             yield return VerifyInitialBoundsCorrect(boundsControl);
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
 
             // front right corner is corner 3
             var frontRightCornerPos = boundsControl.gameObject.transform.Find("rigRoot/corner_3").position;
@@ -298,9 +294,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             expectedSize.z = 0.5f;
             TestUtilities.AssertAboutEqual(endBounds.center, expectedCenter, "endBounds incorrect center");
             TestUtilities.AssertAboutEqual(endBounds.size, expectedSize, "endBounds incorrect size");
-            
-            GameObject.Destroy(boundsControl.gameObject);
-            // Wait for a frame to give Unity a change to actually destroy the object
+
             yield return null;
         }
 


### PR DESCRIPTION
## Overview
- Added precise scaling mode to bounds control scale handles. 
- Added test to verify behavior for near interaction with control.

Note: there's another branch where I integrated the constraint manager into BC which will allow to combine non uniform scaling with scale axis locking. 

## Changes
- Fixes: #6734 

![nonuniformscale](https://user-images.githubusercontent.com/36998103/90173861-f697c680-dd9c-11ea-91fd-56280cf82638.gif)


## Verification
- added new test to verify proper scaling behavior as well as position / center modification when scaling is performed 
- manual tests on example scenes