### PR TITLE
Update author name to align with other UPM packages

### DIFF
--- a/Assets/MRTK/Examples/packagetemplate.json
+++ b/Assets/MRTK/Examples/packagetemplate.json
@@ -14,7 +14,7 @@
         "xr",
         "hololens"
     ],
-    "author": "Microsoft Corporation",
+    "author": "Microsoft",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/Assets/MRTK/Extensions/packagetemplate.json
+++ b/Assets/MRTK/Extensions/packagetemplate.json
@@ -15,7 +15,7 @@
         "xr",
         "extensions"
     ],
-    "author": "Microsoft Corporation",
+    "author": "Microsoft",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/Assets/MRTK/StandardAssets/packagetemplate.json
+++ b/Assets/MRTK/StandardAssets/packagetemplate.json
@@ -17,7 +17,7 @@
         "standardassets",
         "coreassets"
     ],
-    "author": "Microsoft Corporation",
+    "author": "Microsoft",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/Assets/MRTK/Tests/TestUtilities/packagetemplate.json
+++ b/Assets/MRTK/Tests/TestUtilities/packagetemplate.json
@@ -15,7 +15,7 @@
         "hololens",
         "test"
     ],
-    "author": "Microsoft Corporation",
+    "author": "Microsoft",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/Assets/MRTK/Tools/packagetemplate.json
+++ b/Assets/MRTK/Tools/packagetemplate.json
@@ -16,7 +16,7 @@
         "hololens",
         "tools"
     ],
-    "author": "Microsoft Corporation",
+    "author": "Microsoft",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/Assets/MRTK/packagetemplate.json
+++ b/Assets/MRTK/packagetemplate.json
@@ -14,7 +14,7 @@
         "xr",
         "hololens"
     ],
-    "author": "Microsoft Corporation",
+    "author": "Microsoft",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Overview

We're using Microsoft Corporation, while other packages are using Microsoft. To align these (since Unity uses them to group packages by source), we're updating our packages to just be Microsoft.