### PR TITLE
Add the support for motion controller in the test infrastructure

### DIFF
--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -343,8 +343,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestUtilities.AssertAboutEqual(bounds.center, startCenter, "bbox incorrect center at start");
             TestUtilities.AssertAboutEqual(bounds.size, startSize, "bbox incorrect size at start");
 
-            PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
+            PlayModeTestUtilities.PushControllerSimulationProfile();
+            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
 
             CameraCache.Main.transform.LookAt(bbox.ScaleCorners[3].transform);
 
@@ -369,7 +369,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             // Restore the input simulation profile
-            PlayModeTestUtilities.PopHandSimulationProfile();
+            PlayModeTestUtilities.PopControllerSimulationProfile();
 
             yield return null;
         }

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -532,8 +532,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         {
             BoundsControl control = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(control);
-            PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
+            PlayModeTestUtilities.PushControllerSimulationProfile();
+            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
 
             // move camera to look at rotation sphere
             CameraCache.Main.transform.LookAt(new Vector3(0.248f, 0.001f, 1.226f)); // rotation sphere front right
@@ -566,7 +566,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return null;
 
             // Restore the input simulation profile
-            PlayModeTestUtilities.PopHandSimulationProfile();
+            PlayModeTestUtilities.PopControllerSimulationProfile();
 
             yield return null;
         }
@@ -659,8 +659,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
             BoxCollider boxCollider = boundsControl.GetComponent<BoxCollider>();
-            PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
+            PlayModeTestUtilities.PushControllerSimulationProfile();
+            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
 
             CameraCache.Main.transform.LookAt(boundsControl.gameObject.transform.Find("rigRoot/corner_3").transform);
 
@@ -687,7 +687,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return null;
 
             // Restore the input simulation profile
-            PlayModeTestUtilities.PopHandSimulationProfile();
+            PlayModeTestUtilities.PopControllerSimulationProfile();
 
             yield return null;
         }

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
@@ -54,8 +54,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestClickEvents()
         {
-            PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
+            PlayModeTestUtilities.PushControllerSimulationProfile();
+            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
 
             // Subscribe to interactable's on click so we know the click went through
             bool wasClicked = false;
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.True(wasClicked);
 
-            PlayModeTestUtilities.PopHandSimulationProfile();
+            PlayModeTestUtilities.PopControllerSimulationProfile();
         }
 
         [UnityTest]
@@ -129,8 +129,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestToggleEvents()
         {
-            PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
+            PlayModeTestUtilities.PushControllerSimulationProfile();
+            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
 
             var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();
             interactable.transform.position = Vector3.forward * 2f;
@@ -154,7 +154,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(didSelect, "Toggle select did not fire");
             Assert.True(didUnselect, "Toggle unselect did not fire");
 
-            PlayModeTestUtilities.PopHandSimulationProfile();
+            PlayModeTestUtilities.PopControllerSimulationProfile();
         }
 
 

--- a/Assets/MRTK/Tests/PlayModeTests/NearInteractionTouchableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/NearInteractionTouchableTests.cs
@@ -454,9 +454,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSim);
             yield return PlayModeTestUtilities.MoveHand(initialHandPosition, objectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim, 1);
 
