### PR TITLE
Renaming hand to controller in input simulation related files

### DIFF
--- a/Assets/MRTK/Core/Providers/InputSimulation/BaseInputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/BaseInputSimulationService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -14,9 +15,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public abstract class BaseInputSimulationService : BaseInputDeviceManager
     {
         /// <summary>
-        /// Dictionary to capture all active hands detected
+        /// Dictionary to capture all active controllers detected
         /// </summary>
-        private readonly Dictionary<Handedness, SimulatedHand> trackedHands = new Dictionary<Handedness, SimulatedHand>();
+        private readonly Dictionary<Handedness, BaseController> trackedControllers = new Dictionary<Handedness, BaseController>();
 
         /// <summary>
         /// Active controllers
@@ -66,65 +67,74 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #endregion BaseInputDeviceManager Implementation
 
-        // Register input sources for hands based on hand data
-        protected void UpdateHandDevice(HandSimulationMode simulationMode, Handedness handedness, SimulatedHandData handData)
+        // Register input sources for controllers based on controller data
+        protected void UpdateControllerDevice(ControllerSimulationMode simulationMode, Handedness handedness, object controllerData)
         {
-            if (handData != null && handData.IsTracked)
+            if (controllerData != null)
             {
-                SimulatedHand controller = GetOrAddHandDevice(handedness, simulationMode);
-                controller.UpdateState(handData);
+                if(controllerData is SimulatedHandData handData && handData.IsTracked)
+                {
+                    
+                    SimulatedHand hand = GetOrAddControllerDevice(handedness, simulationMode) as SimulatedHand;
+                    hand.UpdateState(handData);
+                    return;
+                    
+                }
             }
-            else
-            {
-                RemoveHandDevice(handedness);
-            }
+            
+            RemoveControllerDevice(handedness);
+            
         }
 
-        public SimulatedHand GetHandDevice(Handedness handedness)
+        public BaseController GetControllerDevice(Handedness handedness)
         {
-            if (trackedHands.TryGetValue(handedness, out SimulatedHand controller))
+            if (trackedControllers.TryGetValue(handedness, out BaseController controller))
             {
                 return controller;
             }
             return null;
         }
 
-        protected SimulatedHand GetOrAddHandDevice(Handedness handedness, HandSimulationMode simulationMode)
+        protected BaseController GetOrAddControllerDevice(Handedness handedness, ControllerSimulationMode simulationMode)
         {
-            var controller = GetHandDevice(handedness);
+            var controller = GetControllerDevice(handedness);
             if (controller != null)
             {
-                if (controller.SimulationMode == simulationMode)
+                if (controller is SimulatedHand hand && hand.SimulationMode == simulationMode)
                 {
                     return controller;
                 }
                 else
                 {
-                    // Remove and recreate hand device if simulation mode doesn't match
-                    RemoveHandDevice(handedness);
+                    // Remove and recreate controller device if simulation mode doesn't match
+                    RemoveControllerDevice(handedness);
                 }
             }
 
-            DebugUtilities.LogVerboseFormat("GetOrAddHandDevice: Adding a new simulated hand of handedness {0} and simulation mode {1}", handedness, simulationMode);
+            DebugUtilities.LogVerboseFormat("GetOrAddControllerDevice: Adding a new simulated controller of handedness {0} and simulation mode {1}", handedness, simulationMode);
+            System.Type controllerType = null;
 
-            SupportedControllerType st = simulationMode == HandSimulationMode.Gestures ? SupportedControllerType.GGVHand : SupportedControllerType.ArticulatedHand;
-            IMixedRealityPointer[] pointers = RequestPointers(st, handedness);
-
-            var inputSource = Service?.RequestNewGenericInputSource($"{handedness} Hand", pointers, InputSourceType.Hand);
+            SupportedControllerType st;
+            IMixedRealityInputSource inputSource;
             switch (simulationMode)
             {
-                case HandSimulationMode.Articulated:
-                    controller = new SimulatedArticulatedHand(TrackingState.Tracked, handedness, inputSource);
-                    break;
-                case HandSimulationMode.Gestures:
+                case ControllerSimulationMode.HandGestures:
+                    st = SupportedControllerType.GGVHand;
+                    inputSource = Service?.RequestNewGenericInputSource($"{handedness} Hand", RequestPointers(st, handedness), InputSourceType.Hand);
                     controller = new SimulatedGestureHand(TrackingState.Tracked, handedness, inputSource);
+                    controllerType = typeof(SimulatedGestureHand);
+                    break;
+                case ControllerSimulationMode.ArticulatedHand:
+                    st = SupportedControllerType.ArticulatedHand;
+                    inputSource = Service?.RequestNewGenericInputSource($"{handedness} Hand", RequestPointers(st, handedness), InputSourceType.Hand);
+                    controller = new SimulatedArticulatedHand(TrackingState.Tracked, handedness, inputSource);
+                    controllerType = typeof(SimulatedArticulatedHand);
+                    break;
                     break;
                 default:
                     controller = null;
                     break;
             }
-
-            System.Type controllerType = simulationMode == HandSimulationMode.Gestures ? typeof(SimulatedGestureHand) : typeof(SimulatedArticulatedHand);
 
             if (controller == null || !controller.Enabled)
             {
@@ -141,44 +151,81 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             Service?.RaiseSourceDetected(controller.InputSource, controller);
 
-            trackedHands.Add(handedness, controller);
+            trackedControllers.Add(handedness, controller);
             UpdateActiveControllers();
 
             return controller;
         }
 
-        protected void RemoveHandDevice(Handedness handedness)
+        protected void RemoveControllerDevice(Handedness handedness)
         {
-            var controller = GetHandDevice(handedness);
+            var controller = GetControllerDevice(handedness);
             if (controller != null)
             {
-                DebugUtilities.LogVerboseFormat("RemoveHandDevice: Removing simulated hand of handedness", handedness);
+                DebugUtilities.LogVerboseFormat("RemoveHandDevice: Removing simulated controller of handedness", handedness);
 
                 Service?.RaiseSourceLost(controller.InputSource, controller);
 
                 RecyclePointers(controller.InputSource);
 
-                trackedHands.Remove(handedness);
+                trackedControllers.Remove(handedness);
                 UpdateActiveControllers();
             }
         }
 
-        protected void RemoveAllHandDevices()
+        protected void RemoveAllControllerDevices()
         {
-            foreach (var controller in trackedHands.Values)
+            foreach (var controller in trackedControllers.Values)
             {
                 Service?.RaiseSourceLost(controller.InputSource, controller);
 
                 RecyclePointers(controller.InputSource);
             }
 
-            trackedHands.Clear();
+            trackedControllers.Clear();
             UpdateActiveControllers();
         }
 
         private void UpdateActiveControllers()
         {
-            activeControllers = trackedHands.Values.ToArray<IMixedRealityController>();
+            activeControllers = trackedControllers.Values.ToArray<IMixedRealityController>();
         }
+
+        #region Obsolete Methods
+
+        // Register input sources for hands based on hand data
+        [Obsolete("Use UpdateControllerDevice instead.")]
+        protected void UpdateHandDevice(ControllerSimulationMode simulationMode, Handedness handedness, SimulatedHandData handData)
+        {
+            UpdateControllerDevice(simulationMode, handedness, handData);
+        }
+
+        [Obsolete("Use GetControllerDevice instead.")]
+        public SimulatedHand GetHandDevice(Handedness handedness)
+        {
+            return GetControllerDevice(handedness) as SimulatedHand;
+        }
+
+        [Obsolete("Use GetOrAddControllerDevice instead.")]
+        protected SimulatedHand GetOrAddHandDevice(Handedness handedness, ControllerSimulationMode simulationMode)
+        {
+            return GetOrAddControllerDevice(handedness, simulationMode) as SimulatedHand;
+        }
+
+        [Obsolete("Use RemoveControllerDevice instead.")]
+        protected void RemoveHandDevice(Handedness handedness)
+        {
+            RemoveControllerDevice(handedness);
+        }
+
+        [Obsolete("Use RemoveAllControllerDevices instead.")]
+        protected void RemoveAllHandDevices()
+        {
+            RemoveAllControllerDevices();
+        }
+
+        #endregion
+
+        
     }
 }

--- a/Assets/MRTK/Core/Providers/InputSimulation/BaseInputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/BaseInputSimulationService.cs
@@ -130,7 +130,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     controller = new SimulatedArticulatedHand(TrackingState.Tracked, handedness, inputSource);
                     controllerType = typeof(SimulatedArticulatedHand);
                     break;
-                    break;
                 default:
                     controller = null;
                     break;

