### PR TITLE
Update new code checker to escape .

### DIFF
--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -429,7 +429,7 @@ function CheckAssemblyTypes {
     process {
         $hasIssue = $false
 
-        if ($FileContent[$LineNumber] -match ".GetTypes()") {
+        if ($FileContent[$LineNumber] -match "\.GetTypes()") {
             $assetFileName = GetProjectRelativePath($FileName)
             if (-Not $AssemblyTypesExceptions.Contains($assetFileName)) {
                 Write-Host "$FileName at line $LineNumber has a possible usage of Assembly.GetTypes()"


### PR DESCRIPTION
## Overview

This new code checker didn't escape the `.`, so it was matching any character that preceded `GetTypes()`. We have a test called `TestTargetTypes`, which was triggering this code issue.

## Changes
- Fixes: https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=13459&view=logs&j=ae5f814d-d003-5afd-2125-fa0189ea8658&t=12d627c1-3bb6-55bf-f915-b77e58828cea
