### PR TITLE
Initial Build Call CI

### DIFF
--- a/pipelines/buildcallmanual.yml
+++ b/pipelines/buildcallmanual.yml
@@ -1,6 +1,6 @@
 # Pipeline for creating files and running tests for Build Call.
 
- variables:
+variables:
 - template: config/settings.yml
 - name: packagingEnabled
   value: false
@@ -12,8 +12,6 @@ parameters:
   values:
   - all
   - common
-  
-trigger: none
 
 jobs:
 - job: BuildCallUnity2019Setup
@@ -26,15 +24,15 @@ jobs:
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
-   - ${{ if contains(parameters.build, 'all') }}:
-     - template: templates/buildcallsetup.yml
+- ${{ if contains(parameters.build, 'all') }}:
+  - template: templates/buildcallsetup.yml
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2019Version)
       MRTKVersion: $(MRTKVersion)
       Binaries: 'all'
-   - ${{ if contains(parameters.build, 'common') }}:
-     - template: templates/buildcallsetup.yml
+- ${{ if contains(parameters.build, 'common') }}:
+  - template: templates/buildcallsetup.yml
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2019Version)
@@ -52,15 +50,15 @@ jobs:
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
-   - ${{ if contains(parameters.build, 'all') }}:
-     - template: templates/buildcallsetup.yml
+- ${{ if contains(parameters.build, 'all') }}:
+  - template: templates/buildcallsetup.yml
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2018Version)
       MRTKVersion: $(MRTKVersion)
       Binaries: 'all'
-   - ${{ if contains(parameters.build, 'common') }}:
-     - template: templates/buildcallsetup.yml
+- ${{ if contains(parameters.build, 'common') }}:
+   - template: templates/buildcallsetup.yml
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2018Version)

--- a/pipelines/buildcallmanual.yml
+++ b/pipelines/buildcallmanual.yml
@@ -58,7 +58,7 @@ jobs:
       MRTKVersion: $(MRTKVersion)
       Binaries: 'all'
 - ${{ if contains(parameters.build, 'common') }}:
-   - template: templates/buildcallsetup.yml
+  - template: templates/buildcallsetup.yml
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2018Version)

--- a/pipelines/buildcallmanual.yml
+++ b/pipelines/buildcallmanual.yml
@@ -26,15 +26,15 @@ jobs:
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
-  - ${{ if contains(parameters.build, 'all') }}:
-  - template: templates/buildcallsetup.yml
+   - ${{ if contains(parameters.build, 'all') }}:
+     - template: templates/buildcallsetup.yml
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2019Version)
       MRTKVersion: $(MRTKVersion)
       Binaries: 'all'
-  - ${{ if contains(parameters.build, 'common') }}:
-  - template: templates/buildcallsetup.yml
+   - ${{ if contains(parameters.build, 'common') }}:
+     - template: templates/buildcallsetup.yml
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2019Version)
@@ -52,15 +52,15 @@ jobs:
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
-  - ${{ if contains(parameters.build, 'all') }}:
-  - template: templates/buildcallsetup.yml
+   - ${{ if contains(parameters.build, 'all') }}:
+     - template: templates/buildcallsetup.yml
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2018Version)
       MRTKVersion: $(MRTKVersion)
       Binaries: 'all'
-  - ${{ if contains(parameters.build, 'common') }}:
-  - template: templates/buildcallsetup.yml
+   - ${{ if contains(parameters.build, 'common') }}:
+     - template: templates/buildcallsetup.yml
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2018Version)

--- a/pipelines/buildcallmanual.yml
+++ b/pipelines/buildcallmanual.yml
@@ -1,0 +1,68 @@
+# Pipeline for creating files and running tests for Build Call.
+
+ variables:
+- template: config/settings.yml
+- name: packagingEnabled
+  value: false
+
+parameters:
+- name: build
+  displayName: Build binary selection
+  default: common
+  values:
+  - all
+  - common
+  
+trigger: none
+
+jobs:
+- job: BuildCallUnity2019Setup
+  displayName: Build Call Unity 2019 binaries and manual testing setup
+  timeoutInMinutes: 120
+  pool:
+    name: On-Prem Unity
+    demands:
+    - Unity2019.4.8f1
+    - COG-UnityCache-WUS2-01
+    - SDK_18362 -equals TRUE
+  steps:
+  - ${{ if contains(parameters.build, 'all') }}:
+  - template: templates/buildcallsetup.yml
+    parameters:
+      packagingEnabled: false
+      UnityVersion: $(Unity2019Version)
+      MRTKVersion: $(MRTKVersion)
+      Binaries: 'all'
+  - ${{ if contains(parameters.build, 'common') }}:
+  - template: templates/buildcallsetup.yml
+    parameters:
+      packagingEnabled: false
+      UnityVersion: $(Unity2019Version)
+      MRTKVersion: $(MRTKVersion)
+      Binaries: 'common'
+
+
+- job: BuildCallUnity2018Setup
+  displayName: Build Call Unity 2018 Binaries and manual testing setup
+  timeoutInMinutes: 120
+  pool:
+    name: On-Prem Unity
+    demands:
+    - Unity2018.4.26f1
+    - COG-UnityCache-WUS2-01
+    - SDK_18362 -equals TRUE
+  steps:
+  - ${{ if contains(parameters.build, 'all') }}:
+  - template: templates/buildcallsetup.yml
+    parameters:
+      packagingEnabled: false
+      UnityVersion: $(Unity2018Version)
+      MRTKVersion: $(MRTKVersion)
+      Binaries: 'all'
+  - ${{ if contains(parameters.build, 'common') }}:
+  - template: templates/buildcallsetup.yml
+    parameters:
+      packagingEnabled: false
+      UnityVersion: $(Unity2018Version)
+      MRTKVersion: $(MRTKVersion)
+      Binaries: 'common'

--- a/pipelines/templates/assetretargeting.yml
+++ b/pipelines/templates/assetretargeting.yml
@@ -30,7 +30,7 @@ steps:
    Write-Output '====================================================='
 
    $unityLogFileName = '$(Build.ArtifactStagingDirectory)\build\build\retargeting_log.log'
-   If (Test-Path $unityLogFileName)
+   if (Test-Path $unityLogFileName)
    {
       Write-Output '====================================================='
       Write-Output '           Begin Unity Player Log                    '
@@ -42,7 +42,7 @@ steps:
       Write-Output '           End Unity Player Log                      '
       Write-Output '====================================================='
    }
-   Else
+   else
    {
       Write-Output 'Unity Player Log missing!'
    }