--- a/Assets/MRTK/Core/Providers/InputSimulation/Editor/InputSimulationWindow.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/Editor/InputSimulationWindow.cs
@@ -189,28 +189,28 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void DrawHandsGUI()
         {
-            HandSimulationMode newHandSimMode = (HandSimulationMode)EditorGUILayout.EnumPopup("Hand Simulation Mode", SimulationService.HandSimulationMode);
+            ControllerSimulationMode newHandSimMode = (ControllerSimulationMode)EditorGUILayout.EnumPopup("Hand Simulation Mode", SimulationService.ControllerSimulationMode);
 
-            if (newHandSimMode != SimulationService.HandSimulationMode)
+            if (newHandSimMode != SimulationService.ControllerSimulationMode)
             {
-                SimulationService.HandSimulationMode = newHandSimMode;
+                SimulationService.ControllerSimulationMode = newHandSimMode;
             }
 
             using (new GUILayout.HorizontalScope())
             {
                 DrawHandGUI(
                     "Left",
-                    SimulationService.IsAlwaysVisibleHandLeft, v => SimulationService.IsAlwaysVisibleHandLeft = v,
-                    SimulationService.HandPositionLeft, v => SimulationService.HandPositionLeft = v,
-                    SimulationService.HandRotationLeft, v => SimulationService.HandRotationLeft = v,
-                    SimulationService.ResetHandLeft);
+                    SimulationService.IsAlwaysVisibleControllerLeft, v => SimulationService.IsAlwaysVisibleControllerLeft = v,
+                    SimulationService.ControllerPositionLeft, v => SimulationService.ControllerPositionLeft = v,
+                    SimulationService.ControllerRotationLeft, v => SimulationService.ControllerRotationLeft = v,
+                    SimulationService.ResetControllerLeft);
 
                 DrawHandGUI(
                     "Right",
-                    SimulationService.IsAlwaysVisibleHandRight, v => SimulationService.IsAlwaysVisibleHandRight = v,
-                    SimulationService.HandPositionRight, v => SimulationService.HandPositionRight = v,
-                    SimulationService.HandRotationRight, v => SimulationService.HandRotationRight = v,
-                    SimulationService.ResetHandRight);
+                    SimulationService.IsAlwaysVisibleControllerRight, v => SimulationService.IsAlwaysVisibleControllerRight = v,
+                    SimulationService.ControllerPositionRight, v => SimulationService.ControllerPositionRight = v,
+                    SimulationService.ControllerRotationRight, v => SimulationService.ControllerRotationRight = v,
+                    SimulationService.ResetControllerRight);
             }
         }
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/Editor/MixedRealityInputSimulationProfileInspector.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/Editor/MixedRealityInputSimulationProfileInspector.cs
@@ -35,17 +35,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private SerializedProperty lookHorizontal;
         private SerializedProperty lookVertical;
 
-        private SerializedProperty defaultHandSimulationMode;
+        private SerializedProperty defaultControllerSimulationMode;
 
         private SerializedProperty defaultEyeGazeSimulationMode;
 
-        private SerializedProperty toggleLeftHandKey;
-        private SerializedProperty toggleRightHandKey;
-        private SerializedProperty handHideTimeout;
-        private SerializedProperty leftHandManipulationKey;
-        private SerializedProperty rightHandManipulationKey;
-        private SerializedProperty mouseHandRotationSpeed;
-        private SerializedProperty handRotateButton;
+        private SerializedProperty toggleLeftControllerKey;
+        private SerializedProperty toggleRightControllerKey;
+        private SerializedProperty controllerHideTimeout;
+        private SerializedProperty leftControllerManipulationKey;
+        private SerializedProperty rightControllerManipulationKey;
+        private SerializedProperty mouseControllerRotationSpeed;
+        private SerializedProperty controllerRotateButton;
 
         private SerializedProperty defaultHandGesture;
         private SerializedProperty leftMouseHandGesture;
@@ -53,9 +53,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private SerializedProperty rightMouseHandGesture;
         private SerializedProperty handGestureAnimationSpeed;
 
-        private SerializedProperty defaultHandDistance;
-        private SerializedProperty handDepthMultiplier;
-        private SerializedProperty handJitterAmount;
+        private SerializedProperty defaultControllerDistance;
+        private SerializedProperty controllerDepthMultiplier;
+        private SerializedProperty controllerJitterAmount;
 
         private SerializedProperty holdStartDuration;
         private SerializedProperty navigationStartThreshold;
@@ -92,15 +92,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
             lookVertical = serializedObject.FindProperty("lookVertical");
 
             defaultEyeGazeSimulationMode = serializedObject.FindProperty("defaultEyeGazeSimulationMode");
-            defaultHandSimulationMode = serializedObject.FindProperty("defaultHandSimulationMode");
+            defaultControllerSimulationMode = serializedObject.FindProperty("defaultControllerSimulationMode");
 
-            toggleLeftHandKey = serializedObject.FindProperty("toggleLeftHandKey");
-            toggleRightHandKey = serializedObject.FindProperty("toggleRightHandKey");
-            handHideTimeout = serializedObject.FindProperty("handHideTimeout");
-            leftHandManipulationKey = serializedObject.FindProperty("leftHandManipulationKey");
-            rightHandManipulationKey = serializedObject.FindProperty("rightHandManipulationKey");
-            mouseHandRotationSpeed = serializedObject.FindProperty("mouseHandRotationSpeed");
-            handRotateButton = serializedObject.FindProperty("handRotateButton");
+            toggleLeftControllerKey = serializedObject.FindProperty("toggleLeftControllerKey");
+            toggleRightControllerKey = serializedObject.FindProperty("toggleRightControllerKey");
+            controllerHideTimeout = serializedObject.FindProperty("controllerHideTimeout");
+            leftControllerManipulationKey = serializedObject.FindProperty("leftControllerManipulationKey");
+            rightControllerManipulationKey = serializedObject.FindProperty("rightControllerManipulationKey");
+            mouseControllerRotationSpeed = serializedObject.FindProperty("mouseControllerRotationSpeed");
+            controllerRotateButton = serializedObject.FindProperty("controllerRotateButton");
 
             defaultHandGesture = serializedObject.FindProperty("defaultHandGesture");
             leftMouseHandGesture = serializedObject.FindProperty("leftMouseHandGesture");
@@ -111,9 +111,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             holdStartDuration = serializedObject.FindProperty("holdStartDuration");
             navigationStartThreshold = serializedObject.FindProperty("navigationStartThreshold");
 
-            defaultHandDistance = serializedObject.FindProperty("defaultHandDistance");
-            handDepthMultiplier = serializedObject.FindProperty("handDepthMultiplier");
-            handJitterAmount = serializedObject.FindProperty("handJitterAmount");
+            defaultControllerDistance = serializedObject.FindProperty("defaultControllerDistance");
+            controllerDepthMultiplier = serializedObject.FindProperty("controllerDepthMultiplier");
+            controllerJitterAmount = serializedObject.FindProperty("controllerJitterAmount");
         }
 
         public override void OnInspectorGUI()
@@ -170,13 +170,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     EditorGUILayout.BeginVertical("Label");
 
-                    EditorGUILayout.PropertyField(toggleLeftHandKey);
-                    EditorGUILayout.PropertyField(toggleRightHandKey);
-                    EditorGUILayout.PropertyField(handHideTimeout);
-                    EditorGUILayout.PropertyField(leftHandManipulationKey);
-                    EditorGUILayout.PropertyField(rightHandManipulationKey);
-                    EditorGUILayout.PropertyField(mouseHandRotationSpeed);
-                    EditorGUILayout.PropertyField(handRotateButton);
+                    EditorGUILayout.PropertyField(toggleLeftControllerKey);
+                    EditorGUILayout.PropertyField(toggleRightControllerKey);
+                    EditorGUILayout.PropertyField(controllerHideTimeout);
+                    EditorGUILayout.PropertyField(leftControllerManipulationKey);
+                    EditorGUILayout.PropertyField(rightControllerManipulationKey);
+                    EditorGUILayout.PropertyField(mouseControllerRotationSpeed);
+                    EditorGUILayout.PropertyField(controllerRotateButton);
                     EditorGUILayout.Space();
 
                     EditorGUILayout.PropertyField(defaultHandGesture);

--- a/Assets/MRTK/Core/Providers/InputSimulation/Editor/MixedRealityInputSimulationProfileInspector.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/Editor/MixedRealityInputSimulationProfileInspector.cs
@@ -166,7 +166,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 EditorGUILayout.PropertyField(defaultEyeGazeSimulationMode);
 
                 EditorGUILayout.Space();
