### PR TITLE
Make the ARFoundation InitializeOnLoad work be manually triggered

### DIFF
--- a/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
@@ -12,22 +12,20 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
     /// <summary>
     /// Class to perform checks for configuration checks for the UnityAR provider.
     /// </summary>
-    [InitializeOnLoad]
+    /// <remarks>
+    /// Note that the checks that this class runs are fairly expensive and are only done manually by the user
+    /// as part of their setup steps described here:
+    /// https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/CrossPlatform/UsingARFoundation.html
+    /// </remarks>
     static class UnityARConfigurationChecker
     {
         private const string FileName = "Unity.XR.ARFoundation.asmdef";
         private static readonly string[] definitions = { "ARFOUNDATION_PRESENT" };
 
-        static UnityARConfigurationChecker()
+        [MenuItem("Mixed Reality Toolkit/Utilities/UnityAR/Update Assembly Definitions")]
+        private static void UpdateAssemblyDefinitions()
         {
-            // TODO(https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8188)
-            // This should be updated to only run on editor launch and on large asset changes
-            // (i.e. post import of asset packages). This should remove this from the inner compile
-            // loop.
-            if (!EditorApplication.isPlayingOrWillChangePlaymode)
-            {
-                UpdateAsmDef(ReconcileArFoundationDefine());
-            }
+            UpdateAsmDef(ReconcileArFoundationDefine());
         }
 
         /// <summary>

--- a/Documentation/CrossPlatform/UsingARFoundation.md
+++ b/Documentation/CrossPlatform/UsingARFoundation.md
@@ -27,6 +27,8 @@
     | AR Foundation  <br/> Version: 3.1.3 |  AR Foundation  <br/> Version: 3.1.3 |
     | ARCore XR Plugin <br/> Version: 3.1.4 | ARKit XR Plugin <br/> Version: 3.1.3 |
 
+1. Update the MRTK UnityAR assembly definitions by invoking the menu item: **Mixed Reality Toolkit > Utilities > UnityAR > Update Assembly Definitions**
+
 ## Enabling the Unity AR camera settings provider
 
 The following steps presume use of the MixedRealityToolkit object. Steps required for other service registrars may be different.

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -80,6 +80,16 @@ There is a confirmation dialog that will be displayed when selecting `Use MSBuil
 
 ![MSBuild for Unity confirmation](Images/ConfigurationDialog/EnableMSB4UPrompt.png)
 
+**Reduction in InitializeOnLoad overhead**
+We've been doing work to reduce the amount of work that runs in InitializeOnLoad handlers, which should lead to
+improvements in inner loop development speed. InitializeOnLoad handlers run every time a script is compiled, prior
+to entering play mode, and also at editor launch. These handlers now run in far fewer cases, resulting in general
+Unity responsiveness improvements.
+
+In some cases there was a tradeoff that had to be made:
+For those who are using ARFoundation, there's now an additional manual step in its getting started steps.
+See [ARFoundation](CrossPlatform/UsingARFoundation.md#install-required-packages) for the new steps.
+
 ### Breaking changes
 
 **IMixedRealityPointerMediator**

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -87,6 +87,7 @@ to entering play mode, and also at editor launch. These handlers now run in far 
 Unity responsiveness improvements.
 
 In some cases there was a tradeoff that had to be made:
+See [Leap Motion Hand Tracking Configuration](CrossPlatform/LeapMotionMRTK.md) for the extra integration step.
 For those who are using ARFoundation, there's now an additional manual step in its getting started steps.
 See [ARFoundation](CrossPlatform/UsingARFoundation.md#install-required-packages) for the new steps.
 

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -368,7 +368,6 @@ $InitializeOnLoadExceptions = [System.Collections.Generic.HashSet[String]]@(
     "Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs",
     "Assets/MRTK/Core/Utilities/Editor/USB/USBDeviceListener.cs",
     "Assets/MRTK/Providers/Oculus/XRSDK/Editor/OculusXRSDKConfigurationChecker.cs",
-    "Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs",
     "Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs",
     "Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Editor/WindowsMixedRealityXRSDKConfigurationChecker.cs",
     "Assets/MRTK/Providers/XRSDK/Editor/XRSDKConfigurationChecker.cs"


### PR DESCRIPTION
This is a revert of a revert - basically the original PR hit an issue in CI related to build machine versions, and we recently updated some of dependencies on our build machines, so now this should be good to go.

Reverts #8292

This also accounts for the fact that LeapMotion was recently fixed up by @CDiaz-MS 

Also yes I realize I made a spelling mistake on my branch name ardoundation.