### PR TITLE
Fix gaze when using an override

### DIFF
--- a/Assets/MRTK/Core/Utilities/MixedRealityPlayspace.cs
+++ b/Assets/MRTK/Core/Utilities/MixedRealityPlayspace.cs
@@ -131,6 +131,18 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
+        /// Transforms a direction from world to local space.
+        /// </summary>
+        /// <param name="worldDirection">The direction to be transformed.</param>
+        /// <returns>
+        /// The direction, in local space.
+        /// </returns>
+        public static Vector3 InverseTransformDirection(Vector3 worldDirection)
+        {
+            return Transform.InverseTransformDirection(worldDirection);
+        }
+
+        /// <summary>
         /// Rotates the playspace around the specified axis.
         /// </summary>
         /// <param name="point">The point to pass through during rotation.</param>

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -528,7 +528,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private static readonly ProfilerMarker RaiseSourceDetectedPerfMarker = new ProfilerMarker("[MRTK] GazeProvider.RaiseSourceDetectec");
+        private static readonly ProfilerMarker RaiseSourceDetectedPerfMarker = new ProfilerMarker("[MRTK] GazeProvider.RaiseSourceDetected");
 
         private async void RaiseSourceDetected()
         {

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -245,9 +245,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         // Update gaze info from stabilizer
                         if (stabilizer != null)
                         {
-                            stabilizer.UpdateStability(gazeTransform.localPosition, gazeTransform.localRotation * Vector3.forward);
-                            newGazeOrigin = gazeTransform.parent.TransformPoint(stabilizer.StablePosition);
-                            newGazeNormal = gazeTransform.parent.TransformDirection(stabilizer.StableRay.direction);
+                            stabilizer.UpdateStability(MixedRealityPlayspace.InverseTransformPoint(newGazeOrigin), MixedRealityPlayspace.InverseTransformDirection(newGazeNormal));
+                            newGazeOrigin = MixedRealityPlayspace.TransformPoint(stabilizer.StablePosition);
+                            newGazeNormal = MixedRealityPlayspace.TransformDirection(stabilizer.StableRay.direction);
                         }
                     }
 


### PR DESCRIPTION
## Overview

Currently, the gaze provider overwrites any override data by passing the default gaze transform into the stabilizer.
This change fulfills the original bug fix (https://github.com/microsoft/MixedRealityToolkit-Unity/pull/3627) by keeping the stabilizer working in local space based on the playspace.

## Changes

- Fixes: #8163 