### PR TITLE
Scene understanding: re-create default profile and some minor code changes in the inspector and attrib usage

### DIFF
--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Editor/SceneUnderstandingObserverProfileInspector.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Editor/SceneUnderstandingObserverProfileInspector.cs
@@ -11,14 +11,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor.WindowsSceneUnderstanding.Experi
     [CustomEditor(typeof(SceneUnderstandingObserverProfile))]
     public class SceneUnderstandingObserverProfileInspector : BaseMixedRealityToolkitConfigurationProfileInspector
     {
-        // BaseSpatialAwarenessObserverProfile
-
         private SerializedProperty updateOnceOnLoad;
-        private SerializedProperty updateInterval;
-
-        // MixedRealitySpatialAwarenessSceneUnderstandingObserverProfile
-
+        private SerializedProperty firstUpdateDelay;
         private SerializedProperty autoUpdate;
+        private SerializedProperty updateInterval;
         private SerializedProperty defaultPhysicsLayer;
         private SerializedProperty surfaceTypes;
         private SerializedProperty instantiationBatchRate;
@@ -30,7 +26,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor.WindowsSceneUnderstanding.Experi
         private SerializedProperty requestPlaneData;
         private SerializedProperty createGameObjects;
         private SerializedProperty inferRegions;
-        private SerializedProperty firstUpdateDelay;
         private SerializedProperty worldMeshLevelOfDetail;
         private SerializedProperty usePersistentObjects;
         private SerializedProperty queryRadius;
@@ -76,7 +71,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor.WindowsSceneUnderstanding.Experi
         {
             RenderProfileHeader(ProfileTitle, ProfileDescription, target, true, BackProfileType.SpatialAwareness);
 
-            //using (new GUIEnabledWrapper(!IsProfileLock((BaseMixedRealityProfile)target)))
             using (new GUIEnabledWrapper())
             {
                 serializedObject.Update();

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Profiles/DefaultSceneUnderstandingObserverProfile.asset
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Profiles/DefaultSceneUnderstandingObserverProfile.asset
@@ -12,30 +12,30 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a66f7659243ab748891f032ff4477e2, type: 3}
   m_Name: DefaultSceneUnderstandingObserverProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   startupBehavior: 0
   isStationaryObserver: 0
   observationExtents: {x: 3, y: 3, z: 3}
   observerVolumeType: 1
-  updateInterval: 3.5
+  updateInterval: 5
   updateOnceOnLoad: 0
   autoUpdate: 0
   defaultPhysicsLayer: 31
   surfaceTypes: 60
   instantiationBatchRate: 1
-  defaultMaterial: {fileID: 0}
-  defaultWorldMeshMaterial: {fileID: 2100000, guid: c6bd404f506e1894289fde7b1689f901,
+  defaultMaterial: {fileID: 2100000, guid: c6bd404f506e1894289fde7b1689f901, type: 2}
+  defaultWorldMeshMaterial: {fileID: 2100000, guid: 47c3d3b0d8143e3489351498fceed55d,
     type: 2}
   shouldLoadFromFile: 0
   serializedScene: {fileID: 0}
-  createGameObjects: 1
+  createGameObjects: 0
   requestPlaneData: 1
-  requestMeshData: 0
+  requestMeshData: 1
   inferRegions: 1
   firstUpdateDelay: 1
   worldMeshLevelOfDetail: 1
   usePersistentObjects: 1
   queryRadius: 5
   requestOcclusionMask: 1
-  occlusionMaskResolution: {x: 128, y: 128}
-  orientScene: 1
+  occlusionMaskResolution: {x: 256, y: 256}
+  orientScene: 0

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Profiles/DefaultSceneUnderstandingObserverProfile.asset
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Profiles/DefaultSceneUnderstandingObserverProfile.asset
@@ -13,28 +13,29 @@ MonoBehaviour:
   m_Name: DefaultSceneUnderstandingObserverProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
-  startupBehavior: 1
+  startupBehavior: 0
   isStationaryObserver: 0
   observationExtents: {x: 3, y: 3, z: 3}
   observerVolumeType: 1
-  updateInterval: 5
+  updateInterval: 3.5
   updateOnceOnLoad: 0
   autoUpdate: 0
   defaultPhysicsLayer: 31
-  surfaceTypes: 30
+  surfaceTypes: 60
   instantiationBatchRate: 1
-  defaultMaterial: {fileID: 2100000, guid: a2137747e94e9744b9c97181972d0ed8, type: 2}
-  defaultWorldMeshMaterial: {fileID: 0}
+  defaultMaterial: {fileID: 0}
+  defaultWorldMeshMaterial: {fileID: 2100000, guid: c6bd404f506e1894289fde7b1689f901,
+    type: 2}
   shouldLoadFromFile: 0
   serializedScene: {fileID: 0}
-  createGameObjects: 0
+  createGameObjects: 1
   requestPlaneData: 1
-  requestMeshData: 1
+  requestMeshData: 0
   inferRegions: 1
   firstUpdateDelay: 1
   worldMeshLevelOfDetail: 1
   usePersistentObjects: 1
   queryRadius: 5
   requestOcclusionMask: 1
-  occlusionMaskResolution: {x: 256, y: 256}
-  orientScene: 0
+  occlusionMaskResolution: {x: 128, y: 128}
+  orientScene: 1

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Profiles/DefaultSceneUnderstandingObserverProfile.asset.meta
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Profiles/DefaultSceneUnderstandingObserverProfile.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 11270491bc79d8c4693fe64b875dbd69
+guid: 1ce015d87321ac7458f2f259a7e1aaa5
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/SceneUnderstandingObserverProfile.cs.meta
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/SceneUnderstandingObserverProfile.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
             IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
+            SceneUnderstandingObserverProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         {
             ReadProfile();
         }
@@ -64,7 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
             SceneUnderstandingObserverProfile profile = ConfigurationProfile as SceneUnderstandingObserverProfile;
             if (profile == null)
             {
-                Debug.LogError("Windows Mixed Reality Scene Understanding Observer's configuration profile must be a SceneUnderstandingObserverProfile.");
+                Debug.LogError("Windows Scene Understanding Observer's configuration profile must be a SceneUnderstandingObserverProfile.");
                 return;
             }
 

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
@@ -31,7 +31,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
         SupportedPlatforms.WindowsUniversal,
         "Windows Scene Understanding Observer",
         "Experimental/WindowsSceneUnderstanding/Profiles/DefaultSceneUnderstandingObserverProfile.asset",
-        "MixedRealityToolkit.Providers")]
+        "MixedRealityToolkit.Providers",
+        true)]
     public class WindowsSceneUnderstandingObserver :
         BaseSpatialObserver,
         IMixedRealitySpatialAwarenessSceneUnderstandingObserver
@@ -46,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
             IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem,
             string name = null,
             uint priority = DefaultPriority,
-            SceneUnderstandingObserverProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
+            BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         {
             ReadProfile();
         }


### PR DESCRIPTION
This change continues the feature branch work for scene understanding.

This one re-creates the default profile and specifies materials that are contained within the standard assets package, instead of examples assets.

Other included changes:

* Minor rearranging of some variables in the inspector
* Remove unneeded comments
* Mark the data provider as _requiring_ a profile