-            for (int i = 0; i < PlayModeTestUtilities.HandMoveSteps; ++i)
+            for (int i = 0; i < PlayModeTestUtilities.ControllerMoveSteps; ++i)
             {
-                float scale = radiusStart + (radiusEnd - radiusStart) * (float)(i + 1) / (float)PlayModeTestUtilities.HandMoveSteps;
+                float scale = radiusStart + (radiusEnd - radiusStart) * (float)(i + 1) / (float)PlayModeTestUtilities.ControllerMoveSteps;
                 for (int j = 0; j < numTouchables; ++j)
                 {
                     Vector3 r = GetRandomPoint(j + 10);

--- a/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
@@ -115,8 +115,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Debug.Assert(slider.SliderValue == 0.5, "Slider should have value 0.5 at start");
 
             // Set up ggv simulation
-            PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
+            PlayModeTestUtilities.PushControllerSimulationProfile();
+            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
 
             var rightHand = new TestHand(Handedness.Right);
             Vector3 initialPos = new Vector3(0.05f, 0, 1.0f);
@@ -131,7 +131,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // clean up
             GameObject.Destroy(pinchSliderObject);
-            PlayModeTestUtilities.PopHandSimulationProfile();
+            PlayModeTestUtilities.PopControllerSimulationProfile();
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             };
 
             // set input simulation mode to GGV
-            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
+            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
 
             TestHand rightHand = new TestHand(Handedness.Right);
             TestHand leftHand = new TestHand(Handedness.Left);

--- a/Assets/MRTK/Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PressableButtonTests.cs
@@ -10,6 +10,7 @@
 // issue will likely persist for 2018, this issue is worked around by wrapping all
 // play mode tests in this check.
 
+using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
@@ -396,6 +397,68 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsTrue(buttonTriggered, "Button did not get triggered with far interaction.");
 
             Object.Destroy(testButton);
+            yield return null;
+        }
+
+        /// <summary>
+        /// This test verifies that buttons will trigger with motion controller far interaction
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TriggerButtonFarInteractionWithMotionController([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
+        {
+            GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
+
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            Interactable interactableComponent = testButton.GetComponent<Interactable>();
+            Button buttonComponent = testButton.GetComponent<Button>();
+
+            Assert.IsTrue(interactableComponent != null || buttonComponent != null, "Depending on button type, there should be either an Interactable or a UnityUI Button on the control");
+
+            if (buttonComponent != null)
+            {
+                // For unknown reasons, Unity UI buttons don't seem to function properly in batch/headless mode when triggered via far field interaction.
+                // So just ignore this until that bug is resolved.
+                // https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5887
+                Assert.Ignore();
+                yield break;
+            }
+
+            var objectToMoveAndScale = testButton.transform;
+
+            if (buttonComponent != null)
+            {
+                objectToMoveAndScale = testButton.transform.parent;
+            }
+
+            objectToMoveAndScale.position += new Vector3(0f, 0.3f, 0.8f);
+            objectToMoveAndScale.localScale *= 15f; // scale button up so it's easier to hit it with the far interaction pointer
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            bool buttonTriggered = false;
+
+            var onClickEvent = (interactableComponent != null) ? interactableComponent.OnClick : buttonComponent.onClick;
+
+            onClickEvent.AddListener(() =>
+            {
+                buttonTriggered = true;
+            });
+
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+            TestMotionController motionController = new TestMotionController(Handedness.Right);
+            Vector3 initialmotionControllerPosition = new Vector3(0.05f, -0.05f, 0.3f); // orient hand so far interaction ray will hit button
+            yield return motionController.Show(initialmotionControllerPosition);
+            yield return motionController.SetState(true, false, false);
+            yield return motionController.SetState(false, false, false);
+            Assert.IsTrue(buttonTriggered, "Button did not get triggered with far interaction.");
+
+            Object.Destroy(testButton);
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldHandSimMode;
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
-            PlayModeTestUtilities.PushHandSimulationProfile();
+            PlayModeTestUtilities.PushControllerSimulationProfile();
             TestUtilities.PlayspaceToOriginLookingForward();
             yield return null;
         }
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             GameObject.Destroy(panObject);
             GameObject.Destroy(panZoom);
-            PlayModeTestUtilities.PopHandSimulationProfile();
+            PlayModeTestUtilities.PopControllerSimulationProfile();
             PlayModeTestUtilities.TearDown();
             yield return null;
         }
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             InstantiateFromPrefab();
 
-            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
+            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
 
             TestHand handRight = new TestHand(Handedness.Right);
             yield return handRight.Show(new Vector3(0.0f, 0.0f, 0.6f));
@@ -226,7 +226,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <param name="expectedScroll">The amount panZoom is expected to scroll</param>
         private IEnumerator RunGGVScrollTest(float expectedScroll)
         {
-            PlayModeTestUtilities.SetHandSimulationMode(ControllerSimulationMode.HandGestures);
+            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
 
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);

--- a/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -20,6 +20,7 @@ using Microsoft.MixedReality.Toolkit.Diagnostics;
 using System.Reflection;
 using System.Collections.Generic;
 using UnityEngine.SceneManagement;
+using System;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -35,19 +36,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private static Stack<MixedRealityInputSimulationProfile> inputSimulationProfiles = new Stack<MixedRealityInputSimulationProfile>();
 
         /// <summary>
-        /// The default number of frames that elapse for each test hand movement.
+        /// The default number of frames that elapse for each test controller movement.
         /// Intentionally a smaller number to keep tests fast.
         /// </summary>
-        private const int HandMoveStepsDefault = 5;
+        private const int ControllerMoveStepsDefault = 5;
 
         /// <summary>
-        /// The default number of frames that elapse when in slow test hand mode.
-        /// See UseSlowTestHand for more information.
+        /// The default number of frames that elapse when in slow test controller mode.
+        /// See UseSlowTestController for more information.
         /// </summary>
-        private const int HandMoveStepsSlow = 60;
+        private const int ControllerMoveStepsSlow = 60;
 
         /// <summary>
-        /// If true, the hand movement test steps will take a longer number of frames. This is especially
+        /// If true, the controller movement test steps will take a longer number of frames. This is especially
         /// useful for seeing motion in play mode tests (where the default smaller number of frames tends
         /// to make tests too fast to be understandable to the human eye). This is false by default
         /// to ensure that tests will run quickly in general, and can be set to true manually in specific
@@ -58,34 +59,34 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// [UnityTest]
         /// public IEnumerator YourTestCase()
         /// {
-        ///     PlayModeTestUtilities.UseSlowTestHand = true;
+        ///     PlayModeTestUtilities.UseSlowTestController = true;
         ///     ...
-        ///     PlayModeTestUtilities.UseSlowTestHand = false;
+        ///     PlayModeTestUtilities.UseSlowTestController = false;
         /// }
         /// </code>
         /// </example>
         /// <remarks>
         /// Note that this value is reset to false after each play mode test that uses
         /// PlayModeTestUtilities.Setup() - this is to reduce the chance that a forgotten
-        /// UseSlowTestHand = true ends up slowing all subsequent tests.
+        /// UseSlowTestController = true ends up slowing all subsequent tests.
         /// </remarks>
-        public static bool UseSlowTestHand = false;
+        public static bool UseSlowTestController = false;
 
         /// <summary>
-        /// The number of frames that elapse for each test hand movement, taking into account if
-        /// slow test hand mode has been engaged.
+        /// The number of frames that elapse for each test controller movement, taking into account if
+        /// slow test controller mode has been engaged.
         /// </summary>
-        public static int HandMoveSteps => UseSlowTestHand ? HandMoveStepsSlow : HandMoveStepsDefault;
+        public static int ControllerMoveSteps => UseSlowTestController ? ControllerMoveStepsSlow : ControllerMoveStepsDefault;
 
         /// <summary>
-        /// A sentinel value used by hand test utilities to indicate that the default number of move
+        /// A sentinel value used by controller test utilities to indicate that the default number of move
         /// steps should be used or not.
         /// </summary>
         /// <remarks>
         /// This is primarily something that exists to get around the limitation of default parameter
         /// values requiring compile-time constants.
         /// </remarks>
-        internal const int HandMoveStepsSentinelValue = -1;
+        internal const int ControllerMoveStepsSentinelValue = -1;
 
         /// <summary>
         /// Creates a play mode test scene, creates an MRTK instance, initializes playspace.
@@ -97,8 +98,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             Assert.True(Application.isPlaying, "This setup method should only be used during play mode tests. Use TestUtilities.");
 
-            // See comments for UseSlowTestHand for why this is reset to false on each test case.
-            PlayModeTestUtilities.UseSlowTestHand = false;
+            // See comments for UseSlowTestController for why this is reset to false on each test case.
+            UseSlowTestController = false;
 
             bool sceneExists = false;
             for (int i = 0; i < SceneManager.sceneCount; i++)
@@ -169,6 +170,22 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 ArticulatedHandPose gesturePose = SimulatedArticulatedHandPoses.GetGesturePose(gesture);
                 Quaternion worldRotation = rotation * CameraCache.Main.transform.rotation;
                 gesturePose.ComputeJointPoses(handedness, worldRotation, worldPosition, jointsOut);
+            };
+        }
+
+        public static SimulatedMotionControllerData.MotionControllerPoseUpdater UpdateMotionControllerPose(Handedness handedness, Vector3 worldPosition, Quaternion rotation)
+        {
+            return () =>
+            {
+                Quaternion worldRotation = rotation * CameraCache.Main.transform.rotation;
+                Vector3 eulerAngles = worldRotation.eulerAngles;
+
+                // Create an offset to rotation to align with the behavior of simulated hand
+                float rotationXOffset = -15f;
+                float rotationYOffset = -10f;
+                int yOffsetSign = handedness == Handedness.Left ? -1 : 1;
+                Quaternion modifiedRotation = Quaternion.Euler(eulerAngles.x + rotationXOffset, eulerAngles.y + rotationYOffset * yOffsetSign, eulerAngles.z);
+                return new MixedRealityPose(worldPosition, modifiedRotation);
             };
         }
 
