### PR TITLE
it's -> its in possessive usages

### DIFF
--- a/Assets/MRTK/Core/Definitions/BoundarySystem/InscribedRectangle.cs
+++ b/Assets/MRTK/Core/Definitions/BoundarySystem/InscribedRectangle.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// Is the described rectangle valid?
         /// </summary>
         /// <remarks>
-        /// A rectangle is considered valid if it's center point is valid.
+        /// A rectangle is considered valid if its center point is valid.
         /// </remarks>
         public bool IsValid => EdgeUtilities.IsValidPoint(Center);
 

--- a/Assets/MRTK/Core/Definitions/Utilities/AutoStartBehavior.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/AutoStartBehavior.cs
@@ -5,7 +5,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     /// <summary>
     /// This enumeration identifies two different ways to handle the startup behavior for a feature. 
-    /// Both will warm up the component, ready for it's use (e.g. connecting backend services or registering for events. 
+    /// Both will warm up the component, ready for its use (e.g. connecting backend services or registering for events. 
     /// The first causes the feature to start immediately. The second allows the feature to be manually started at a later time.
     /// </summary>
     public enum AutoStartBehavior

--- a/Assets/MRTK/Core/EventDatum/README.md
+++ b/Assets/MRTK/Core/EventDatum/README.md
@@ -1,5 +1,5 @@
 # Mixed Reality Toolkit - EventDatum
 
-Data model classes for the inner workings of the Mixed Reality Toolkit and it's supported Core systems.
+Data model classes for the inner workings of the Mixed Reality Toolkit and its supported Core systems.
 
 All data models required for system use within the MRTK should be recorded here.

--- a/Assets/MRTK/Core/Extensions/CanvasExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/CanvasExtensions.cs
@@ -162,7 +162,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="worldPoint">The world point</param>
         /// <param name="recursive">Indicates if the check should be done recursively</param>
         /// <param name="shouldReturnActive">If true, will only check children that are active, otherwise it will check all children.</param>
-        /// <param name="shouldReturnRaycastable">If true, will only check children that if they have a graphic and have it's member raycastTarget set to true, otherwise will ignore the raycastTarget value. Will still allow children to be checked that do not have a graphic component.</param>
+        /// <param name="shouldReturnRaycastable">If true, will only check children that if they have a graphic and have its member raycastTarget set to true, otherwise will ignore the raycastTarget value. Will still allow children to be checked that do not have a graphic component.</param>
         public static RectTransform GetChildRectTransformAtPoint(this RectTransform rectTransformParent, Vector3 worldPoint, bool recursive, bool shouldReturnActive, bool shouldReturnRaycastable)
         {
             Vector3[] localCorners = new Vector3[4];

--- a/Assets/MRTK/Core/Extensions/TransformExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/TransformExtensions.cs
@@ -93,7 +93,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Calculates the bounds of all the colliders attached to this GameObject and all it's children
+        /// Calculates the bounds of all the colliders attached to this GameObject and all its children
         /// </summary>
         /// <param name="transform">Transform of root GameObject the colliders are attached to </param>
         /// <returns>The total bounds of all colliders attached to this GameObject. 

--- a/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
@@ -153,7 +153,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         /// <summary>
         /// Renders properties of <see cref="IMixedRealityServiceConfiguration"/> instance at provided index in inspector.
-        /// Also renders inspector view of data provider's profile object and it's contents if applicable and foldout is expanded.
+        /// Also renders inspector view of data provider's profile object and its contents if applicable and foldout is expanded.
         /// </summary>
         protected bool RenderDataProviderEntry(int index, GUIContent removeContent, System.Type dataProviderProfileType = null)
         {

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -471,12 +471,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         }
 
         /// <summary>
-        /// Render helpbox that provided service string is disabled and none of it's functionality will be loaded at runtime
+        /// Render helpbox that provided service string is disabled and none of its functionality will be loaded at runtime
         /// </summary>
         protected static void RenderSystemDisabled(string service)
         {
             EditorGUILayout.Space();
-            EditorGUILayout.HelpBox($"The {service} is disabled.\n\nThis module will not be loaded and thus none of it's feature will be available at runtime.", MessageType.Info);
+            EditorGUILayout.HelpBox($"The {service} is disabled.\n\nThis module will not be loaded and thus none of its features will be available at runtime.", MessageType.Info);
             EditorGUILayout.Space();
         }
 

--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -591,7 +591,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         }
 
         /// <summary>