--- a/pipelines/templates/buildcallsetup.yml
+++ b/pipelines/templates/buildcallsetup.yml
@@ -1,0 +1,1843 @@
+# [Template] Build binaries for Build Call in Unity.
+parameters:
+  UnityVersion: ""
+  Binaries: "" # Brings the binaries parameter from pipelines/buildcallmanual.yml
+#
+# Build for the 'common' parameter.
+# Each step is an example scene that builds a binary for each device.
+
+# This step builds the HandInteractionExamples scene and publishes the project files.
+steps:
+- ${{ if contains(parameters.Binaries, 'all,common') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HandInteractionExamples'
+    PublishProject: 'yes'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HandInteractionExamples'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HandInteractionExamples'
+    PublishProject: 'yes'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+#Builds the LeapMotion example scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all,common') }}:
+# Build Standalone x86 with Leap Motion 4.5.1 imported.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArti'facts: true
+    Scene: 'LeapMotion'
+    PublishProject: 'no'
+
+# This step builds the SolverExamples scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all,common') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SolverExamples'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SolverExamples'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SolverExamples'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the AudioLofi scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all,common') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'AudioLofi'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'AudioLofi'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'AudioLofi'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the AudioOcclusion scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all,common') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'AudioOcclusion'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'AudioOcclusion'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'AudioOcclusion'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the SpatialAwareness example scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all,common') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SpatialAwareness'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SpatialAwareness'
+    PublishProject: 'no'
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the GLTF scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all,common') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'GLTF'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'GLTF'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'GLTF'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the BoundaryVisualization scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all,common') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'BoundaryVisualization'
+    PublishProject: 'no'
+
+# Build Standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'BoundaryVisualization'
+    PublishProject: 'no'    
+
+# Begin building for only the 'all' Binaries parameter.
+# This step builds the GLB scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'GLB'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'GLB'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'GLB'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the ClippingExamples scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'ClippingExamples'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'ClippingExamples'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'ClippingExamples'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the MaterialGallery scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'MaterialGallery'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'MaterialGallery'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'MaterialGallery'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the StandardMaterialComparison scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'StandardMaterialComparison'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'StandardMaterialComparison'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'StandardMaterialComparison'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the StandardMaterials scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'StandardMaterials'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'StandardMaterials'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'StandardMaterials'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the MixedRealityCapabilityDemo scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'MixedRealityCapabilityDemo'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'MixedRealityCapabilityDemo'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'MixedRealityCapabilityDemo'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the SurfaceMagnetismSA scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SurfaceMagnetismSA'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SurfaceMagnetismSA'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SurfaceMagnetismSA'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the TapToPlace scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'TapToPlace'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'TapToPlace'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'TapToPlace'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the HIGestureEvents scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HIGestureEvents'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HIGestureEvents'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HIGestureEvents'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the HIRecordAHPose scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HIRecordAHPose'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HIRecordAHPose'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HIRecordAHPose'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the HandMenuExamples scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HandMenuExamples'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HandMenuExamples'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'HandMenuExamples'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the NearMenuExamples scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'NearMenuExamples'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'NearMenuExamples'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'NearMenuExamples'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the DiagnosticsDemo scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'DiagnosticsDemo'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'DiagnosticsDemo'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'DiagnosticsDemo'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the InputActionsExample scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'InputActionsExample'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'InputActionsExample'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'InputActionsExample'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the DisablePointersExample scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'DisablePointersExample'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'DisablePointersExample'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'DisablePointersExample'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the Dictation scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'Dictation'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'Dictation'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'Dictation'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the InputData scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'InputData'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'InputData'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'InputData'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the PointerResult scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'PointerResult'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'PointerResult'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'PointerResult'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the PrimaryPointer scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'PrimaryPointer'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'PrimaryPointer'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'PrimaryPointer'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the SpeechInput scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SpeechInput'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SpeechInput'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'SpeechInput'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# Start building the Experimental scenes
+# This step builds the EXBoundsControlExamples scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXBoundsControlExamples'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXBoundsControlExamples'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXBoundsControlExamples'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXBoundsControlRuntime scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXBoundsControlRuntime'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXBoundsControlRuntime'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXBoundsControlRuntime'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXColorPicker scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXColorPicker'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXColorPicker'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXColorPicker'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXDialog scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXDialog'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXDialog'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXDialog'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXDock scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXDock'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXDock'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXDock'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXDwell scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXDwell'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXDwell'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXDwell'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXElastic scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXElastic'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXElastic'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXElastic'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXExamplesHub scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXExamplesHub'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXExamplesHub'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXExamplesHub'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXHandCoach scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXHandCoach'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXHandCoach'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXHandCoach'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXHandMenuLayout scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXHandMenuLayout'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXHandMenuLayout'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXHandMenuLayout'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXJoystick scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXJoystick'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXJoystick'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXJoystick'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXMRKeyboard scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXMRKeyboard'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXMRKeyboard'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXMRKeyboard'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXNNKeyboard scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXNNKeyboard'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXNNKeyboard'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXNNKeyboard'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXPulseShader scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXPulseShader'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXPulseShader'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXPulseShader'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXRiggedHandVisual scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXRiggedHandVisual'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXRiggedHandVisual'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXRiggedHandVisual'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXScrollObject scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXScrollObject'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXScrollObject'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXScrollObject'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml
+
+# This step builds the EXSolvers scene.
+steps:
+- ${{ if contains(parameters.Binaries, 'all') }}:
+# Build UWP ARM64.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'arm64'
+    Platform: 'UWP'
+    PackagingDir: 'ARM64'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXSolvers'
+    PublishProject: 'no'
+    
+# Build UWP x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXSolvers'
+    PublishProject: 'no'
+
+# Build standalone x86.
+- template: tasks/bcunitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+    PackagingDir: 'x86'
+    UnityVersion: ${{ parameters.UnityVersion }}
+    PublishArtifacts: true
+    Scene: 'EXSolvers'
+    PublishProject: 'no'    
+
+- template: tests.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
+
+- template: end.yml

--- a/pipelines/templates/buildcallsetup.yml
+++ b/pipelines/templates/buildcallsetup.yml
@@ -10,1834 +10,1834 @@ parameters:
 steps:
 - ${{ if contains(parameters.Binaries, 'all,common') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HandInteractionExamples'
-    PublishProject: 'yes'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HandInteractionExamples'
+      PublishProject: 'yes'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HandInteractionExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HandInteractionExamples'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HandInteractionExamples'
-    PublishProject: 'yes'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HandInteractionExamples'
+      PublishProject: 'yes'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 #Builds the LeapMotion example scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all,common') }}:
 # Build Standalone x86 with Leap Motion 4.5.1 imported.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArti'facts: true
-    Scene: 'LeapMotion'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArti'facts: true
+      Scene: 'LeapMotion'
+      PublishProject: 'no'
 
 # This step builds the SolverExamples scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all,common') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SolverExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SolverExamples'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SolverExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SolverExamples'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SolverExamples'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SolverExamples'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the AudioLofi scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all,common') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'AudioLofi'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'AudioLofi'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'AudioLofi'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+     Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'AudioLofi'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'AudioLofi'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'AudioLofi'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the AudioOcclusion scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all,common') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'AudioOcclusion'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'AudioOcclusion'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'AudioOcclusion'
-    PublishProject: 'no'
+ - template: tasks/bcunitybuild.yml
+   parameters:
+     Arch: 'x86'
+     Platform: 'UWP'
+     PackagingDir: 'x86'
+     UnityVersion: ${{ parameters.UnityVersion }}
+     PublishArtifacts: true
+     Scene: 'AudioOcclusion'
+     PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'AudioOcclusion'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'AudioOcclusion'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the SpatialAwareness example scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all,common') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SpatialAwareness'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SpatialAwareness'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SpatialAwareness'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SpatialAwareness'
+      PublishProject: 'no'
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the GLTF scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all,common') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'GLTF'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'GLTF'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'GLTF'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'GLTF'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'GLTF'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'GLTF'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the BoundaryVisualization scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all,common') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'BoundaryVisualization'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'BoundaryVisualization'
+      PublishProject: 'no'
 
 # Build Standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'BoundaryVisualization'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'BoundaryVisualization'
+      PublishProject: 'no'    
 
 # Begin building for only the 'all' Binaries parameter.
 # This step builds the GLB scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'GLB'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'GLB'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'GLB'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'GLB'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'GLB'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'GLB'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the ClippingExamples scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'ClippingExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'ClippingExamples'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'ClippingExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'ClippingExamples'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'ClippingExamples'
-    PublishProject: 'no'    
+-   template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'ClippingExamples'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the MaterialGallery scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'MaterialGallery'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'MaterialGallery'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'MaterialGallery'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'MaterialGallery'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'MaterialGallery'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'MaterialGallery'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the StandardMaterialComparison scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'StandardMaterialComparison'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'StandardMaterialComparison'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'StandardMaterialComparison'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'StandardMaterialComparison'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'StandardMaterialComparison'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'StandardMaterialComparison'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the StandardMaterials scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'StandardMaterials'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'StandardMaterials'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'StandardMaterials'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'StandardMaterials'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'StandardMaterials'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'StandardMaterials'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the MixedRealityCapabilityDemo scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'MixedRealityCapabilityDemo'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'MixedRealityCapabilityDemo'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'MixedRealityCapabilityDemo'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'MixedRealityCapabilityDemo'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'MixedRealityCapabilityDemo'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'MixedRealityCapabilityDemo'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the SurfaceMagnetismSA scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SurfaceMagnetismSA'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SurfaceMagnetismSA'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SurfaceMagnetismSA'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SurfaceMagnetismSA'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SurfaceMagnetismSA'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SurfaceMagnetismSA'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the TapToPlace scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'TapToPlace'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'TapToPlace'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'TapToPlace'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'TapToPlace'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'TapToPlace'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'TapToPlace'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the HIGestureEvents scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HIGestureEvents'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HIGestureEvents'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HIGestureEvents'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HIGestureEvents'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HIGestureEvents'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HIGestureEvents'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the HIRecordAHPose scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HIRecordAHPose'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HIRecordAHPose'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HIRecordAHPose'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HIRecordAHPose'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HIRecordAHPose'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HIRecordAHPose'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the HandMenuExamples scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HandMenuExamples'
-    PublishProject: 'no'
-    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HandMenuExamples'
+      PublishProject: 'no'
+ 
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HandMenuExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HandMenuExamples'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'HandMenuExamples'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'HandMenuExamples'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the NearMenuExamples scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'NearMenuExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'NearMenuExamples'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'NearMenuExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'NearMenuExamples'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'NearMenuExamples'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'NearMenuExamples'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the DiagnosticsDemo scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'DiagnosticsDemo'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'DiagnosticsDemo'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'DiagnosticsDemo'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'DiagnosticsDemo'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'DiagnosticsDemo'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'DiagnosticsDemo'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the InputActionsExample scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'InputActionsExample'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'InputActionsExample'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'InputActionsExample'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'InputActionsExample'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'InputActionsExample'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'InputActionsExample'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the DisablePointersExample scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'DisablePointersExample'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'DisablePointersExample'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'DisablePointersExample'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'DisablePointersExample'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'DisablePointersExample'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'DisablePointersExample'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the Dictation scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'Dictation'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'Dictation'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'Dictation'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'Dictation'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'Dictation'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'Dictation'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the InputData scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'InputData'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'InputData'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'InputData'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'InputData'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'InputData'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'InputData'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the PointerResult scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'PointerResult'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'PointerResult'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'PointerResult'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'PointerResult'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'PointerResult'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'PointerResult'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the PrimaryPointer scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'PrimaryPointer'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'PrimaryPointer'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'PrimaryPointer'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'PrimaryPointer'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'PrimaryPointer'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'PrimaryPointer'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the SpeechInput scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SpeechInput'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SpeechInput'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SpeechInput'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SpeechInput'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'SpeechInput'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'SpeechInput'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # Start building the Experimental scenes
 # This step builds the EXBoundsControlExamples scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXBoundsControlExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXBoundsControlExamples'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXBoundsControlExamples'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXBoundsControlExamples'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXBoundsControlExamples'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXBoundsControlExamples'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXBoundsControlRuntime scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXBoundsControlRuntime'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXBoundsControlRuntime'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXBoundsControlRuntime'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXBoundsControlRuntime'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXBoundsControlRuntime'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXBoundsControlRuntime'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXColorPicker scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXColorPicker'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXColorPicker'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXColorPicker'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXColorPicker'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXColorPicker'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXColorPicker'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXDialog scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXDialog'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXDialog'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXDialog'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXDialog'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXDialog'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXDialog'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXDock scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXDock'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXDock'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXDock'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXDock'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXDock'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXDock'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXDwell scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXDwell'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXDwell'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXDwell'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXDwell'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXDwell'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXDwell'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXElastic scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXElastic'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXElastic'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXElastic'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXElastic'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXElastic'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXElastic'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXExamplesHub scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXExamplesHub'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXExamplesHub'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXExamplesHub'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXExamplesHub'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXExamplesHub'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXExamplesHub'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXHandCoach scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXHandCoach'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXHandCoach'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXHandCoach'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXHandCoach'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXHandCoach'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXHandCoach'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXHandMenuLayout scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXHandMenuLayout'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXHandMenuLayout'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXHandMenuLayout'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXHandMenuLayout'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXHandMenuLayout'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXHandMenuLayout'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXJoystick scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXJoystick'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXJoystick'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXJoystick'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXJoystick'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXJoystick'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXJoystick'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXMRKeyboard scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXMRKeyboard'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXMRKeyboard'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXMRKeyboard'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXMRKeyboard'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXMRKeyboard'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXMRKeyboard'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXNNKeyboard scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXNNKeyboard'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXNNKeyboard'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXNNKeyboard'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXNNKeyboard'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXNNKeyboard'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXNNKeyboard'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXPulseShader scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXPulseShader'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXPulseShader'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXPulseShader'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXPulseShader'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXPulseShader'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXPulseShader'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXRiggedHandVisual scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXRiggedHandVisual'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXRiggedHandVisual'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXRiggedHandVisual'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXRiggedHandVisual'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXRiggedHandVisual'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXRiggedHandVisual'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXScrollObject scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXScrollObject'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXScrollObject'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXScrollObject'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXScrollObject'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXScrollObject'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXScrollObject'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml
 
 # This step builds the EXSolvers scene.
 steps:
 - ${{ if contains(parameters.Binaries, 'all') }}:
 # Build UWP ARM64.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'arm64'
-    Platform: 'UWP'
-    PackagingDir: 'ARM64'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXSolvers'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'arm64'
+      Platform: 'UWP'
+      PackagingDir: 'ARM64'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXSolvers'
+      PublishProject: 'no'
     
 # Build UWP x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXSolvers'
-    PublishProject: 'no'
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXSolvers'
+      PublishProject: 'no'
 
 # Build standalone x86.
-- template: tasks/bcunitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
-    PackagingDir: 'x86'
-    UnityVersion: ${{ parameters.UnityVersion }}
-    PublishArtifacts: true
-    Scene: 'EXSolvers'
-    PublishProject: 'no'    
+  - template: tasks/bcunitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
+      PackagingDir: 'x86'
+      UnityVersion: ${{ parameters.UnityVersion }}
+      PublishArtifacts: true
+      Scene: 'EXSolvers'
+      PublishProject: 'no'    
 
-- template: tests.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
-- template: end.yml
+  - template: end.yml

--- a/pipelines/templates/tasks/bcunitybuild.yml
+++ b/pipelines/templates/tasks/bcunitybuild.yml
@@ -1,0 +1,45 @@
+# [Template] Compile MRTK inside Unity for Build Call.
+
+parameters: 
+  Arch: ''  # x86|arm
+  Platform: ''  # UWP|Standalone
+  UnityArgs: 'none' # [optional] additional args passed to Unity
+  ScriptingBackend: 'default'  # [optional] default|.NET
+  PublishArtifacts: false
+  PackagingDir: '' # Takes input from pipelines/templates/buildcallsetup.yml
+  Scene: '' # Possible scenes are located in the $sceneList variable in the scripts/test/SceneBuilder.ps1 script.
+  UnityVersion: "" # Takes input from pipelines/buildcallmanual.yml
+  PublishProject: '' # yes|no Tells the SceneBuilder.ps1 script to publish (or not publish) the project files to the build artifacts.
+
+# This 
+steps:
+- task: PowerShell@2
+  displayName: 'Build Example Scene'
+  inputs:
+    targetType: filePath
+    filePath: ./scripts/test/SceneBuilder.ps1
+
+- task: PowerShell@2
+  displayName: 'Validate build logs'
+  inputs:
+    targetType: filePath
+    filePath: ./scripts/ci/validatebuildlog.ps1
+    arguments: >
+      -LogFile: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.UnityVersion }}\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.Scene }}\build\build.log'
+
+- task: PublishBuildArtifacts@1
+  enabled: ${{ parameters.PublishArtifacts }}
+  displayName: 'Publish ${{ parameters.Platform }} ${{ parameters.Arch }} (${{ parameters.PackagingDir }}) ${{ parameters.ScriptingBackend }} ${{ parameters.Scene }} ${{ parameters.UnityVersion }}'
+  inputs:
+    ArtifactName: 'mrtk-build-${{ parameters.Arch }}'
+    # The final location of the generated package depends on the type of scripting backend it's built against.
+    # For the default scripting backend (IL2CPP) the naming of the appx follows the form below:
+    ${{ if eq(parameters.ScriptingBackend, 'default') }}:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.UnityVersion }}\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}\${{ parameters.Scene }}\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
+    # For .NET scripting backends, the naming is slightly different (mainly the AppPackages and MixedRealityToolkit folder
+    # names are reversed, and the Architecture is part of the AppX name)
+    ${{ if eq(parameters.ScriptingBackend, '.NET') }}:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}\${{ parameters.Scene }}\MixedRealityToolkit\AppPackages\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.Arch }}_Master_Test'
+    # This publishes the project files for in-editor testing.
+    ${{ if eq(parameters.PublishProject, 'yes') }}:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.UnityVersion }}\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.Scene }}\ProjectFiles'

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -24,21 +24,21 @@ steps:
    $sceneList = "Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
    
    $extraArgs = ''
