### PR TITLE
Convert from legacy XR check to display subsystem running check

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
@@ -318,7 +318,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
 #if UNITY_WSA && !UNITY_2020_1_OR_NEWER
             // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
             // with legacy requirements.
-            if (XRSettingsUtilities.IsLegacyXRActive)
+            if (XRSubsystemHelpers.DisplaySubsystem == null)
             {
 #pragma warning disable 0618
                 // Place the plane at the desired depth in front of the user and billboard it to the gaze origin.


### PR DESCRIPTION
## Overview

The legacy XR check happens in an editor-only assembly. This updates it to instead check for a display subsystem running, which implies XR SDK vs legacy.

## Changes

- Fixes: https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=13266&view=results