### PR TITLE
Constraint Manager now available for Bounds Control

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -653,6 +653,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             return isExpanded;
         }
 
+        /// <summary>
+        /// Draws a foldout enlisting all components (or derived types) of the given type attached to the passed gameobject.
+        /// Adds a button for adding any of the component (or dervied types) and a follow button to highlight existing attached components.
+        /// </summary>
         static public bool DrawComponentTypeFoldout<T>(GameObject gameObject, bool isExpanded, string typeDescription) where T : MonoBehaviour
         {
             isExpanded = EditorGUILayout.Foldout(isExpanded, typeDescription + "s", true);

--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -646,6 +647,49 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                         EditorGUILayout.PropertyField(scriptable, new GUIContent(scriptable.displayName + " (local): "));
                         DrawScriptableSubEditor(scriptable);
                     }
+                }
+            }
+
+            return isExpanded;
+        }
+
+        static public bool DrawComponentTypeFoldout<T>(GameObject gameObject, bool isExpanded, string typeDescription) where T : MonoBehaviour
+        {
+            isExpanded = EditorGUILayout.Foldout(isExpanded, typeDescription + "s", true);
+
+            if (isExpanded)
+            { 
+                if (EditorGUILayout.DropdownButton(new GUIContent("Add " + typeDescription), FocusType.Keyboard))
+                {
+                    // create the menu and add items to it
+                    GenericMenu menu = new GenericMenu();
+
+                    var type = typeof(T);
+                    var types = AppDomain.CurrentDomain.GetAssemblies()
+                                .SelectMany(s => s.GetLoadableTypes())
+                                .Where(p => type.IsAssignableFrom(p) && !p.IsAbstract);
+
+                    foreach (var derivedType in types)
+                    {
+                        menu.AddItem(new GUIContent(derivedType.Name), false, t => gameObject.AddComponent((Type)t), derivedType);
+                    }
+
+                    menu.ShowAsContext();
+                }
+
+                var constraints = gameObject.GetComponents<T>();
+
+                foreach (var constraint in constraints)
+                {
+                    EditorGUILayout.BeginHorizontal();
+                    string constraintName = constraint.GetType().Name;
+                    EditorGUILayout.LabelField(constraintName);
+                    if (GUILayout.Button("Go to component"))
+                    {
+                        Highlighter.Highlight("Inspector", $"{ObjectNames.NicifyVariableName(constraintName)} (Script)");
+                        EditorGUIUtility.ExitGUI();
+                    }
+                    EditorGUILayout.EndHorizontal();
                 }
             }
 

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -5,8 +5,6 @@ using Microsoft.MixedReality.Toolkit.Experimental.Physics;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using System;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
@@ -149,43 +147,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             var rb = mh.HostTransform.GetComponent<Rigidbody>();
 
             EditorGUILayout.Space();
-            constraintsFoldout = EditorGUILayout.Foldout(constraintsFoldout, "Constraints", true);
-
-            if (constraintsFoldout)
-            {
-                if (EditorGUILayout.DropdownButton(new GUIContent("Add Constraint"), FocusType.Keyboard))
-                {
-                    // create the menu and add items to it
-                    GenericMenu menu = new GenericMenu();
-
-                    var type = typeof(TransformConstraint);
-                    var types = AppDomain.CurrentDomain.GetAssemblies()
-                                .SelectMany(s => s.GetLoadableTypes())
-                                .Where(p => type.IsAssignableFrom(p) && !p.IsAbstract);
-
-                    foreach (var derivedType in types)
-                    {
-                        menu.AddItem(new GUIContent(derivedType.Name), false, t => mh.gameObject.AddComponent((Type)t), derivedType);
-                    }
-
-                    menu.ShowAsContext();
-                }
-
-                var constraints = mh.GetComponents<TransformConstraint>();
-
-                foreach (var constraint in constraints)
-                {
-                    EditorGUILayout.BeginHorizontal();
-                    string constraintName = constraint.GetType().Name;
-                    EditorGUILayout.LabelField(constraintName);
-                    if (GUILayout.Button("Go to component"))
-                    {
-                        Highlighter.Highlight("Inspector", $"{ObjectNames.NicifyVariableName(constraintName)} (Script)");
-                        EditorGUIUtility.ExitGUI();
-                    }
-                    EditorGUILayout.EndHorizontal();
-                }
-            }
+            constraintsFoldout = InspectorUIUtility.DrawComponentTypeFoldout<TransformConstraint>(mh.gameObject, constraintsFoldout, "Constraint");
 
             EditorGUILayout.Space();
             physicsFoldout = EditorGUILayout.Foldout(physicsFoldout, "Physics", true);

--- a/Assets/MRTK/SDK/Experimental/Editor/Inspectors/BoundsControl/BoundsControlInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Editor/Inspectors/BoundsControl/BoundsControlInspector.cs
@@ -9,7 +9,6 @@ using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 using Microsoft.MixedReality.Toolkit.UI;
-using System.Linq;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 {
@@ -135,43 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
                     }
 
                     EditorGUILayout.Space();
-                    constraintsFoldout = EditorGUILayout.Foldout(constraintsFoldout, "Constraints", true);
-
-                    if (constraintsFoldout)
-                    {
-                        if (EditorGUILayout.DropdownButton(new GUIContent("Add Constraint"), FocusType.Keyboard))
-                        {
-                            // create the menu and add items to it
-                            GenericMenu menu = new GenericMenu();
-
-                            var type = typeof(TransformConstraint);
-                            var types = System.AppDomain.CurrentDomain.GetAssemblies()
-                                        .SelectMany(s => s.GetLoadableTypes())
-                                        .Where(p => type.IsAssignableFrom(p) && !p.IsAbstract);
-
-                            foreach (var derivedType in types)
-                            {
-                                menu.AddItem(new GUIContent(derivedType.Name), false, t => boundsControl.gameObject.AddComponent((System.Type)t), derivedType);
-                            }
-
-                            menu.ShowAsContext();
-                        }
-
-                        var constraints = boundsControl.GetComponents<TransformConstraint>();
-
-                        foreach (var constraint in constraints)
-                        {
-                            EditorGUILayout.BeginHorizontal();
-                            string constraintName = constraint.GetType().Name;
-                            EditorGUILayout.LabelField(constraintName);
-                            if (GUILayout.Button("Go to component"))
-                            {
-                                Highlighter.Highlight("Inspector", $"{ObjectNames.NicifyVariableName(constraintName)} (Script)");
-                                EditorGUIUtility.ExitGUI();
-                            }
-                            EditorGUILayout.EndHorizontal();
-                        }
-                    }
+                    constraintsFoldout = InspectorUIUtility.DrawComponentTypeFoldout<TransformConstraint>(boundsControl.gameObject, constraintsFoldout, "Constraint");
 
                     EditorGUILayout.Space();
                     EditorGUILayout.LabelField(new GUIContent("Events", "Bounds Control Events"), EditorStyles.boldLabel, GUILayout.ExpandWidth(true));

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -1011,6 +1011,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     Quaternion goal = Quaternion.FromToRotation(initDir, currentDir) * initialRotationOnGrabStart;
                     MixedRealityTransform constraintRotation = MixedRealityTransform.NewRotate(goal);
                     constraints.ApplyRotationConstraints(ref constraintRotation, true, isNear);
+                    goal = constraintRotation.Rotation;
                     Target.transform.rotation = smoothingActive ? Smoothing.SmoothTo(Target.transform.rotation, goal, rotateLerpTime, Time.deltaTime) : goal;
                 }
                 else if (transformType == HandleType.Scale)

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -5,7 +5,6 @@ using Microsoft.MixedReality.Toolkit.Input;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.Serialization;
 using UnityPhysics = UnityEngine.Physics;
 using Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControlTypes;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -21,6 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
     /// Todo: replace doc link - point to BoundsControl docs
     /// </summary>
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_BoundingBox.html")]
+    [RequireComponent(typeof(ConstraintManager))]
     public class BoundsControl : MonoBehaviour,
         IMixedRealitySourceStateHandler,
         IMixedRealityFocusChangedHandler,
