### PR TITLE
Update WorldAnchorManager and StabilizationPlaneModifier for Unity 2020

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
@@ -4,14 +4,18 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using UnityEngine;
+
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using UnityEngine.XR.WSA;
+#endif // UNITY_WSA && !UNITY_2020_1_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
 {
-    [Serializable]
     /// <summary>
     /// StablizationPlaneOverride is a class used to describe the plane to be used by the StabilizationPlaneModifier class
     /// </summary>
+    [Serializable]
     public struct StabilizationPlaneOverride
     {
         /// <summary>
@@ -34,8 +38,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
     [AddComponentMenu("Scripts/MRTK/SDK/StabilizationPlaneModifier")]
     public class StabilizationPlaneModifier : MonoBehaviour
     {
-        [System.Serializable]
-        public enum StabilizationPlaneMode
+        [Serializable]
+        private enum StabilizationPlaneMode
         {
             /// <summary>
             /// Does not call SetFocusPoint
@@ -123,19 +127,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         private bool drawGizmos = false;
 #pragma warning restore 414
 
-        [SerializeField, Tooltip("Override plane to use. Usually used to set plane to a slate like a menu")]
+        [SerializeField, Tooltip("Override plane to use. Usually used to set plane to a slate like a menu.")]
         private StabilizationPlaneOverride overridePlane;
 
+        /// <summary>
+        /// Override plane to use. Usually used to set plane to a slate like a menu.
+        /// </summary>
         public StabilizationPlaneOverride OverridePlane
         {
-            get
-            {
-                return overridePlane;
-            }
-            set
-            {
-                overridePlane = value;
-            }
+            get => overridePlane;
+            set => overridePlane = value;
         }
 
         /// <summary>
@@ -310,14 +311,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             gazeToPlane.Normalize();
             planePosition = gazeOrigin + (gazeToPlane * currentPlaneDistance);
 
-#if UNITY_WSA
+#if UNITY_2019_3_OR_NEWER
+            XRSubsystemHelpers.DisplaySubsystem?.SetFocusPlane(planePosition, OverridePlane.Normal, velocity);
+#endif // UNITY_2019_3_OR_NEWER
+
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
             // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
             // with legacy requirements.
+            if (XRSettingsUtilities.IsLegacyXRActive)
+            {
 #pragma warning disable 0618
-            // Place the plane at the desired depth in front of the user and billboard it to the gaze origin.
-            HolographicSettings.SetFocusPointForFrame(planePosition, OverridePlane.Normal, velocity);
+                // Place the plane at the desired depth in front of the user and billboard it to the gaze origin.
+                HolographicSettings.SetFocusPointForFrame(planePosition, OverridePlane.Normal, velocity);
 #pragma warning restore 0618
-#endif
+            }
+#endif // UNITY_WSA && !UNITY_2020_1_OR_NEWER
 
             return gazeToPlane;
         }

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
@@ -3,7 +3,7 @@
 
 using UnityEngine;
 
-#if UNITY_WSA
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
 using System;
 using System.Collections.Generic;
 using UnityEngine.XR.WSA;
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         /// </summary>
         public bool PersistentAnchors => persistentAnchors;
 
-#if UNITY_WSA
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
         /// <summary>
         /// The WorldAnchorStore for the current application.
         /// Can be null when the application starts.
@@ -206,7 +206,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         }
 
         #endregion // Event Callbacks
-#endif
+#endif // UNITY_WSA && !UNITY_2020_1_OR_NEWER
 
         /// <summary>
         /// Attaches an anchor to the GameObject.
@@ -219,7 +219,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         /// <returns>The name of the newly attached anchor.</returns>
         public string AttachAnchor(GameObject gameObjectToAnchor, string anchorName = null)
         {
-#if !UNITY_WSA || UNITY_EDITOR
+#if !UNITY_WSA || UNITY_EDITOR || UNITY_2020_1_OR_NEWER
             Debug.LogWarning("World Anchor Manager does not work for this build. AttachAnchor will not be called.");
             return null;
 #else
@@ -247,7 +247,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             );
 
             return anchorName;
-#endif
+#endif // !UNITY_WSA || UNITY_EDITOR || UNITY_2020_1_OR_NEWER
         }
 
         /// <summary>
@@ -303,7 +303,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 return;
             }
 