@@ -281,19 +298,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
         }
 
-        public static void PushHandSimulationProfile()
+        public static void PushControllerSimulationProfile()
         {
             var iss = GetInputSimulationService();
             inputSimulationProfiles.Push(iss.InputSimulationProfile);
         }
 
-        public static void PopHandSimulationProfile()
+        public static void PopControllerSimulationProfile()
         {
             var iss = GetInputSimulationService();
             iss.InputSimulationProfile = inputSimulationProfiles.Pop();
         }
 
-        public static void SetHandSimulationMode(ControllerSimulationMode mode)
+        public static void SetControllerSimulationMode(ControllerSimulationMode mode)
         {
             var iss = GetInputSimulationService();
             iss.ControllerSimulationMode = mode;
@@ -304,13 +321,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return MoveHand(handPos, handPos, ArticulatedHandPose.GestureId.Pinch, handedness, inputSimulationService, 2);
         }
 
+        public static IEnumerator SetMotionControllerState(Vector3 motionControllerPos, bool isSelecting, bool isGrabbing, bool isPressingMenu, Handedness handedness, InputSimulationService inputSimulationService)
+        {
+            yield return MoveMotionController(motionControllerPos, motionControllerPos, isSelecting, isGrabbing, isPressingMenu, handedness, inputSimulationService, 2);
+        }
+
         public static T GetPointer<T>(Handedness handedness) where T : class, IMixedRealityPointer
         {
             InputSimulationService simulationService = GetInputSimulationService();
-            var hand = simulationService.GetControllerDevice(handedness);
-            if (hand != null && hand.InputSource != null)
+            var controller = simulationService.GetControllerDevice(handedness);
+            if (controller != null && controller.InputSource != null)
             {
-                foreach (var pointer in hand.InputSource.Pointers)
+                foreach (var pointer in controller.InputSource.Pointers)
                 {
                     if (pointer is T result)
                     {
@@ -326,13 +348,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </summary>
         /// <remarks>
         /// Note that numSteps defaults to a value of -1, which is a sentinel value to indicate that the
-        /// default number of steps should be used (i.e. HandMoveSteps). HandMoveSteps is not a compile
+        /// default number of steps should be used (i.e. ControllerMoveSteps). ControllerMoveSteps is not a compile
         /// time constant, which is a requirement for default parameter values.
         /// </remarks>
         public static IEnumerator MoveHand(
             Vector3 startPos, Vector3 endPos,
             ArticulatedHandPose.GestureId gestureId, Handedness handedness, InputSimulationService inputSimulationService,
-            int numSteps = HandMoveStepsSentinelValue)
+            int numSteps = ControllerMoveStepsSentinelValue)
         {
             Debug.Assert(handedness == Handedness.Right || handedness == Handedness.Left, "handedness must be either right or left");
             bool isPinching = gestureId == ArticulatedHandPose.GestureId.Grab || gestureId == ArticulatedHandPose.GestureId.Pinch || gestureId == ArticulatedHandPose.GestureId.PinchSteadyWrist;
@@ -349,6 +371,36 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                         Quaternion.identity);
                 SimulatedHandData handData = handedness == Handedness.Right ? inputSimulationService.HandDataRight : inputSimulationService.HandDataLeft;
                 handData.Update(true, isPinching, handDataGenerator);
+                yield return null;
+            }
+        }
+
+        /// <summary>
+        /// Moves the motion controller from startPos to endPos.
+        /// </summary>
+        /// <remarks>
+        /// Note that numSteps defaults to a value of -1, which is a sentinel value to indicate that the
+        /// default number of steps should be used (i.e. ControllerMoveSteps). ControllerMoveSteps is not a compile
+        /// time constant, which is a requirement for default parameter values.
+        /// </remarks>
+        public static IEnumerator MoveMotionController(
+            Vector3 startPos, Vector3 endPos, bool isSelecting, bool isGrabbing, bool isPressingMenu,
+            Handedness handedness, InputSimulationService inputSimulationService,
+            int numSteps = ControllerMoveStepsSentinelValue)
+        {
+            Debug.Assert(handedness == Handedness.Right || handedness == Handedness.Left, "handedness must be either right or left");
+            numSteps = CalculateNumSteps(numSteps);
+
+            for (int i = 1; i <= numSteps; i++)
+            {
+                float t = i / (float)numSteps;
+                Vector3 motionControllerPos = Vector3.Lerp(startPos, endPos, t);
+                var motionControllerDataUpdater = UpdateMotionControllerPose(
+                        handedness,
+                        motionControllerPos,
+                        Quaternion.identity);
+                SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataLeft : inputSimulationService.MotionControllerDataRight;
+                motionControllerData.Update(true, isSelecting, isGrabbing, isPressingMenu, motionControllerDataUpdater);
                 yield return null;
             }
         }
@@ -374,6 +426,25 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
         }
 
