### PR TITLE
Remove the MRTK files InitializeOnLoad handler

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -43,7 +43,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// for example, MRTK.Core.sentinel) in order to identify where the MRTK is located
     /// within the project.
     /// </remarks>
-    [InitializeOnLoad]
     public static class MixedRealityToolkitFiles
     {
         /// <summary>
@@ -227,13 +226,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
         }
 
-        static MixedRealityToolkitFiles()
-        {
-            Init();
-        }
-
         private static void Init()
         {
+            // Note that this file used to have an InitializeOnLoad handler to handle
+            // early initialization of the folder refresh. However, this had an effect of slowing down
+            // the Unity editor (i.e. on play mode entry, on recompile) even in cases where the MRTK
+            // isn't in the scene.
             if (!isInitialized)
             {
                 RefreshFolders();

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -365,7 +365,6 @@ $InitializeOnLoadExceptions = [System.Collections.Generic.HashSet[String]]@(
     "Assets/MRTK/Core/Utilities/WindowsApiChecker.cs",
     "Assets/MRTK/Core/Utilities/Async/Internal/SyncContextUtility.cs",
     "Assets/MRTK/Core/Utilities/Editor/EditorProjectUtilities.cs",
-    "Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs",
     "Assets/MRTK/Core/Utilities/Editor/USB/USBDeviceListener.cs",
     "Assets/MRTK/Providers/Oculus/XRSDK/Editor/OculusXRSDKConfigurationChecker.cs",
     "Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs",

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -386,7 +386,13 @@ function CheckInitializeOnLoad {
     )
     process {
         $hasIssue = $false
-        if ($FileContent[$LineNumber] -match "InitializeOnLoad") {
+        # This checks that the InitializeOnLoad string is both present and also not within
+        # a // comment block (cases that are inside a comment block are perfectly okay since
+        # the obviously do not have any actual effect)
+        # "^\s*//" -> will match a case where the line begins with any amount of whitespace
+        # followed by the two // characters.
+        if (($FileContent[$LineNumber] -match "InitializeOnLoad") -and 
+                ($FileContent[$LineNumber] -notmatch "^\s*//")) {
             $assetFileName = GetProjectRelativePath($FileName)
             if (-Not $InitializeOnLoadExceptions.Contains($assetFileName)) {
                 Write-Warning "A new InitializeOnLoad handler was introduced in: $assetFileName. An exception may be added "


### PR DESCRIPTION
The MixedRealityToolkitFiles InitializeOnLoad handler runs on every play mode entry/script recompile, even if the MRTK object/features aren't being used in the current scene. This overhead is painful for folks who want to have MRTK in their project but not have to use it on every single scene.

This removes the InitializeOnLoad handler and makes things become lazy-inited (i.e. the first usage of any of the public APIs of this file will end up causing the initialization to happen only when the MRTK files functionality is needed. This will have the effect, however, of causing a micro-delay in any Unity editor UI that ends up invoking this, but that should be better than having the same delay happen on every single compile of non-MRTK code (which is what happens today)