### PR TITLE
Fixes to the Oculus Quest prefabs for CI

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Resources/MRTK-OculusConfig.asset
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Resources/MRTK-OculusConfig.asset
@@ -12,8 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 17acf00f59af96c4bb501d1f9620d1c4, type: 3}
   m_Name: MRTK-OculusConfig
   m_EditorClassIdentifier: 
-  ovrCameraRigPrefab: {fileID: 2343937678411072827, guid: 69a746aa83d0d0e45b4e2d33eab0fff4,
-    type: 3}
+  ovrCameraRigPrefab: {fileID: 100004, guid: 126d619cf4daa52469682f85c1378b4a, type: 3}
   renderAvatarHandsInsteadOfControllers: 1
   localAvatarPrefab: {fileID: 6297684789857299957, guid: 5357c8e6c4495c04f90e97272375c294,
     type: 3}

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
@@ -54,17 +54,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus
             }
         }
 
-#if OCULUSINTEGRATION_PRESENT
         [Header("Prefab references")]
         [SerializeField]
         [Tooltip("Prefab reference for OVRCameraRig to load, if none are found in scene.")]
-        private OVRCameraRig ovrCameraRigPrefab = null;
+        private GameObject ovrCameraRigPrefab = null;
 
         /// <summary>
         /// Prefab reference for OVRCameraRig to load, if none are found in scene.
         /// </summary>
-        public OVRCameraRig OVRCameraRigPrefab => ovrCameraRigPrefab;
-#endif
+        public GameObject OVRCameraRigPrefab => ovrCameraRigPrefab;
 
 
         [SerializeField]

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -150,7 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus
                 var mainCamera = CameraCache.Main;
 
                 // Instantiate camera rig as a child of the MixedRealityPlayspace
-                cameraRig = GameObject.Instantiate(MRTKOculusConfig.Instance.OVRCameraRigPrefab);
+                cameraRig = GameObject.Instantiate(MRTKOculusConfig.Instance.OVRCameraRigPrefab).GetComponent<OVRCameraRig>();
 
                 // Ensure all related game objects are configured
                 cameraRig.EnsureGameObjectIntegrity();


### PR DESCRIPTION
## Overview
Fields on the prefabs were hidden due to OCULUSINTEGRATION_PRESENT flags, which probably broke CI