### PR TITLE
Replace InitOnLoad with MRTK > Utils > WMR > Check Config

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs
@@ -19,7 +19,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         /// Ensures that the appropriate symbolic constant is defined based on the presence of the DotNetWinRT binary.
         /// </summary>
         [MenuItem("Mixed Reality Toolkit/Utilities/Windows Mixed Reality/Check Configuration")]
-
         private static void ReconcileDotNetWinRTDefine()
         {
             FileInfo[] files = FileUtilities.FindFilesInAssets(FileName);

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs
@@ -10,20 +10,16 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
     /// <summary>
     /// Class to perform checks for configuration checks for the Windows Mixed Reality provider.
     /// </summary>
-    [InitializeOnLoad]
     static class WindowsMixedRealityConfigurationChecker
     {
         private const string FileName = "Microsoft.Windows.MixedReality.DotNetWinRT.dll";
         private static readonly string[] definitions = { "DOTNETWINRT_PRESENT" };
 
-        static WindowsMixedRealityConfigurationChecker()
-        {
-            ReconcileDotNetWinRTDefine();
-        }
-
         /// <summary>
         /// Ensures that the appropriate symbolic constant is defined based on the presence of the DotNetWinRT binary.
         /// </summary>
+        [MenuItem("Mixed Reality Toolkit/Utilities/Windows Mixed Reality/Check Configuration")]
+
         private static void ReconcileDotNetWinRTDefine()
         {
             FileInfo[] files = FileUtilities.FindFilesInAssets(FileName);

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -91,7 +91,6 @@ See [Leap Motion Hand Tracking Configuration](CrossPlatform/LeapMotionMRTK.md) f
 For those who are using ARFoundation, there's now an additional manual step in its getting started steps.
 See [ARFoundation](CrossPlatform/UsingARFoundation.md#install-required-packages) for the new steps.
 For those who will be using [Holographic Remoting](Tools/HolographicRemoting.md) on HoloLens 2, there is now a manual step to perform.
-Please see [DOTNETWINRT_PRESENT](Tools/HolographicRemoting.md#dotnetwinrt-present) for more new steps.
 
 ### Breaking changes
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -90,8 +90,8 @@ In some cases there was a tradeoff that had to be made:
 See [Leap Motion Hand Tracking Configuration](CrossPlatform/LeapMotionMRTK.md) for the extra integration step.
 For those who are using ARFoundation, there's now an additional manual step in its getting started steps.
 See [ARFoundation](CrossPlatform/UsingARFoundation.md#install-required-packages) for the new steps.
-For those who will be using [Holographic Remoting](Tools/HolographicRemoting.md) on HoloLens 2, there is now a manyual step to perform.
-Please see [DOTNETWINRT_PRESENT](Tools/HolographicRemoting.md#dotnetwinrt-present-define-written-into-player-settings) for more new steps.
+For those who will be using [Holographic Remoting](Tools/HolographicRemoting.md) on HoloLens 2, there is now a manual step to perform.
+Please see [DOTNETWINRT_PRESENT](Tools/HolographicRemoting.md#dotnetwinrt-present) for more new steps.
 
 ### Breaking changes
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -87,10 +87,11 @@ to entering play mode, and also at editor launch. These handlers now run in far 
 Unity responsiveness improvements.
 
 In some cases there was a tradeoff that had to be made:
-See [Leap Motion Hand Tracking Configuration](CrossPlatform/LeapMotionMRTK.md) for the extra integration step.
-For those who are using ARFoundation, there's now an additional manual step in its getting started steps.
+
+- See [Leap Motion Hand Tracking Configuration](CrossPlatform/LeapMotionMRTK.md) for the extra integration step.
+- For those who are using ARFoundation, there's now an additional manual step in its getting started steps.
 See [ARFoundation](CrossPlatform/UsingARFoundation.md#install-required-packages) for the new steps.
-For those who will be using [Holographic Remoting](Tools/HolographicRemoting.md) on HoloLens 2, there is now a manual step to perform.
+- For those who will be using [Holographic Remoting](Tools/HolographicRemoting.md#hololens-2) on HoloLens 2, there is now a manual step to perform.
 
 ### Breaking changes
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -90,6 +90,8 @@ In some cases there was a tradeoff that had to be made:
 See [Leap Motion Hand Tracking Configuration](CrossPlatform/LeapMotionMRTK.md) for the extra integration step.
 For those who are using ARFoundation, there's now an additional manual step in its getting started steps.
 See [ARFoundation](CrossPlatform/UsingARFoundation.md#install-required-packages) for the new steps.
+For those who will be using [Holographic Remoting](Tools/HolographicRemoting.md) on HoloLens 2, there is now a manyual step to perform.
+Please see [DOTNETWINRT_PRESENT](Tools/HolographicRemoting.md#dotnetwinrt-present-define-written-into-player-settings) for more new steps.
 
 ### Breaking changes
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -12,7 +12,11 @@ To enable remoting to a HoloLens, it is important to ensure that the project is 
 
 ### HoloLens 2
 
-When using a HoloLens 2, support for remoting articulated hand and eye tracking data has been added to MRTK. To enable these features, please select **Mixed Reality Toolkit** > **MSBuild** > **Use MSBuild for Unity dependency resolution**. This will install the required dependencies for Holographic Remoting.
+When using a HoloLens 2, support for remoting articulated hand and eye tracking data has been added to MRTK. To enable these features, please run the followin:
+
+- **Mixed Reality Toolkit** > **MSBuild** > **Use MSBuild for Unity dependency resolution**. 
+
+These steps  will install the required dependencies for Holographic Remoting and set the appropriate compiler flags.
 
 Some versions of Unity 2019 have encountered issues when using MSBuild for Unity. If the **Use MSBuild for Unity dependency resolution** option fails, please use the following steps to enable holographic remoting.
 
@@ -37,10 +41,12 @@ These issues are particularly relevant when running on **Unity 2019.3** or later
 
 #### MSBuildForUnity package import via writing into the package.manifest
 
-> [!Note]
-> There is an issue that prevents MSBuild for Unity from functioning properly on some versions of Unity 2019. If **Mixed Reality Toolkit** > **MSBuild** > **Use MSBuild for Unity dependency resolution** does not work correctly, please refer to the [manual installation instructions](#manual-dotnetadapter-installation).
+To enable MSBuild for Unity, please run **Mixed Reality Toolkit** > **MSBuild** > **Use MSBuild for Unity dependency resolution**. After running this command, MSBuild should begin importing dependencies. It may take a few seconds for importing to begin.
 
-The best way to check is to open **Window** > **Package Manager** and make sure MSBuild for Unity shows up in the packages list. If it's there, assume this step succeeded. If it's not there, try running **Mixed Reality Toolkit** > **Utilities** > **Configure Unity** and repeat the steps above for running the MRTK Configurator.
+The **Use MSBuild for Unity dependency resolution** command does not display a confirmation. To confirm that it succeeded, open **Window** > **Package Manager** and make sure MSBuild for Unity shows up in the packages list. If it's there, assume this step succeeded.
+
+> [!Note]
+> There is an issue that prevents MSBuild for Unity from functioning properly on some versions of Unity 2019. If issues are encountered, please refer to the [manual installation instructions](#manual-dotnetadapter-installation).
 
 ![MSB4U Package Manager](../Images/Tools/Remoting/MSB4UPackageManager.png)
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -54,7 +54,7 @@ The best way to check is to search the Assets folder for DotNetWinRT.dll. If thi
 
 If the previous step didn't succeed, it's good to double check that the appropriate csproj exists in your project. Check under **MRTK** / **Providers** / **WindowsMixedReality** / **Shared** / **DotNetAdapter** and confirm that DotNetAdapter.csproj exists. One common case where this file might not exist is if your .gitignore ignores csproj files and you've committed the MRTK files to a remote repo. In this case, please make sure you force add DotNetAdapter.csproj with `git add -f [path/to]/DotNetAdapter.csproj` to make sure it gets committed and cloned for all other collaborators or computers.
 
-#### `DOTNETWINRT_PRESENT`
+#### `DOTNETWINRT_PRESENT` #define written into player settings
 
 Beginning with MRTK version 2.5.0, for performance reasons, this define is no longer automatically set. To enable this flag, please use the **Mixed Reality Toolkit** > **Utilities** > **Windows Mixed Reality** > **Check Configuration** menu item.
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -54,7 +54,7 @@ The best way to check is to search the Assets folder for DotNetWinRT.dll. If thi
 
 If the previous step didn't succeed, it's good to double check that the appropriate csproj exists in your project. Check under **MRTK** / **Providers** / **WindowsMixedReality** / **Shared** / **DotNetAdapter** and confirm that DotNetAdapter.csproj exists. One common case where this file might not exist is if your .gitignore ignores csproj files and you've committed the MRTK files to a remote repo. In this case, please make sure you force add DotNetAdapter.csproj with `git add -f [path/to]/DotNetAdapter.csproj` to make sure it gets committed and cloned for all other collaborators or computers.
 
-#### `DOTNETWINRT_PRESENT` #define written into player settings
+#### `DOTNETWINRT_PRESENT`
 
 Beginning with MRTK version 2.5.0, for performance reasons, this define is no longer automatically set. To enable this flag, please use the **Mixed Reality Toolkit** > **Utilities** > **Windows Mixed Reality** > **Check Configuration** menu item.
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -14,7 +14,7 @@ To enable remoting to a HoloLens, it is important to ensure that the project is 
 
 When using a HoloLens 2, support for remoting articulated hand and eye tracking data has been added to MRTK. To enable these features, please select **Mixed Reality Toolkit** > **MSBuild** > **Use MSBuild for Unity dependency resolution**. This will install the required dependencies for Holographic Remoting.
 
-Once MSBuild completes the import process, the next step is to select 
+Once MSBuild completes the import process, the next step is to select **Mixed Reality Toolkit** > **Utilities** > **Windows Mixed Reality** > **Check Configuration**. This step adds a scripting define that enables the DotNetWinRT dependency that is installed by MSBuild for Unity.
 
 Some versions of Unity 2019 have encountered issues when using MSBuild for Unity. If the **Use MSBuild for Unity dependency resolution** option fails, please use the following steps to enable holographic remoting.
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -40,7 +40,7 @@ These issues are particularly relevant when running on **Unity 2019.3** or later
 > [!Note]
 > There is an issue that prevents MSBuild for Unity from functioning properly on some versions of Unity 2019. If **Mixed Reality Toolkit** > **MSBuild** > **Use MSBuild for Unity dependency resolution** does not work correctly, please refer to the [manual installation instructions](#manual-dotnetadapter-installation).
 
-The best way to check is to open Window -> Package Manager and make sure MSBuild for Unity shows up in the packages list. If it's there, assume this step succeeded. If it's not there, try running Mixed Reality Toolkit -> Utilities -> Configure Unity and repeat the steps above for running the MRTK Configurator.
+The best way to check is to open **Window** > **Package Manager** and make sure MSBuild for Unity shows up in the packages list. If it's there, assume this step succeeded. If it's not there, try running **Mixed Reality Toolkit** > **Utilities** > **Configure Unity** and repeat the steps above for running the MRTK Configurator.
 
 ![MSB4U Package Manager](../Images/Tools/Remoting/MSB4UPackageManager.png)
 
@@ -52,11 +52,14 @@ The best way to check is to search the Assets folder for DotNetWinRT.dll. If thi
 
 #### DotNetAdapter.csproj missing
 
-If the previous step didn't succeed, it's good to double check that the appropriate csproj exists in your project. Check under MRTK / Providers / WindowsMixedReality / Shared / DotNetAdapter and check that DotNetAdapter.csproj exists. One common case where this file might not exist is if your .gitignore ignores csproj files and you've committed the MRTK files to a remote repo. In this case, please make sure you force add DotNetAdapter.csproj with `git add -f [path/to]/DotNetAdapter.csproj` to make sure it gets committed and cloned for all other collaborators or computers.
+If the previous step didn't succeed, it's good to double check that the appropriate csproj exists in your project. Check under **MRTK** / **Providers** / **WindowsMixedReality** / **Shared** / **DotNetAdapter** and confirm that DotNetAdapter.csproj exists. One common case where this file might not exist is if your .gitignore ignores csproj files and you've committed the MRTK files to a remote repo. In this case, please make sure you force add DotNetAdapter.csproj with `git add -f [path/to]/DotNetAdapter.csproj` to make sure it gets committed and cloned for all other collaborators or computers.
 
 #### `DOTNETWINRT_PRESENT` #define written into player settings
 
-Navigate to the Unity Player Settings. From there, under the UWP tab, check under Other Settings for the Scripting Define Symbols. Make sure DOTNETWINRT_PRESENT is properly written in that list. If that's there, this step succeeded.
+Beginning with MRTK version 2.5.0, for performance reasons, this define is no longer automatically set. To enable this flag, please use the **Mixed Reality Toolkit** > **Utilities** > **Windows Mixed Reality** > **Check Configuration** menu item.
+
+> [!Note]
+> The Check Configuration item does not display a confirmation. To confirm that the define has been set, please navigate to the Unity Player Settings. From there, under the UWP tab, check under Other Settings for the Scripting Define Symbols. Make sure DOTNETWINRT_PRESENT is properly written in that list. If that's there, this step succeeded.
 
 ![DotNetWinRT Present](../Images/Tools/Remoting/DotNetWinRTPresent.png)
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -12,11 +12,9 @@ To enable remoting to a HoloLens, it is important to ensure that the project is 
 
 ### HoloLens 2
 
-When using a HoloLens 2, support for remoting articulated hand and eye tracking data has been added to MRTK. To enable these features, please run the followin:
+When using a HoloLens 2, support for remoting articulated hand and eye tracking data has been added to MRTK. To enable these features, please select **Mixed Reality Toolkit** > **MSBuild** > **Use MSBuild for Unity dependency resolution**. This will install the required dependencies for Holographic Remoting.
 
-- **Mixed Reality Toolkit** > **MSBuild** > **Use MSBuild for Unity dependency resolution**. 
-
-These steps  will install the required dependencies for Holographic Remoting and set the appropriate compiler flags.
+Once MSBuild completes the import process, the next step is to select 
 
 Some versions of Unity 2019 have encountered issues when using MSBuild for Unity. If the **Use MSBuild for Unity dependency resolution** option fails, please use the following steps to enable holographic remoting.
 


### PR DESCRIPTION
This change continues the work started by @wiwei to replace InitOnLoad classes with discrete menu options.

The new Mixed Reality Toolkit > Utilities > Windows Mixed Reality > Check Configuration menu item checks to see if the Dot Net WinRT NuGet package has been imported and appropriately sets the DOTNETWINRT_PRESENT flag.