### PR TITLE
Update dev branch mrtk version to the next release version.

### DIFF
--- a/Assets/MRTK/Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Build.Editor
                      xmlns:mobile='http://schemas.microsoft.com/appx/manifest/mobile/windows10'
                      IgnorableNamespaces='uap uap2 uap3 uap4 mp mobile iot'
                      xmlns='http://schemas.microsoft.com/appx/manifest/foundation/windows10'>
-              <Identity Name='Microsoft.MixedReality.Toolkit' Publisher='CN=Microsoft' Version='2.5.0.0' />
+              <Identity Name='Microsoft.MixedReality.Toolkit' Publisher='CN=Microsoft' Version='2.6.0.0' />
               <mp:PhoneIdentity PhoneProductId='85c8bcd4-fbac-44ed-adf6-bfc01242a27f' PhonePublisherId='00000000-0000-0000-0000-000000000000' />
               <Properties>
                 <DisplayName>MixedRealityToolkit</DisplayName>

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -118,7 +118,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.5.0
+  bundleVersion: 2.6.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -687,7 +687,7 @@ PlayerSettings:
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: Microsoft.MixedReality.Toolkit
-  metroPackageVersion: 2.5.0.0
+  metroPackageVersion: 2.6.0.0
   metroCertificatePath: Assets/WSATestCertificate.pfx
   metroCertificatePassword: 
   metroCertificateSubject: Microsoft

--- a/pipelines/config/settings.yml
+++ b/pipelines/config/settings.yml
@@ -11,7 +11,7 @@ variables:
   # match (see scripts/packaging/versionmetadata.ps1)
   # ProjectSettings/ProjectSettings.asset:  bundleVersion: x.x.x
   # ProjectSettings/ProjectSettings.asset:  metroPackageVersion: x.x.x.0
-  MRTKVersion: 2.5.0
+  MRTKVersion: 2.6.0
   MRTKReleaseTag: ''  # final version component, e.g. 'RC2.1' or empty string
   ToolsRepoName: mixedrealitytoolkit.build
   ToolsDir: $(Build.SourcesDirectory)\$(ToolsRepoName)

--- a/scripts/packaging/updateMRTKVersion.ps1
+++ b/scripts/packaging/updateMRTKVersion.ps1
@@ -54,8 +54,6 @@ Set-Location $PSScriptRoot
 $GitRoot = (git rev-parse --show-toplevel) | Out-String
 $GitRoot = ($GitRoot -replace "/", "\").Trim()
 
-$FullProductName = "Microsoft Mixed Reality Toolkit"
-
 $Errors = @()
 
 $PipelinesDir = Get-Item (Join-Path $GitRoot "pipelines")
@@ -84,17 +82,6 @@ foreach ($file in (Get-ChildItem -Path $GitRoot -Recurse))
     ElseIf ($file.Name -eq "UwpAppxBuildToolsTest.cs")
     {
         $Errors += ReplaceVersionInFile -Path $file.FullName -NewVersion $NewVersion -Patterns  @("(?<=\sVersion=')(\d+\.\d+\.\d+)(?=\.\d+\')") -Strict $True
-    }
-}
-
-$AssetsDir = Get-Item (Join-Path $GitRoot "Assets")
-
-foreach ($file in (Get-ChildItem -Path $AssetsDir -Recurse))
-{
-    if ($file.Name -eq "AssemblyInfo.cs")
-    {
-        $Errors += ReplaceVersionInFile -Path $file.FullName -NewVersion $NewVersion -Patterns  @("(?<=AssemblyVersion[(][""])(\d+\.\d+\.\d+)(?=\.\d+)") -Strict $True
-        $Errors += ReplaceVersionInFile -Path $file.FullName -NewVersion $NewVersion -Patterns  @("(?<=AssemblyFileVersion[(][""])(\d+\.\d+\.\d+)(?=\.\d+)") -Strict $True
     }
 }
 


### PR DESCRIPTION
Now that we've created a 2.5 stabilization branch, we're updating the version associated with the mainline dev branch to the next version (2.6). Note that this change will affect the following release (i.e. not the upcoming, but the one after that).

Doing this early on so that it's one less thing for us to think about in the future.