### PR TITLE
Improve spatial mesh material handling - fix 8394 and 8396

### DIFF
--- a/Assets/MRTK/Examples/Demos/SpatialAwareness/Scripts/DemoSpatialMeshHandler.cs
+++ b/Assets/MRTK/Examples/Demos/SpatialAwareness/Scripts/DemoSpatialMeshHandler.cs
@@ -74,20 +74,15 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         public virtual void OnObservationAdded(MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> eventData)
         {
             // A new mesh has been added.
-            if (!meshUpdateData.ContainsKey(eventData.Id))
-            {
-                Debug.Log($"Tracking mesh {eventData.Id}");
-                meshUpdateData.Add(eventData.Id, 0);
-            }
+            Debug.Log($"Tracking mesh {eventData.Id}");
+            meshUpdateData.Add(eventData.Id, 0);
         }
 
         /// <inheritdoc />
         public virtual void OnObservationUpdated(MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> eventData)
         {
-            uint updateCount = 0;
-
             // A mesh has been updated. Find it and increment the update count.
-            if (meshUpdateData.TryGetValue(eventData.Id, out updateCount))
+            if (meshUpdateData.TryGetValue(eventData.Id, out uint updateCount))
             {
                 // Set the new update count.
                 meshUpdateData[eventData.Id] = ++updateCount;

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -657,22 +657,19 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                 outstandingMeshObject = null;
 
                 // Check to see if this is a new or updated mesh.
-                bool isMeshUpdate = meshes.ContainsKey(cookedData.id.handle);
+                bool isMeshUpdate = meshes.ContainsKey(meshObject.Id);
 
-                // Apply the appropriate material to the mesh.
-                SpatialAwarenessMeshDisplayOptions displayOption = DisplayOption;
-                if (displayOption != SpatialAwarenessMeshDisplayOptions.None)
-                {
-                    meshObject.Renderer.enabled = true;
-                    meshObject.Renderer.sharedMaterial = (displayOption == SpatialAwarenessMeshDisplayOptions.Visible) ?
-                        VisibleMaterial :
-                        OcclusionMaterial;
-                    meshObject.Collider.material = PhysicsMaterial;
-                }
-                else
-                {
-                    meshObject.Renderer.enabled = false;
-                }
+                // We presume that if the display option is not occlusion, that we should 
+                // default to the visible material. 
+                // Note: We check explicitly for a display option of none later in this method.
+                Material material = (DisplayOption == SpatialAwarenessMeshDisplayOptions.Occlusion) ?
+                    OcclusionMaterial : VisibleMaterial;
+
+                // If this is a mesh update, we want to preserve the mesh's previous material.
+                material = isMeshUpdate ? meshes[meshObject.Id].Renderer.sharedMaterial : material;
+
+                // Apply the appropriate material.
+                meshObject.Renderer.sharedMaterial = material;
 
                 // Recalculate the mesh normals if requested.
                 if (RecalculateNormals)
@@ -680,22 +677,30 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                     meshObject.Filter.sharedMesh.RecalculateNormals();
                 }
 
+                // Check to see if the display option is set to none. If so, we disable
+                // the renderer.
+                meshObject.Renderer.enabled = (DisplayOption != SpatialAwarenessMeshDisplayOptions.None);
+                
+                // Set the physics material
+                if (meshObject.Renderer.enabled)
+                {
+                    meshObject.Collider.material = PhysicsMaterial;
+                }
+
                 // Add / update the mesh to our collection
                 if (isMeshUpdate)
                 {
                     // Reclaim the old mesh object for future use.
-                    ReclaimMeshObject(meshes[cookedData.id.handle]);
-                    meshes.Remove(cookedData.id.handle);
+                    ReclaimMeshObject(meshes[meshObject.Id]);
+                    meshes.Remove(meshObject.Id);
                 }
-                meshes.Add(cookedData.id.handle, meshObject);
+                meshes.Add(meshObject.Id, meshObject);
 
-                /// Preserve local transform relative to parent.
-                meshObject.GameObject.transform.SetParent(ObservedObjectParent != null 
-                        ? ObservedObjectParent.transform
-                        : null,
-                    false);
+                // Preserve local transform relative to parent.
+                meshObject.GameObject.transform.SetParent(ObservedObjectParent != null ?
+                    ObservedObjectParent.transform: null, false);
 
-                meshEventData.Initialize(this, cookedData.id.handle, meshObject);
+                meshEventData.Initialize(this, meshObject.Id, meshObject);
                 if (isMeshUpdate)
                 {
                     SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshUpdated);

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -656,6 +656,9 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                 meshObject.Id = cookedData.id.handle;
                 outstandingMeshObject = null;
 
+                // Check to see if this is a new or updated mesh.
+                bool isMeshUpdate = meshes.ContainsKey(cookedData.id.handle);
+
                 // Apply the appropriate material to the mesh.
                 SpatialAwarenessMeshDisplayOptions displayOption = DisplayOption;
                 if (displayOption != SpatialAwarenessMeshDisplayOptions.None)
@@ -678,14 +681,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                 }
 
                 // Add / update the mesh to our collection
