### PR TITLE
Add more motion controller tests

### DIFF
--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
@@ -443,6 +443,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 DebugUtilities.LogVerbose("Creating a new hand simulation data provider");
                 dataProvider = new SimulatedHandDataProvider(InputSimulationProfile);
             }
+            else if (dataProvider is SimulatedMotionControllerDataProvider)
+            {
+                DebugUtilities.LogVerbose("Replacing motion controller simulation data provider with hand simulation data provider");
+                RemoveAllControllerDevices();
+                dataProvider = new SimulatedHandDataProvider(InputSimulationProfile);
+            }
         }
 
         private void EnableMotionControllerSimulation()
@@ -452,6 +458,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 DebugUtilities.LogVerbose("Creating a new motion controller simulation data provider");
                 dataProvider = new SimulatedMotionControllerDataProvider(InputSimulationProfile);
             }
+            else if (dataProvider is SimulatedHandDataProvider)
+            {
+                DebugUtilities.LogVerbose("Replacing hand simulation data provider with motion controller simulation data provider");
+                RemoveAllControllerDevices();
+                dataProvider = new SimulatedMotionControllerDataProvider(InputSimulationProfile);
+            }
+
         }
 
         private void DisableControllerSimulation()

--- a/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
@@ -195,11 +195,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// Tests that right after being instantiated, the pointer's direction 
+        /// Tests that right after hand being instantiated, the pointer's direction 
         /// is in the same general direction as the forward direction of the camera
         /// </summary>
         [UnityTest]
-        public IEnumerator TestPointerDirectionToCameraDirection()
+        public IEnumerator TestHandPointerDirectionToCameraDirection()
         {
             var inputSystem = PlayModeTestUtilities.GetInputSystem();
 
@@ -211,7 +211,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return rightHand.Show(initialPos);
 
             // Return first hand controller that is right and source type hand
-            var handController = inputSystem.DetectedControllers.First(x => x.ControllerHandedness == Utilities.Handedness.Right && x.InputSource.SourceType == InputSourceType.Hand);
+            var handController = inputSystem.DetectedControllers.First(x => x.ControllerHandedness == Handedness.Right && x.InputSource.SourceType == InputSourceType.Hand);
             Assert.IsNotNull(handController);
 
             // Get the line pointer from the hand controller
@@ -227,6 +227,50 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Check that the angle between the line pointer ray and camera forward does not exceed 40 degrees
             float angle = Vector3.Angle(linePointer.Rays[0].Direction, CameraCache.Main.transform.forward);
             Assert.LessOrEqual(angle, 40.0f);
+        }
+
+        /// <summary>
+        /// Tests that right after motion controller being instantiated, the pointer's direction 
+        /// is in the same general direction as the forward direction of the camera
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestMotionControllerPointerDirectionToCameraDirection()
+        {
+            var inputSystem = PlayModeTestUtilities.GetInputSystem();
+
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+
+            // Raise the motion controller
+            var rightMotionController = new TestMotionController(Handedness.Right);
+
+            // Set initial position and show motion controller
+            Vector3 initialPos = TestUtilities.PositionRelativeToPlayspace(new Vector3(0.01f, 0.1f, 0.5f));
+            yield return rightMotionController.Show(initialPos);
+
+            // Return first motion controller that is right and source type controller
+            var motionController = inputSystem.DetectedControllers.First(x => x.ControllerHandedness == Handedness.Right && x.InputSource.SourceType == InputSourceType.Controller);
+            Assert.IsNotNull(motionController);
+
+            // Get the line pointer from the motion controller
+            var linePointer = motionController.InputSource.Pointers.OfType<ShellHandRayPointer>().First();
+            Assert.IsNotNull(linePointer);
+
+            Vector3 linePointerOrigin = linePointer.Position;
+
+            // Check that the line pointer origin is within half a centimeter of the initial position of the motion controller
+            var distance = Vector3.Distance(initialPos, linePointerOrigin);
+            Assert.LessOrEqual(distance, 0.005f);
+
+            // Check that the angle between the line pointer ray and camera forward does not exceed 40 degrees
+            float angle = Vector3.Angle(linePointer.Rays[0].Direction, CameraCache.Main.transform.forward);
+            Assert.LessOrEqual(angle, 40.0f);
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldSimMode;
+            yield return null;
         }
 
 

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -10,7 +10,6 @@
 // issue will likely persist for 2018, this issue is worked around by wrapping all
 // play mode tests in this check.
 