-        /// Get the index of a serialized array item based on it's name, pop-up field helper
+        /// Get the index of a serialized array item based on its name, pop-up field helper
         /// </summary>
         public static int GetOptionsIndex(SerializedProperty options, string selection)
         {

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -253,7 +253,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             var newNode = propertyGroupNode.Element(defaultNamespace + "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch");
             if (newNode != null)
             {
-                // If this setting already exists in the project, ensure it's value is "None"
+                // If this setting already exists in the project, ensure its value is "None"
                 newNode.Value = "None";
             }
             else

--- a/Assets/MRTK/Core/Utilities/EdgeUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/EdgeUtilities.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="point">The point to check.</param>
         /// <returns>True if the point is valid, false otherwise.</returns>
         /// <remarks>
-        /// A point is considered invalid if any one of it's coordinate values are infinite or not a number.
+        /// A point is considered invalid if any one of its coordinate values are infinite or not a number.
         /// </remarks>
         public static bool IsValidPoint(Vector2 point)
         {

--- a/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     public static class SizeUtilities
     {
         /// <summary>
-        /// Finds the first Renderer type component on the selected GameObject in scene and returns it's world space bounds size.
+        /// Finds the first Renderer type component on the selected GameObject in scene and returns its world space bounds size.
         /// </summary>
         [MenuItem("GameObject/MRTK Debug Utilities/Print Renderer Size", false, 40)]
         public static void RendererSize()

--- a/Assets/MRTK/Core/Utilities/GameObjectManagement/GameObjectCreator.cs
+++ b/Assets/MRTK/Core/Utilities/GameObjectManagement/GameObjectCreator.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.GameObjectManagement
         }
 
         /// <summary>
-        /// Called before the GameObject's position and rotation are set (as well as it's active state) by the GameObjectPool
+        /// Called before the GameObject's position and rotation are set (as well as its active state) by the GameObjectPool
         /// when GetGameObject is called. If the GameObject has a component that implements
         /// the IGameObjectCreatorHandler interface, it will call its PrepareForUse function.
         /// </summary>

--- a/Assets/MRTK/Core/Utilities/GameObjectManagement/IGameObjectCreatorListener.cs
+++ b/Assets/MRTK/Core/Utilities/GameObjectManagement/IGameObjectCreatorListener.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.GameObjectManagement
         void PrepareForRecycle();
 
         /// <summary>
-        /// Called before the GameObject's position and rotation are set (as well as it's active state) by the GameObjectPool
+        /// Called before the GameObject's position and rotation are set (as well as its active state) by the GameObjectPool
         /// when GetGameObject is called.
         /// </summary>
         void PrepareForUse();

--- a/Assets/MRTK/Core/Utilities/MaintainBorderLightWidth.cs
+++ b/Assets/MRTK/Core/Utilities/MaintainBorderLightWidth.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     }
                 }
 
-                // Multiply the initial border width by the amount need to maintain it's value at the new scale.
+                // Multiply the initial border width by the amount need to maintain its value at the new scale.
                 var scalePercentage = minScale / initialScale[minAxis];
 
                 if (scalePercentage.Equals(0.0f))

--- a/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
@@ -198,7 +198,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
                 {
                     defaultMaterials = CachedRenderer.sharedMaterials;
                 }
-                else if (!materialsInstanced) // Restore the clone to it's initial state.
+                else if (!materialsInstanced) // Restore the clone to its initial state.
                 {
                     CachedRenderer.sharedMaterials = defaultMaterials;
                 }

--- a/Assets/MRTK/Core/Utilities/StandardShader/MeshSmoother.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/MeshSmoother.cs
@@ -207,7 +207,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             var smoothNormals = new List<Vector3>(normals);
 