-                EditorGUILayout.PropertyField(defaultHandSimulationMode);
+                EditorGUILayout.PropertyField(defaultControllerSimulationMode);
                 {
                     EditorGUILayout.BeginVertical("Label");
 
@@ -190,9 +190,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     EditorGUILayout.PropertyField(navigationStartThreshold);
                     EditorGUILayout.Space();
 
-                    EditorGUILayout.PropertyField(defaultHandDistance);
-                    EditorGUILayout.PropertyField(handDepthMultiplier);
-                    EditorGUILayout.PropertyField(handJitterAmount);
+                    EditorGUILayout.PropertyField(defaultControllerDistance);
+                    EditorGUILayout.PropertyField(controllerDepthMultiplier);
+                    EditorGUILayout.PropertyField(controllerJitterAmount);
                     EditorGUILayout.Space();
 
                     EditorGUILayout.EndVertical();

--- a/Assets/MRTK/Core/Providers/InputSimulation/IInputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/IInputSimulationService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -18,9 +19,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         EyeGazeSimulationMode EyeGazeSimulationMode { get; set; }
 
         /// <summary>
-        /// Simulated hand behavior.
+        /// Simulated controller behavior.
         /// </summary>
-        HandSimulationMode HandSimulationMode { get; set; }
+        ControllerSimulationMode ControllerSimulationMode { get; set; }
 
         /// <summary>
         /// Pose data for the left hand.
@@ -32,53 +33,116 @@ namespace Microsoft.MixedReality.Toolkit.Input
         SimulatedHandData HandDataRight { get; }
 
         /// <summary>
-        /// If true then keyboard and mouse input are used to simulate hands.
+        /// If true then keyboard and mouse input are used to simulate controllers.
         /// </summary>
         bool UserInputEnabled { get; set; }
 
         /// <summary>
+        /// The left controller is controlled by user input.
+        /// </summary>
+        bool IsSimulatingControllerLeft { get; }
+        /// <summary>
+        /// The right controller is controlled by user input.
+        /// </summary>
+        bool IsSimulatingControllerRight { get; }
+
+        /// <summary>
+        /// The left controller is always tracking.
+        /// </summary>
+        bool IsAlwaysVisibleControllerLeft { get; set; }
+        /// <summary>
+        /// The right controller is always tracking.
+        /// </summary>
+        bool IsAlwaysVisibleControllerRight { get; set; }
+
+        /// <summary>
+        /// Position of the left controller in view space.
+        /// </summary>
+        Vector3 ControllerPositionLeft { get; set; }
+        /// <summary>
+        /// Position of the right controller in view space.
+        /// </summary>
+        Vector3 ControllerPositionRight { get; set; }
+
+        /// <summary>
+        /// Rotation euler angles of the left controller in view space.
+        /// </summary>
+        Vector3 ControllerRotationLeft { get; set; }
+        /// <summary>
+        /// Rotation euler angles of the right controller in view space.
+        /// </summary>
+        Vector3 ControllerRotationRight { get; set; }
+
+        /// <summary>
+        /// Reset the left controller.
+        /// </summary>
+        void ResetControllerLeft();
+        /// <summary>
+        /// Reset the right controller.
+        /// </summary>
+        void ResetControllerRight();
+
+        #region Obsolete Properties
+        /// <summary>
+        /// Simulated hand behavior.
+        /// </summary>
+        [Obsolete("Use ControllerSimulationMode instead.")]
+        HandSimulationMode HandSimulationMode { get; set; }
+
+        /// <summary>
         /// The left hand is controlled by user input.
         /// </summary>
+        [Obsolete("Use IsSimulatingControllerLeft instead.")]
         bool IsSimulatingHandLeft { get; }
         /// <summary>
         /// The right hand is controlled by user input.
         /// </summary>
+        [Obsolete("Use IsSimulatingControllerRight instead.")]
         bool IsSimulatingHandRight { get; }
 
         /// <summary>
         /// The left hand is always tracking.
         /// </summary>
+        [Obsolete("Use IsAlwaysVisibleControllerLeft instead.")]
         bool IsAlwaysVisibleHandLeft { get; set; }
         /// <summary>
         /// The right hand is always tracking.
         /// </summary>
+        [Obsolete("Use IsAlwaysVisibleControllerRight instead.")]
         bool IsAlwaysVisibleHandRight { get; set; }
 
         /// <summary>
         /// Position of the left hand in view space.
         /// </summary>
+        [Obsolete("Use ControllerPositionLeft instead.")]
         Vector3 HandPositionLeft { get; set; }
         /// <summary>
         /// Position of the right hand in view space.
         /// </summary>
+        [Obsolete("Use ControllerPositionRight instead.")]
         Vector3 HandPositionRight { get; set; }
 
         /// <summary>
         /// Rotation euler angles of the left hand in view space.
         /// </summary>
+        [Obsolete("Use ControllerRotationLeft instead.")]
         Vector3 HandRotationLeft { get; set; }
         /// <summary>
         /// Rotation euler angles of the right hand in view space.
         /// </summary>
+        [Obsolete("Use ControllerRotationRight instead.")]
         Vector3 HandRotationRight { get; set; }
 
         /// <summary>
         /// Reset the left hand.
         /// </summary>
+        [Obsolete("Use ResetControllerLeft instead.")]
         void ResetHandLeft();
         /// <summary>
         /// Reset the right hand.
         /// </summary>
+        [Obsolete("Use ResetControllerRight instead.")]
         void ResetHandRight();
+        #endregion
     }
 }

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputPlaybackService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputPlaybackService.cs
@@ -189,7 +189,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                 }))
             {
-                UpdateHandDevice(HandSimulationMode.Articulated, handedness, handData);
+                UpdateControllerDevice(ControllerSimulationMode.ArticulatedHand, handedness, handData);
             }
         }
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationEnum.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationEnum.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -43,25 +44,58 @@ namespace Microsoft.MixedReality.Toolkit.Input
     }
 
     /// <summary>
-    /// Defines for how input simulation handles hands
+    /// Defines for how input simulation handles controllers
     /// </summary>
-    public enum HandSimulationMode
+    public enum ControllerSimulationMode
     {
 
         /// <summary>
-        /// Disable hand simulation
+        /// Disable controller simulation
         /// </summary>
         Disabled,
 
         /// <summary>
-        /// Raises gesture events only
+        /// Raises hand gesture events only
         /// </summary>
-        Gestures,
+        HandGestures,
 
         /// <summary>
         /// Provide a fully articulated hand controller
         /// </summary>
-        Articulated,
+        ArticulatedHand,
+
+        /// <summary>
+        /// Provide a 6DoF motion controller
+        /// </summary>
+        MotionController,
+    }
+
+    /// <summary>
+    /// Defines for how input simulation handles controllers
+    /// </summary>
+    [Obsolete("Use ControllerSimulationMode instead.")]
+    public enum HandSimulationMode
+    {
+
+        /// <summary>
+        /// Disable controller simulation
+        /// </summary>
+        Disabled = ControllerSimulationMode.Disabled,
+
+        /// <summary>
+        /// Raises hand gesture events only
+        /// </summary>
+        Gestures = ControllerSimulationMode.HandGestures,
+
+        /// <summary>
+        /// Provide a fully articulated hand controller
+        /// </summary>
+        Articulated = ControllerSimulationMode.ArticulatedHand,
+
+        /// <summary>
+        /// Provide a 6DoF motion controller
+        /// </summary>
+        MotionController = ControllerSimulationMode.MotionController,
     }
 
 }

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationEnum.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationEnum.cs
@@ -70,6 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         MotionController,
     }
 
+    #region Obsolete Enum
     /// <summary>
     /// Defines for how input simulation handles controllers
     /// </summary>
@@ -97,5 +98,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         MotionController = ControllerSimulationMode.MotionController,
     }
+    #endregion
 
 }

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
@@ -46,18 +46,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         IMixedRealityCapabilityCheck
     {
         private ManualCameraControl cameraControl = null;
-        private SimulatedHandDataProvider handDataProvider = null;
+        private SimulatedDataProvider dataProvider = null;
 
-        private HandSimulationMode handSimulationMode;
         /// <inheritdoc />
-        public HandSimulationMode HandSimulationMode
-        {
-            get => handSimulationMode;
-            set
-            {
-                handSimulationMode = value;
-            }
-        }
+        public ControllerSimulationMode ControllerSimulationMode { get; set; }
 
         /// <inheritdoc />
         public SimulatedHandData HandDataLeft { get; } = new SimulatedHandData();
@@ -67,67 +59,67 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private SimulatedHandData HandDataGaze { get; } = new SimulatedHandData();
 
         /// <inheritdoc />
-        public bool IsSimulatingHandLeft => (handDataProvider != null ? handDataProvider.IsSimulatingLeft : false);
+        public bool IsSimulatingControllerLeft => (dataProvider != null ? dataProvider.IsSimulatingLeft : false);
         /// <inheritdoc />
-        public bool IsSimulatingHandRight => (handDataProvider != null ? handDataProvider.IsSimulatingRight : false);
+        public bool IsSimulatingControllerRight => (dataProvider != null ? dataProvider.IsSimulatingRight : false);
 
         /// <inheritdoc />
-        public bool IsAlwaysVisibleHandLeft
+        public bool IsAlwaysVisibleControllerLeft
         {
-            get { return handDataProvider != null ? handDataProvider.IsAlwaysVisibleLeft : false; }
-            set { if (handDataProvider != null) { handDataProvider.IsAlwaysVisibleLeft = value; } }
+            get { return dataProvider != null ? dataProvider.IsAlwaysVisibleLeft : false; }
+            set { if (dataProvider != null) { dataProvider.IsAlwaysVisibleLeft = value; } }
         }
 
         /// <inheritdoc />
-        public bool IsAlwaysVisibleHandRight
+        public bool IsAlwaysVisibleControllerRight
         {
-            get { return handDataProvider != null ? handDataProvider.IsAlwaysVisibleRight : false; }
-            set { if (handDataProvider != null) { handDataProvider.IsAlwaysVisibleRight = value; } }
+            get { return dataProvider != null ? dataProvider.IsAlwaysVisibleRight : false; }
+            set { if (dataProvider != null) { dataProvider.IsAlwaysVisibleRight = value; } }
         }
 
         /// <inheritdoc />
-        public Vector3 HandPositionLeft
+        public Vector3 ControllerPositionLeft
         {
-            get { return handDataProvider != null ? handDataProvider.HandStateLeft.ViewportPosition : Vector3.zero; }
-            set { if (handDataProvider != null) { handDataProvider.HandStateLeft.ViewportPosition = value; } }
+            get { return dataProvider != null ? dataProvider.InputStateLeft.ViewportPosition : Vector3.zero; }
+            set { if (dataProvider != null) { dataProvider.InputStateLeft.ViewportPosition = value; } }
         }
 
         /// <inheritdoc />
-        public Vector3 HandPositionRight
+        public Vector3 ControllerPositionRight
         {
-            get { return handDataProvider != null ? handDataProvider.HandStateRight.ViewportPosition : Vector3.zero; }
-            set { if (handDataProvider != null) { handDataProvider.HandStateRight.ViewportPosition = value; } }
+            get { return dataProvider != null ? dataProvider.InputStateRight.ViewportPosition : Vector3.zero; }
+            set { if (dataProvider != null) { dataProvider.InputStateRight.ViewportPosition = value; } }
         }
 
         /// <inheritdoc />
-        public Vector3 HandRotationLeft
+        public Vector3 ControllerRotationLeft
         {
-            get { return handDataProvider != null ? handDataProvider.HandStateLeft.ViewportRotation : Vector3.zero; }
-            set { if (handDataProvider != null) { handDataProvider.HandStateLeft.ViewportRotation = value; } }
+            get { return dataProvider != null ? dataProvider.InputStateLeft.ViewportRotation : Vector3.zero; }
+            set { if (dataProvider != null) { dataProvider.InputStateLeft.ViewportRotation = value; } }
         }
 
         /// <inheritdoc />
-        public Vector3 HandRotationRight
+        public Vector3 ControllerRotationRight
         {
-            get { return handDataProvider != null ? handDataProvider.HandStateRight.ViewportRotation : Vector3.zero; }
-            set { if (handDataProvider != null) { handDataProvider.HandStateRight.ViewportRotation = value; } }
+            get { return dataProvider != null ? dataProvider.InputStateRight.ViewportRotation : Vector3.zero; }
+            set { if (dataProvider != null) { dataProvider.InputStateRight.ViewportRotation = value; } }
         }
 
         /// <inheritdoc />
-        public void ResetHandLeft()
+        public void ResetControllerLeft()
         {
-            if (handDataProvider != null)
+            if (dataProvider != null)
             {
-                handDataProvider.ResetHand(Handedness.Left);
+                dataProvider.ResetInput(Handedness.Left);
             }
         }
 
         /// <inheritdoc />
-        public void ResetHandRight()
+        public void ResetControllerRight()
         {
-            if (handDataProvider != null)
+            if (dataProvider != null)
             {
-                handDataProvider.ResetHand(Handedness.Right);
+                dataProvider.ResetInput(Handedness.Right);
             }
         }
 
@@ -139,35 +131,26 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             get
             {
-                return eyeGazeSimulationMode != EyeGazeSimulationMode.Disabled;
+                return EyeGazeSimulationMode != EyeGazeSimulationMode.Disabled;
             }
             set
             {
-                eyeGazeSimulationMode = value ? EyeGazeSimulationMode.CameraForwardAxis : EyeGazeSimulationMode.Disabled;
+                EyeGazeSimulationMode = value ? EyeGazeSimulationMode.CameraForwardAxis : EyeGazeSimulationMode.Disabled;
             }
         }
 
