### PR TITLE
Revert "Revert "Updates the LeapMotion and UnityAR configuration checkers to be manually triggered""

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -13,7 +13,11 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
     /// <summary>
     /// Class that checks if the Leap Motion Core assets are present and configures the project if they are.
     /// </summary>
-    [InitializeOnLoad]
+    /// <remarks>
+    /// Note that the checks that this class runs are fairly expensive and are only done manually by the user
+    /// as part of their setup steps described here:
+    /// https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/CrossPlatform/LeapMotionMRTK.html
+    /// </remarks>
     static class LeapMotionConfigurationChecker
     {
         // The presence of the LeapXRServiceProvider.cs is used to determine if the Leap Motion Core Assets are in the project.
@@ -62,14 +66,6 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             { "LeapMotion.Core.Scripts.XR.Editor", new string[] { "LeapMotion", "LeapMotion.Core.Editor" } },
             { "LeapMotion.Core.Tests.Editor", new string[] { "LeapMotion" } }
         };
-
-        static LeapMotionConfigurationChecker()
-        {
-            // Check if leap core is in the project
-            isLeapInProject = ReconcileLeapMotionDefine();
-
-            ConfigureLeapMotion(isLeapInProject);
-        }
 
         /// <summary>
         /// Ensures that the appropriate symbolic constant is defined based on the presence of the Leap Motion Core Assets.
@@ -403,7 +399,6 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             Debug.Log($"Saving {cscFilePath}");
         }
 
-#if UNITY_2018       
         /// <summary>
         /// Force Leap Motion integration after the Leap Motion Core Assets import.  In Unity 2018.4, the configuration checker sometimes does not update after the 
         /// Leap Motion Core Assets import, this case only occurs if the MRTK source is from the unity packages. If the integration of leap and MRTK has not occurred, users can 
@@ -417,7 +412,5 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
 
             ConfigureLeapMotion(isLeapInProject);
         }
-#endif
     }
 }
-

--- a/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
@@ -12,22 +12,20 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
     /// <summary>
     /// Class to perform checks for configuration checks for the UnityAR provider.
     /// </summary>
-    [InitializeOnLoad]
+    /// <remarks>
+    /// Note that the checks that this class runs are fairly expensive and are only done manually by the user
+    /// as part of their setup steps described here:
+    /// https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/CrossPlatform/UsingARFoundation.html
+    /// </remarks>
     static class UnityARConfigurationChecker
     {
         private const string FileName = "Unity.XR.ARFoundation.asmdef";
         private static readonly string[] definitions = { "ARFOUNDATION_PRESENT" };
 
-        static UnityARConfigurationChecker()
+        [MenuItem("Mixed Reality Toolkit/Utilities/UnityAR/Update Assembly Definitions")]
+        private static void UpdateAssemblyDefinitions()
         {
-            // TODO(https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8188)
-            // This should be updated to only run on editor launch and on large asset changes
-            // (i.e. post import of asset packages). This should remove this from the inner compile
-            // loop.
-            if (!EditorApplication.isPlayingOrWillChangePlaymode)
-            {
-                UpdateAsmDef(ReconcileArFoundationDefine());
-            }
+            UpdateAsmDef(ReconcileArFoundationDefine());
         }
 
         /// <summary>

--- a/Documentation/CrossPlatform/LeapMotionMRTK.md
+++ b/Documentation/CrossPlatform/LeapMotionMRTK.md
@@ -26,10 +26,10 @@ This provider can be used in editor and on device while on the Standalone platfo
         - If using Core Assets from Leap Motion Unity Modules version 4.5.0, import the **Core** package into the Unity project.
     > [!NOTE]
     > On import of the Core Assets, test directories are removed and 10 assembly definitions are added to the project. Make sure Visual Studio is closed.
-    - If using Unity 2018.4.x
-        - After the Core Assets import, navigate to **Assets/LeapMotion/**, there should be a LeapMotion.asmdef file next to the Core directory.  If the asmdef file is not present, go to the [Leap Motion Common Errors](#leap-motion-has-not-integrated-with-mrtk). If the file is present, go to the next step.
 
-    - If using Unity 2019.3.x, go to the next step
+1. Update the MRTK assembly definition files to reference LeapMotion assembly definitions
+
+    This can be done by invoking the menu item: **Mixed Reality Toolkit > Utilities > Leap Motion > Configure Leap Motion**
 
 1. Adding the Leap Motion Data Provider
     - Create a new Unity scene
@@ -172,7 +172,7 @@ These errors appear if **Mixed Reality Toolkit > Utilities > Leap Motion > Confi
 
 ### Leap Motion has not integrated with MRTK
 
-This error can occur if the Unity version is 2018.4.x, the MRTK source is from the Unity packages and after the import of the Leap Motion Unity Core Assets.
+This error can occur after the import of the Leap Motion Unity Core Assets if the "Configure Leap Motion" step is not followed.
 
 To test if MRTK recognizes the presence of the Leap Motion Unity Core Assets, open the LeapMotionHandTrackingExample scene located in MRTK/Examples/Demos/HandTracking/ and press play.  If the Leap Motion Unity Core Assets are recognized a green message on the informational panel in the scene will appear.  If the Leap Motion Unity Core Assets are not recognized a red message will appear.
 

--- a/Documentation/CrossPlatform/UsingARFoundation.md
+++ b/Documentation/CrossPlatform/UsingARFoundation.md
@@ -27,6 +27,8 @@
     | AR Foundation  <br/> Version: 3.1.3 |  AR Foundation  <br/> Version: 3.1.3 |
     | ARCore XR Plugin <br/> Version: 3.1.4 | ARKit XR Plugin <br/> Version: 3.1.3 |
 
+1. Update the MRTK UnityAR assembly definitions by invoking the menu item: **Mixed Reality Toolkit > Utilities > UnityAR > Update Assembly Definitions**
+
 ## Enabling the Unity AR camera settings provider
 
 The following steps presume use of the MixedRealityToolkit object. Steps required for other service registrars may be different.

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -69,6 +69,18 @@ There is a confirmation dialog that will be displayed when selecting `Use MSBuil
 
 ![MSBuild for Unity confirmation](Images/ConfigurationDialog/EnableMSB4UPrompt.png)
 
+**Reduction in InitializeOnLoad overhead**
+
+We've been doing work to reduce the amount of work that runs in InitializeOnLoad handlers, which should lead to
+improvements in inner loop development speed. InitializeOnLoad handlers run every time a script is compiled, prior
+to entering play mode, and also at editor launch. These handlers now run in far fewer cases, resulting in general
+Unity responsiveness improvements.
+
+In some cases there was a tradeoff that had to be made:
+For those who are using Leap Motion or ARFoundation, there's now an additional manual step in their respective getting
+started steps. See [Leap Motion](CrossPlatform/LeapMotionMRTK.md#using-leap-motion-by-ultraleap-hand-tracking-in-mrtk) and [ARFoundation]
+(CrossPlatform/UsingARFoundation.md#install-required-packages) for the new steps.
+
 ### Breaking changes
 
 **IMixedRealityPointerMediator**


### PR DESCRIPTION
Yes, this is a revert of a revert - basically the original PR hit an issue in CI related to build machine versions, and we recently updated some of dependencies on our build machines, so now this should be good to go.

Reverts microsoft/MixedRealityToolkit-Unity#8292