### PR TITLE
Update internal CI Unity versions

### DIFF
--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: Analog On-Prem
     demands:
-    - Unity2018.4.12f1
+    - Unity2018.4.23f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -19,7 +19,7 @@ jobs:
   pool:
     name: Analog On-Prem
     demands:
-    - Unity2018.4.12f1
+    - Unity2018.4.23f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-weekly-internal.yml
+++ b/pipelines/ci-weekly-internal.yml
@@ -21,7 +21,7 @@ jobs:
   pool:
     name: Analog On-Prem
     demands:
-    - Unity2018.4.12f1
+    - Unity2018.4.23f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/config/settings.yml
+++ b/pipelines/config/settings.yml
@@ -3,8 +3,8 @@ variables:
   Unity2018Version: Unity2018.4.26f1
   Unity2019Version: Unity2019.4.8f1
   # Unity version on internal build agents (release builds)
-  Unity2018VersionInternal: Unity2018.4.12f1
-  Unity2019VersionInternal: Unity2019.2.0f1
+  Unity2018VersionInternal: Unity2018.4.23f1
+  Unity2019VersionInternal: Unity2019.4.6f1
 
   # Note that when updating this value also ensure that you update the
   # following locations to match. There will be a CI failure if they don't


### PR DESCRIPTION
## Overview

The internal machines have a newer version of Unity 2018.4 installed, so let's use that!