### PR TITLE
Update UnityProjectInfo to avoid the build break

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -23,7 +23,17 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         /// </summary>
         private static readonly HashSet<string> ExcludedPackageReferences = new HashSet<string>()
         {
-            "Windows.UI.Input.Spatial"
+            "Windows.UI.Input.Spatial",
+        };
+
+        /// <summary>
+        /// Any packages that take a direct dependency on any of these packages will not be included
+        /// in the final output
+        /// </summary>
+        private static readonly HashSet<string> ExcludedReferenceChains = new HashSet<string>()
+        {
+            "Oculus.VR",
+            "Oculus.VR.Editor",
         };
 
         /// <summary>
@@ -170,6 +180,12 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             foreach (string reference in toReturn.AssemblyDefinitionInfo.References)
             {
+                if (ExcludedReferenceChains.Contains(reference))
+                {
+                    Debug.LogWarning($"Ignoring {reference} for {toReturn.Name}, as it's marked as having an excluded dependency chain.");
+                    projectsMap.Remove(projectKey);
+                    return null;
+                }
                 if (ExcludedPackageReferences.Contains(reference))
                 {
                     Debug.LogWarning($"Skipping processing {reference} for {toReturn.Name}, as it's marked as excluded.");

--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         /// </summary>
         private static readonly HashSet<string> ExcludedPackageReferences = new HashSet<string>()
         {
-            "Windows.UI.Input.Spatial",
+            "Windows.UI.Input.Spatial"
         };
 
         /// <summary>


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/pull/8259/files led to a CI pipeline break in the msbuildforunity project generation step - in particular it looks like the system has some indigestion when dealing with new Oculus.VR.* packages that we've added dependencies on in a few cases.

Since we've turned down the public NuGet updates in favor of upcoming UPM work for 2.5, I've made a tweak to the project generation step to ignore any asmdefs that we have that reference Oculus.VR packages (which should unblock the build)