-        private EyeGazeSimulationMode eyeGazeSimulationMode;
         /// <inheritdoc />
-        public EyeGazeSimulationMode EyeGazeSimulationMode
-        {
-            get => eyeGazeSimulationMode;
-            set
-            {
-                eyeGazeSimulationMode = value;
-            }
-        }
-
+        public EyeGazeSimulationMode EyeGazeSimulationMode { get; set; }
 
         /// <summary>
-        /// If true then keyboard and mouse input are used to simulate hands.
+        /// If true then keyboard and mouse input are used to simulate controllers.
         /// </summary>
         public bool UserInputEnabled { get; set; } = true;
 
         /// <summary>
-        /// Timestamp of the last hand device update
+        /// Timestamp of the last controller device update
         /// </summary>
-        private long lastHandUpdateTimestamp = 0;
+        private long lastControllerUpdateTimestamp = 0;
 
         /// <summary>
         /// Indicators to show input simulation state in the viewport.
@@ -223,11 +206,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             switch (capability)
             {
                 case MixedRealityCapability.ArticulatedHand:
-                    return (HandSimulationMode == HandSimulationMode.Articulated);
+                    return (ControllerSimulationMode == ControllerSimulationMode.ArticulatedHand);
 
                 case MixedRealityCapability.GGVHand:
                     // If any hand simulation is enabled, GGV interactions are supported.
-                    return (HandSimulationMode != HandSimulationMode.Disabled);
+                    return (ControllerSimulationMode != ControllerSimulationMode.Disabled);
 
                 case MixedRealityCapability.EyeTracking:
                     return EyeGazeSimulationMode != EyeGazeSimulationMode.Disabled;
@@ -241,7 +224,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.Initialize();
 
-            HandSimulationMode = InputSimulationProfile.DefaultHandSimulationMode;
+            ControllerSimulationMode = InputSimulationProfile.DefaultControllerSimulationMode;
             EyeGazeSimulationMode = InputSimulationProfile.DefaultEyeGazeSimulationMode;
         }
 
@@ -277,7 +260,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             DisableCameraControl();
-            DisableHandSimulation();
+            DisableControllerSimulation();
         }
 
         /// <inheritdoc />
@@ -287,14 +270,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             var profile = InputSimulationProfile;
 
-            switch (HandSimulationMode)
+            switch (ControllerSimulationMode)
             {
-                case HandSimulationMode.Disabled:
-                    DisableHandSimulation();
+                case ControllerSimulationMode.Disabled:
+                    DisableControllerSimulation();
                     break;
 
-                case HandSimulationMode.Articulated:
-                case HandSimulationMode.Gestures:
+                case ControllerSimulationMode.ArticulatedHand:
+                case ControllerSimulationMode.HandGestures:
                     EnableHandSimulation();
                     break;
             }
@@ -318,9 +301,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             if (UserInputEnabled)
             {
-                if (handDataProvider != null)
+                if (dataProvider != null)
                 {
-                    handDataProvider.UpdateHandData(HandDataLeft, HandDataRight, HandDataGaze, mouseDelta);
+                    if (dataProvider is SimulatedHandDataProvider handDataProvider)
+                    {
+                        handDataProvider.UpdateHandData(HandDataLeft, HandDataRight, HandDataGaze, mouseDelta);
+                    }
                 }
 
                 if (cameraControl != null && CameraCache.Main)
@@ -355,24 +341,34 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             // Apply hand data in LateUpdate to ensure external changes are applied.
             // HandDataLeft/Right can be modified after the services Update() call.
-            if (HandSimulationMode == HandSimulationMode.Disabled)
+            if (ControllerSimulationMode == ControllerSimulationMode.Disabled)
             {
-                RemoveAllHandDevices();
+                RemoveAllControllerDevices();
             }
             else
             {
                 DateTime currentTime = DateTime.UtcNow;
-                double msSinceLastHandUpdate = currentTime.Subtract(new DateTime(lastHandUpdateTimestamp)).TotalMilliseconds;
+                double msSinceLastControllerUpdate = currentTime.Subtract(new DateTime(lastControllerUpdateTimestamp)).TotalMilliseconds;
                 // TODO implement custom hand device update frequency here, use 1000/fps instead of 0
-                if (msSinceLastHandUpdate > 0)
+                if (msSinceLastControllerUpdate > 0)
                 {
-                    UpdateHandDevice(HandSimulationMode, Handedness.Left, HandDataLeft);
-                    UpdateHandDevice(HandSimulationMode, Handedness.Right, HandDataRight);
+                    object controllerDataLeft = null;
+                    object controllerDataRight = null;
+                    switch (ControllerSimulationMode)
+                    {
+                        case ControllerSimulationMode.ArticulatedHand:
+                        case ControllerSimulationMode.HandGestures:
+                            controllerDataLeft = HandDataLeft;
+                            controllerDataRight = HandDataRight;
+                            break;
+                    }
+                    UpdateControllerDevice(ControllerSimulationMode, Handedness.Left, controllerDataLeft);
+                    UpdateControllerDevice(ControllerSimulationMode, Handedness.Right, controllerDataRight);
 
                     // HandDataGaze is only enabled if the user is simulating via mouse and keyboard
                     if (UserInputEnabled && profile.IsHandsFreeInputEnabled)
-                        UpdateHandDevice(HandSimulationMode.Gestures, Handedness.None, HandDataGaze);
-                    lastHandUpdateTimestamp = currentTime.Ticks;
+                        UpdateControllerDevice(ControllerSimulationMode.HandGestures, Handedness.None, HandDataGaze);
+                    lastControllerUpdateTimestamp = currentTime.Ticks;
                 }
             }
         }
@@ -422,21 +418,30 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void EnableHandSimulation()
         {
-            if (handDataProvider == null)
+            if (dataProvider == null)
             {
                 DebugUtilities.LogVerbose("Creating a new hand simulation data provider");
-                handDataProvider = new SimulatedHandDataProvider(InputSimulationProfile);
+                dataProvider = new SimulatedHandDataProvider(InputSimulationProfile);
             }
         }
 
-        private void DisableHandSimulation()
+        private void EnableControllerSimulation()
         {
-            RemoveAllHandDevices();
-
-            if (handDataProvider != null)
+            if (dataProvider == null)
             {
-                DebugUtilities.LogVerbose("Destroying the hand simulation data provider");
-                handDataProvider = null;
+                DebugUtilities.LogVerbose("Creating a new controller simulation data provider");
+                dataProvider = new SimulatedControllerDataProvider(InputSimulationProfile);
+            }
+        }
+
+        private void DisableControllerSimulation()
+        {
+            RemoveAllControllerDevices();
+
+            if (dataProvider != null)
+            {
+                DebugUtilities.LogVerbose("Destroying the controller simulation data provider");
+                dataProvider = null;
             }
         }
 