-   If ("${{ parameters.Platform }}" -eq "UWP")
+   if ("${{ parameters.Platform }}" -eq "UWP")
    {
        $extraArgs += '-buildTarget WSAPlayer -buildAppx'
    }
-   ElseIf ("${{ parameters.Platform }}" -eq "Standalone")
+   elseif ("${{ parameters.Platform }}" -eq "Standalone")
    {
        $extraArgs += "-buildTarget StandaloneWindows"
    }
 
-   If ("${{ parameters.UnityArgs }}" -ne "none")
+   if ("${{ parameters.UnityArgs }}" -ne "none")
    {
        $extraArgs += " ${{ parameters.UnityArgs }}"
    }
 
-   If ("${{ parameters.ScriptingBackend }}" -eq ".NET")
+   if ("${{ parameters.ScriptingBackend }}" -eq ".NET")
    {
        $extraArgs += " -scriptingBackend 2"
    }
@@ -62,7 +62,7 @@ steps:
    Write-Output '           Unity Build Player Finished               '
    Write-Output '====================================================='
 
-   If (Test-Path $logFile.FullName)
+   if (Test-Path $logFile.FullName)
    {
       Write-Output '====================================================='
       Write-Output '           Begin Unity Player Log                    '
@@ -74,16 +74,16 @@ steps:
       Write-Output '           End Unity Player Log                      '
       Write-Output '====================================================='
    }