+        public static IEnumerator SetMotionControllerRotation(Quaternion fromRotation, Quaternion toRotation, Vector3 motionControllerPos, bool isSelecting, bool isGrabbing, bool isPressingMenu,
+            Handedness handedness, int numSteps, InputSimulationService inputSimulationService)
+        {
+            Debug.Assert(handedness == Handedness.Right || handedness == Handedness.Left, "handedness must be either right or left");
+
+            for (int i = 1; i <= numSteps; i++)
+            {
+                float t = i / (float)numSteps;
+                Quaternion motionControllerRotation = Quaternion.Lerp(fromRotation, toRotation, t);
+                var motionControllerDataUpdater = UpdateMotionControllerPose(
+                        handedness,
+                        motionControllerPos,
+                        motionControllerRotation);
+                SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataLeft : inputSimulationService.MotionControllerDataRight;
+                motionControllerData.Update(true, isSelecting, isGrabbing, isPressingMenu, motionControllerDataUpdater);
+                yield return null;
+            }
+        }
+
         public static IEnumerator HideHand(Handedness handedness, InputSimulationService inputSimulationService)
         {
             yield return null;
@@ -382,6 +453,17 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             handData.Update(false, false, GenerateHandPose(ArticulatedHandPose.GestureId.Open, handedness, Vector3.zero, Quaternion.identity));
 
             // Wait one frame for the hand to actually disappear
+            yield return null;
+        }
+
+        public static IEnumerator HideController(Handedness handedness, InputSimulationService inputSimulationService)
+        {
+            yield return null;
+
+            SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataLeft : inputSimulationService.MotionControllerDataRight;
+            motionControllerData.Update(false, false, false, false, UpdateMotionControllerPose(handedness, Vector3.zero, Quaternion.identity));
+
+            // Wait one frame for the motion controller to actually disappear
             yield return null;
         }
 
