### PR TITLE
Update the MRTK configurator to turn off "Graphics Jobs" by default in Unity 2019

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -37,6 +37,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { MRConfig.IOSMinOSVersion, true },
             { MRConfig.IOSArchitecture, true },
             { MRConfig.IOSCameraUsageDescription, true },
+
+#if UNITY_2019_3_OR_NEWER
+            // A workaround for the Unity bug described in https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8326.
+            { MRConfig.GraphicsJobWorkaround, true },
+#endif // UNITY_2019_3_OR_NEWER
         };
 
         private const float Default_Window_Height = 640.0f;
@@ -194,6 +199,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     RenderToggle(MRConfig.SpatialPerceptionCapability, "Enable Spatial Perception Capability");
 #if UNITY_2019_3_OR_NEWER
                     RenderToggle(MRConfig.EyeTrackingCapability, "Enable Eye Gaze Input Capability");
+                    RenderToggle(MRConfig.GraphicsJobWorkaround, "Avoid Unity 'PlayerSettings.graphicsJob' crash");
 #endif // UNITY_2019_3_OR_NEWER
                 }
                 else
@@ -203,6 +209,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     trackToggles[MRConfig.SpatialPerceptionCapability] = false;
 #if UNITY_2019_3_OR_NEWER
                     trackToggles[MRConfig.EyeTrackingCapability] = false;
+                    trackToggles[MRConfig.GraphicsJobWorkaround] = false;
 #endif // UNITY_2019_3_OR_NEWER
                 }
 

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -63,6 +63,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             IOSMinOSVersion = 3000,
             IOSArchitecture,
             IOSCameraUsageDescription,
+
+#if UNITY_2019_3_OR_NEWER
+            // A workaround for the Unity bug described in https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8326.
+            GraphicsJobWorkaround,
+#endif // UNITY_2019_3_OR_NEWER
         };
 
         private class ConfigGetter
@@ -133,6 +138,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.IOSMinOSVersion, new ConfigGetter(() => float.TryParse(PlayerSettings.iOS.targetOSVersionString, out float version) ? version >= iOSMinOsVersion : false, BuildTarget.iOS) },
             { Configurations.IOSArchitecture, new ConfigGetter(() => PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequirediOSArchitecture, BuildTarget.iOS) },
             { Configurations.IOSCameraUsageDescription, new ConfigGetter(() => !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription), BuildTarget.iOS) },
+
+#if UNITY_2019_3_OR_NEWER
+            { Configurations.GraphicsJobWorkaround, new ConfigGetter(() => !PlayerSettings.graphicsJobs, BuildTarget.WSAPlayer) },
+#endif // UNITY_2019_3_OR_NEWER
+
         };
 
         // The configure functions for each type of setting
@@ -162,6 +172,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.IOSMinOSVersion, () => PlayerSettings.iOS.targetOSVersionString = iOSMinOsVersion.ToString("n1") },
             { Configurations.IOSArchitecture, () => PlayerSettings.SetArchitecture(BuildTargetGroup.iOS, RequirediOSArchitecture) },
             { Configurations.IOSCameraUsageDescription, () => PlayerSettings.iOS.cameraUsageDescription = iOSCameraUsageDescription },
+
+#if UNITY_2019_3_OR_NEWER
+            { Configurations.GraphicsJobWorkaround, () => PlayerSettings.graphicsJobs = false },
+#endif // UNITY_2019_3_OR_NEWER
         };
 
         /// <summary>

--- a/Documentation/MRTK_Configuration_Dialog.md
+++ b/Documentation/MRTK_Configuration_Dialog.md
@@ -101,11 +101,6 @@ This setting is enabled by default in Unity - while this bug exists (see [Unity 
 (https://issuetracker.unity3d.com/issues/enabling-graphics-jobs-in-2019-dot-3-x-results-in-a-crash-or-nothing-rendering-on-hololens-2)),
 the configurator will default to setting Graphics Jobs to 'false' (thus allowing apps deployed to HoloLens 2 not to crash).
 
-**Unity 2019.2 and earlier**
-
-MSBuild for Unity is a component that enables automatic restoring of specific NuGet packages. In this version, the **Microsoft.Windows.MixedReality.DotNetWinRT** package will be installed after enabling MSBuild for Unity.
-
-
 ## Android settings
 
 Configuration settings to support AR applications on Android powered devices.

--- a/Documentation/MRTK_Configuration_Dialog.md
+++ b/Documentation/MRTK_Configuration_Dialog.md
@@ -92,6 +92,20 @@ Enables specific application capabilities for Universal Windows Platform applica
 
   Enables support for tracking the user's eye gaze.
 
+### Avoid Unity 'PlayerSettings.graphicsJob' crash
+
+**Unity 2019.3 and newer**
+
+In the latest version of Unity 2019, when "Graphics Jobs" is enabled, the app will crash when deployed to a HoloLens 2.
+This setting is enabled by default in Unity - while this bug exists (see [Unity bug]
+(https://issuetracker.unity3d.com/issues/enabling-graphics-jobs-in-2019-dot-3-x-results-in-a-crash-or-nothing-rendering-on-hololens-2)),
+the configurator will default to setting Graphics Jobs to 'false' (thus allowing apps deployed to HoloLens 2 not to crash).
+
+**Unity 2019.2 and earlier**
+
+MSBuild for Unity is a component that enables automatic restoring of specific NuGet packages. In this version, the **Microsoft.Windows.MixedReality.DotNetWinRT** package will be installed after enabling MSBuild for Unity.
+
+
 ## Android settings
 
 Configuration settings to support AR applications on Android powered devices.


### PR DESCRIPTION
See linked issue https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8326 for more details - this is a pretty bad issue for folks using Unity 2019 and trying to deploy to HL2.

This updates the configurator to turn off this setting by default for 2019 (and when under UWP). This is obviously not specific to HL2 (since HL1 also uses UWP and WMR as well) but is the level of detail that we can distinguish to make sure we don't affect standalone or other platforms.