-   Else
+   else
    {
       Write-Output 'Unity Player Log Missing!'
    }
 
    # The NuGet and AppX logs are only relevant for UWP builds.
-   If ("${{ parameters.Platform }}" -eq "UWP")
+   if ("${{ parameters.Platform }}" -eq "UWP")
    {
         $nugetRestoreLogFileName = "$logDirectory\nugetRestore.log"
-        If (Test-Path $nugetRestoreLogFileName)
+        if (Test-Path $nugetRestoreLogFileName)
         {
             Write-Output '====================================================='
             Write-Output '           Begin NuGet Restore Log                   '
@@ -95,13 +95,13 @@ steps:
             Write-Output '           End NuGet Restore Log                     '
             Write-Output '====================================================='
         }
-        Else
+        else
         {
             Write-Output "NuGet Restore Log Missing $nugetRestoreLogFileName!"
         }
 
         $appxBuildLogFileName = "$logDirectory\buildAppx.log"
-        If (Test-Path $appxBuildLogFileName)
+        if (Test-Path $appxBuildLogFileName)
         {
             Write-Output '====================================================='
             Write-Output '           Begin AppX Build Log                      '
@@ -113,13 +113,13 @@ steps:
             Write-Output '           End AppX Build Log                        '
             Write-Output '====================================================='
         }
-        Else
+        else
         {
             Write-Output "AppX Build Log Missing $appxBuildLogFileName!"
         }
    }
 