@@ -397,8 +479,30 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             yield return null;
 
+            Assert.That(inputSimulationService.ControllerSimulationMode == ControllerSimulationMode.HandGestures || 
+                inputSimulationService.ControllerSimulationMode == ControllerSimulationMode.ArticulatedHand, "The current ControllerSimulationMode must be HandGestures or ArticulatedHand!");
             SimulatedHandData handData = handedness == Handedness.Right ? inputSimulationService.HandDataRight : inputSimulationService.HandDataLeft;
             handData.Update(true, false, GenerateHandPose(handPose, handedness, handLocation, Quaternion.identity));
+
+            // Wait one frame for the hand to actually appear
+            yield return null;
+        }
+
+        /// <summary>
+        /// Shows the motion controller in the default state, at the origin
+        /// </summary>
+        public static IEnumerator ShowMontionController(Handedness handedness, InputSimulationService inputSimulationService)
+        {
+            yield return ShowMontionController(handedness, inputSimulationService, false, false, false, Vector3.zero);
+        }
+
+        public static IEnumerator ShowMontionController(Handedness handedness, InputSimulationService inputSimulationService, bool isSelecting, bool isGrabbing, bool isPressingMenu, Vector3 handLocation)
+        {
+            yield return null;
+
+            Assert.AreEqual(inputSimulationService.ControllerSimulationMode, ControllerSimulationMode.MotionController, "The current ControllerSimulationMode must be MotionController!");
+            SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataLeft : inputSimulationService.MotionControllerDataRight;
+            motionControllerData.Update(true, isSelecting, isGrabbing, isPressingMenu, UpdateMotionControllerPose(handedness, handLocation, Quaternion.identity));
 
             // Wait one frame for the hand to actually appear
             yield return null;
@@ -452,14 +556,82 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         /// <summary>
         /// Given a numSteps value, determines if the value is a 'sentinel' value of
-        /// HandMoveStepsSentinelValue, which should be converted to the current
-        /// default value of HandMoveSteps. If it's not the sentinel value,
+        /// ControllerMoveStepsSentinelValue, which should be converted to the current
+        /// default value of ControllerMoveSteps. If it's not the sentinel value,
         /// this returns numSteps unchanged.
         /// </summary>
         public static int CalculateNumSteps(int numSteps)
         {
-            return numSteps == HandMoveStepsSentinelValue ? HandMoveSteps : numSteps;
+            return numSteps == ControllerMoveStepsSentinelValue ? ControllerMoveSteps : numSteps;
         }
+
+        #region Obsolete Fields, Functions, and Properties
+        /// <summary>
+        /// If true, the controller movement test steps will take a longer number of frames. This is especially
+        /// useful for seeing motion in play mode tests (where the default smaller number of frames tends
+        /// to make tests too fast to be understandable to the human eye). This is false by default
+        /// to ensure that tests will run quickly in general, and can be set to true manually in specific
+        /// test cases using the example below.
+        /// </summary>
+        /// <example> 
+        /// <code>
+        /// [UnityTest]
+        /// public IEnumerator YourTestCase()
+        /// {
+        ///     PlayModeTestUtilities.UseSlowTestController = true;
+        ///     ...
+        ///     PlayModeTestUtilities.UseSlowTestController = false;
+        /// }
+        /// </code>
+        /// </example>
+        /// <remarks>
+        /// Note that this value is reset to false after each play mode test that uses
+        /// PlayModeTestUtilities.Setup() - this is to reduce the chance that a forgotten
+        /// UseSlowTestController = true ends up slowing all subsequent tests.
+        /// </remarks>
+        [Obsolete("Use UseSlowTestController instead.")]
+        public static bool UseSlowTestHand
+        {
+            get => UseSlowTestController;
+            set { UseSlowTestController = value; }
+        }
+
+        /// <summary>
+        /// The number of frames that elapse for each test controller movement, taking into account if
+        /// slow test controller mode has been engaged.
+        /// </summary>
+        [Obsolete("Use ControllerMoveSteps instead.")]
+        public static int HandMoveSteps => ControllerMoveSteps;
+
+        /// <summary>
+        /// A sentinel value used by controller test utilities to indicate that the default number of move
+        /// steps should be used or not.
+        /// </summary>
+        /// <remarks>
+        /// This is primarily something that exists to get around the limitation of default parameter
+        /// values requiring compile-time constants.
+        /// </remarks>
+        [Obsolete("Use ControllerMoveStepsSentinelValue instead.")]
+        internal const int HandMoveStepsSentinelValue = ControllerMoveStepsSentinelValue;
+
+        [Obsolete("Use SetControllerSimulationMode instead.")]
+        public static void SetHandSimulationMode(ControllerSimulationMode mode)
+        {
+            SetControllerSimulationMode(mode);
+        }
+
+        [Obsolete("Use PushControllerSimulationProfile instead.")]
+        public static void PushHandSimulationProfile()
+        {
+            PushControllerSimulationProfile();
+        }
+
+        [Obsolete("Use PopControllerSimulationProfile instead.")]
+        public static void PopHandSimulationProfile()
+        {
+            PopControllerSimulationProfile();
+        }
+        #endregion
     }
 }
 #endif

