### PR TITLE
Unity 2018 LTS version updates

### DIFF
--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -22,7 +22,7 @@ The Mixed Reality Toolkit is an all-new product, built to be cross MR/AR/VR/XR p
 
 The Mixed Reality Toolkit will require Unity 2018.4.x
 
-> When Unity releases an LTS (Long Term Support) product, the Mixed Reality Toolkit will update to the LTS release. MRTK will also support the latest non-beta (ex: 2019.4.8f) tech branch version of Unity, at the time at which MRTK was released.
+> When Unity releases an LTS (Long Term Support) product, the Mixed Reality Toolkit will update to the LTS release. MRTK will also support the latest non-beta (ex: 2020.1) tech branch version of Unity, at the time at which MRTK was released.
 
 ### 2.5.0
 

--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -4,7 +4,7 @@ This document outlines the roadmap of the Mixed Reality Toolkit.
 
 ## Current release
 
-[Microsoft Mixed Reality Toolkit v2.3.0](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v2.3.0)
+[Microsoft Mixed Reality Toolkit v2.4.0](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v2.4.0)
 
 ## Upcoming releases
 
@@ -20,9 +20,9 @@ Release details, including backlog items, can be found on the [GitHub milestone 
 
 The Mixed Reality Toolkit is an all-new product, built to be cross MR/AR/VR/XR platform by design. There are two planned pre-releases after which the Mixed Reality Toolkit will become the primary product.
 
-The Mixed Reality Toolkit will require Unity 2018.4.
+The Mixed Reality Toolkit will require Unity 2018.4.x
 
-> When Unity releases an LTS (Long Term Support) product, the Mixed Reality Toolkit will update to the LTS release. MRTK will also support the latest non-beta (ex: 2019.1) tech branch version of Unity, at the time at which MRTK was released.
+> When Unity releases an LTS (Long Term Support) product, the Mixed Reality Toolkit will update to the LTS release. MRTK will also support the latest non-beta (ex: 2019.4.8f) tech branch version of Unity, at the time at which MRTK was released.
 
 ### 2.5.0
 

--- a/Documentation/Contributing/UnitTests.md
+++ b/Documentation/Contributing/UnitTests.md
@@ -27,16 +27,16 @@ The [Unity Test Runner](https://docs.unity3d.com/Manual/testing-editortestsrunne
 
 Tests can also be run by a [powershell](https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-6) script located at `Scripts\test\run_playmode_tests.ps1`. This will run the playmode tests exactly as they are executed on github / CI (see below), and print results. Here are some examples of how to run the script
 
-Run the tests on the project located at H:\mrtk.dev, with Unity 2018.4 (for example Unity 2018.4.1f1)
+Run the tests on the project located at H:\mrtk.dev, with Unity 2018.4 (for example Unity 2018.4.26f1)
 
 ```ps
-.\run_playmode_tests.ps1 H:\mrtk.dev -unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.1f1\Editor\Unity.exe"
+.\run_playmode_tests.ps1 H:\mrtk.dev -unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.26f1\Editor\Unity.exe"
 ```
 
 Run the tests on the project located at H:\mrtk.dev, with Unity 2018.4, output results to C:\playmode_test_out
 
 ```ps
-.\run_playmode_tests.ps1 H:\mrtk.dev -unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.1f1\Editor\Unity.exe" -outFolder "C:\playmode_test_out\"
+.\run_playmode_tests.ps1 H:\mrtk.dev -unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.26f1\Editor\Unity.exe" -outFolder "C:\playmode_test_out\"
 ```
 
 It's also possible to run the playmode tests multiple times via the `run_repeat_tests.ps1` script. All parameters used in `run_playmode_tests.ps1` may be used.

--- a/scripts/test/run_playmode_tests.ps1
+++ b/scripts/test/run_playmode_tests.ps1
@@ -15,7 +15,7 @@ param(
     # Path to your Unity Executable
     [ValidateScript({[System.IO.File]::Exists($_) -and $_.EndsWith(".exe") })]
     [string]
-    $unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.6f1\Editor\Unity.exe",
+    $unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.26f1\Editor\Unity.exe",
     # Optional test filter
     [Parameter(Mandatory=$false)]
     [string]

--- a/scripts/test/run_repeat_tests.ps1
+++ b/scripts/test/run_repeat_tests.ps1
@@ -15,7 +15,7 @@ param (
     # Path to your Unity Executable
     [ValidateScript({[System.IO.File]::Exists($_) -and $_.EndsWith(".exe") })]
     [string]
-    $unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.6f1\Editor\Unity.exe",
+    $unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.26f1\Editor\Unity.exe",
     # Optional test filter
     [Parameter(Mandatory=$false)]
     [string]


### PR DESCRIPTION
## Overview
I have updated the Unity 2018 LTS version to the latest 2018.4.26f1 in examples in the documents and the two test scripts in Scripts/test/run_*.ps1. I also updated the current release in the roadmap.md to v2.4.0 from v2.3.0.

## Changes
- Fixes: Updated version numbers in documents and two CI test scripts.


