### PR TITLE
Improve CoreServices.GetService by removing a double Dictionary lookup

### DIFF
--- a/Assets/MRTK/Core/Utilities/CoreServices.cs
+++ b/Assets/MRTK/Core/Utilities/CoreServices.cs
@@ -145,11 +145,11 @@ namespace Microsoft.MixedReality.Toolkit
             Type serviceType = typeof(T);
 
             // See if we already have a WeakReference entry for this service type
-            if (serviceCache.ContainsKey(serviceType))
+            if (serviceCache.TryGetValue(serviceType, out WeakReference<IMixedRealityService> weakService))
             {
                 IMixedRealityService svc;
                 // If our reference object is still alive, return it
-                if (serviceCache[serviceType].TryGetTarget(out svc))
+                if (weakService.TryGetTarget(out svc))
                 {
                     return (T)svc;
                 }
@@ -165,7 +165,7 @@ namespace Microsoft.MixedReality.Toolkit
                 return default(T);
             }
 
-            serviceCache.Add(typeof(T), new WeakReference<IMixedRealityService>(service, false));
+            serviceCache.Add(serviceType, new WeakReference<IMixedRealityService>(service, false));
             return service;
         }
     }


### PR DESCRIPTION
## Overview
Accessing CoreServices properties shows up as a performance hot path for Remote Assist. This fix makes performance better for CoreServices.GetService by avoiding looking up the service twice in the dictionary (once from ContainsKey and another time from the indexer).