--- a/Assets/MRTK/Tests/TestUtilities/TestController.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestController.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System.Collections;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    /// <summary>
+    ///  Utility class to use a simulated controller
+    /// </summary>
+    public abstract class TestController
+    {
+        protected Handedness handedness;
+        protected Vector3 position;
+        protected Quaternion rotation = Quaternion.identity;
+        protected InputSimulationService simulationService;
+
+        public TestController(Handedness handedness)
+        {
+            this.handedness = handedness;
+            simulationService = PlayModeTestUtilities.GetInputSimulationService();
+        }
+
+        /// <summary>
+        /// Return the velocity of the simulated controller
+        /// </summary>
+        public Vector3 GetVelocity()
+        {
+            var controller = simulationService.GetControllerDevice(handedness);
+            return controller.Velocity;
+        }
+
+        /// <summary>
+        /// Show the controller at a specified position
+        /// </summary>
+        /// <param name="position">Where to show the controller</param>
+        /// <param name="waitForFixedUpdate">If true, will wait for a physics frame after showing the controller.</param>
+        public abstract IEnumerator Show(Vector3 position, bool waitForFixedUpdate = true);
+
+        /// <summary>
+        /// Hide the controller
+        /// </summary>
+        /// <param name="waitForFixedUpdate">If true, will wait a physics frame after hiding</param>
+        public abstract IEnumerator Hide(bool waitForFixedUpdate = true);
+
+        /// <summary>
+        /// Move controller to given position over some number of frames
+        /// </summary>
+        /// <param name="newPosition">Where to move controller to</param>
+        /// <param name="numSteps">
+        /// How many frames to move over. This defaults to the "sentinel" value which tells the system
+        /// to use the default number of steps. For more information on this value, see
+        /// <see cref="PlayModeTestUtilities.ControllerMoveStepsSentinelValue"/>
+        /// </param>
+        /// <param name="waitForFixedUpdate">If true, waits a physics frame after moving the controller</param>
+        public abstract IEnumerator MoveTo(Vector3 newPosition, int numSteps = PlayModeTestUtilities.ControllerMoveStepsSentinelValue, bool waitForFixedUpdate = true);
+
+        /// <summary>
+        /// Move the controller by some given delta
+        /// </summary>
+        /// <param name="delta">Amount to move the controller by.</param>
+        /// <param name="numSteps">
+        /// How many frames to move over. This defaults to the "sentinel" value which tells the system
+        /// to use the default number of steps. For more information on this value, see
+        /// <see cref="PlayModeTestUtilities.ControllerMoveStepsSentinelValue"/>
+        /// </param>
+        public abstract IEnumerator Move(Vector3 delta, int numSteps = PlayModeTestUtilities.ControllerMoveStepsSentinelValue);
+
+        /// <summary>
+        /// Rotate the controller to new rotation
+        /// </summary>
+        /// <param name="newRotation">New rotation of controller</param>
+        /// <param name="numSteps">Number of frames to rotate over.</param>
+        public abstract IEnumerator SetRotation(
+            Quaternion newRotation,
+            int numSteps = PlayModeTestUtilities.ControllerMoveStepsSentinelValue);
+
+        /// <summary>
+        /// Perform a sequence of actions that represent a click for the controller
+        /// </summary>
+        public abstract IEnumerator Click();
+
+        /// <summary>
+        /// Return the first pointer of given type that is associated with this controller
+        /// </summary>
+        /// <typeparam name="T">Type of pointer to look for.</typeparam>
+        public T GetPointer<T>() where T : class, IMixedRealityPointer
+        {
+            var controller = simulationService.GetControllerDevice(handedness);
+            foreach (var pointer in controller.InputSource.Pointers)
+            {
+                if (pointer is T)
+                {
+                    return pointer as T;
+                }
+            }
+            return null;
+        }
+    }
+}
+#endif

--- a/Assets/MRTK/Tests/TestUtilities/TestController.cs.meta
+++ b/Assets/MRTK/Tests/TestUtilities/TestController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b21092ade8bd4d9438f3520ff62613dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/TestUtilities/TestMotionController.cs.meta
+++ b/Assets/MRTK/Tests/TestUtilities/TestMotionController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 201c3cfc413d22c409afa449c0512b9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
This is the third PR of a series that will eventually add motion controller simulation and test support to MRTK. This PR specifically focuses on supporting motion controller in the test infrastructure. User can now create simulated motion controller in test cases just like hands. One test case is added to PressableButtonTests to demonstrate how to create test cases with motion controller. More test cases will be included in a subsequent PR to reduce the size of this one.

## Changes
- Continuation of #8313 and #8296.