### PR TITLE
Add the prerelease branch to the mrtk docs dropdown

### DIFF
--- a/scripts/docs/web/version.js
+++ b/scripts/docs/web/version.js
@@ -9,7 +9,8 @@ function createDropdown()
 		"releases/2.1.0",
 		"releases/2.2.0",
 		"releases/2.3.0",
-		"releases/2.4.0"
+		"releases/2.4.0",
+		"prerelease/2.5.0_stabilization",
 	];
 	
 	var ignoreDefaultInVersionFolder = true;


### PR DESCRIPTION
As part of getting ready for 2.5 release, we're updating the dropdown menu for docs so that we can see the generated docs (and also to allow others to see a preview of what we're going to be releasing).