@@ -486,7 +491,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 // Interpret scroll values as world space delta
-                worldDelta.z *= profile.HandDepthMultiplier;
+                worldDelta.z *= profile.ControllerDepthMultiplier;
 
                 Vector2 worldDepthDelta = new Vector2(worldDelta.z, 0);
 
@@ -551,5 +556,87 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             return new Vector2(deltaViewport3D.x, deltaViewport3D.y);
         }
+
+        #region Obsolete Properties and Methods
+        /// <inheritdoc />
+        [Obsolete("Use ControllerSimulationMode instead.")]
+        public HandSimulationMode HandSimulationMode
+        {
+            get => (HandSimulationMode)ControllerSimulationMode;
+            set
+            {
+                ControllerSimulationMode = (ControllerSimulationMode)value;
+            }
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use IsSimulatingControllerLeft instead.")]
+        public bool IsSimulatingHandLeft => IsSimulatingControllerLeft;
+        /// <inheritdoc />
+        [Obsolete("Use IsSimulatingControllerRight instead.")]
+        public bool IsSimulatingHandRight => IsSimulatingControllerRight;
+
+        /// <inheritdoc />
+        [Obsolete("Use IsAlwaysVisibleControllerLeft instead.")]
+        public bool IsAlwaysVisibleHandLeft
+        {
+            get => IsAlwaysVisibleControllerLeft;
+            set { IsAlwaysVisibleControllerLeft = value; }
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use IsAlwaysVisibleControllerRight instead.")]
+        public bool IsAlwaysVisibleHandRight
+        {
+            get => IsAlwaysVisibleControllerRight;
+            set { IsAlwaysVisibleControllerRight = value; }
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ControllerPositionLeft instead.")]
+        public Vector3 HandPositionLeft
+        {
+            get => ControllerPositionLeft;
+            set { ControllerPositionLeft = value; }
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ControllerPositionRight instead.")]
+        public Vector3 HandPositionRight
+        {
+            get => ControllerPositionRight;
+            set { ControllerPositionRight = value; }
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ControllerRotationLeft instead.")]
+        public Vector3 HandRotationLeft
+        {
+            get => ControllerRotationLeft;
+            set { ControllerRotationLeft = value; }
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ControllerRotationRight instead.")]
+        public Vector3 HandRotationRight
+        {
+            get => ControllerRotationRight;
+            set { ControllerRotationRight = value; }
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ResetControllerLeft instead.")]
+        public void ResetHandLeft()
+        {
+            ResetControllerLeft();
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use ResetControllerRight instead.")]
+        public void ResetHandRight()
+        {
+            ResetControllerRight();
+        }
+        #endregion
     }
 }

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         IMixedRealityCapabilityCheck
     {
         private ManualCameraControl cameraControl = null;
-        private SimulatedDataProvider dataProvider = null;
+        private SimulatedHandDataProvider dataProvider = null;
 
         /// <inheritdoc />
         public ControllerSimulationMode ControllerSimulationMode { get; set; }
@@ -80,29 +80,29 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public Vector3 ControllerPositionLeft
         {
-            get { return dataProvider != null ? dataProvider.InputStateLeft.ViewportPosition : Vector3.zero; }
-            set { if (dataProvider != null) { dataProvider.InputStateLeft.ViewportPosition = value; } }
+            get { return dataProvider != null ? dataProvider.HandStateLeft.ViewportPosition : Vector3.zero; }
+            set { if (dataProvider != null) { dataProvider.HandStateLeft.ViewportPosition = value; } }
         }
 
         /// <inheritdoc />
         public Vector3 ControllerPositionRight
         {
-            get { return dataProvider != null ? dataProvider.InputStateRight.ViewportPosition : Vector3.zero; }
-            set { if (dataProvider != null) { dataProvider.InputStateRight.ViewportPosition = value; } }
+            get { return dataProvider != null ? dataProvider.HandStateRight.ViewportPosition : Vector3.zero; }
+            set { if (dataProvider != null) { dataProvider.HandStateRight.ViewportPosition = value; } }
         }
 
         /// <inheritdoc />
         public Vector3 ControllerRotationLeft
         {
-            get { return dataProvider != null ? dataProvider.InputStateLeft.ViewportRotation : Vector3.zero; }
-            set { if (dataProvider != null) { dataProvider.InputStateLeft.ViewportRotation = value; } }
+            get { return dataProvider != null ? dataProvider.HandStateLeft.ViewportRotation : Vector3.zero; }
+            set { if (dataProvider != null) { dataProvider.HandStateLeft.ViewportRotation = value; } }
         }
 
         /// <inheritdoc />
         public Vector3 ControllerRotationRight
         {
-            get { return dataProvider != null ? dataProvider.InputStateRight.ViewportRotation : Vector3.zero; }
-            set { if (dataProvider != null) { dataProvider.InputStateRight.ViewportRotation = value; } }
+            get { return dataProvider != null ? dataProvider.HandStateRight.ViewportRotation : Vector3.zero; }
+            set { if (dataProvider != null) { dataProvider.HandStateRight.ViewportRotation = value; } }
         }
 
         /// <inheritdoc />
@@ -110,7 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (dataProvider != null)
             {
-                dataProvider.ResetInput(Handedness.Left);
+                dataProvider.ResetHand(Handedness.Left);
             }
         }
 
@@ -119,7 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (dataProvider != null)
             {
-                dataProvider.ResetInput(Handedness.Right);
+                dataProvider.ResetHand(Handedness.Right);
             }
         }
 
@@ -422,15 +422,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 DebugUtilities.LogVerbose("Creating a new hand simulation data provider");
                 dataProvider = new SimulatedHandDataProvider(InputSimulationProfile);
-            }
-        }
-
-        private void EnableControllerSimulation()
-        {
-            if (dataProvider == null)
-            {
-                DebugUtilities.LogVerbose("Creating a new controller simulation data provider");
-                dataProvider = new SimulatedControllerDataProvider(InputSimulationProfile);
             }
         }
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/MixedRealityInputSimulationProfile.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/MixedRealityInputSimulationProfile.cs
@@ -201,66 +201,74 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public EyeGazeSimulationMode DefaultEyeGazeSimulationMode => defaultEyeGazeSimulationMode;
 
-        [Header("Hand Simulation")]
+        [Header("Controller Simulation")]
         [SerializeField]
-        [Tooltip("Enable hand simulation")]
+        [Tooltip("Enable controller simulation")]
         [FormerlySerializedAs("handSimulationMode")]
-        private HandSimulationMode defaultHandSimulationMode = HandSimulationMode.Articulated;
+        [FormerlySerializedAs("defaultHandSimulationMode")]
+        private ControllerSimulationMode defaultControllerSimulationMode = ControllerSimulationMode.ArticulatedHand;
         /// <summary>
-        /// Enable hand simulation
+        /// Enable controller simulation
         /// </summary>
-        public HandSimulationMode DefaultHandSimulationMode => defaultHandSimulationMode;
+        public ControllerSimulationMode DefaultControllerSimulationMode => defaultControllerSimulationMode;
 
-        [Header("Hand Control Settings")]
+        [Header("Controller Control Settings")]
         [SerializeField]
-        [Tooltip("Key to toggle persistent mode for the left hand")]
-        private KeyBinding toggleLeftHandKey = KeyBinding.FromKey(KeyCode.T);
+        [Tooltip("Key to toggle persistent mode for the left controller")]
+        [FormerlySerializedAs("toggleLeftHandKey")]
+        private KeyBinding toggleLeftControllerKey = KeyBinding.FromKey(KeyCode.T);
         /// <summary>
-        /// Key to toggle persistent mode for the left hand
+        /// Key to toggle persistent mode for the left controller
         /// </summary>
-        public KeyBinding ToggleLeftHandKey => toggleLeftHandKey;
+        public KeyBinding ToggleLeftControllerKey => toggleLeftControllerKey;
         [SerializeField]
-        [Tooltip("Key to toggle persistent mode for the right hand")]
-        private KeyBinding toggleRightHandKey = KeyBinding.FromKey(KeyCode.Y);
+        [Tooltip("Key to toggle persistent mode for the right controller")]
+        [FormerlySerializedAs("toggleRightHandKey")]
+        private KeyBinding toggleRightControllerKey = KeyBinding.FromKey(KeyCode.Y);
         /// <summary>
-        /// Key to toggle persistent mode for the right hand
+        /// Key to toggle persistent mode for the right controller
         /// </summary>
-        public KeyBinding ToggleRightHandKey => toggleRightHandKey;
+        public KeyBinding ToggleRightControllerKey => toggleRightControllerKey;
         [SerializeField]
-        [Tooltip("Time after which uncontrolled hands are hidden")]
-        private float handHideTimeout = 0.2f;
+        [Tooltip("Time after which uncontrolled controllers are hidden")]
+        [FormerlySerializedAs("handHideTimeout")]
+        private float controllerHideTimeout = 0.2f;
         /// <summary>
-        /// Time after which uncontrolled hands are hidden
+        /// Time after which uncontrolled controllers are hidden
         /// </summary>
-        public float HandHideTimeout => handHideTimeout;
+        public float ControllerHideTimeout => controllerHideTimeout;
         [SerializeField]
-        [Tooltip("Key to manipulate the left hand")]
-        private KeyBinding leftHandManipulationKey = KeyBinding.FromKey(KeyCode.LeftShift);
+        [Tooltip("Key to manipulate the left controller")]
+        [FormerlySerializedAs("leftHandManipulationKey")]
+        private KeyBinding leftControllerManipulationKey = KeyBinding.FromKey(KeyCode.LeftShift);
         /// <summary>
-        /// Key to manipulate the left hand
+        /// Key to manipulate the left controller
         /// </summary>
-        public KeyBinding LeftHandManipulationKey => leftHandManipulationKey;
+        public KeyBinding LeftControllerManipulationKey => leftControllerManipulationKey;
         [SerializeField]
-        [Tooltip("Key to manipulate the right hand")]
-        private KeyBinding rightHandManipulationKey = KeyBinding.FromKey(KeyCode.Space);
+        [Tooltip("Key to manipulate the right controller")]
+        [FormerlySerializedAs("rightHandManipulationKey")]
+        private KeyBinding rightControllerManipulationKey = KeyBinding.FromKey(KeyCode.Space);
         /// <summary>
-        /// Key to manipulate the right hand
+        /// Key to manipulate the right controller
         /// </summary>
-        public KeyBinding RightHandManipulationKey => rightHandManipulationKey;
+        public KeyBinding RightControllerManipulationKey => rightControllerManipulationKey;
         [SerializeField]
         [Tooltip("Additional rotation factor after input smoothing has been applied")]
-        private float mouseHandRotationSpeed = 6.0f;
+        [FormerlySerializedAs("mouseHandRotationSpeed")]
+        private float mouseControllerRotationSpeed = 6.0f;
         /// <summary>
         /// Additional rotation factor after input smoothing has been applied
         /// </summary>
-        public float MouseHandRotationSpeed => mouseHandRotationSpeed;
+        public float MouseControllerRotationSpeed => mouseControllerRotationSpeed;
         [SerializeField]
-        [Tooltip("Controls how hand rotation is activated")]
-        private KeyBinding handRotateButton = KeyBinding.FromKey(KeyCode.LeftControl);
+        [Tooltip("Controls how controller rotation is activated")]
+        [FormerlySerializedAs("handRotateButton")]
+        private KeyBinding controllerRotateButton = KeyBinding.FromKey(KeyCode.LeftControl);
         /// <summary>
-        /// Controls how hand rotation is activated
+        /// Controls how controller rotation is activated
         /// </summary>
-        public KeyBinding HandRotateButton => handRotateButton;
+        public KeyBinding ControllerRotateButton => controllerRotateButton;
 
         [Header("Hand Gesture Settings")]
         [SerializeField]
@@ -315,27 +323,89 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public float NavigationStartThreshold => navigationStartThreshold;
 
-        [Header("Hand Placement Settings")]
+        [Header("Controller Placement Settings")]
         [SerializeField]
-        [Tooltip("Default distance of the hand from the camera")]
-        private float defaultHandDistance = 0.5f;
+        [Tooltip("Default distance of the controller from the camera")]
+        [FormerlySerializedAs("defaultHandDistance")]
+        private float defaultControllerDistance = 0.5f;
         /// <summary>
-        /// Default distance of the hand from the camera
+        /// Default distance of the controller from the camera
         /// </summary>
-        public float DefaultHandDistance => defaultHandDistance;
+        public float DefaultControllerDistance => defaultControllerDistance;
         [SerializeField]
         [Tooltip("Depth change when scrolling the mouse wheel")]
-        private float handDepthMultiplier = 0.03f;
+        [FormerlySerializedAs("handDepthMultiplier")]
+        private float controllerDepthMultiplier = 0.03f;
         /// <summary>
         /// Depth change when scrolling the mouse wheel
         /// </summary>
-        public float HandDepthMultiplier => handDepthMultiplier;
+        public float ControllerDepthMultiplier => controllerDepthMultiplier;
         [SerializeField]
-        [Tooltip("Apply random offset to the hand position")]
-        private float handJitterAmount = 0.0f;
+        [Tooltip("Apply random offset to the controller position")]
+        [FormerlySerializedAs("handJitterAmount")]
+        private float controllerJitterAmount = 0.0f;
+        /// <summary>
+        /// Apply random offset to the controller position
+        /// </summary>
+        public float ControllerJitterAmount => controllerJitterAmount;
+        [SerializeField]
+
+        #region Obsolete Properties
+        /// <summary>
+        /// Enable controller simulation
+        /// </summary>
+        [Obsolete("Use DefaultControllerSimulationMode instead.")]
+        public ControllerSimulationMode DefaultHandSimulationMode => DefaultControllerSimulationMode;
+        /// <summary>
+        /// Key to toggle persistent mode for the left controller
+        /// </summary>
+        [Obsolete("Use ToggleLeftControllerKey instead.")]
+        public KeyBinding ToggleLeftHandKey => ToggleLeftControllerKey;
+        /// <summary>
+        /// Key to toggle persistent mode for the right controller
+        /// </summary>
+        [Obsolete("Use ToggleRightControllerKey instead.")]
+        public KeyBinding ToggleRightHandKey => ToggleRightControllerKey;
+        /// <summary>
+        /// Time after which uncontrolled hands are hidden
+        /// </summary>
+        [Obsolete("Use ControllerHideTimeout instead.")]
+        public float HandHideTimeout => ControllerHideTimeout;
+        /// <summary>
+        /// Key to manipulate the left hand
+        /// </summary>
+        [Obsolete("Use LeftControllerManipulationKey instead.")]
+        public KeyBinding LeftHandManipulationKey => LeftControllerManipulationKey;
+        /// <summary>
+        /// Key to manipulate the right hand
+        /// </summary>
+        [Obsolete("Use RightControllerManipulationKey instead.")]
+        public KeyBinding RightHandManipulationKey => RightControllerManipulationKey;
+        /// <summary>
+        /// Additional rotation factor after input smoothing has been applied
+        /// </summary>
+        [Obsolete("Use MouseControllerRotationSpeed instead.")]
+        public float MouseHandRotationSpeed => MouseControllerRotationSpeed;
+        /// <summary>
+        /// Controls how hand rotation is activated
+        /// </summary>
+        [Obsolete("Use ControllerRotateButton instead.")]
+        public KeyBinding HandRotateButton => ControllerRotateButton;
+        /// <summary>
+        /// Default distance of the hand from the camera
+        /// </summary>
+        [Obsolete("Use DefaultControllerDistance instead.")]
+        public float DefaultHandDistance => DefaultControllerDistance;
+        /// <summary>
+        /// Depth change when scrolling the mouse wheel
+        /// </summary>
+        [Obsolete("Use ControllerDepthMultiplier instead.")]
+        public float HandDepthMultiplier => ControllerDepthMultiplier;
         /// <summary>
         /// Apply random offset to the hand position
         /// </summary>
-        public float HandJitterAmount => handJitterAmount;
+        [Obsolete("Use ControllerJitterAmount instead.")]
+        public float HandJitterAmount => ControllerJitterAmount;
+        #endregion
     }
 }

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedArticulatedHand.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedArticulatedHand.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         new[] { Handedness.Left, Handedness.Right })]
     public class SimulatedArticulatedHand : SimulatedHand
     {
-        public override HandSimulationMode SimulationMode => HandSimulationMode.Articulated;
+        public override ControllerSimulationMode SimulationMode => ControllerSimulationMode.ArticulatedHand;
 
         private Vector3 currentPointerPosition = Vector3.zero;
         private Quaternion currentPointerRotation = Quaternion.identity;

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedGestureHand.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedGestureHand.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public class SimulatedGestureHand : SimulatedHand
     {
         /// <inheritdoc />
-        public override HandSimulationMode SimulationMode => HandSimulationMode.Gestures;
+        public override ControllerSimulationMode SimulationMode => ControllerSimulationMode.HandGestures;
 
         private bool initializedFromProfile = false;
         private MixedRealityInputAction holdAction = MixedRealityInputAction.None;

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
     public abstract class SimulatedHand : BaseHand
     {
-        public abstract HandSimulationMode SimulationMode { get; }
+        public abstract ControllerSimulationMode SimulationMode { get; }
 
         protected static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandDataProvider.cs
@@ -264,11 +264,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             float time = Time.time;
 
-            if (KeyInputSystem.GetKeyDown(profile.ToggleLeftHandKey))
+            if (KeyInputSystem.GetKeyDown(profile.ToggleLeftControllerKey))
             {
                 IsAlwaysVisibleLeft = !IsAlwaysVisibleLeft;
             }
-            if (KeyInputSystem.GetKeyDown(profile.ToggleRightHandKey))
+            if (KeyInputSystem.GetKeyDown(profile.ToggleRightControllerKey))
             {
                 IsAlwaysVisibleRight = !IsAlwaysVisibleRight;
             }
@@ -280,7 +280,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
             else
             {
-                if (KeyInputSystem.GetKeyDown(profile.LeftHandManipulationKey))
+                if (KeyInputSystem.GetKeyDown(profile.LeftControllerManipulationKey))
                 {
                     isSimulatingLeft = true;
                     if (lastSimulationLeft > 0.0f && time - lastSimulationLeft <= profile.DoublePressTime)
@@ -289,12 +289,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                     lastSimulationLeft = time;
                 }
-                if (KeyInputSystem.GetKeyUp(profile.LeftHandManipulationKey))
+                if (KeyInputSystem.GetKeyUp(profile.LeftControllerManipulationKey))
                 {
                     isSimulatingLeft = false;
                 }
 
-                if (KeyInputSystem.GetKeyDown(profile.RightHandManipulationKey))
+                if (KeyInputSystem.GetKeyDown(profile.RightControllerManipulationKey))
                 {
                     isSimulatingRight = true;
                     if (lastSimulationRight > 0.0f && time - lastSimulationRight <= profile.DoublePressTime)
@@ -303,7 +303,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                     lastSimulationRight = time;
                 }
-                if (KeyInputSystem.GetKeyUp(profile.RightHandManipulationKey))
+                if (KeyInputSystem.GetKeyUp(profile.RightControllerManipulationKey))
                 {
                     isSimulatingRight = false;
                 }
@@ -311,7 +311,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     lastSimulationGaze = time;
             }
 
-            mouseRotation.Update(profile.HandRotateButton, cancelRotationKey, false);
+            mouseRotation.Update(profile.ControllerRotateButton, cancelRotationKey, false);
 
             SimulateHandInput(ref lastHandTrackedTimestampLeft, HandStateLeft, isSimulatingLeft, IsAlwaysVisibleLeft, mouseDelta, mouseRotation.IsRotating);
             SimulateHandInput(ref lastHandTrackedTimestampRight, HandStateRight, isSimulatingRight, IsAlwaysVisibleRight, mouseDelta, mouseRotation.IsRotating);
@@ -343,7 +343,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             if (isSimulating)
             {
-                state.SimulateInput(mouseDelta, useMouseRotation, profile.MouseRotationSensitivity, profile.MouseHandRotationSpeed, profile.HandJitterAmount);
+                state.SimulateInput(mouseDelta, useMouseRotation, profile.MouseRotationSensitivity, profile.MouseControllerRotationSpeed, profile.ControllerJitterAmount);
 
                 if (isAlwaysVisible)
                 {
@@ -370,7 +370,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             else
             {
                 float timeSinceTracking = (float)currentTime.Subtract(new DateTime(lastHandTrackedTimestamp)).TotalSeconds;
-                if (timeSinceTracking > profile.HandHideTimeout)
+                if (timeSinceTracking > profile.ControllerHideTimeout)
                 {
                     state.IsTracked = false;
                 }
@@ -395,11 +395,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 // Start at current mouse position
                 Vector3 mousePos = UnityEngine.Input.mousePosition;
-                state.ResetPosition(CameraCache.Main.ScreenToViewportPoint(new Vector3(mousePos.x, mousePos.y, profile.DefaultHandDistance)));
+                state.ResetPosition(CameraCache.Main.ScreenToViewportPoint(new Vector3(mousePos.x, mousePos.y, profile.DefaultControllerDistance)));
             }
             else
             {
-                state.ResetPosition(new Vector3(0.5f, 0.5f, profile.DefaultHandDistance));
+                state.ResetPosition(new Vector3(0.5f, 0.5f, profile.DefaultControllerDistance));
             }
 
             state.Gesture = profile.DefaultHandGesture;

--- a/Assets/MRTK/SDK/Features/Input/InputSimulationIndicators.cs
+++ b/Assets/MRTK/SDK/Features/Input/InputSimulationIndicators.cs
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (imageHandLeft)
             {
                 Sprite iconHandLeft;
-                if (InputSimService.IsSimulatingHandLeft)
+                if (InputSimService.IsSimulatingControllerLeft)
                 {
                     iconHandLeft = iconHandActiveLeft;
                 }
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (imageHandRight)
             {
                 Sprite iconHandRight;
-                if (InputSimService.IsSimulatingHandRight)
+                if (InputSimService.IsSimulatingControllerRight)
                 {
                     iconHandRight = iconHandActiveRight;
                 }
@@ -114,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public void ToggleLeftHand()
         {
-            InputSimService.IsAlwaysVisibleHandLeft = !InputSimService.IsAlwaysVisibleHandLeft;
+            InputSimService.IsAlwaysVisibleControllerLeft = !InputSimService.IsAlwaysVisibleControllerLeft;
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public void ToggleRightHand()
         {
-            InputSimService.IsAlwaysVisibleHandRight = !InputSimService.IsAlwaysVisibleHandRight;
+            InputSimService.IsAlwaysVisibleControllerRight = !InputSimService.IsAlwaysVisibleControllerRight;
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public void ResetLeftHand()
         {
-            InputSimService.ResetHandLeft();
+            InputSimService.ResetControllerLeft();
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public void ResetRightHand()
         {
-            InputSimService.ResetHandRight();
+            InputSimService.ResetControllerRight();
         }
 #endif
     }

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputSimulationProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputSimulationProfile.asset
@@ -42,22 +42,22 @@ MonoBehaviour:
   lookHorizontal: AXIS_4
   lookVertical: AXIS_5
   defaultEyeGazeSimulationMode: 0
-  defaultHandSimulationMode: 2
-  toggleLeftHandKey:
+  defaultControllerSimulationMode: 3
+  toggleLeftControllerKey:
     bindingType: 2
     code: 116
-  toggleRightHandKey:
+  toggleRightControllerKey:
     bindingType: 2
     code: 121
-  handHideTimeout: 0.2
-  leftHandManipulationKey:
+  controllerHideTimeout: 0.2
+  leftControllerManipulationKey:
     bindingType: 2
     code: 304
-  rightHandManipulationKey:
+  rightControllerManipulationKey:
     bindingType: 2
     code: 32
-  mouseHandRotationSpeed: 30
-  handRotateButton:
+  mouseControllerRotationSpeed: 30
+  controllerRotateButton:
     bindingType: 2
     code: 306
   defaultHandGesture: 2
@@ -67,6 +67,15 @@ MonoBehaviour:
   handGestureAnimationSpeed: 8
   holdStartDuration: 0.5
   navigationStartThreshold: 0.03
-  defaultHandDistance: 0.5
-  handDepthMultiplier: 0.03
-  handJitterAmount: 0
+  defaultControllerDistance: 0.5
+  controllerDepthMultiplier: 0.03
+  controllerJitterAmount: 0
+  motionControllerTriggerKey:
+    bindingType: 2
+    code: 104
+  motionControllerGrabKey:
+    bindingType: 2
+    code: 103
+  motionControllerMenuKey:
+    bindingType: 2
+    code: 109

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputSimulationProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputSimulationProfile.asset
@@ -42,7 +42,7 @@ MonoBehaviour:
   lookHorizontal: AXIS_4
   lookVertical: AXIS_5
   defaultEyeGazeSimulationMode: 0
-  defaultControllerSimulationMode: 3
+  defaultControllerSimulationMode: 2
   toggleLeftControllerKey:
     bindingType: 2
     code: 116
@@ -70,12 +70,3 @@ MonoBehaviour:
   defaultControllerDistance: 0.5
   controllerDepthMultiplier: 0.03
   controllerJitterAmount: 0
-  motionControllerTriggerKey:
-    bindingType: 2
-    code: 104
-  motionControllerGrabKey:
-    bindingType: 2
-    code: 103
-  motionControllerMenuKey:
-    bindingType: 2
-    code: 109

--- a/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
@@ -135,8 +135,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputSystem = PlayModeTestUtilities.GetInputSystem();
 
             var iss = PlayModeTestUtilities.GetInputSimulationService();
-            var oldHandSimMode = iss.HandSimulationMode;
-            iss.HandSimulationMode = HandSimulationMode.Gestures;
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             Vector3 underPointerPos = new Vector3(0, 0, 2);
             Vector3 abovePointerPos = new Vector3(0, -2, 2);
@@ -209,7 +209,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             VerifyCursorState(inputSystem.GazeProvider.GazeCursor, CursorStateEnum.Select);
 
             // Restore the input simulation profile
-            iss.HandSimulationMode = oldHandSimMode;
+            iss.ControllerSimulationMode = oldHandSimMode;
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -344,7 +344,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestUtilities.AssertAboutEqual(bounds.size, startSize, "bbox incorrect size at start");
 
             PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
 
             CameraCache.Main.transform.LookAt(bbox.ScaleCorners[3].transform);
 

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -464,7 +464,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             BoundsControl control = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(control);
             PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
 
             // move camera to look at rotation sphere
             CameraCache.Main.transform.LookAt(new Vector3(0.248f, 0.001f, 1.226f)); // rotation sphere front right
@@ -592,7 +592,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return VerifyInitialBoundsCorrect(boundsControl);
             BoxCollider boxCollider = boundsControl.GetComponent<BoxCollider>();
             PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
 
             CameraCache.Main.transform.LookAt(boundsControl.gameObject.transform.Find("rigRoot/corner_3").transform);
 

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator TestClickEvents()
         {
             PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
 
             // Subscribe to interactable's on click so we know the click went through
             bool wasClicked = false;
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator TestToggleEvents()
         {
             PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
 
             var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();
             interactable.transform.position = Vector3.forward * 2f;

--- a/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -875,8 +875,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Switch to Gestures
             var iss = PlayModeTestUtilities.GetInputSimulationService();
-            var oldHandSimMode = iss.HandSimulationMode;
-            iss.HandSimulationMode = HandSimulationMode.Gestures;
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -919,7 +919,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
 
             // Restore the input simulation profile
-            iss.HandSimulationMode = oldHandSimMode;
+            iss.ControllerSimulationMode = oldHandSimMode;
             yield return null;
         }
 
@@ -937,8 +937,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Switch to Gestures
             var iss = PlayModeTestUtilities.GetInputSimulationService();
-            var oldHandSimMode = iss.HandSimulationMode;
-            iss.HandSimulationMode = HandSimulationMode.Gestures;
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -987,7 +987,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position), 0.02f);
 
             // Restore the input simulation profile
-            iss.HandSimulationMode = oldHandSimMode;
+            iss.ControllerSimulationMode = oldHandSimMode;
             yield return null;
         }
 
@@ -1004,8 +1004,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Switch to Gestures
             var iss = PlayModeTestUtilities.GetInputSimulationService();
-            var oldHandSimMode = iss.HandSimulationMode;
-            iss.HandSimulationMode = HandSimulationMode.Gestures;
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -1051,7 +1051,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(xPos, Mathf.Abs(yPosDown), 0.02f);
 
             // Restore the input simulation profile
-            iss.HandSimulationMode = oldHandSimMode;
+            iss.ControllerSimulationMode = oldHandSimMode;
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -754,8 +754,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Switch to Gestures
             var iss = PlayModeTestUtilities.GetInputSimulationService();
-            var oldHandSimMode = iss.HandSimulationMode;
-            iss.HandSimulationMode = HandSimulationMode.Gestures;
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -799,7 +799,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
 
             // Restore the input simulation profile
-            iss.HandSimulationMode = oldHandSimMode;
+            iss.ControllerSimulationMode = oldHandSimMode;
             yield return null;
         }
 
@@ -817,8 +817,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Switch to Gestures
             var iss = PlayModeTestUtilities.GetInputSimulationService();
-            var oldHandSimMode = iss.HandSimulationMode;
-            iss.HandSimulationMode = HandSimulationMode.Gestures;
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -868,7 +868,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position), 0.02f);
 
             // Restore the input simulation profile
-            iss.HandSimulationMode = oldHandSimMode;
+            iss.ControllerSimulationMode = oldHandSimMode;
             yield return null;
         }
 
@@ -885,8 +885,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Switch to Gestures
             var iss = PlayModeTestUtilities.GetInputSimulationService();
-            var oldHandSimMode = iss.HandSimulationMode;
-            iss.HandSimulationMode = HandSimulationMode.Gestures;
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -928,7 +928,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(xPos, yPos, 0.02f);
 
             // Restore the input simulation profile
-            iss.HandSimulationMode = oldHandSimMode;
+            iss.ControllerSimulationMode = oldHandSimMode;
             yield return null;
         }
 
@@ -1493,8 +1493,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestUtilities.PlayspaceToOriginLookingForward();
 
             var iss = PlayModeTestUtilities.GetInputSimulationService();
-            var oldHandSimMode = iss.HandSimulationMode;
-            iss.HandSimulationMode = HandSimulationMode.Gestures;
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // Track the gaze cursor
             var inputSystem = PlayModeTestUtilities.GetInputSystem();
@@ -1568,7 +1568,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
 
             // Restore the input simulation profile
-            iss.HandSimulationMode = oldHandSimMode;
+            iss.ControllerSimulationMode = oldHandSimMode;
             yield return null;
         }
     }

