### PR TITLE
Move Editor reference from MRTK.cs to config profile inspector

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.﻿
+// Licensed under the MIT License.
 
-using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor.Search;

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -225,6 +225,5 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         }
 
         #endregion
-
     }
 }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Boundary;
 using Microsoft.MixedReality.Toolkit.Diagnostics;
 using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Input.Editor;
 using Microsoft.MixedReality.Toolkit.Rendering;
 using Microsoft.MixedReality.Toolkit.SceneSystem;
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
@@ -168,11 +169,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                                 EditorGUILayout.PropertyField(inputSystemType);
 
+                                // Make sure Unity axis mappings are set.
+                                InputMappingAxisUtility.CheckUnityInputManagerMappings(ControllerMappingLibrary.UnityInputManagerAxes);
+
                                 changed |= RenderProfile(inputSystemProfile, null, true, false, typeof(IMixedRealityInputSystem));
                             }
                             else
                             {
                                 RenderSystemDisabled(service);
+
+                                InputMappingAxisUtility.RemoveMappings(ControllerMappingLibrary.UnityInputManagerAxes);
                             }
 
                             changed |= c.changed;

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -18,7 +18,6 @@ using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Rendering;
 
 #if UNITY_EDITOR
-using Microsoft.MixedReality.Toolkit.Input.Editor;
 using UnityEditor;
 #endif
 
@@ -401,11 +400,6 @@ namespace Microsoft.MixedReality.Toolkit
             {
                 DebugUtilities.LogVerbose("Begin registration of the input system");
 
-#if UNITY_EDITOR
-                // Make sure unity axis mappings are set.
-                InputMappingAxisUtility.CheckUnityInputManagerMappings(ControllerMappingLibrary.UnityInputManagerAxes);
-#endif
-
                 object[] args = { ActiveProfile.InputSystemProfile };
                 if (!RegisterService<IMixedRealityInputSystem>(ActiveProfile.InputSystemType, args: args) || CoreServices.InputSystem == null)
                 {
@@ -427,12 +421,6 @@ namespace Microsoft.MixedReality.Toolkit
                 }
 
                 DebugUtilities.LogVerbose("End registration of the input system");
-            }
-            else
-            {
-#if UNITY_EDITOR
-                InputMappingAxisUtility.RemoveMappings(ControllerMappingLibrary.UnityInputManagerAxes);
-#endif
             }
 
             // If the Boundary system has been selected for initialization in the Active profile, enable it in the project


### PR DESCRIPTION
## Overview

A partial change to start moving editor references in the core assembly into more logical editor-only assemblies.
This change moves the code where the input actions are set from MRTK.cs in an `if` that checks for the input system being enabled into the profile's inspector in an `if` that checks the same data.

Also some minor cleanup of related files.

## Changes

- Part of https://github.com/microsoft/MixedRealityToolkit-Unity/issues/3952