### PR TITLE
Hack to stop guid from breaking CI

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -239,7 +239,12 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                             }
                             else if (nonClassDictionary.ContainsKey(guid))
                             {
-                                throw new InvalidDataException($"A script without a class ({nonClassDictionary[guid]}) is being processed.");
+                                // this guid bypasses throwing the exception. The reason for this is that there is currently an asset (MRTK-OculusConfig.asset) that is reliant
+                                // on Unity 2019+ specific code (MRTKOculusConfig.cs), which causes CI to fail since it's running on Unity 2018.
+                                if (guid != "17acf00f59af96c4bb501d1f9620d1c4")
+                                {
+                                    throw new InvalidDataException($"A script without a class ({nonClassDictionary[guid]}) is being processed.");
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
## Overview
Guid issue due to having Unity 2019+ code compile on Unity 2018 versions
