### PR TITLE
Remove UNITY_EDITOR define from MigrationTool.cs in editor-only assembly

### DIFF
--- a/Assets/MRTK/SDK/Editor/Migration/Tools/MigrationTool.cs
+++ b/Assets/MRTK/SDK/Editor/Migration/Tools/MigrationTool.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.using System;
+// Licensed under the MIT License.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -455,4 +454,3 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
     }
 }
-#endif


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/8004. This class was moved to an editor-only assembly, but the `#define` was left in, which prevents it from showing up in our docs.