@@ -549,7 +549,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             links = new Links(linksConfiguration);
             proximityEffect = new ProximityEffect(handleProximityEffectConfiguration);
 
-            constraints = new ConstraintManager(gameObject);
+            constraints = gameObject.EnsureComponent<ConstraintManager>();
         }
 
         private static T EnsureScriptable<T>(T instance) where T : ScriptableObject

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -396,8 +396,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         // Current position of the grab point
         private Vector3 currentGrabPoint;
 
-        private MinMaxScaleConstraint scaleConstraint;
-
         // Grab point position in pointer space. Used to calculate the current grab point from the current pointer pose.
         private Vector3 grabPointInPointer;
 
@@ -429,6 +427,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         private Vector3[] boundsCorners = new Vector3[8];
         public Vector3[] BoundsCorners { get; private set; }
 
+        private ConstraintManager constraints;
         #endregion
 
         #region public Properties
@@ -527,21 +526,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             UpdateRigVisibilityInInspector();
         }
 
-
-        /// <summary>
-        /// Register a transform scale handler to bounding box to limit the scaling range
-        /// This is useful for adding/switching your scale handler during runtime
-        /// </summary>
-        /// <param name="transformScaleHandler">scale handler you want to switch to - can be null if scaling shouldn't be constrained</param>
-        public void RegisterTransformScaleHandler(MinMaxScaleConstraint transformScaleHandler)
-        {
-            scaleConstraint = transformScaleHandler;
-            if (scaleConstraint)
-            {
-                scaleConstraint.Initialize(new MixedRealityTransform(transform));
-            }
-        }
-
         #endregion
 
         #region MonoBehaviour Methods