-            // If we don't hit the degenerate case of each vertex is it's own group (no vertices shared a location), average the normals of each group.
+            // If we don't hit the degenerate case of each vertex is its own group (no vertices shared a location), average the normals of each group.
             if (groupedVerticies.Count != vertices.Length)
             {
                 foreach (var group in groupedVerticies)

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -728,7 +728,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
             Transform targetTransform = Target.transform;
 
-            // In case we found nothing and this is the Target, we add it's inevitable collider's bounds
+            // In case we found nothing and this is the Target, we add its inevitable collider's bounds
             if (totalBoundsCorners.Count == 0 && Target == gameObject)
             {
                 ExtractBoundsCorners(targetTransform, BoundsCalculationMethod.ColliderOnly);

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         /// <summary>
-        /// Updates proximity effect and it's registered objects.
+        /// Updates proximity effect and its registered objects.
         /// Highlights and scales objects in proximity according to the pointer distance
         /// </summary>
         /// <param name="boundsCenter">gameobject position the proximity effect is attached to</param>

--- a/Assets/MRTK/SDK/Features/Audio/Influencers/AudioInfluencerController.cs
+++ b/Assets/MRTK/SDK/Features/Audio/Influencers/AudioInfluencerController.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
     /// </summary>
     /// <remarks>
     /// AudioInfluencerController requires an <see href="https://docs.unity3d.com/ScriptReference/AudioSource.html">AudioSource</see> component. If one is not attached, it will be added automatically.
-    /// Each sound playing game object needs to have an AudioInfluencerController attached in order to have it's audio influenced.
+    /// Each sound playing game object needs to have an AudioInfluencerController attached in order to have its audio influenced.
     /// </remarks>
     [RequireComponent(typeof(AudioSource))]
     [DisallowMultipleComponent]

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         [SerializeField]
-        [Tooltip("Should this GameObject clean itself up when it's controller is lost?")]
+        [Tooltip("Should this GameObject clean itself up when its controller is lost?")]
         private bool destroyOnSourceLost = true;
 
         /// <inheritdoc />

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -84,11 +84,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [FormerlySerializedAs("IsGlobal")]
         [SerializeField]
         [Tooltip("If true, this Interactable will listen globally for any IMixedRealityInputHandler input events. These include general input up/down and clicks." +
-        "If false, this Interactable will only respond to general input click events if the pointer target is this GameObject's, or one of it's children's, collider.")]
+        "If false, this Interactable will only respond to general input click events if the pointer target is this GameObject's, or one of its children's, collider.")]
         protected bool isGlobal = false;
         /// <summary>
         /// If true, this Interactable will listen globally for any IMixedRealityInputHandler input events. These include general input up/down and clicks.