--- a/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Set up ggv simulation
             PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
 
             var rightHand = new TestHand(Handedness.Right);
             Vector3 initialPos = new Vector3(0.05f, 0, 1.0f);

--- a/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             };
 
             // set input simulation mode to GGV
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
 
             TestHand rightHand = new TestHand(Handedness.Right);
             TestHand leftHand = new TestHand(Handedness.Left);

--- a/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             InstantiateFromPrefab();
 
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
 
             TestHand handRight = new TestHand(Handedness.Right);
             yield return handRight.Show(new Vector3(0.0f, 0.0f, 0.6f));
@@ -226,7 +226,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <param name="expectedScroll">The amount panZoom is expected to scroll</param>
         private IEnumerator RunGGVScrollTest(float expectedScroll)
         {
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
 
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -527,7 +527,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return leftHand.SetRotation(handRotation);
 
             yield return WaitForFrames(2);
-            var hand = PlayModeTestUtilities.GetInputSimulationService().GetHandDevice(Handedness.Left);
+            var hand = PlayModeTestUtilities.GetInputSimulationService().GetControllerDevice(Handedness.Left) as SimulatedHand;
             Assert.IsNotNull(hand);
             Assert.IsTrue(hand.TryGetJoint(TrackedHandJoint.Palm, out MixedRealityPose pose));
 

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             Assert.IsTrue(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible, "Head gaze cursor should be visible");
 
             // Begin right hand manipulation
-            KeyInputSystem.PressKey(iss.InputSimulationProfile.ToggleRightHandKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.ToggleRightControllerKey);
             yield return null;
             KeyInputSystem.AdvanceSimulation();
             yield return null;
@@ -139,7 +139,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             Assert.True(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
 
             // Begin right hand manipulation
-            KeyInputSystem.PressKey(iss.InputSimulationProfile.RightHandManipulationKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.RightControllerManipulationKey);
             yield return null;
             KeyInputSystem.AdvanceSimulation();
             yield return null;
@@ -172,11 +172,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             Assert.True(!iss.HandDataLeft.IsPinching);
 
             // End right hand manipulation
-            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.RightHandManipulationKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.RightControllerManipulationKey);
             yield return null;
             KeyInputSystem.AdvanceSimulation();
             // Wait for the hand hide timeout to hide the hands
-            yield return new WaitForSeconds(iss.InputSimulationProfile.HandHideTimeout + 0.1f);
+            yield return new WaitForSeconds(iss.InputSimulationProfile.ControllerHideTimeout + 0.1f);
 
             // Make sure right hand is not tracked
             Assert.True(!iss.HandDataRight.IsTracked);
@@ -187,7 +187,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
             // Repeat with left hand
             // Begin left hand manipulation
-            KeyInputSystem.PressKey(iss.InputSimulationProfile.LeftHandManipulationKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.LeftControllerManipulationKey);
             yield return null;
             KeyInputSystem.AdvanceSimulation();
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
@@ -221,11 +221,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
 
             // End left hand manipulation
-            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.LeftHandManipulationKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.LeftControllerManipulationKey);
             yield return null;
             KeyInputSystem.AdvanceSimulation();
             // Wait for the hand hide timeout to hide the hands
