### PR TITLE
Compile out non-2020-compliant code in MixedRealityOptimizeUtils

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/MixedRealityOptimizeUtils.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/MixedRealityOptimizeUtils.cs
@@ -6,6 +6,10 @@ using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
+#if !UNITY_2020_1_OR_NEWER
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+#endif // !UNITY_2020_1_OR_NEWER
+
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     public static class MixedRealityOptimizeUtils
@@ -30,6 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <returns>True if the project has depth buffer sharing enabled, false otherwise.</returns>
         public static bool IsDepthBufferSharingEnabled()
         {
+#if !UNITY_2020_1_OR_NEWER
             if (IsBuildTargetOpenVR())
             {
                 // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
@@ -59,14 +64,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 {
                     return true;
                 }
-#endif
-            }
+#endif // UNITY_2019_1_OR_NEWER
+        }
+#endif // !UNITY_2020_1_OR_NEWER
 
-            return false;
+            return true;
         }
 
         public static void SetDepthBufferSharing(bool enableDepthBuffer)
         {
+#if !UNITY_2020_1_OR_NEWER
             if (IsBuildTargetOpenVR())
             {
                 // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
@@ -88,29 +95,37 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 ChangeProperty(playerSettings,
                     "vrSettings.hololens.depthBufferSharingEnabled",
                     property => property.boolValue = enableDepthBuffer);
-#endif
+#endif // UNITY_2019_1_OR_NEWER
             }
+#endif // !UNITY_2020_1_OR_NEWER
         }
 
         public static bool IsWMRDepthBufferFormat16bit()
         {
+#if !UNITY_2020_1_OR_NEWER
+            if (XRSettingsUtilities.IsLegacyXRActive)
+            {
 #if UNITY_2019_1_OR_NEWER
-            // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
-            // with legacy requirements.
+                // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
+                // with legacy requirements.
 #pragma warning disable 0618
-            return PlayerSettings.VRWindowsMixedReality.depthBufferFormat == PlayerSettings.VRWindowsMixedReality.DepthBufferFormat.DepthBufferFormat16Bit;
+                return PlayerSettings.VRWindowsMixedReality.depthBufferFormat == PlayerSettings.VRWindowsMixedReality.DepthBufferFormat.DepthBufferFormat16Bit;
 #pragma warning restore 0618
 #else
-            var playerSettings = GetSettingsObject("PlayerSettings");
-            var property = playerSettings?.FindProperty("vrSettings.hololens.depthFormat");
-            return property != null && property.intValue == 0;
-#endif
+                var playerSettings = GetSettingsObject("PlayerSettings");
+                var property = playerSettings?.FindProperty("vrSettings.hololens.depthFormat");
+                return property != null && property.intValue == 0;
+#endif // UNITY_2019_1_OR_NEWER
+            }
+#endif // !UNITY_2020_1_OR_NEWER
+            return true;
         }
 
         public static void SetDepthBufferFormat(bool set16BitDepthBuffer)
         {
             int depthFormat = set16BitDepthBuffer ? 0 : 1;
 
+#if !UNITY_2020_1_OR_NEWER
             // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
             // with legacy requirements.
 #pragma warning disable 0618
@@ -132,10 +147,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 "vrSettings.lumin.depthFormat",
                 property => property.intValue = depthFormat);
 #else
+
             ChangeProperty(playerSettings,
                 "vrSettings.hololens.depthFormat",
                 property => property.intValue = depthFormat);
-#endif
+#endif // UNITY_2019_1_OR_NEWER
+#endif // !UNITY_2020_1_OR_NEWER
         }
 
         public static bool IsRealtimeGlobalIlluminationEnabled()


### PR DESCRIPTION
## Overview

First pass to get things compiling in Unity 2020.
Second pass will be to complete #7514/#7513, which will enable 2019, 2020, etc.

## Changes
- Part of #8269 