@@ -564,6 +548,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             boxDisplay = new BoxDisplay(boxDisplayConfiguration);
             links = new Links(linksConfiguration);
             proximityEffect = new ProximityEffect(handleProximityEffectConfiguration);
+
+            constraints = new ConstraintManager(gameObject);
         }
 
         private static T EnsureScriptable<T>(T instance) where T : ScriptableObject
@@ -852,7 +838,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             {
                 isChildOfTarget = transform.IsChildOf(Target.transform);
             }
-            RegisterTransformScaleHandler(GetComponent<MinMaxScaleConstraint>());
         }
 
 
@@ -1017,12 +1002,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             if (transformType != HandleType.None)
             {
                 currentGrabPoint = (currentPointer.Rotation * grabPointInPointer) + currentPointer.Position;
+                bool isNear = currentPointer is IMixedRealityNearPointer;
 
                 if (transformType == HandleType.Rotation)
                 {
                     Vector3 initDir = Vector3.ProjectOnPlane(initialGrabPoint - transform.position, currentRotationAxis).normalized;
                     Vector3 currentDir = Vector3.ProjectOnPlane(currentGrabPoint - transform.position, currentRotationAxis).normalized;
                     Quaternion goal = Quaternion.FromToRotation(initDir, currentDir) * initialRotationOnGrabStart;
+                    MixedRealityTransform constraintRotation = MixedRealityTransform.NewRotate(goal);
+                    constraints.ApplyRotationConstraints(ref constraintRotation, true, isNear);
                     Target.transform.rotation = smoothingActive ? Smoothing.SmoothTo(Target.transform.rotation, goal, rotateLerpTime, Time.deltaTime) : goal;
                 }
                 else if (transformType == HandleType.Scale)
@@ -1047,13 +1035,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
                     Vector3 newScale = initialScaleOnGrabStart.Mul(scaleFactor);
                     MixedRealityTransform clampedTransform = MixedRealityTransform.NewScale(newScale);
-                    if (scaleConstraint != null)
+                    constraints.ApplyScaleConstraints(ref clampedTransform, true, isNear);
+                    if (clampedTransform.Scale != newScale)
                     {
-                        scaleConstraint.ApplyConstraint(ref clampedTransform);
-                        if (clampedTransform.Scale != newScale)
-                        {
-                            scaleFactor = clampedTransform.Scale.Div(initialScaleOnGrabStart);
-                        }
+                        scaleFactor = clampedTransform.Scale.Div(initialScaleOnGrabStart);
                     }
 
                     Target.transform.localScale = smoothingActive ? Smoothing.SmoothTo(Target.transform.localScale, clampedTransform.Scale, scaleLerpTime, Time.deltaTime) : clampedTransform.Scale;
@@ -1164,6 +1149,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                             debugText.text = "OnPointerDown:RotateStarted";
                         }
                     }
+
+                    constraints.Initialize(new MixedRealityTransform(Target.transform));
 
                     eventData.Use();
                 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
@@ -15,9 +15,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
     internal class ConstraintManager
     {
         private List<TransformConstraint> constraints;
+        private MixedRealityTransform initialWorldPose;
+        private GameObject host;
 
         public ConstraintManager(GameObject gameObject)
         {
+            host = gameObject;
             constraints = gameObject.GetComponents<TransformConstraint>().ToList();
         }
 
@@ -38,6 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void Initialize(MixedRealityTransform worldPose)
         {
+            initialWorldPose = worldPose;
             foreach (var constraint in constraints)
             {
                 constraint.Initialize(worldPose);
@@ -46,6 +50,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void ApplyConstraintsForType(ref MixedRealityTransform transform, bool isOneHanded, bool isNear, TransformFlags transformType)
         {
+            EnsureNewConstraintsInitialized();
+
             ManipulationHandFlags handMode = isOneHanded ? ManipulationHandFlags.OneHanded : ManipulationHandFlags.TwoHanded;
             ManipulationProximityFlags proximityMode = isNear ? ManipulationProximityFlags.Near : ManipulationProximityFlags.Far;
 
@@ -58,6 +64,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     constraint.ApplyConstraint(ref transform);
                 }
             }
+        }
+
+        private void EnsureNewConstraintsInitialized()
+        {
+            var currentConstraints = host.GetComponents<TransformConstraint>();
+
+            foreach (var newConstraint in currentConstraints)
+            {
+                if (constraints.IndexOf(newConstraint) < 0)
+                {
+                    newConstraint.Initialize(initialWorldPose);
+                }
+            }
+
+
+            constraints = currentConstraints.ToList();
         }
     }
 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