-            yield return new WaitForSeconds(iss.InputSimulationProfile.HandHideTimeout + 0.1f);
+            yield return new WaitForSeconds(iss.InputSimulationProfile.ControllerHideTimeout + 0.1f);
 
             // Make sure left hand is not tracked
             Assert.True(!iss.HandDataRight.IsTracked);
@@ -236,8 +236,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
             // Lastly with 2 hands
             // Begin hand manipulation
-            KeyInputSystem.PressKey(iss.InputSimulationProfile.RightHandManipulationKey);
-            KeyInputSystem.PressKey(iss.InputSimulationProfile.LeftHandManipulationKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.RightControllerManipulationKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.LeftControllerManipulationKey);
             yield return null;
             KeyInputSystem.AdvanceSimulation();
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
@@ -271,12 +271,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
 
             // End hand manipulation
-            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.RightHandManipulationKey);
-            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.LeftHandManipulationKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.RightControllerManipulationKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.LeftControllerManipulationKey);
             yield return null;
             KeyInputSystem.AdvanceSimulation();
             // Wait for the hand hide timeout to hide the hands
-            yield return new WaitForSeconds(iss.InputSimulationProfile.HandHideTimeout + 0.1f);
+            yield return new WaitForSeconds(iss.InputSimulationProfile.ControllerHideTimeout + 0.1f);
 
 
             // Make sure hands are not tracked