-   If ($proc.ExitCode -ne 0)
+   if ($proc.ExitCode -ne 0)
    {
        exit $proc.ExitCode
    }

--- a/scripts/packaging/updateMRTKVersion.ps1
+++ b/scripts/packaging/updateMRTKVersion.ps1
@@ -40,7 +40,7 @@ function ReplaceVersionInFile($Path, $NewVersion, $Patterns, $Strict=$False)
                 $contents | Out-File -FilePath $Path -Encoding $Encoding
             }
         }
-        ElseIf ($Strict)
+        elseif ($Strict)
         {
             $errors += "${Path}: pattern not found: $pattern"
         }
@@ -70,18 +70,18 @@ foreach ($file in (Get-ChildItem -Path $GitRoot -Recurse))
     {
         $Errors += ReplaceVersionInFile -Path $file.FullName -NewVersion $NewVersion -Patterns @("(?<=Microsoft Mixed Reality Toolkit\s+)(\d+\.\d+\.\d+)") -Strict $True
     }
-    ElseIf ($file.Directory.FullName.StartsWith($PipelinesDir.FullName))
+    elseif ($file.Directory.FullName.StartsWith($PipelinesDir.FullName))
     {
         if (($file.Extension -eq ".yml") -or ($file.Extension -eq ".yaml"))
         {
             $Errors += ReplaceVersionInFile -Path $file.FullName -NewVersion $NewVersion -Patterns @("(?<=MRTKVersion:\s+)(\d+\.\d+\.\d+)")
         }
     }
-    ElseIf ($file.Name -eq "ProjectSettings.asset")
+    elseif ($file.Name -eq "ProjectSettings.asset")
     {
         $Errors += ReplaceVersionInFile -Path $file.FullName -NewVersion $NewVersion -Patterns @("(?<=bundleVersion:\s+)(\d+\.\d+\.\d+)", "(?<=metroPackageVersion:\s+)(\d+\.\d+\.\d+)(?=\.\d+)")
     }
-    ElseIf ($file.Name -eq "UwpAppxBuildToolsTest.cs")
+    elseif ($file.Name -eq "UwpAppxBuildToolsTest.cs")
     {
         $Errors += ReplaceVersionInFile -Path $file.FullName -NewVersion $NewVersion -Patterns  @("(?<=\sVersion=')(\d+\.\d+\.\d+)(?=\.\d+\')") -Strict $True
     }

--- a/scripts/test/SceneBuilder.ps1
+++ b/scripts/test/SceneBuilder.ps1
@@ -9,217 +9,217 @@
    $logDirectory = "$outDir\logs"
    $projectPath = $(Get-Location)
    $sceneList = ''