-                bool sendUpdatedEvent = false;
-                if (meshes.ContainsKey(cookedData.id.handle))
+                if (isMeshUpdate)
                 {
                     // Reclaim the old mesh object for future use.
                     ReclaimMeshObject(meshes[cookedData.id.handle]);
                     meshes.Remove(cookedData.id.handle);
-
-                    sendUpdatedEvent = true;
                 }
                 meshes.Add(cookedData.id.handle, meshObject);
 
@@ -696,7 +696,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                     false);
 
                 meshEventData.Initialize(this, cookedData.id.handle, meshObject);
-                if (sendUpdatedEvent)
+                if (isMeshUpdate)
                 {
                     SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshUpdated);
                 }

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -487,27 +487,34 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                         outstandingMeshObject = null;
 
                         // Check to see if this is a new or updated mesh.
-                        bool isMeshUpdate = meshes.ContainsKey(cookedData.id.handle);
+                        bool isMeshUpdate = meshes.ContainsKey(meshObject.Id);
 
-                        // Apply the appropriate material to the mesh.
-                        SpatialAwarenessMeshDisplayOptions displayOption = DisplayOption;
-                        if (displayOption != SpatialAwarenessMeshDisplayOptions.None)
-                        {
-                            meshObject.Renderer.enabled = true;
-                            meshObject.Renderer.sharedMaterial = (displayOption == SpatialAwarenessMeshDisplayOptions.Visible) ?
-                                VisibleMaterial :
-                                OcclusionMaterial;
-                            meshObject.Collider.material = PhysicsMaterial;
-                        }
-                        else
-                        {
-                            meshObject.Renderer.enabled = false;
-                        }
+                        // We presume that if the display option is not occlusion, that we should 
+                        // default to the visible material. 
+                        // Note: We check explicitly for a display option of none later in this method.
+                        Material material = (DisplayOption == SpatialAwarenessMeshDisplayOptions.Occlusion) ?
+                            OcclusionMaterial : VisibleMaterial;
+
+                        // If this is a mesh update, we want to preserve the mesh's previous material.
+                        material = isMeshUpdate ? meshes[meshObject.Id].Renderer.sharedMaterial : material;
+
+                        // Apply the appropriate material.
+                        meshObject.Renderer.sharedMaterial = material;
 
                         // Recalculate the mesh normals if requested.
                         if (RecalculateNormals)
                         {
                             meshObject.Filter.sharedMesh.RecalculateNormals();
+                        }
+
+                        // Check to see if the display option is set to none. If so, we disable
+                        // the renderer.
+                        meshObject.Renderer.enabled = (DisplayOption != SpatialAwarenessMeshDisplayOptions.None);
+
+                        // Set the physics material
+                        if (meshObject.Renderer.enabled)
+                        {
+                            meshObject.Collider.material = PhysicsMaterial;
                         }
 
                         // Add / update the mesh to our collection