-#if !UNITY_WSA || UNITY_EDITOR
+#if !UNITY_WSA || UNITY_EDITOR || UNITY_2020_1_OR_NEWER
             Debug.LogWarning("World Anchor Manager does not work for this build. RemoveAnchor will not be called.");
 #else
             // This case is unexpected, but just in case.
@@ -319,7 +319,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                     AnchorName = anchorName,
                     Operation = AnchorOperation.Delete
                 });
-#endif
+#endif // !UNITY_WSA || UNITY_EDITOR || UNITY_2020_1_OR_NEWER
         }
 
         /// <summary>
@@ -327,7 +327,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         /// </summary>
         public void RemoveAllAnchors()
         {
-#if !UNITY_WSA || UNITY_EDITOR
+#if !UNITY_WSA || UNITY_EDITOR || UNITY_2020_1_OR_NEWER
             Debug.LogWarning("World Anchor Manager does not work for this build. RemoveAnchor will not be called.");
 #else
             // This case is unexpected, but just in case.
@@ -363,10 +363,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                     Operation = AnchorOperation.Delete
                 });
             }
-#endif
+#endif // !UNITY_WSA || UNITY_EDITOR || UNITY_2020_1_OR_NEWER
         }
 
-#if UNITY_WSA
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
         /// <summary>
         /// Called before creating anchor.  Used to check if import required.
         /// </summary>
@@ -632,6 +632,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         {
             return string.IsNullOrEmpty(proposedAnchorName) ? gameObjectToAnchor.name : proposedAnchorName;
         }
-#endif
+#endif // UNITY_WSA && !UNITY_2020_1_OR_NEWER
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
@@ -105,12 +105,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         /// <summary>
         /// The queue for local device anchor operations.
         /// </summary>
-        private Queue<AnchorAttachmentInfo> LocalAnchorOperations = new Queue<AnchorAttachmentInfo>();
+        private readonly Queue<AnchorAttachmentInfo> localAnchorOperations = new Queue<AnchorAttachmentInfo>();
 
         /// <summary>
         /// Internal list of anchors and their GameObject references.
         /// </summary>
-        private Dictionary<string, GameObject> AnchorGameObjectReferenceList = new Dictionary<string, GameObject>(0);
+        private readonly Dictionary<string, GameObject> anchorGameObjectReferenceList = new Dictionary<string, GameObject>(0);
 
         #region Unity Methods
 
@@ -135,9 +135,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 return;
             }
 
-            if (LocalAnchorOperations.Count > 0)
+            if (localAnchorOperations.Count > 0)
             {
-                DoAnchorOperation(LocalAnchorOperations.Dequeue());
+                DoAnchorOperation(localAnchorOperations.Dequeue());
             }
         }
 
@@ -197,8 +197,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 }
 
                 GameObject anchoredObject;
-                AnchorGameObjectReferenceList.TryGetValue(anchor.name, out anchoredObject);
-                AnchorGameObjectReferenceList.Remove(anchor.name);
+                anchorGameObjectReferenceList.TryGetValue(anchor.name, out anchoredObject);
+                anchorGameObjectReferenceList.Remove(anchor.name);
                 AttachAnchor(anchoredObject, anchor.name);
             }
 
@@ -237,7 +237,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
 
             anchorName = GenerateAnchorName(gameObjectToAnchor, anchorName);
 