-   If ("${{ parameters.Scene }}" -eq "HandInteractionExamples")
+   if ("${{ parameters.Scene }}" -eq "HandInteractionExamples")
    {
        $sceneList += 'Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity'
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "SolverExamples")
+   elseif ("${{ parameters.Scene }}" -eq "SolverExamples")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Solvers\Scenes\SolverExamples.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "AudioLoFi")
+   elseif ("${{ parameters.Scene }}" -eq "AudioLoFi")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Audio\Scenes\AudioLoFiEffectDemo.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "AudioOcclusion")
+   elseif ("${{ parameters.Scene }}" -eq "AudioOcclusion")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Audio\Scenes\AudioOcclusionDemo.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "LeapMotion")
+   elseif ("${{ parameters.Scene }}" -eq "LeapMotion")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\LeapMotionHandTrackingExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "SpatialAwareness")
+   elseif ("${{ parameters.Scene }}" -eq "SpatialAwareness")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\SpatialAwareness\Scenes\SpatialAwarenessMeshDemo.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "GLTF")
+   elseif ("${{ parameters.Scene }}" -eq "GLTF")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Gltf\Scenes\Gltf-Loading-Demo.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "GLB")
+   elseif ("${{ parameters.Scene }}" -eq "GLB")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Gltf\Scenes\Glb-Loading-Demo.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "BoundaryVisualization")
+   elseif ("${{ parameters.Scene }}" -eq "BoundaryVisualization")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Boundary\Scenes\BoundaryVisualization.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "ClippingExamples")
+   elseif ("${{ parameters.Scene }}" -eq "ClippingExamples")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\StandardShader\Scenes\ClippingExamples.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "MaterialGallery")
+   elseif ("${{ parameters.Scene }}" -eq "MaterialGallery")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\StandardShader\Scenes\MaterialGallery.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "StandardMaterialComparison")
+   elseif ("${{ parameters.Scene }}" -eq "StandardMaterialComparison")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\StandardShader\Scenes\StandardMaterialComparison.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "StandardMaterials")
+   elseif ("${{ parameters.Scene }}" -eq "StandardMaterials")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\StandardShader\Scenes\StandardMaterials.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "MixedRealityCapabilityDemo")
+   elseif ("${{ parameters.Scene }}" -eq "MixedRealityCapabilityDemo")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Utilities\Scenes\MixedRealityCapabilityDemo.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "SurfaceMagnetismSA")
+   elseif ("${{ parameters.Scene }}" -eq "SurfaceMagnetismSA")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Solvers\Scenes\SurfaceMagnetismSpatialAwarenessExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "TapToPlace")
+   elseif ("${{ parameters.Scene }}" -eq "TapToPlace")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Solvers\Scenes\TapToPlaceExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "HIGestureEvents")
+   elseif ("${{ parameters.Scene }}" -eq "HIGestureEvents")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandInteractionGestureEventsExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "HIRecordAHPose")
+   elseif ("${{ parameters.Scene }}" -eq "HIRecordAHPose")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandInteractionRecordArticulatedHandPose.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "HandMenuExamples")
+   elseif ("${{ parameters.Scene }}" -eq "HandMenuExamples")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandMenuExamples.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "NearMenuExamples")
+   elseif ("${{ parameters.Scene }}" -eq "NearMenuExamples")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\NearMenuExamples.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "DiagnosticsDemo")
+   elseif ("${{ parameters.Scene }}" -eq "DiagnosticsDemo")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Diagnostics\Scenes\DiagnosticsDemo.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "InputActionsExample")
+   elseif ("${{ parameters.Scene }}" -eq "InputActionsExample")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\InputActions\InputActionsExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "DisablePointersExample")
+   elseif ("${{ parameters.Scene }}" -eq "DisablePointersExample")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\DisablePointers\DisablePointersExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "Dictation")
+   elseif ("${{ parameters.Scene }}" -eq "Dictation")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\Dictation\Dictation.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "InputData")
+   elseif ("${{ parameters.Scene }}" -eq "InputData")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\InputData\InputDataExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "PointerResult")
+   elseif ("${{ parameters.Scene }}" -eq "PointerResult")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\PointerResult\PointerResultExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "PrimaryPointer")
+   elseif ("${{ parameters.Scene }}" -eq "PrimaryPointer")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\PrimaryPointer\PrimaryPointerExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "SpeechInput")
+   elseif ("${{ parameters.Scene }}" -eq "SpeechInput")
    {
        $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\Speech\SpeechInputExamples.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXBoundsControlExamples")
+   elseif ("${{ parameters.Scene }}" -eq "EXBoundsControlExamples")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\BoundsControl\Scenes\BoundsControlExamples.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXBoundsControlRuntime")
+   elseif ("${{ parameters.Scene }}" -eq "EXBoundsControlRuntime")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\BoundsControl\Scenes\BoundsControlRuntimeExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXColorPicker")
+   elseif ("${{ parameters.Scene }}" -eq "EXColorPicker")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\ColorPicker\ColorPickerScene.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXDialog")
+   elseif ("${{ parameters.Scene }}" -eq "EXDialog")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\Dialog\DialogExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXDock")
+   elseif ("${{ parameters.Scene }}" -eq "EXDock")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\Dock\DockExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXDwell")
+   elseif ("${{ parameters.Scene }}" -eq "EXDwell")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\Dwell\DwellScene.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXElastic")
+   elseif ("${{ parameters.Scene }}" -eq "EXElastic")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\Elastic\Scenes\ElasticDemo.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXExamplesHub")
+   elseif ("${{ parameters.Scene }}" -eq "EXExamplesHub")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\ExamplesHub\Scenes\MRTKExamplesHub.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXHandCoach")
+   elseif ("${{ parameters.Scene }}" -eq "EXHandCoach")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\HandCoach\Scenes\HandCoachExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXHandMenuLayout")
+   elseif ("${{ parameters.Scene }}" -eq "EXHandMenuLayout")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\HandMenuLayout\Scenes\HandMenuLayoutExamples.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXJoystick")
+   elseif ("${{ parameters.Scene }}" -eq "EXJoystick")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\Joystick\Scenes\JoystickExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXMRKeyboard")
+   elseif ("${{ parameters.Scene }}" -eq "EXMRKeyboard")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\MixedRealityKeyboard\Scenes\MixedRealityKeyboardExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXNNKeyboard")
+   elseif ("${{ parameters.Scene }}" -eq "EXNNKeyboard")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\NonNativeKeyboard\Scenes\NonNativeKeyboardExample.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXPulseShader")
+   elseif ("${{ parameters.Scene }}" -eq "EXPulseShader")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\PulseShader\Scenes\PulseShaderExamples.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXRiggedHandVisual")
+   elseif ("${{ parameters.Scene }}" -eq "EXRiggedHandVisual")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\RiggedHand\Scenes\RiggedHandVisualizer.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXScrollObject")
+   elseif ("${{ parameters.Scene }}" -eq "EXScrollObject")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\ScrollingObjectCollection\Scenes\ScrollingObjectCollection.unity"
    }
-   ElseIf ("${{ parameters.Scene }}" -eq "EXSolvers")
+   elseif ("${{ parameters.Scene }}" -eq "EXSolvers")
    {
        $sceneList += "Assets\MRTK\Examples\Experimental\Solvers\DirectionalIndicatorExample.unity"
    }
 
    $extraArgs = ''
-   If ("${{ parameters.Platform }}" -eq "UWP")
+   if ("${{ parameters.Platform }}" -eq "UWP")
    {
        $extraArgs += '-buildTarget WSAPlayer -buildAppx'
    }
-   ElseIf ("${{ parameters.Platform }}" -eq "Standalone")
+   elseif ("${{ parameters.Platform }}" -eq "Standalone")
    {
        $extraArgs += "-buildTarget StandaloneWindows"
    }
-   If ("${{ parameters.UnityArgs }}" -ne "none")
+   if ("${{ parameters.UnityArgs }}" -ne "none")
    {
        $extraArgs += " ${{ parameters.UnityArgs }}"
    }
-   If ("${{ parameters.ScriptingBackend }}" -eq ".NET")
+   if ("${{ parameters.ScriptingBackend }}" -eq ".NET")
    {
        $extraArgs += " -scriptingBackend 2"
    }
 
    $proc = ''
-   If ("${{ parameters.Scene }}" -eq "LeapMotion")
+   if ("${{ parameters.Scene }}" -eq "LeapMotion")
    {
        Write-Output 'Coming soon importing Leap Motion core Unity package. This just builds an audio example scene.'
        Start-Process -FilePath "$editor" -ArgumentList "-projectPath $projectPath -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList Assets\MRTK\Examples\Demos\Audio\Scenes\AudioLoFiEffectDemo.unity -logFile $($logFile.FullName) -batchMode -${{ parameters.Arch }} -buildOutput $outDir $extraArgs -CacheServerIPAddress $(Unity.CacheServer.Address) -logDirectory $logDirectory" -PassThru
    }