-        /// If false, this Interactable will only respond to general input click events if the pointer target is this GameObject's, or one of it's children's, collider.
+        /// If false, this Interactable will only respond to general input click events if the pointer target is this GameObject's, or one of its children's, collider.
         /// </summary>
         public bool IsGlobal
         {

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/States/InteractableStates.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/States/InteractableStates.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             /// </summary>
             Gesture,
             /// <summary>
-            /// Gesture has reached it's max movement
+            /// Gesture has reached its max movement
             /// </summary>
             GestureMax,
             /// <summary>

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1847,7 +1847,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             Transform targetTransform = Target.transform;
 
-            // In case we found nothing and this is the Target, we add it's inevitable collider's bounds
+            // In case we found nothing and this is the Target, we add its inevitable collider's bounds
 
             if (totalBoundsCorners.Count == 0 && Target == gameObject)
             {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/CursorModifier.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/CursorModifier.cs
@@ -159,7 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             if (cursor.Pointer == null)
             {
-                Debug.LogError($"{cursor.GameObjectReference.name} has no pointer set in it's cursor component!");
+                Debug.LogError($"{cursor.GameObjectReference.name} has no pointer set in its cursor component!");
                 return Vector3.zero;
             }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ScreenSpaceMousePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ScreenSpaceMousePointer.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// Uses the desktop mouse cursor instead of any mouse representation within the scene.
-    /// It's movement is bound to screenspace.
+    /// Its movement is bound to screenspace.
     /// </summary>
     [AddComponentMenu("Scripts/MRTK/SDK/ScreenSpaceMousePointer")]
     public class ScreenSpaceMousePointer : BaseMousePointer

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -480,7 +480,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             }
 
             // If we were tracking a particular hand, check that our transform is still valid
-            // The HandJointService does not destroy it's own hand joint tracked GameObjects even when a hand is no longer tracked
+            // The HandJointService does not destroy its own hand joint tracked GameObjects even when a hand is no longer tracked
             // Those HandJointService's GameObjects though are the parents of our tracked transform and thus will not be null/destroyed
             if (TrackedTargetType == TrackedObjectType.HandJoint && !currentTrackedHandedness.IsNone())
             {

--- a/Assets/MRTK/Services/InputSystem/Utilities/ScaleMeshEffect.cs
+++ b/Assets/MRTK/Services/InputSystem/Utilities/ScaleMeshEffect.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Utilities
 {
     /// <summary>
     /// On Unity UI components the unity_ObjectToWorld matrix is not the transformation matrix of the local 
-    /// transform the Graphic component lives on, but that of it's parent Canvas. Many MRTK/Standard shader 
+    /// transform the Graphic component lives on, but that of its parent Canvas. Many MRTK/Standard shader 
     /// effects require object scale to be known. To solve this issue the ScaleMeshEffect will store scaling 
     /// information into UV channel attributes during UI mesh construction. Ideally we would store the scale 
     /// in one attribute but UGUI only supports two scalers per attribute (even in the tangent attribute).

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
-        /// Tests if the initial transform setup of bounds control has been propagated to it's collider
+        /// Tests if the initial transform setup of bounds control has been propagated to its collider
         /// </summary>
         /// <param name="boundsControl">Bounds control that controls the collider size</param>
         private IEnumerator VerifyInitialBoundsCorrect(BoundsControl boundsControl)

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
@@ -842,7 +842,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// Ensure a disabled Interactable initializes when accessing one of it's properties even though it's Awake() has not been called
+        /// Ensure a disabled Interactable initializes when accessing one of its properties even though its Awake() has not been called
         /// </summary>
         [UnityTest]
         public IEnumerator TestForceInitialize()
@@ -863,7 +863,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             enabledCheckbox.IsToggled = true;
             Assert.IsTrue(enabledCheckbox.IsToggled);
 
-            // Disabled checkbox should auto-initialize even though it's Awake() has not been called
+            // Disabled checkbox should auto-initialize even though its Awake() has not been called
             disabledCheckbox.IsToggled = true;
             Assert.IsTrue(disabledCheckbox.IsToggled);
 

--- a/Assets/MRTK/Tests/PlayModeTests/LoadingIndicatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/LoadingIndicatorTests.cs
@@ -4,7 +4,7 @@
 #if !WINDOWS_UWP
 // When the .NET scripting backend is enabled and C# projects are built
 // Unity doesn't include the required assemblies (i.e. the ones below).
-// Given that the .NET backend is deprecated by Unity at this point it's we have
+// Given that the .NET backend is deprecated by Unity at this point, we have
 // to work around this on our end.
 
 using Microsoft.MixedReality.Toolkit.UI;

--- a/Assets/MRTK/Tests/PlayModeTests/Utils/UnityUiUtilities.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Utils/UnityUiUtilities.cs
@@ -4,7 +4,7 @@
 #if !WINDOWS_UWP
 // When the .NET scripting backend is enabled and C# projects are built
 // Unity doesn't include the required assemblies (i.e. the ones below).
-// Given that the .NET backend is deprecated by Unity at this point it's we have
+// Given that the .NET backend is deprecated by Unity at this point, we have
 // to work around this on our end.
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Input.Utilities;

--- a/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
+++ b/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
@@ -357,7 +357,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     dependencies.AddRange(GetDependenciesInFile(metaFile));
                 }
 
-                // Add linkage between this node and it's dependencies and the dependency and this node.
+                // Add linkage between this node and its dependencies and the dependency and this node.
                 foreach (var dependency in dependencies)
                 {
                     node.assetsThisDependsOn.Add(EnsureNode(dependency));


### PR DESCRIPTION
## Overview

It was called out in holodevelopers that we have two typos in the message that prints out when a system is disabled (`it's` and the singular `feature`):

![image](https://user-images.githubusercontent.com/3580640/90811686-e2425500-e2d9-11ea-9d7a-05d0fb0bb5c7.png)

I fixed that, and went through to fix any other [incorrect usages of it's instead of its](https://www.dictionary.com/e/its-vs-its/).

## Changes
- Fixes: https://holodevelopers.slack.com/archives/C2H4HT858/p1597917059000900
