### PR TITLE
Improving clipping primitive performance and deleting instanced mater…

### DIFF
--- a/Assets/MRTK/Core/Inspectors/ClippingPrimitiveInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/ClippingPrimitiveInspector.cs
@@ -27,15 +27,31 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <returns>The bounds of the clipping primitive.</returns>
         protected abstract Bounds OnGetFrameBounds();
 
+        private ClippingPrimitive clippingPrimitive;
+
+        private void OnEnable()
+        {
+            clippingPrimitive = (ClippingPrimitive)target;
+        }
+
         /// <summary>
         /// Looks for changes to the list of renderers and gracefully adds and removes them.
         /// </summary>
         public override void OnInspectorGUI()
         {
-            var clippingPrimitive = (ClippingPrimitive)target;
-
             var previousRenderers = clippingPrimitive.GetRenderersCopy();
-            DrawDefaultInspector();
+
+            using (var check = new EditorGUI.ChangeCheckScope())
+            {
+                DrawDefaultInspector();
+
+                if (check.changed)
+                {
+                    // Flagging changes other than renderers
+                    clippingPrimitive.IsDirty = true;
+                }
+            }
+
             var currentRenderers = clippingPrimitive.GetRenderersCopy();
 
             // Add or remove and renderers that were added or removed via the inspector.

--- a/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
@@ -87,6 +87,12 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             if (autoDestroy && materialOwners.Count == 0)
             {
                 DestorySafe(this);
+
+                // OnDestroy not called on inactive objects
+                if (!gameObject.activeInHierarchy)
+                {
+                    RestoreRenderer();
+                }
             }
         }
 
@@ -177,6 +183,11 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         }
 
         private void OnDestroy()
+        {
+            RestoreRenderer();
+        }
+
+        private void RestoreRenderer()
         {
             if (CachedRenderer != null && defaultMaterials != null)
             {

--- a/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
@@ -152,14 +152,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return new List<Renderer>(renderers);
         }
 
-        /// <summary>
-        /// Checks is renderer is being clipped by this clipping primitive.
-        /// </summary>
-        public bool CheckIfClipped(Renderer renderer)
-        {
-            return renderers.Contains(renderer);
-        }
-
         #region MonoBehaviour Implementation
 
         protected void OnEnable()

--- a/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
@@ -271,10 +271,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     materialPropertyBlock.SetFloat(clippingSideID, (float)clippingSide);
                     UpdateShaderProperties(materialPropertyBlock);
                     _renderer.SetPropertyBlock(materialPropertyBlock);
-
-                    IsDirty = false;
-                }
+                }              
             }
+            
+            IsDirty = false;
         }
 
         protected abstract void UpdateShaderProperties(MaterialPropertyBlock materialPropertyBlock);


### PR DESCRIPTION
## Overview
During ScrollObjectCollection graduation the following issues were identified when adding and removing objects to the scroll clipping primitive:

MaterialInstance not destroying instanced materials if renderer object is not active.
ClippingPrimitive is slow when the number of scrolling object increases. The profiler points to spikes  when applying property drawers.

## Changes
Making sure the renderer material is reverted to the default material on MaterialInstance.cs if the object is inactive without waiting for OnDestroy to be called. 
Updating property drawers only if clipping primitive object transform has changed.

- Fixes: #8423 
- Fixes #6270