@@ -69,17 +69,21 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private void EnsureNewConstraintsInitialized()
         {
             var currentConstraints = host.GetComponents<TransformConstraint>();
+            bool hasNewConstraint = false;
 
             foreach (var newConstraint in currentConstraints)
             {
                 if (constraints.IndexOf(newConstraint) < 0)
                 {
                     newConstraint.Initialize(initialWorldPose);
+                    hasNewConstraint = true;
                 }
             }
 
-
-            constraints = currentConstraints.ToList();
+            if (hasNewConstraint)
+            {
+                constraints = currentConstraints.ToList();
+            }
         }
     }
 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/FixedDistanceConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/FixedDistanceConstraint.cs
@@ -37,10 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void Start()
         {
-            if (ConstraintTransform == null)
-            {
-                ConstraintTransform = CameraCache.Main.transform;
-            }
+            EnsureConstraintTransform();
         }
 
         #endregion MonoBehaviour Methods
@@ -51,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public override void Initialize(MixedRealityTransform worldPose)
         {
             base.Initialize(worldPose);
-
+            EnsureConstraintTransform();
             distanceAtManipulationStart = Vector3.Distance(worldPose.Position, constraintTransform.position);
         }
 
@@ -67,5 +64,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         #endregion Public Methods
+
+        private void EnsureConstraintTransform()
+        {
+            if (ConstraintTransform == null)
+            {
+                ConstraintTransform = CameraCache.Main.transform;
+            }
+        }
     }
 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/TransformConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/TransformConstraint.cs
@@ -62,8 +62,29 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public abstract void ApplyConstraint(ref MixedRealityTransform transform);
 
+
         #endregion Public Methods
 
+        #region MonoBeaviour
+        protected void OnEnable()
+        {
+            var managers = gameObject.GetComponents<ConstraintManager>();
+            foreach (var manager in managers)
+            {
+                manager.RegisterConstraint(this);
+            }
+        }
+
+        protected void OnDisable()
+        {
+            var managers = gameObject.GetComponents<ConstraintManager>();
+            foreach (var manager in managers)
+            {
+                manager.UnregisterConstraint(this);
+            }
+        }
+
+        #endregion
 
         #region Deprecated
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -21,6 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// both HoloLens' gesture input and immersive headset's motion controller input.
     /// </summary>
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_ObjectManipulator.html")]
+    [RequireComponent(typeof(ConstraintManager))]
     public class ObjectManipulator : MonoBehaviour, IMixedRealityPointerHandler, IMixedRealityFocusChangedHandler
     {
         #region Public Enums
@@ -474,7 +475,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private void Start()
         {
             rigidBody = HostTransform.GetComponent<Rigidbody>();
-            constraints = new ConstraintManager(gameObject);
+            constraints = gameObject.EnsureComponent<ConstraintManager>();
         }
         private void Update()
         {

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -465,11 +465,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Vector3 axis = new Vector3();
             boundsControl.transform.rotation.ToAngleAxis(out angle, out axis);
             Assert.IsTrue(angle == 0f, "cube didn't constraint on rotation");
-            TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube moved while rotating");
-            TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube scaled while rotating");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube shouldn't move while rotating");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube shouldn't scale while rotating");
 
-            GameObject.Destroy(boundsControl.gameObject);
-            // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -575,7 +575,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             var scaleHandler = boundsControl.EnsureComponent<MinMaxScaleConstraint>();
             scaleHandler.ScaleMinimum = minScale;
             scaleHandler.ScaleMaximum = maxScale;
-            boundsControl.RegisterTransformScaleHandler(scaleHandler);
 
             Vector3 initialScale = boundsControl.transform.localScale;
 


### PR DESCRIPTION
## Overview
PR integrates Constraint Manager into Bounds Control. 

- removed hardcoded min max scale constraint
- bounds control now supports scale and rotation constraints (translation constraints to be added once translation handles are in)
- adjusted min max scale constraint test and added test to verify rotation constraint
- adjusted constraint manager to check for added constraints during runtime (old design only allowed to have constraints registered that were added before the component that includes the constraint manager)

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8304
part of #5340 


