### PR TITLE
Enable publishing of upm packages in release pipelines

### DIFF
--- a/pipelines/packageupmpublic-preview.yaml
+++ b/pipelines/packageupmpublic-preview.yaml
@@ -4,7 +4,7 @@ variables:
 - template: config/settings.yml
 
 jobs:
-- job: CreatePublicPreviewUPMArtifacts
+- job: UPMPublicPreviewRelease
   timeoutInMinutes: 30
   pool:
     name: On-Prem Unity

--- a/pipelines/packageupmpublic-preview.yaml
+++ b/pipelines/packageupmpublic-preview.yaml
@@ -4,7 +4,7 @@ variables:
 - template: config/settings.yml
 
 jobs:
-- job: CreatePublicUPMArtifacts
+- job: CreatePublicPreviewUPMArtifacts
   timeoutInMinutes: 30
   pool:
     name: On-Prem Unity
@@ -12,3 +12,11 @@ jobs:
   - template: templates/tasks/upmpackages.yml
     parameters:
       excludeBuildNumber: 0
+  - task: PowerShell@2
+    displayName: 'UPM packages to registry'
+    inputs:
+      targetType: filePath
+      filePath: ./scripts/packaging/publishupmpackages.ps1
+      arguments: >
+        -PackageDirectory $(Build.ArtifactStagingDirectory)\build\upm\output
+        -RegistryPath $(UpmRegistry)

--- a/pipelines/packageupmpublic.yaml
+++ b/pipelines/packageupmpublic.yaml
@@ -12,3 +12,11 @@ jobs:
   - template: templates/tasks/upmpackages.yml
     parameters:
       excludeBuildNumber: 1
+  - task: PowerShell@2
+    displayName: 'UPM packages to registry'
+    inputs:
+      targetType: filePath
+      filePath: ./scripts/packaging/publishupmpackages.ps1
+      arguments: >
+        -PackageDirectory $(Build.ArtifactStagingDirectory)\build\upm\output
+        -RegistryPath $(UpmRegistry)

--- a/pipelines/packageupmpublic.yaml
+++ b/pipelines/packageupmpublic.yaml
@@ -4,7 +4,7 @@ variables:
 - template: config/settings.yml
 
 jobs:
-- job: CreatePublicUPMArtifacts
+- job: UPMPublicRelease
   timeoutInMinutes: 30
   pool:
     name: On-Prem Unity


### PR DESCRIPTION
This change reads the registry path from the pipeline run and publishes the artifacts. This completes the UPM publishing work!