### PR TITLE
GetLoadableTypes strikes again

### DIFF
--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -246,7 +246,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                foreach (Type t in assembly.GetTypes().Where(t => t.IsSubclassOf(typeof(Component))))
+                foreach (Type t in assembly.GetLoadableTypes().Where(t => t.IsSubclassOf(typeof(Component))))
                 {
                     foreach (FieldInfo f in t.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
                     {


### PR DESCRIPTION
Usage of Assembly.LoadTypes() has bitten us at least four times in the past:

https://github.com/microsoft/MixedRealityToolkit-Unity/pulls?q=is%3Apr+gettypes+is%3Aclosed+

This change removes the latest case that is problematic and also adds some code checkers so that we don't do this again, because this is the legit 5th time I've had to solve this problem.

https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8331

