### PR TITLE
Add bounds control controller simulation tests

### DIFF
--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -379,6 +379,59 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test bounds control rotation via motion controller
+        /// Verifies gameobject has rotation in one axis only applied and no other transform changes happen during interaction
+        /// </summary>
+        [UnityTest]
+        public IEnumerator RotateViaMotionController()
+        {
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+
+            BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where ray points on the test cube
+            Vector3 rightFrontRotationHandlePoint = new Vector3(0.122f, -0.201f, 0.518f); // position of motion controller for far interacting with front right rotation sphere 
+            Vector3 endRotation = new Vector3(-0.18f, -0.109f, 0.504f); // end position for far interaction scaling
+
+            TestMotionController motionController = new TestMotionController(Handedness.Left);
+            yield return motionController.Show(pointOnCube); // Initially make sure that ray is pointed on cube surface so we won't go behind the cube with our ray
+            // grab front right rotation point
+            yield return motionController.MoveTo(rightFrontRotationHandlePoint);
+            SimulatedMotionControllerButtonState buttonState = new SimulatedMotionControllerButtonState()
+            {
+                IsSelecting = true
+            };
+            yield return motionController.SetState(buttonState);
+            // move to left side of cube
+            yield return motionController.MoveTo(endRotation);
+
+            // make sure rotation is as expected and no other transform values have been modified through this
+            Vector3 expectedPosition = new Vector3(0f, 0f, 1.5f);
+            Vector3 expectedSize = Vector3.one * 0.5f;
+            float angle;
+            Vector3 axis = new Vector3();
+            boundsControl.transform.rotation.ToAngleAxis(out angle, out axis);
+            float expectedAngle = 54f;
+            float angleDiff = Mathf.Abs(expectedAngle - angle);
+            Vector3 expectedAxis = new Vector3(0f, 1f, 0f);
+            TestUtilities.AssertAboutEqual(axis, expectedAxis, "Rotated around wrong axis");
+            Assert.IsTrue(angleDiff <= 1f, "cube didn't rotate as expected");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube moved while rotating");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube scaled while rotating");
+            GameObject.Destroy(boundsControl.gameObject);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldSimMode;
+            yield return null;
+        }
+
+        /// <summary>
         /// Test bounds control rotation via far interaction, while moving extremely slowly.
         /// Rotation amount should be coherent even with extremely small per-frame motion
         /// </summary>
@@ -426,6 +479,69 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             GameObject.Destroy(boundsControl.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+        }
+
+        /// <summary>
+        /// Test bounds control rotation via motion controller, while moving extremely slowly.
+        /// Rotation amount should be coherent even with extremely small per-frame motion
+        /// </summary>
+        [UnityTest]
+        public IEnumerator RotateVerySlowlyViaMotionController()
+        {
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+
+            BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where ray points on the test cube
+            Vector3 rightFrontRotationHandlePoint = new Vector3(0.122f, -0.201f, 0.518f); // position of motion controller for far interacting with front right rotation sphere 
+            Vector3 endRotation = new Vector3(-0.18f, -0.109f, 0.504f); // end position for far interaction scaling
+
+            TestMotionController motionController = new TestMotionController(Handedness.Left);
+            yield return motionController.Show(pointOnCube); // Initially make sure that ray is pointed on cube surface so we won't go behind the cube with our ray
+            // grab front right rotation point
+            yield return motionController.MoveTo(rightFrontRotationHandlePoint);
+            SimulatedMotionControllerButtonState buttonState = new SimulatedMotionControllerButtonState()
+            {
+                IsSelecting = true
+            };
+            yield return motionController.SetState(buttonState);
+
+            // First, we make a series of very very tiny movements, as if the user
+            // is making very precise adjustments to the rotation. If the rotation is
+            // being calculated per-frame instead of per-manipulation-event, this should
+            // induce drift/error.
+            for (int i = 0; i < 50; i++)
+            {
+                yield return motionController.MoveTo(Vector3.Lerp(rightFrontRotationHandlePoint, endRotation, (1 / 1000.0f) * i));
+            }
+
+            // Move the rest of the way very quickly.
+            yield return motionController.MoveTo(endRotation);
+
+            // make sure rotation is as expected and no other transform values have been modified through this
+            Vector3 expectedPosition = new Vector3(0f, 0f, 1.5f);
+            Vector3 expectedSize = Vector3.one * 0.5f;
+            float angle;
+            Vector3 axis = new Vector3();
+            boundsControl.transform.rotation.ToAngleAxis(out angle, out axis);
+            float expectedAngle = 54f;
+            float angleDiff = Mathf.Abs(expectedAngle - angle);
+            Vector3 expectedAxis = new Vector3(0f, 1f, 0f);
+            TestUtilities.AssertAboutEqual(axis, expectedAxis, "Rotated around wrong axis");
+            Assert.IsTrue(angleDiff <= 1f, "cube didn't rotate as expected");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube moved while rotating");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube scaled while rotating");
+
+            GameObject.Destroy(boundsControl.gameObject);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldSimMode;
             yield return null;
         }
 