@@ -519,7 +526,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                         }
                         meshes.Add(meshObject.Id, meshObject);
 
-                        meshObject.GameObject.transform.parent = (ObservedObjectParent.transform != null) ? ObservedObjectParent.transform : null;
+                        meshObject.GameObject.transform.parent = (ObservedObjectParent.transform != null) ?
+                            ObservedObjectParent.transform : null;
 
                         meshEventData.Initialize(this, meshObject.Id, meshObject);
                         if (isMeshUpdate)

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -486,6 +486,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                         meshObject.Id = meshGenerationResult.MeshId.GetHashCode();
                         outstandingMeshObject = null;
 
+                        // Check to see if this is a new or updated mesh.
+                        bool isMeshUpdate = meshes.ContainsKey(cookedData.id.handle);
+
                         // Apply the appropriate material to the mesh.
                         SpatialAwarenessMeshDisplayOptions displayOption = DisplayOption;
                         if (displayOption != SpatialAwarenessMeshDisplayOptions.None)
@@ -508,21 +511,18 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                         }
 
                         // Add / update the mesh to our collection
-                        bool sendUpdatedEvent = false;
-                        if (meshes.ContainsKey(meshObject.Id))
+                        if (isMeshUpdate)
                         {
                             // Reclaim the old mesh object for future use.
                             ReclaimMeshObject(meshes[meshObject.Id]);
                             meshes.Remove(meshObject.Id);
-
-                            sendUpdatedEvent = true;
                         }
                         meshes.Add(meshObject.Id, meshObject);
 
                         meshObject.GameObject.transform.parent = (ObservedObjectParent.transform != null) ? ObservedObjectParent.transform : null;
 
                         meshEventData.Initialize(this, meshObject.Id, meshObject);
-                        if (sendUpdatedEvent)
+                        if (isMeshUpdate)
                         {
                             SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshUpdated);
                         }

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -62,6 +62,12 @@ Support for the Leap Motion Unity Modules version 4.5.1 has been added and suppo
 
 There is also an additional step for initial Leap Motion integration, see [How to Configure the Leap Motion Hand Tracking in MRTK](CrossPlatform/LeapMotionMRTK.md) for more information.
 
+**Spatial Awareness Mesh Observer better handles customization of materials**
+
+With this release, the `Windows Mixed Reality Spatial Mesh Observer` and the `Generic XR SDK Spatial Mesh Observer` components have improved visual material handling. Materials are now preserved when a mesh has been updated by the observer where, previously, they were reset to the default VisibleMaterial as configured in the profile.
+
+This enables developers to alter the mesh material and not have the changes overwritten unexpectedly.
+
 **Link.xml created in the MixedRealityToolkit.Generated folder**
 
 With the introduction of Unity Package Manger MRTK, MRTK now writes a `link.xml` file to the `Assets/MixedRealityToolkit.Generated` folder, if none is present. It is recommended to add this file (and `link.xml.meta`) be added to source control. Link.xml is used to influence the [managed code stripping](https://docs.unity3d.com/Manual/ManagedCodeStripping.html#LinkXML) functionality of the Unity linker.


### PR DESCRIPTION
This change improves how materials are handled in the spatial mesh observers.

The first change (fixes #8394) determines the material and always applies it to the renderer, even if the display option in use is None.

The second change (fixes #8396), determines (earlier than in previous releases) whether or not the mesh event will be an add or an update. If update, the material for the mesh being replaced is applied to the new mesh.

Combining the two fixes enables developers who customize their spatial mesh materials to have the changes persist through mesh updates and toggles between Visible and None display options without requiring the application to continually reset the material.

This change does _not_ address #8397.