-using Microsoft.MixedReality.Toolkit.Experimental.UI;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -285,6 +284,416 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
             // Check that gaze cursor is visible
             Assert.True(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+        }
+
+        [UnityTest]
+        public IEnumerator InputSimulationRightMotionControllerButtonState()
+        {
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            // Switch to motion controller
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+            TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
+
+            // Check that gaze cursor is initially visible
+            Assert.True(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // Begin right motion controller manipulation
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.RightControllerManipulationKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure right motion controller is tracked
+            Assert.True(iss.MotionControllerDataRight.IsTracked);
+            Assert.True(!iss.MotionControllerDataLeft.IsTracked);
+
+            // Make sure gaze cursor is not visible
+            Assert.True(!CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // press trigger
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure correct motion controller is selecting
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not selecting anymore
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+
+            // press grab
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure correct motion controller is grabbing
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not grabbing anymore
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+
+            // press menu
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure correct motion controller is pressing menu
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not pressing menu anymore
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+
+            // press all three buttons
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure correct motion controller is pressing three buttons
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not pressing three buttons anymore
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+            
+
+            // End right motion controller manipulation
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.RightControllerManipulationKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            // Wait for the motion controller hide timeout to hide the motion controllers
+            yield return new WaitForSeconds(iss.InputSimulationProfile.ControllerHideTimeout + 0.1f);
+
+            // Make sure right motion controller is not tracked
+            Assert.True(!iss.MotionControllerDataRight.IsTracked);
+            Assert.True(!iss.MotionControllerDataLeft.IsTracked);
+
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldHandSimMode;
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator InputSimulationLeftMotionControllerButtonState()
+        {
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            // Switch to motion controller
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+            TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
+
+            // Check that gaze cursor is initially visible
+            Assert.True(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // Begin left motion controller manipulation
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.LeftControllerManipulationKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure left motion controller is tracked
+            Assert.True(iss.MotionControllerDataLeft.IsTracked);
+            Assert.True(!iss.MotionControllerDataRight.IsTracked);
+
+            // Make sure gaze cursor is not visible
+            Assert.True(!CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // press trigger
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure correct motion controller is selecting
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsSelecting);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not selecting anymore
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsSelecting);
+
+            // press grab
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure correct motion controller is grabbing
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not grabbing anymore
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+
+            // press menu
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure correct motion controller is pressing menu
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not pressing menu anymore
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+
+            // press all three buttons
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure correct motion controller is pressing three buttons
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsSelecting);
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not pressing three buttons anymore
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+
+
+            // End left motion controller manipulation
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.LeftControllerManipulationKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            // Wait for the motion controller hide timeout to hide the motion controllers
+            yield return new WaitForSeconds(iss.InputSimulationProfile.ControllerHideTimeout + 0.1f);
+
+            // Make sure left motion controller is not tracked
+            Assert.True(!iss.MotionControllerDataLeft.IsTracked);
+            Assert.True(!iss.MotionControllerDataRight.IsTracked);
+
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldHandSimMode;
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator InputSimulationBothMotionControllerButtonState()
+        {
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            // Switch to motion controller
+            var oldHandSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+            TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
+
+            // Check that gaze cursor is initially visible
+            Assert.True(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // Begin both motion controller manipulation
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.LeftControllerManipulationKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.RightControllerManipulationKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure both motion controllers are tracked
+            Assert.True(iss.MotionControllerDataLeft.IsTracked);
+            Assert.True(iss.MotionControllerDataRight.IsTracked);
+
+            // Make sure gaze cursor is not visible
+            Assert.True(!CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // press trigger
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure both motion controllers are selecting
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsSelecting);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not selecting anymore
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsSelecting);
+
+            // press grab
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure both motion controllers are grabbing
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not grabbing anymore
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+
+            // press menu
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure both motion controllers are pressing menu
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not pressing menu anymore
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+
+            // press all three buttons
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Make sure both motion controllers are pressing three buttons
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsSelecting);
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+            Assert.True(iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+            Assert.True(iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+
+            // release the button
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerTriggerKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerGrabKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.MotionControllerMenuKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure motion controllers are not pressing three buttons anymore
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsSelecting);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsGrabbing);
+            Assert.True(!iss.MotionControllerDataLeft.ButtonState.IsPressingMenu);
+            Assert.True(!iss.MotionControllerDataRight.ButtonState.IsPressingMenu);
+
+
+            // End both motion controller manipulation
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.LeftControllerManipulationKey);
+            KeyInputSystem.ReleaseKey(iss.InputSimulationProfile.RightControllerManipulationKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            // Wait for the motion controller hide timeout to hide the motion controllers
+            yield return new WaitForSeconds(iss.InputSimulationProfile.ControllerHideTimeout + 0.1f);
+
+            // Make sure both motion controllers are not tracked
+            Assert.True(!iss.MotionControllerDataLeft.IsTracked);
+            Assert.True(!iss.MotionControllerDataRight.IsTracked);
+
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldHandSimMode;
+            yield return null;
         }
     }
 }