@@ -640,6 +756,49 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Tests scaling of bounds control by grabbing a corner with the motion controller
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScaleViaMotionController()
+        {
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+
+            BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            Vector3 rightCornerInteractionPoint = new Vector3(0.1673f, 0.121f, 0.7813f); // position of motion controller for interacting with front right corner 
+            Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where ray points on the test cube
+            Vector3 scalePoint = new Vector3(0.165f, 0.267f, 0.794f); // end position for motion controller scaling
+
+            TestMotionController motionController = new TestMotionController(Handedness.Left);
+            yield return motionController.Show(pointOnCube); // Initially make sure that ray is pointed on cube surface so we won't go behind the cube with our ray
+            yield return motionController.MoveTo(rightCornerInteractionPoint);
+            SimulatedMotionControllerButtonState buttonState = new SimulatedMotionControllerButtonState()
+            {
+                IsSelecting = true
+            };
+            yield return motionController.SetState(buttonState);
+            yield return motionController.MoveTo(scalePoint);
+            var endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
+            Vector3 expectedCenter = new Vector3(0.022f, 0.022f, 1.478f);
+            Vector3 expectedSize = Vector3.one * 0.543f;
+            TestUtilities.AssertAboutEqual(endBounds.center, expectedCenter, "endBounds incorrect center");
+            TestUtilities.AssertAboutEqual(endBounds.size, expectedSize, "endBounds incorrect size");
+
+            GameObject.Destroy(boundsControl.gameObject);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldSimMode;
+
+            yield return null;
+        }
+
+        /// <summary>
         /// This tests the minimum and maximum scaling for the bounds control.
         /// </summary>
         [UnityTest]
@@ -766,6 +925,57 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
         }
+
+        /// <summary>
+        /// Test bounds control translation via motion controller
+        /// Verifies gameobject has translation in one axis only applied and no other transform changes happen during interaction
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TranslateViaMotionController()
+        {
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+
+            BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            boundsControl.TranslationHandlesConfig.ShowHandleForX = true;
+            boundsControl.SmoothingActive = false;
+            boundsControl.transform.position = new Vector3(-1.0f, 0.0f, 1.5f);
+
+            Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where ray points on the test cube
+            Vector3 transformHandlePosition = new Vector3(-0.538f, -0.313f, 0.31f);
+            Vector3 endPosition = new Vector3(0.497f, -0.188f, 0.499f);
+
+            TestMotionController motionController = new TestMotionController(Handedness.Right);
+            yield return motionController.Show(pointOnCube); // Initially make sure that ray is pointed on cube surface so we won't go behind the cube with our ray
+            yield return motionController.MoveTo(transformHandlePosition);
+            SimulatedMotionControllerButtonState buttonState = new SimulatedMotionControllerButtonState()
+            {
+                IsSelecting = true
+            };
+            yield return motionController.SetState(buttonState);
+            // move to left side of cube
+            yield return motionController.MoveTo(endPosition);
+
+            // make sure translation is as expected and no other transform values have been modified through this
+            Vector3 expectedPosition = new Vector3(0.035f, 0f, 1.5f);
+            Vector3 expectedSize = Vector3.one * 0.5f;
+            TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube didn't move as expected");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube scaled while translating");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.rotation, Quaternion.identity, "cube rotated while translating");
+
+            GameObject.Destroy(boundsControl.gameObject);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldSimMode;
+
+            yield return null;
+        }
+
         /// <summary>
         /// Test bounds control translation via near interaction
         /// Verifies gameobject has translation in one axis only applied and no other transform changes happen during interaction
