### PR TITLE
fix appbar custom button visibility

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
@@ -423,15 +423,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 AppBarButton button = buttons[i];
 
-                switch (button.ButtonType)
-                {
-                    case ButtonTypeEnum.Custom:
-                        break;
-
-                    default:
-                        button.SetVisible(GetButtonVisible(button.ButtonType));
-                        break;
-                }
+                button.SetVisible(GetButtonVisible(button.ButtonType));
 
                 if (!buttons[i].Visible)
                 {


### PR DESCRIPTION
## Overview
If a custom button is added to Appbar prefab, in hidden or manipulation state the button is shown

## Changes
Remove check for custom button in UpdateButton, so the logic in the GetButtonVisible method can be executed


## How to test
Copy and paste a button in AppBar prefab and change type to custom, the button is always visible also when hide or manipulate button is checked
