### PR TITLE
Fix object mesh observer not auto finding the profile

### DIFF
--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
@@ -15,8 +15,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         typeof(IMixedRealitySpatialAwarenessSystem),
         SupportedPlatforms.WindowsEditor | SupportedPlatforms.MacEditor | SupportedPlatforms.LinuxEditor,
         "Spatial Object Mesh Observer",
-        "ObjectMeshObserver/Profiles/DefaultObjectMeshObserverProfile.asset",
-        "MixedRealityToolkit.Providers")]
+        "Providers/ObjectMeshObserver/Profiles/DefaultObjectMeshObserverProfile.asset",
+        "MixedRealityToolkit.Core")]
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.html")]
     public class SpatialObjectMeshObserver :
         BaseSpatialMeshObserver,


### PR DESCRIPTION
With the move of SpatialObjectMeshObserver from the Providers to the Core/Providers folder, it failed to auto populate the default profile on selection.

This change fixes the data provider attribute values.