@@ -2072,6 +2282,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // deactivate the bounds control via app bar
             yield return hand.MoveTo(appBarButtonAfterScale);
+            yield return new WaitForSeconds(0.5f); // make sure animation does not cause interference
             yield return hand.Click();
 
             // check if we can scale the box - box shouldn't scale
@@ -2088,6 +2299,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // activate the bounds control via app bar
             yield return hand.MoveTo(appBarButtonAfterScale);
+            yield return new WaitForSeconds(0.5f); // make sure animation does not cause interference
             yield return hand.Click();
 
             // try again to scale the box back
@@ -2099,6 +2311,116 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
             TestUtilities.AssertAboutEqual(endBounds.center, boundsControlStartCenter, "endBounds incorrect center");
             TestUtilities.AssertAboutEqual(endBounds.size, boundsControlStartScale, "endBounds incorrect size");
+
+            yield return null;
+        }
+
+        /// <summary>
+        /// Test starting and ending manipulating an object via the app bar
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulateViaAppBarMotionController()
+        {
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+
+            // create cube with bounds control and app bar
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = boundsControlStartCenter;
+            BoundsControl boundsControl = cube.AddComponent<BoundsControl>();
+
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            boundsControl.transform.localScale = boundsControlStartScale;
+            Object appBarPrefab = AssetDatabase.LoadAssetAtPath(appBarPrefabLink, typeof(Object));
+            Assert.IsNotNull(appBarPrefab, "Couldn't load app bar prefab from assetdatabase");
+            GameObject appBarGameObject = Object.Instantiate(appBarPrefab) as GameObject;
+            Assert.IsNotNull(appBarGameObject, "Couldn't instantiate appbar prefab");
+            appBarGameObject.SetActive(false);
+            AppBar appBar = appBarGameObject.GetComponent<AppBar>();
+            Assert.IsNotNull(appBar, "Couldn't find AppBar component in prefab");
+
+            appBarGameObject.transform.localScale = Vector3.one * 5.0f;
+            appBar.Target = boundsControl;
+            appBarGameObject.SetActive(true);
+
+            // manipulation coords
+            Vector3 rightCornerInteractionPoint = new Vector3(0.1659f, 0.123f, 0.79f); // position of motion controller for far interacting with front right corner 
+            Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where ray points on the test cube
+            Vector3 scalePoint = new Vector3(0.165f, 0.267f, 0.794f); // end position for motion controller scaling
+            Vector3 appBarButtonStart = new Vector3(-0.12f, -0.435f, 0.499f); // location of motion controller for interaction with the app bar manipulation button after scene setup
+            Vector3 appBarButtonAfterScale = new Vector3(-0.075f, -0.414f, 0.499f); // location of the motion controller for interaction with the app bar manipulation button after scaling
+
+            // first test to interact with the cube without activating the app bar
+            // this shouldn't scale the cube
+            TestMotionController motionController = new TestMotionController(Handedness.Left);
+            yield return motionController.Show(pointOnCube); // Initially make sure that ray is pointed on cube surface so we won't go behind the cube with our ray
+            yield return motionController.MoveTo(rightCornerInteractionPoint);
+            SimulatedMotionControllerButtonState selectButtonState = new SimulatedMotionControllerButtonState()
+            {
+                IsSelecting = true
+            };
+            yield return motionController.SetState(selectButtonState);
+            yield return motionController.MoveTo(scalePoint);
+            yield return motionController.SetState(new SimulatedMotionControllerButtonState());
+            var endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
+            TestUtilities.AssertAboutEqual(endBounds.center, boundsControlStartCenter, "endBounds incorrect center");
+            TestUtilities.AssertAboutEqual(endBounds.size, boundsControlStartScale, "endBounds incorrect size");
+
+            // now activate the bounds control via app bar
+            yield return motionController.MoveTo(appBarButtonStart);
+            yield return motionController.Click();
+
+            // check if we can scale the box now
+            yield return motionController.MoveTo(pointOnCube); // make sure our ray is on the cube again before moving to the scale corner
+            yield return motionController.MoveTo(rightCornerInteractionPoint); // move to scale corner
+            yield return motionController.SetState(selectButtonState);
+            yield return motionController.MoveTo(scalePoint);
+            yield return motionController.SetState(new SimulatedMotionControllerButtonState());
+            endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
+            Vector3 expectedScaleCenter = new Vector3(0.023f, 0.023f, 1.477f);
+            Vector3 expectedScaleSize = Vector3.one * 0.546f;
+            TestUtilities.AssertAboutEqual(endBounds.center, expectedScaleCenter, "endBounds incorrect center");
+            TestUtilities.AssertAboutEqual(endBounds.size, expectedScaleSize, "endBounds incorrect size");
+
+            // deactivate the bounds control via app bar
+            yield return motionController.MoveTo(appBarButtonAfterScale);
+            yield return new WaitForSeconds(0.5f); // make sure animation does not cause interference
+            yield return motionController.Click();
+
+            // check if we can scale the box - box shouldn't scale
+            Vector3 startScaleLocation = new Vector3(0.173f, 0.104f, 0.499f);
+            Vector3 endScaleLocation = new Vector3(0.406f, 0.271f, 0.499f);
+            yield return motionController.MoveTo(pointOnCube); // make sure our ray is on the cube again before moving to the scale corner
+            yield return motionController.MoveTo(startScaleLocation); // move to scale corner
+            yield return motionController.SetState(selectButtonState);
+            yield return motionController.MoveTo(endScaleLocation);
+            yield return motionController.SetState(new SimulatedMotionControllerButtonState());
+            endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
+            TestUtilities.AssertAboutEqual(endBounds.center, expectedScaleCenter, "endBounds incorrect center");
+            TestUtilities.AssertAboutEqual(endBounds.size, expectedScaleSize, "endBounds incorrect size");
+
+            // activate the bounds control via app bar
+            yield return motionController.MoveTo(appBarButtonAfterScale);
+            yield return new WaitForSeconds(0.5f); // make sure animation does not cause interference
+            yield return motionController.Click();
+
+            // try again to scale the box back
+            yield return motionController.MoveTo(pointOnCube); // make sure our ray is on the cube again before moving to the scale corner
+            yield return motionController.MoveTo(startScaleLocation); // move to scale corner
+            yield return motionController.SetState(selectButtonState);
+            yield return motionController.MoveTo(endScaleLocation);
+            yield return motionController.SetState(new SimulatedMotionControllerButtonState());
+            endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
+            TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.089f, 0.089f, 1.411f), "endBounds incorrect center");
+            TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * 0.679f, "endBounds incorrect size");
+
+            yield return null;
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldSimMode;
 
             yield return null;
         }

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -2282,7 +2282,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // deactivate the bounds control via app bar
             yield return hand.MoveTo(appBarButtonAfterScale);
