### PR TITLE
Add HandJointService to XR SDK profile

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKConfigurationProfile.asset
+++ b/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKConfigurationProfile.asset
@@ -53,3 +53,4 @@ MonoBehaviour:
     type: 2}
   useServiceInspectors: 1
   renderDepthBuffer: 0
+  enableVerboseLogging: 0

--- a/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKInputSystemProfile.asset
+++ b/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKInputSystemProfile.asset
@@ -35,6 +35,12 @@ MonoBehaviour:
     runtimePlatform: 208
     deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
       type: 2}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.HandJointService, Microsoft.MixedReality.Toolkit
+    componentName: Hand Joint Service
+    priority: 0
+    runtimePlatform: -1
+    deviceManagerProfile: {fileID: 0}
   focusProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.FocusProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
   raycastProviderType:


### PR DESCRIPTION
## Overview

[On Slack](https://holodevelopers.slack.com/archives/C2H4HT858/p1597784419352700), it was pointed out that our hand menu samples depend on the hand joint service being registered in the input providers. This PR adds the service to the XR SDK profile so hand menus work again!