### PR TITLE
Fix standard assets loading and fix controller mapping profile image loading

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/ControllerMappingLibrary.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ControllerMappingLibrary.cs
@@ -286,7 +286,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
-            return GetControllerTextureInternal("StandardAssets/Textures/Generic_controller", Handedness.None, suffix);
+            return GetControllerTextureInternal("Textures/Generic_controller", Handedness.None, suffix);
         }
 
         private static Texture2D GetControllerTextureInternal(string relativeTexturePath, Handedness handedness, string suffix)
@@ -303,7 +303,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             string themeSuffix = EditorGUIUtility.isProSkin ? "_white" : "_black";
 
-            string fullTexturePath = MixedRealityToolkitFiles.MapRelativeFilePath($"{relativeTexturePath}{handednessSuffix}{themeSuffix}{suffix}.png");
+            string fullTexturePath = MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.StandardAssets, $"{relativeTexturePath}{handednessSuffix}{themeSuffix}{suffix}.png");
             return (Texture2D)AssetDatabase.LoadAssetAtPath(fullTexturePath, typeof(Texture2D));
         }
 

--- a/Assets/MRTK/Core/Providers/UnityInput/XboxController.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/XboxController.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
     [MixedRealityController(
         SupportedControllerType.Xbox,
         new[] { Handedness.None },
-        "StandardAssets/Textures/XboxController")]
+        "Textures/XboxController")]
     public class XboxController : GenericJoystickController
     {
         /// <summary>

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -28,6 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         Tests,
         Extensions,
         Tools,
+        StandardAssets,
         // This module only exists for testing purposes, and is used in edit mode tests in conjunction
         // with MixedRealityToolkitFiles to ensure that this class is able to reason over MRTK
         // files that are placed outside of the root asset folder.
@@ -124,6 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { "Tests", MixedRealityToolkitModuleType.Tests },
             { "Extensions", MixedRealityToolkitModuleType.Extensions },
             { "Tools", MixedRealityToolkitModuleType.Tools },
+            { "StandardAssets", MixedRealityToolkitModuleType.StandardAssets },
 
             // This module only exists for testing purposes, and is used in edit mode tests in conjunction
             // with MixedRealityToolkitFiles to ensure that this class is able to reason over MRTK

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -253,10 +253,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             // MRTK may be located in Assets (.unitypackage import) or the Packages (UPM import)
             // folder. Check both locations.
-            List<string> rootFolders = new List<string>();
-            rootFolders.Add(Application.dataPath);
-            rootFolders.Add(Path.GetFullPath("Packages"));
-            rootFolders.Add(Path.GetFullPath(Path.Combine("Library", "PackageCache")));
+            List<string> rootFolders = new List<string>
+            {
+                Application.dataPath,
+                Path.GetFullPath("Packages"),
+                Path.GetFullPath(Path.Combine("Library", "PackageCache"))
+            };
             searchForFoldersTask = Task.Run(() => SearchForFoldersAsync(rootFolders));
         }
 

--- a/Assets/MRTK/Providers/OpenVR/OculusRemoteController.cs
+++ b/Assets/MRTK/Providers/OpenVR/OculusRemoteController.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityController(
         SupportedControllerType.OculusRemote,
         new[] { Handedness.None },
-        "StandardAssets/Textures/OculusRemoteController")]
+        "Textures/OculusRemoteController")]
     public class OculusRemoteController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/OculusTouchController.cs
+++ b/Assets/MRTK/Providers/OpenVR/OculusTouchController.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityController(
         SupportedControllerType.OculusTouch,
         new[] { Handedness.Left, Handedness.Right },
-        "StandardAssets/Textures/OculusControllersTouch")]
+        "Textures/OculusControllersTouch")]
     public class OculusTouchController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/ViveWandController.cs
+++ b/Assets/MRTK/Providers/OpenVR/ViveWandController.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityController(
         SupportedControllerType.ViveWand,
         new[] { Handedness.Left, Handedness.Right },
-        "StandardAssets/Textures/ViveWandController")]
+        "Textures/ViveWandController")]
     public class ViveWandController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
+++ b/Assets/MRTK/Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityController(
         SupportedControllerType.WindowsMixedReality,
         new[] { Handedness.Left, Handedness.Right },
-        "StandardAssets/Textures/MotionController")]
+        "Textures/MotionController")]
     public class WindowsMixedRealityOpenVRMotionController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
     [MixedRealityController(
         SupportedControllerType.WindowsMixedReality,
         new[] { Handedness.Left, Handedness.Right },
-        "StandardAssets/Textures/MotionController")]
+        "Textures/MotionController")]
     public class WindowsMixedRealityController : BaseWindowsMixedRealitySource
     {
         /// <summary>

--- a/Assets/MRTK/StandardAssets/MRTK.StandardAssets.sentinel.meta
+++ b/Assets/MRTK/StandardAssets/MRTK.StandardAssets.sentinel.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3ff0b4e95f3847e488da67dc226d04ea
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

With the addition of the standalone Standard Assets package in https://github.com/microsoft/MixedRealityToolkit-Unity/pull/8232, the controller mapping images began failing to load. This is because they're currently still loaded via a file path, and the new StandardAssets folder didn't have a sentinel file.

This PR adds the sentinel file, updates MRTKFiles to allow loading from the new module, and updates the paths for the controller mapping images.

![image](https://user-images.githubusercontent.com/3580640/90830471-93ef7f00-e2f6-11ea-9cad-6cb04c2529fa.png)

## Changes
- Fixes:

![image](https://user-images.githubusercontent.com/3580640/90830197-1a579100-e2f6-11ea-9a73-8054e33c60e5.png)
