### PR TITLE
HoloLens 2 Button material update

### DIFF
--- a/Assets/MRTK/SDK/StandardAssets/Materials/MRTK_PressableInteractablesButtonBox.mat
+++ b/Assets/MRTK/SDK/StandardAssets/Materials/MRTK_PressableInteractablesButtonBox.mat
@@ -17,7 +17,7 @@ Material:
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 3000
   stringTagMap:
-    RenderType: Transparent
+    RenderType: Fade
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -78,6 +78,7 @@ Material:
     - _FluentLightIntensity: 1
     - _HoverLight: 0
     - _IgnoreZScale: 0
+    - _IndependentCorners: 0
     - _InnerGlow: 0
     - _InnerGlowPower: 24.5
     - _InstancedColor: 0
@@ -121,7 +122,7 @@ Material:
     - _ZWrite: 0
     m_Colors:
     - _ClippingBorderColor: {r: 1, g: 0.2, b: 0, a: 1}
-    - _Color: {r: 0.1254902, g: 0.1254902, b: 0.1254902, a: 1}
+    - _Color: {r: 0.1254902, g: 0.1254902, b: 0.1254902, a: 0}
     - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
     - _EnvironmentColorX: {r: 1, g: 0, b: 0, a: 1}
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
@@ -132,3 +133,4 @@ Material:
     - _ProximityLightMiddleColorOverride: {r: 0, g: 1, b: 0, a: 0.5}
     - _ProximityLightOuterColorOverride: {r: 0, g: 0, b: 1, a: 1}
     - _RimColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _RoundCornersRadius: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}


### PR DESCRIPTION
## Overview
Updated HoloLens 2 Button's front cage material to transparent to remove black color in MRC. 
(we already did this update for Bounding Box while ago)

Removes black color on the button's front box in Mixed Reality Capture:
![2020-08-19 10_49_34-Photos](https://user-images.githubusercontent.com/13754172/90583270-b4daa600-e20a-11ea-9bd1-91690548e59b.png)

## Changes
**MRTK_PressableInteractablesButtonBox.mat**  Adjusted alpha from 255 to 0:
![2020-08-19 10_46_45-Color](https://user-images.githubusercontent.com/13754172/90583194-8e1c6f80-e20a-11ea-9e65-abbd29c5812d.png)
![2020-08-19 10_46_53-Color](https://user-images.githubusercontent.com/13754172/90583192-8d83d900-e20a-11ea-9a9b-f8abbda8323e.png)