-            yield return new WaitForSeconds(0.5f); // make sure animation does not cause interference
             yield return hand.Click();
 
             // check if we can scale the box - box shouldn't scale
@@ -2299,7 +2298,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // activate the bounds control via app bar
             yield return hand.MoveTo(appBarButtonAfterScale);
-            yield return new WaitForSeconds(0.5f); // make sure animation does not cause interference
             yield return hand.Click();
 
             // try again to scale the box back
@@ -2387,7 +2385,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // deactivate the bounds control via app bar
             yield return motionController.MoveTo(appBarButtonAfterScale);
-            yield return new WaitForSeconds(0.5f); // make sure animation does not cause interference
             yield return motionController.Click();
 
             // check if we can scale the box - box shouldn't scale
@@ -2404,7 +2401,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // activate the bounds control via app bar
             yield return motionController.MoveTo(appBarButtonAfterScale);
-            yield return new WaitForSeconds(0.5f); // make sure animation does not cause interference
             yield return motionController.Click();
 
             // try again to scale the box back

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
@@ -75,6 +75,31 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [UnityTest]
+        public IEnumerator TestMotionControllerClickEvents()
+        {
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+
+            // Subscribe to interactable's on click so we know the click went through
+            bool wasClicked = false;
+            interactable.OnClick.AddListener(() => { wasClicked = true; });
+
+            var testMotionController = new TestMotionController(Handedness.Right);
+            yield return testMotionController.Show(new Vector3(1, 0, 0));
+            yield return testMotionController.Click();
+            yield return testMotionController.Hide();
+
+            Assert.True(wasClicked);
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldSimMode;
+
+            yield return null;
+        }
+
+        [UnityTest]
         public IEnumerator TestGrabEvents()
         {
             var grabReceiver = interactable.AddReceiver<InteractableOnGrabReceiver>();
@@ -109,6 +134,40 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return testHand.Hide();
             Assert.True(didHold, "Did not receive hold event");
             GameObject.Destroy(cube);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator TestMotionControllerHoldEvents()
+        {
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+
+            // Hold
+            var holdReceiver = interactable.AddReceiver<InteractableOnHoldReceiver>();
+            bool didHold = false;
+            holdReceiver.OnHold.AddListener(() => didHold = true);
+
+            var testMotionController = new TestMotionController(Handedness.Right);
+            yield return testMotionController.Show(new Vector3(1, 0, 0));
+
+            SimulatedMotionControllerButtonState selectButtonState = new SimulatedMotionControllerButtonState()
+            {
+                IsSelecting = true
+            };
+            yield return testMotionController.SetState(selectButtonState);
+            yield return new WaitForSeconds(holdReceiver.HoldTime);
+            yield return testMotionController.Hide();
+
+            Assert.True(didHold, "Did not receive hold event");
+            GameObject.Destroy(cube);
+            yield return null;
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldSimMode;
+
             yield return null;
         }
 
@@ -155,6 +214,41 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(didUnselect, "Toggle unselect did not fire");
 
             PlayModeTestUtilities.PopControllerSimulationProfile();
+        }
+
+        [UnityTest]
+        public IEnumerator TestMotionControllerToggleEvents()
+        {
+            // Switch to motion controller
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.MotionController;
+
+            var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();
+            interactable.transform.position = Vector3.forward * 2f;
+            interactable.NumOfDimensions = 2;
+            interactable.CanSelect = true;
+            interactable.CanDeselect = true;
+            bool didSelect = false;
+            bool didUnselect = false;
+            toggleReceiver.OnSelect.AddListener(() => didSelect = true);
+            toggleReceiver.OnDeselect.AddListener(() => didUnselect = true);
+
+            var testMotionController = new TestMotionController(Handedness.Right);
+            yield return testMotionController.Show(Vector3.zero);
+
+            yield return testMotionController.Click();
+            yield return testMotionController.Click();
+            yield return testMotionController.Hide();
+
+            Assert.True(didSelect, "Toggle select did not fire");
+            Assert.True(didUnselect, "Toggle unselect did not fire");
+            yield return null;
+
+            // Restore the input simulation profile
+            iss.ControllerSimulationMode = oldSimMode;
+
+            yield return null;
         }
 
 


### PR DESCRIPTION
## Overview
Add controller simulation tests to bounds control tests as the feature is no longer experimental. Also add some tests to InteractableEvent.

## Changes
- Follows #8401.