--- a/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -399,7 +399,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                         handedness,
                         motionControllerPos,
                         Quaternion.identity);
-                SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataLeft : inputSimulationService.MotionControllerDataRight;
+                SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataRight : inputSimulationService.MotionControllerDataLeft;
                 motionControllerData.Update(true, buttonState, motionControllerDataUpdater);
                 yield return null;
             }
@@ -439,7 +439,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                         handedness,
                         motionControllerPos,
                         motionControllerRotation);
-                SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataLeft : inputSimulationService.MotionControllerDataRight;
+                SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataRight : inputSimulationService.MotionControllerDataLeft;
                 motionControllerData.Update(true, buttonState, motionControllerDataUpdater);
                 yield return null;
             }
@@ -460,7 +460,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             yield return null;
 
-            SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataLeft : inputSimulationService.MotionControllerDataRight;
+            SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataRight : inputSimulationService.MotionControllerDataLeft;
             SimulatedMotionControllerButtonState defaultButtonState = new SimulatedMotionControllerButtonState();
             motionControllerData.Update(false, defaultButtonState, UpdateMotionControllerPose(handedness, Vector3.zero, Quaternion.identity));
 
@@ -498,13 +498,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return ShowMontionController(handedness, inputSimulationService, defaultButtonState, Vector3.zero);
         }
 
-        public static IEnumerator ShowMontionController(Handedness handedness, InputSimulationService inputSimulationService, SimulatedMotionControllerButtonState buttonState, Vector3 handLocation)
+        public static IEnumerator ShowMontionController(Handedness handedness, InputSimulationService inputSimulationService, SimulatedMotionControllerButtonState buttonState, Vector3 motionControllerLocation)
         {
             yield return null;
 
-            Assert.AreEqual(inputSimulationService.ControllerSimulationMode, ControllerSimulationMode.MotionController, "The current ControllerSimulationMode must be MotionController!");
-            SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataLeft : inputSimulationService.MotionControllerDataRight;
-            motionControllerData.Update(true, buttonState, UpdateMotionControllerPose(handedness, handLocation, Quaternion.identity));
+            Assert.AreEqual(ControllerSimulationMode.MotionController, inputSimulationService.ControllerSimulationMode, "The current ControllerSimulationMode must be MotionController!");
+            SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataRight : inputSimulationService.MotionControllerDataLeft;
+            motionControllerData.Update(true, buttonState, UpdateMotionControllerPose(handedness, motionControllerLocation, Quaternion.identity));
 
             // Wait one frame for the hand to actually appear
             yield return null;

--- a/Assets/MRTK/Tests/TestUtilities/TestMotionController.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestMotionController.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public override IEnumerator Show(Vector3 position, bool waitForFixedUpdate = true)
         {
             this.position = position;
-            yield return PlayModeTestUtilities.ShowMontionController(handedness, simulationService);
+            yield return PlayModeTestUtilities.ShowMontionController(handedness, simulationService, new SimulatedMotionControllerButtonState(), position);
             if (waitForFixedUpdate)
             {
                 yield return new WaitForFixedUpdate();


### PR DESCRIPTION
## Overview
This is the final PR of a series of four that adds motion controller simulation and test support to MRTK. This PR specifically focuses on adding more motion controller related tests based on the test infrastructure introduced earlier. Some bugs discovered when creating the tests are also fixed.

## Changes
- Continuation of #8313, #8296 and #8348.