### PR TITLE
Fix MRTKFiles tests

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -144,12 +144,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             string newRoot = string.Empty;
             if (assetDatabasePath.Contains("/Assets/"))
             {
-                token = "Assets";
+                token = "/Assets/";
                 newRoot = "Assets";
             }
             else if (assetDatabasePath.Contains("/PackageCache/"))
             {
-                token = "PackageCache";
+                token = "/PackageCache/";
                 newRoot = "Packages";
 
                 // PackageCache folders need the embedded version removed.
@@ -160,16 +160,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
             else if (assetDatabasePath.Contains("/Packages/"))
             {
-                token = "Packages";
+                token = "/Packages/";
                 newRoot = "Packages";
             }
 
-            // Use Path.GetFullPath to ensure proper Path.DirectorySeparatorChar is used depending on our editor platform
             if (!string.IsNullOrWhiteSpace(newRoot) &&
                 !string.IsNullOrWhiteSpace(token))
             {
                 string oldRoot = assetDatabasePath.Substring(0,
-                    assetDatabasePath.IndexOf(token) + token.Length);
+                    assetDatabasePath.LastIndexOf(token) + token.Length - 1); // Subtract 1 to keep the trailing slash
                 assetDatabasePath = assetDatabasePath.Replace(oldRoot, newRoot);
             }
             return assetDatabasePath;

--- a/Assets/MRTK/Tests/EditModeTests/Core/MixedRealityToolkitFilesTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/MixedRealityToolkitFilesTests.cs
@@ -122,35 +122,40 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core
             string inputPath = @"c:\projects\MyUnityProject\Assets\materials\test.mat";
             string expectedPath = "Assets/materials/test.mat";
             string actualPath = MixedRealityToolkitFiles.GetAssetDatabasePath(inputPath);
-            Asset.Equals(expectedPath, actualPath);
+            Assert.AreEqual(expectedPath, actualPath);
 
-            // File in the Packages folder structire
+            // File in the Packages folder structure
             inputPath = "d:/source/projects/Packages/CoolFeature/textures/background.png";
             expectedPath = "Packages/CoolFeature/textures/background.png";
             actualPath = MixedRealityToolkitFiles.GetAssetDatabasePath(inputPath);
-            Asset.Equals(expectedPath, actualPath);
+            Assert.AreEqual(expectedPath, actualPath);
 
             // File in the Library/PackageCache folder structure
-            inputPath = @"c:\development\projects\space\Library\PackageCache\com.contoso.custompackage@17.43.0-preview.13\scripable.asset";
+            inputPath = @"c:\development\projects\space\Library\PackageCache\com.contoso.custompackage@17.43.0-preview.13\scriptable.asset";
             expectedPath = "Packages/com.contoso.custompackage/scriptable.asset";
             actualPath = MixedRealityToolkitFiles.GetAssetDatabasePath(inputPath);
-            Asset.Equals(expectedPath, actualPath);
+            Assert.AreEqual(expectedPath, actualPath);
 
             // Edge cases
             inputPath = @"c:\projects\AssetsViewer\Assets\materials\test.mat";
             expectedPath = "Assets/materials/test.mat";
             actualPath = MixedRealityToolkitFiles.GetAssetDatabasePath(inputPath);
-            Asset.Equals(expectedPath, actualPath);
+            Assert.AreEqual(expectedPath, actualPath);
 
             inputPath = "d:/source/projects/Packages/CoolFeature/MyAssets/textures/background.png";
             expectedPath = "Packages/CoolFeature/MyAssets/textures/background.png";
             actualPath = MixedRealityToolkitFiles.GetAssetDatabasePath(inputPath);
-            Asset.Equals(expectedPath, actualPath);
+            Assert.AreEqual(expectedPath, actualPath);
 
             inputPath = @"c:\development\projects\space\Library\PackageCache\com.microsoft.mixedreality.toolkit.foundation@17.43.0-preview.13\Core\StandardAssets\Textures\MRTK_Logo_Black.png";
             expectedPath = "Packages/com.microsoft.mixedreality.toolkit.foundation/Core/StandardAssets/Textures/MRTK_Logo_Black.png";
             actualPath = MixedRealityToolkitFiles.GetAssetDatabasePath(inputPath);
-            Asset.Equals(expectedPath, actualPath);
+            Assert.AreEqual(expectedPath, actualPath);
+
+            inputPath = @"c:\projects\AssetsViewer\Assets\StandardAssets\materials\test.mat";
+            expectedPath = "Assets/StandardAssets/materials/test.mat";
+            actualPath = MixedRealityToolkitFiles.GetAssetDatabasePath(inputPath);
+            Assert.AreEqual(expectedPath, actualPath);
         }
 
         [TearDown]


### PR DESCRIPTION
## Overview

Some of our existing MixedRealityToolkitFilesTests used `Asset.Equals` instead of an assert `Assert.AreEqual` when comparing, so no test comparison was run.

After fixing this, one of the existing edge cases (`inputPath = @"c:\projects\AssetsViewer\Assets\materials\test.mat";`) started failing the test due to Assets existing in the path twice.

Initially to fix this, I changed the MRTKFiles from checking `IndexOf` to `LastIndexOf`, but then I realized this would start failing if we were looking for something in the StandardAssets folder in an Assets folder (I added this as a test case).

To solve that, MRTKFiles now uses a lookup including the slashes on either side, so we can be sure we're indexing on a folder with the exact same name.