-            LocalAnchorOperations.Enqueue(
+            localAnchorOperations.Enqueue(
                 new AnchorAttachmentInfo
                 {
                     AnchoredGameObject = gameObjectToAnchor,
@@ -312,7 +312,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 Debug.LogWarning("[WorldAnchorManager] RemoveAnchor called before anchor store is ready.");
             }
 
-            LocalAnchorOperations.Enqueue(
+            localAnchorOperations.Enqueue(
                 new AnchorAttachmentInfo
                 {
                     AnchoredGameObject = gameObjectToUnanchor,
@@ -347,7 +347,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             {
                 // Let's check to see if there are anchors we weren't accounting for.
                 // Maybe they were created without using the WorldAnchorManager.
-                if (!AnchorGameObjectReferenceList.ContainsKey(anchors[i].name))
+                if (!anchorGameObjectReferenceList.ContainsKey(anchors[i].name))
                 {
                     Debug.LogWarning("[WorldAnchorManager] Removing an anchor that was created outside of the WorldAnchorManager.  Please use the WorldAnchorManager to create or delete anchors.");
                     if (anchorDebugText != null)
@@ -356,7 +356,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                     }
                 }
 
-                LocalAnchorOperations.Enqueue(new AnchorAttachmentInfo
+                localAnchorOperations.Enqueue(new AnchorAttachmentInfo
                 {
                     AnchorName = anchors[i].name,
                     AnchoredGameObject = anchors[i].gameObject,
@@ -473,7 +473,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 }
             }
 
-            AnchorGameObjectReferenceList.Add(anchorId, anchoredGameObject);
+            anchorGameObjectReferenceList.Add(anchorId, anchoredGameObject);
         }
 
         /// <summary>
@@ -484,7 +484,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             // If we don't have a GameObject reference, let's try to get the GameObject reference from our dictionary.
             if (!string.IsNullOrEmpty(anchorId) && anchoredGameObject == null)
             {
-                AnchorGameObjectReferenceList.TryGetValue(anchorId, out anchoredGameObject);
+                anchorGameObjectReferenceList.TryGetValue(anchorId, out anchoredGameObject);
             }
 
             if (anchoredGameObject != null)
@@ -516,7 +516,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
 
             if (!string.IsNullOrEmpty(anchorId))
             {
-                AnchorGameObjectReferenceList.Remove(anchorId);
+                anchorGameObjectReferenceList.Remove(anchorId);
                 DeleteAnchor(anchorId);
             }
             else

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
@@ -16,8 +16,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
     /// Wrapper around Unity's WorldAnchorStore to simplify usage of persistence operations.
     /// </summary>
     /// <remarks>
-    /// This class only functions when built for the WSA platform. It uses APIs that are only present
-    /// on that platform.
+    /// This class only functions when built for the WSA platform using legacy XR.
+    /// It uses APIs that are only present on that platform.
     /// </remarks>
     [AddComponentMenu("Scripts/MRTK/SDK/WorldAnchorManager")]
     public class WorldAnchorManager : MonoBehaviour

--- a/Assets/MRTK/SDK/Microsoft.MixedReality.Toolkit.SDK.asmdef
+++ b/Assets/MRTK/SDK/Microsoft.MixedReality.Toolkit.SDK.asmdef
@@ -3,7 +3,6 @@
     "references": [
         "Microsoft.MixedReality.Toolkit",
         "Microsoft.MixedReality.Toolkit.Async",
-        "Microsoft.MixedReality.Toolkit.Editor.Inspectors",
         "Microsoft.MixedReality.Toolkit.Editor.Utilities",
         "Microsoft.MixedReality.Toolkit.Services.InputAnimation",
         "Microsoft.MixedReality.Toolkit.Services.InputSimulation",


### PR DESCRIPTION
## Overview

1. Compiles out calls to legacy `XR.WSA` APIs on 2020.1+, where the APIs no longer exist.
1. Adds support for XR SDK's `SetFocusPlane` API in StabilizationPlaneModifier, to add back the functionality when running on non-legacy XR.
1. Removed an unused assembly reference in the SDK .asmdef.
1. Some formatting and code style updates.

WorldAnchorManager could be converted to the XR{ReferencePoint|Anchor}Subsystem, but there's still some active work on the WMR implementation of that subsystem underway that prevents testing. Once that work is done, we can revisit this component.

## Changes

- Part of #8269 