--- a/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -283,10 +283,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             iss.InputSimulationProfile = inputSimulationProfiles.Pop();
         }
 
-        public static void SetHandSimulationMode(HandSimulationMode mode)
+        public static void SetHandSimulationMode(ControllerSimulationMode mode)
         {
             var iss = GetInputSimulationService();
-            iss.HandSimulationMode = mode;
+            iss.ControllerSimulationMode = mode;
         }
 
         public static IEnumerator SetHandState(Vector3 handPos, ArticulatedHandPose.GestureId gestureId, Handedness handedness, InputSimulationService inputSimulationService)
@@ -297,7 +297,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public static T GetPointer<T>(Handedness handedness) where T : class, IMixedRealityPointer
         {
             InputSimulationService simulationService = GetInputSimulationService();
-            var hand = simulationService.GetHandDevice(handedness);
+            var hand = simulationService.GetControllerDevice(handedness);
             if (hand != null && hand.InputSource != null)
             {
                 foreach (var pointer in hand.InputSource.Pointers)

--- a/Assets/MRTK/Tests/TestUtilities/TestHand.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestHand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </summary>
         public Vector3 GetVelocity()
         {
-            var hand = simulationService.GetHandDevice(handedness);
+            var hand = simulationService.GetControllerDevice(handedness);
             return hand.Velocity;
         }
 
@@ -190,7 +190,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <typeparam name="T">Type of pointer to look for.</typeparam>
         public T GetPointer<T>() where T : class, IMixedRealityPointer
         {
-            var hand = simulationService.GetHandDevice(handedness);
+            var hand = simulationService.GetControllerDevice(handedness);
             foreach (var pointer in hand.InputSource.Pointers)
             {
                 if (pointer is T)


### PR DESCRIPTION
## Overview
This is the first of a set of PRs that will eventually add motion controller simulation and test support to MRTK. This PR specifically focuses on making name changes so that simulation is no longer confined to just hands but applies to controllers in general.

## Changes
- Change reference to "hand" to a more generic term "controller" to get ready for the upcoming support of simulated controller in editor play mode and tests.