-   Else
+   else
    {
        Start-Process -FilePath "$editor" -ArgumentList "-projectPath $projectPath -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -${{ parameters.Arch }} -buildOutput $outDir $extraArgs -CacheServerIPAddress $(Unity.CacheServer.Address) -logDirectory $logDirectory" -PassThru
    }
 
-       $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
    
    while (-not $proc.HasExited -and $ljob.HasMoreData)
    {
@@ -235,7 +235,7 @@
    Write-Output '====================================================='
    Write-Output '           Unity Build Player Finished               '
    Write-Output '====================================================='
-   If (Test-Path $logFile.FullName)
+   if (Test-Path $logFile.FullName)
    {
       Write-Output '====================================================='
       Write-Output '           Begin Unity Player Log                    '
@@ -245,15 +245,15 @@
       Write-Output '           End Unity Player Log                      '
       Write-Output '====================================================='
    }
-   Else
+   else
    {
       Write-Output 'Unity Player Log Missing!'
    }
    # The NuGet and AppX logs are only relevant for UWP builds.
-   If ("${{ parameters.Platform }}" -eq "UWP")
+   if ("${{ parameters.Platform }}" -eq "UWP")
    {
         $nugetRestoreLogFileName = "$logDirectory\nugetRestore.log"
-        If (Test-Path $nugetRestoreLogFileName)
+        if (Test-Path $nugetRestoreLogFileName)
         {
             Write-Output '====================================================='
             Write-Output '           Begin NuGet Restore Log                   '
@@ -263,12 +263,12 @@
             Write-Output '           End NuGet Restore Log                     '
             Write-Output '====================================================='
         }
-        Else
+        else
         {
             Write-Output "NuGet Restore Log Missing $nugetRestoreLogFileName!"
         }
         $appxBuildLogFileName = "$logDirectory\buildAppx.log"
-        If (Test-Path $appxBuildLogFileName)
+        if (Test-Path $appxBuildLogFileName)
         {
             Write-Output '====================================================='
             Write-Output '           Begin AppX Build Log                      '
@@ -278,22 +278,22 @@
             Write-Output '           End AppX Build Log                        '
             Write-Output '====================================================='
         }
-        Else
+        else
         {
             Write-Output "AppX Build Log Missing $appxBuildLogFileName!"
         }
-    # If the Publish Project Parameter is set to yes, this if statement will stage the project files for publishing to build artifacts. 
-    If ("${{ parameters.PublishProject }}" -eq "yes")
+    # if the Publish Project Parameter is set to yes, this if statement will stage the project files for publishing to build artifacts. 
+    if ("${{ parameters.PublishProject }}" -eq "yes")
     {
         Write-Output '***** Preparing project files for publishing *****'
         Copy-Item -Path '$projectPath' -Destination "$(Build.ArtifactStagingDirectory)\build\${{ parameters.UnityVersion }}\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.Scene }}\ProjectFiles\"
     }
-    ElseIf ("${{ parameters.PublishProject }}" -eq "no")
+    elseif ("${{ parameters.PublishProject }}" -eq "no")
     {
         Write-Output '***** Project files already published *****'
     }
    }
-   If ($proc.ExitCode -ne 0)
+   if ($proc.ExitCode -ne 0)
    {
        exit $proc.ExitCode
    }

--- a/scripts/test/SceneBuilder.ps1
+++ b/scripts/test/SceneBuilder.ps1
@@ -1,0 +1,300 @@
+   $UnityPath = ${Env:${{ parameters.UnityVersion }}}
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   # The build output goes to a unique combination of Platform + Arch + Scene to ensure that
+   # each build will have a fresh destination folder.
+   $outDir = "$(Build.ArtifactStagingDirectory)\build\${{ parameters.UnityVersion }}\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.Scene }}"
+   $logFile = New-Item -Path "$outDir\build\build.log" -ItemType File -Force
+   $logDirectory = "$outDir\logs"
+   $projectPath = $(Get-Location)
+   $sceneList = ''
+   If ("${{ parameters.Scene }}" -eq "HandInteractionExamples")
+   {
+       $sceneList += 'Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity'
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "SolverExamples")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Solvers\Scenes\SolverExamples.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "AudioLoFi")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Audio\Scenes\AudioLoFiEffectDemo.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "AudioOcclusion")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Audio\Scenes\AudioOcclusionDemo.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "LeapMotion")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\LeapMotionHandTrackingExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "SpatialAwareness")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\SpatialAwareness\Scenes\SpatialAwarenessMeshDemo.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "GLTF")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Gltf\Scenes\Gltf-Loading-Demo.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "GLB")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Gltf\Scenes\Glb-Loading-Demo.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "BoundaryVisualization")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Boundary\Scenes\BoundaryVisualization.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "ClippingExamples")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\StandardShader\Scenes\ClippingExamples.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "MaterialGallery")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\StandardShader\Scenes\MaterialGallery.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "StandardMaterialComparison")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\StandardShader\Scenes\StandardMaterialComparison.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "StandardMaterials")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\StandardShader\Scenes\StandardMaterials.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "MixedRealityCapabilityDemo")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Utilities\Scenes\MixedRealityCapabilityDemo.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "SurfaceMagnetismSA")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Solvers\Scenes\SurfaceMagnetismSpatialAwarenessExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "TapToPlace")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Solvers\Scenes\TapToPlaceExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "HIGestureEvents")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandInteractionGestureEventsExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "HIRecordAHPose")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandInteractionRecordArticulatedHandPose.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "HandMenuExamples")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandMenuExamples.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "NearMenuExamples")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\HandTracking\Scenes\NearMenuExamples.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "DiagnosticsDemo")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Diagnostics\Scenes\DiagnosticsDemo.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "InputActionsExample")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\InputActions\InputActionsExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "DisablePointersExample")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\DisablePointers\DisablePointersExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "Dictation")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\Dictation\Dictation.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "InputData")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\InputData\InputDataExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "PointerResult")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\PointerResult\PointerResultExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "PrimaryPointer")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\PrimaryPointer\PrimaryPointerExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "SpeechInput")
+   {
+       $sceneList += "Assets\MRTK\Examples\Demos\Input\Scenes\Speech\SpeechInputExamples.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXBoundsControlExamples")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\BoundsControl\Scenes\BoundsControlExamples.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXBoundsControlRuntime")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\BoundsControl\Scenes\BoundsControlRuntimeExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXColorPicker")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\ColorPicker\ColorPickerScene.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXDialog")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\Dialog\DialogExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXDock")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\Dock\DockExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXDwell")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\Dwell\DwellScene.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXElastic")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\Elastic\Scenes\ElasticDemo.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXExamplesHub")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\ExamplesHub\Scenes\MRTKExamplesHub.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXHandCoach")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\HandCoach\Scenes\HandCoachExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXHandMenuLayout")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\HandMenuLayout\Scenes\HandMenuLayoutExamples.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXJoystick")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\Joystick\Scenes\JoystickExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXMRKeyboard")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\MixedRealityKeyboard\Scenes\MixedRealityKeyboardExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXNNKeyboard")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\NonNativeKeyboard\Scenes\NonNativeKeyboardExample.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXPulseShader")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\PulseShader\Scenes\PulseShaderExamples.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXRiggedHandVisual")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\RiggedHand\Scenes\RiggedHandVisualizer.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXScrollObject")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\ScrollingObjectCollection\Scenes\ScrollingObjectCollection.unity"
+   }
+   ElseIf ("${{ parameters.Scene }}" -eq "EXSolvers")
+   {
+       $sceneList += "Assets\MRTK\Examples\Experimental\Solvers\DirectionalIndicatorExample.unity"
+   }
+
+   $extraArgs = ''
+   If ("${{ parameters.Platform }}" -eq "UWP")
+   {
+       $extraArgs += '-buildTarget WSAPlayer -buildAppx'
+   }
+   ElseIf ("${{ parameters.Platform }}" -eq "Standalone")
+   {
+       $extraArgs += "-buildTarget StandaloneWindows"
+   }
+   If ("${{ parameters.UnityArgs }}" -ne "none")
+   {
+       $extraArgs += " ${{ parameters.UnityArgs }}"
+   }
+   If ("${{ parameters.ScriptingBackend }}" -eq ".NET")
+   {
+       $extraArgs += " -scriptingBackend 2"
+   }
+
+   $proc = ''
+   If ("${{ parameters.Scene }}" -eq "LeapMotion")
+   {
+       Write-Output 'Coming soon importing Leap Motion core Unity package. This just builds an audio example scene.'
+       Start-Process -FilePath "$editor" -ArgumentList "-projectPath $projectPath -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList Assets\MRTK\Examples\Demos\Audio\Scenes\AudioLoFiEffectDemo.unity -logFile $($logFile.FullName) -batchMode -${{ parameters.Arch }} -buildOutput $outDir $extraArgs -CacheServerIPAddress $(Unity.CacheServer.Address) -logDirectory $logDirectory" -PassThru
+   }
+   Else
+   {
+       Start-Process -FilePath "$editor" -ArgumentList "-projectPath $projectPath -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -${{ parameters.Arch }} -buildOutput $outDir $extraArgs -CacheServerIPAddress $(Unity.CacheServer.Address) -logDirectory $logDirectory" -PassThru
+   }
+
+       $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+   Write-Output '====================================================='
+   Write-Output '           Unity Build Player Finished               '
+   Write-Output '====================================================='
+   If (Test-Path $logFile.FullName)
+   {
+      Write-Output '====================================================='
+      Write-Output '           Begin Unity Player Log                    '
+      Write-Output '====================================================='
+      Get-Content $logFile.FullName
+      Write-Output '====================================================='
+      Write-Output '           End Unity Player Log                      '
+      Write-Output '====================================================='
+   }
+   Else
+   {
+      Write-Output 'Unity Player Log Missing!'
+   }
+   # The NuGet and AppX logs are only relevant for UWP builds.
+   If ("${{ parameters.Platform }}" -eq "UWP")
+   {
+        $nugetRestoreLogFileName = "$logDirectory\nugetRestore.log"
+        If (Test-Path $nugetRestoreLogFileName)
+        {
+            Write-Output '====================================================='
+            Write-Output '           Begin NuGet Restore Log                   '
+            Write-Output '====================================================='
+            Get-Content $nugetRestoreLogFileName
+            Write-Output '====================================================='
+            Write-Output '           End NuGet Restore Log                     '
+            Write-Output '====================================================='
+        }
+        Else
+        {
+            Write-Output "NuGet Restore Log Missing $nugetRestoreLogFileName!"
+        }
+        $appxBuildLogFileName = "$logDirectory\buildAppx.log"
+        If (Test-Path $appxBuildLogFileName)
+        {
+            Write-Output '====================================================='
+            Write-Output '           Begin AppX Build Log                      '
+            Write-Output '====================================================='
+            Get-Content $appxBuildLogFileName
+            Write-Output '====================================================='
+            Write-Output '           End AppX Build Log                        '
+            Write-Output '====================================================='
+        }
+        Else
+        {
+            Write-Output "AppX Build Log Missing $appxBuildLogFileName!"
+        }
+    # If the Publish Project Parameter is set to yes, this if statement will stage the project files for publishing to build artifacts. 
+    If ("${{ parameters.PublishProject }}" -eq "yes")
+    {
+        Write-Output '***** Preparing project files for publishing *****'
+        Copy-Item -Path '$projectPath' -Destination "$(Build.ArtifactStagingDirectory)\build\${{ parameters.UnityVersion }}\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.Scene }}\ProjectFiles\"
+    }
+    ElseIf ("${{ parameters.PublishProject }}" -eq "no")
+    {
+        Write-Output '***** Project files already published *****'
+    }
+   }
+   If ($proc.ExitCode -ne 0)
+   {
+       exit $proc.ExitCode
+   }
+  displayName: "Build ${{ parameters.Scene }} ${{ parameters.Arch }} ${{ parameters.Scene }}"


### PR DESCRIPTION
## Overview
This is the Initial Build Call CI for building binaries and Unity projects for manual build call validation. The binaries and projects are built with both Unity 2018 LTS and Unity 2019 LTS.

## Changes
Adds the '.yml' for pipeline, template, task, and supporting the PowerShell script to the appropriate folders in the repo.


## Verification
I am concerned that 'pipelines\templates\buildcallsetup.yml' will not build correctly because of the mixed parameters in the ***- ${{ if contains(parameters.Binaries, 'all,common') }}:*** conditions for the scenes that are in the 'common' and 'all' parameters.

I think that there might be another issue in 'pipelines\templates\tasks\bcunitybuild.yml' with publishing the project files in the ***- task: PublishBuildArtifacts@1*** task.