### PR TITLE
Scroll View Graduation - Part 6 - Reverting propagation

### DIFF
--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
@@ -126,9 +126,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
             if (scrollView == null)
             {
                 GameObject newScroll = new GameObject("Scrolling Object Collection");
-                newScroll.transform.parent = transform;
-                newScroll.transform.localPosition = scrollPositionRef ? scrollPositionRef.localPosition : Vector3.zero;
-                newScroll.transform.localRotation = scrollPositionRef ? scrollPositionRef.rotation : Quaternion.identity;
+                newScroll.transform.parent = scrollPositionRef ? scrollPositionRef : transform;
+                newScroll.transform.localPosition = Vector3.zero;
+                newScroll.transform.localRotation = Quaternion.identity;
                 newScroll.SetActive(false);
                 scrollView = newScroll.AddComponent<ScrollingObjectCollection>();
 

--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollablePagination.cs
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollablePagination.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Experimental.UI;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
+{
+    /// <summary>
+    /// Example script of how to navigate a <see cref="Microsoft.MixedReality.Toolkit.Experimental.UI.ScrollingObjectCollection"/> by pagination.
+    /// Allows the call to scroll pagination methods from the inspector.
+    /// </summary>
+    public class ScrollablePagination : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("The ScrollingObjectCollection to navigate")]
+        private ScrollingObjectCollection scrollView;
+
+        public ScrollingObjectCollection Scrollview
+        {
+            get
+            {
+                if (scrollView == null)
+                {
+                    scrollView = GetComponent<ScrollingObjectCollection>();
+                }
+                return scrollView;
+            }
+            set
+            {
+                scrollView = value;
+            }
+        }
+
+        public void ScrollByTier(int amount)
+        {
+            Debug.Assert(Scrollview != null, "Scroll view needs to be defined before using pagination.");
+            scrollView.MoveByTiers(amount);
+        }
+    }
+}

--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollablePagination.cs
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollablePagination.cs
@@ -16,7 +16,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
         [Tooltip("The ScrollingObjectCollection to navigate")]
         private ScrollingObjectCollection scrollView;
 
-        public ScrollingObjectCollection Scrollview
+        /// <summary>
+        /// The ScrollingObjectCollection to navigate.
+        /// </summary>
+        public ScrollingObjectCollection ScrollView
         {
             get
             {
@@ -32,9 +35,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
             }
         }
 
+        /// <summary>
+        /// Smoothly moves the scroll container a relative number of tiers of cells.
+        /// </summary>
         public void ScrollByTier(int amount)
         {
-            Debug.Assert(Scrollview != null, "Scroll view needs to be defined before using pagination.");
+            Debug.Assert(ScrollView != null, "Scroll view needs to be defined before using pagination.");
             scrollView.MoveByTiers(amount);
         }
     }

--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollablePagination.cs.meta
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollablePagination.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2be9efbe3616d5140ab50246321b3031
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
@@ -22,6 +22,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private SerializedProperty canScroll;
         private SerializedProperty scrollDirection;
         private SerializedProperty maskEditMode;
+        private SerializedProperty maskEnabled;
+        private SerializedProperty colliderEditMode;
         private SerializedProperty tiersPerPage;
         private SerializedProperty cellsPerTier;
         private SerializedProperty useCameraPreRender;
@@ -89,6 +91,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             canScroll = serializedObject.FindProperty("canScroll");
             scrollDirection = serializedObject.FindProperty("scrollDirection");
             maskEditMode = serializedObject.FindProperty("maskEditMode");
+            maskEnabled = serializedObject.FindProperty("maskEnabled");
+            colliderEditMode = serializedObject.FindProperty("colliderEditMode");
             tiersPerPage = serializedObject.FindProperty("tiersPerPage");
             useCameraPreRender = serializedObject.FindProperty("useOnPreRender");
 
@@ -200,12 +204,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
                 rect.x += rect.width + 2f;
                 EditorGUI.PropertyField(rect, cellHeight, new GUIContent("Height"));
 
-                // Cell depth not needded for pagination. Hiding it if clipping box is to be modified manually.
-                if ((EditMode)maskEditMode.enumValueIndex == EditMode.Auto)
-                {
-                    rect.x += rect.width + 2f;
-                    EditorGUI.PropertyField(rect, cellDepth, new GUIContent("Depth"));
-                }
+                rect.x += rect.width + 2f;
+                EditorGUI.PropertyField(rect, cellDepth, new GUIContent("Depth"));
 
                 // Reseting layout
                 EditorGUIUtility.labelWidth = 0;
@@ -223,9 +223,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             }
             using (new EditorGUI.IndentLevelScope())
             {
-                EditorGUILayout.PropertyField(canScroll);
                 EditorGUILayout.PropertyField(scrollDirection);
-                EditorGUILayout.PropertyField(maskEditMode);
                 EditorGUILayout.Space();
             }
         }
@@ -236,6 +234,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             {
                 using (new EditorGUI.IndentLevelScope(2))
                 {
+                    EditorGUILayout.PropertyField(maskEditMode);
+                    EditorGUILayout.PropertyField(colliderEditMode);
+                    EditorGUILayout.Space();
+
+                    EditorGUILayout.PropertyField(canScroll);
+                    EditorGUILayout.Space();
+
                     EditorGUILayout.PropertyField(useCameraPreRender);
                     EditorGUILayout.Space();
 
@@ -265,6 +270,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             {
                 using (new EditorGUI.IndentLevelScope())
                 {
+                    using (var check = new EditorGUI.ChangeCheckScope())
+                    {
+                        EditorGUILayout.PropertyField(maskEnabled);
+                        if (check.changed)
+                        {
+                            scrollView.MaskEnabled = maskEnabled.boolValue;
+                        }
+                    }              
+
                     using (new EditorGUI.DisabledGroupScope(EditorApplication.isPlaying))
                     {
                         visibleDebugPlanes = EditorGUILayout.Toggle("Show Threshold Planes", visibleDebugPlanes);

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -1613,7 +1613,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// </summary>
         private void ManageVisibility(bool isRestoring = false)
         {
-            if (!MaskEnabled)
+            if (!MaskEnabled && !isRestoring)
             {
                 return;
             }
@@ -1641,7 +1641,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             // Check render visibility
             foreach (var renderer in contentRenderers)
             {
-                if (MaskEnabled && !clippedRenderers.Contains(renderer))
+                // All content renderers should be added to clipping primitive
+                if (!isRestoring && MaskEnabled && !clippedRenderers.Contains(renderer))
                 {
                     renderersToClip.Add(renderer);
                 }

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using System;
@@ -61,12 +60,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <summary>
-        /// Edit modes for defining the clipping box masking boundaries.
+        /// Edit modes for defining scroll viewable area and scroll interaction boundaries.
         /// </summary>
         public enum EditMode
         {
             Auto = 0, // Use pagination values
-            Manual, // Use direct manipulation of the clipping box object
+            Manual, // Use direct manipulation of the object
         }
 
         [SerializeField]
@@ -74,13 +73,50 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         private EditMode maskEditMode;
 
         /// <summary>
-        /// Edit modes for defining the clipping box masking boundaries. Choose 'Auto' for automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the clipping box object.
+        /// Edit modes for defining the clipping box masking boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the clipping box object.
         /// </summary>
         public EditMode MaskEditMode
         {
             get { return maskEditMode; }
             set { maskEditMode = value; }
         }
+
+        [SerializeField]
+        [Tooltip("Edit modes for defining the scroll interaction collider boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the collider.")]
+        private EditMode colliderEditMode;
+
+        /// <summary>
+        /// Edit modes for defining the scroll interaction collider boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the collider.
+        /// </summary>
+        public EditMode ColliderEditMode
+        {
+            get { return colliderEditMode; }
+            set { colliderEditMode = value; }
+        }
+
+        [SerializeField]
+        [HideInInspector]
+        private bool maskEnabled = true;
+
+        /// <summary>
+        /// Visibility mode of scroll content. Default value will mask all objects outside of the scroll viewable area.
+        /// </summary>
+        public bool MaskEnabled
+        {
+            get { return maskEnabled; }
+            set 
+            {
+                if (!value && value != wasMaskEnabled)
+                {
+                    RestoreContentVisibility();
+                }
+                wasMaskEnabled = value;
+                maskEnabled = value;
+            }
+        }
+
+        // Workaround for serializing mask enabled as the editor dot not handle property setters
+        private bool wasMaskEnabled = true;
 
         [SerializeField]
         [Tooltip("The distance, in meters, the current pointer can travel along the scroll direction before triggering a scroll drag.")]
@@ -171,7 +207,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         [SerializeField]
-        [Tooltip("Toggles whether the scrollingObjectCollection will use the Camera OnPreRender event to hide items in the list.")]
+        [Tooltip("Toggles whether the scrollingObjectCollection will use the Camera OnPreRender event to manage content visibility.")]
         private bool useOnPreRender;
 
         /// <summary>
@@ -205,6 +241,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 }
 
                 useOnPreRender = value;
+
+                ClipBox.UseOnPreRender = useOnPreRender;
             }
         }
 
@@ -304,7 +342,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         [Tooltip("Number of visible tiers in the scrolling area.")]
         [FormerlySerializedAs("viewableArea")]
         [Min(1)]
-        private int tiersPerPage = 4;
+        private int tiersPerPage = 2;
 
         /// <summary>
         /// Number of visible tiers in the scrolling area.
@@ -401,9 +439,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         // Lerping time interval used for smoothing between positions during scroll drag. Number was empirically defined.
         private const float DragLerpInterval = 0.5f;
 
-        // Lerping time interval used for smoothing between positions during release. Number was empirically defined.
-        private const float ReleaseLerpInterval = 0.9275f;
-
         // Lerping time interval used for smoothing between positions during bouncing. Number was empirically defined.
         private const float BounceLerpInterval = 0.2f;
 
@@ -453,8 +488,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             get
             {
-                return (contentMaxBounds == null || contentMaxBounds.size.y <= 0) ? 0 :
-                    Mathf.Max(0, SafeDivisionFloat(contentMaxBounds.size.y, transform.lossyScale.y) - TiersPerPage * CellHeight);
+                var max = (contentBounds == null || contentBounds.size.y <= 0) ? 0 :
+                        Mathf.Max(0, contentBounds.size.y - TiersPerPage * CellHeight);
+
+                if (maskEditMode == EditMode.Auto)
+                {
+                    // Making it a multiple of cell height
+                    max = Mathf.Round(SafeDivisionFloat(max, CellHeight)) * CellHeight;
+                }
+
+                return max;
             }
         }
 
@@ -469,20 +512,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             get
             {
-                return (contentMaxBounds == null || contentMaxBounds.size.x <= 0) ? 0 :
-                     Mathf.Max(0, SafeDivisionFloat(contentMaxBounds.size.x, transform.lossyScale.x) - TiersPerPage * CellWidth) * -1.0f;
+                var max = (contentBounds == null || contentBounds.size.x <= 0) ? 0 :
+                     Mathf.Max(0, contentBounds.size.x - TiersPerPage * CellWidth);
+
+                if (maskEditMode == EditMode.Auto)
+                {
+                    // Making it a multiple of cell width
+                    max = Mathf.Round(SafeDivisionFloat(max, CellWidth)) * CellWidth;
+                }
+
+                return max * -1.0f;
             }
         }
 
-        // Depth of scrolling background box collider. Used as a plane that catches pointer and touch events on empty spaces.
-        private const float ScrollingBackgroundDepth = 0.001f;
-
         // Bounds that wrap all scroll container content. Used for calculating MinX and MaxY.
-        private Bounds contentMaxBounds;
-
-        // Ratio used for defining the inner clipping bounds size, relative to the actual clipping bounds size.
-        // The inner clipping bounds is used for ensuring that a partially visible content object has minimum visibility to keep interactability.
-        private readonly float innerClippingBoundsRatio = 0.995f;
+        private Bounds contentBounds;
 
         /// <summary>
         // Index of the first visible cell.
@@ -521,10 +565,42 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
         }
 
-        // Allows scroll when interacting with empty spaces
-        private BoxCollider scrollingBackground;
+        private BoxCollider scrollingCollider;
+        /// <summary>
+        /// Scrolling interaction collider used to catch pointer and touch events on empty spaces.
+        /// </summary>
+        public BoxCollider ScrollingCollider
+        {
+            get
+            {
+                if (scrollingCollider == null)
+                {
+                    scrollingCollider = gameObject.EnsureComponent<BoxCollider>();
+                }
 
-        private bool isRegisteredForGlobalPointerEvents = false;
+                return scrollingCollider;
+            }
+        }
+
+        // Depth of the scrolling interaction collider. Used for defining a plane depth if 'Auto' collider edit mode is selected.
+        private const float ScrollingColliderDepth = 0.001f;
+
+        private NearInteractionTouchable scrollingTouchable;
+        /// <summary>
+        /// Scrolling interaction touchable used to catch touch events on empty spaces.
+        /// </summary>
+        public NearInteractionTouchable ScrollingTouchable
+        {
+            get
+            {
+                if (scrollingTouchable == null)
+                {
+                    scrollingTouchable = gameObject.EnsureComponent<NearInteractionTouchable>();
+                }
+
+                return scrollingTouchable;
+            }
+        }
 
         /// <summary>
         /// The local position of the moving scroll container. Can be used to represent the container drag displacement.
@@ -620,6 +696,26 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 return clipBox;
             }
         }
+       
+        // This collider will be used for checking intersection of the scroll visible area with any content collider or renderer bounds.
+        private Collider clippingBoundsCollider;
+        private Collider ClippingBoundsCollider
+        {
+            get
+            {
+                if (clippingBoundsCollider == null)
+                {
+                    clippingBoundsCollider = ClippingObject.EnsureComponent<BoxCollider>();
+                    clippingBoundsCollider.enabled = false;
+                }
+
+                return clippingBoundsCollider;
+            }
+        }
+
+        // Ratio that defines the outer clipping bounds size relative to the actual clipping bounds.
+        // The outer clipping bounds is used for ensuring that content collider that are mostly visible can still stay interactable.
+        private readonly float contentVisibilityThresholdRatio = 1.025f;
 
         private bool oldIsTargetPositionLockedOnFocusLock;
 
@@ -749,49 +845,17 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         #region Setup methods
 
         /// <summary>
-        /// Setup scroll clipping object and touch background according to the content added to the container object and chosen settings.
+        /// Sets up the scroll clipping object and the interactable components according to the scroll content and chosen settings.
         /// </summary>
         public void UpdateContent()
         {
-            SetupClippingPrimitive();
-            SetupContentBounds();
-            SetupScrollingBackground();
-
-            ResolveClippingLayout();
-            AddAllRenderersToClippingObject();
-            HideItems();
-
-            ReconcileClippingNodes();
+            UpdateContentBounds();
+            SetupScrollingInteractionCollider();
+            SetupClippingObject();
+            ManageVisibility();
         }
 
-        private void SetupClippingPrimitive()
-        {
-            if (useOnPreRender)
-            {
-                ClipBox.UseOnPreRender = true;
-
-                // Subscribe to the preRender callback on the main camera so we can intercept it and make sure we catch
-                // any dynamically created children in our list
-                cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
-                cameraMethods.OnCameraPreRender += OnCameraPreRender;
-            }
-
-#if UNITY_EDITOR
-            // Disabling clipping object direct manipulation if selected mask mode set to auto
-            if (maskEditMode == EditMode.Manual)
-            {
-                ClippingObject.hideFlags = HideFlags.None;
-                return;
-            }
-            else
-            {
-                ClippingObject.hideFlags = HideFlags.NotEditable;
-            }
-            UnityEditor.EditorApplication.DirtyHierarchyWindowSorting();
-#endif
-        }
-
-        private void SetupContentBounds()
+        private void UpdateContentBounds()
         {
             var originalRotation = transform.rotation;
             transform.rotation = Quaternion.identity;
@@ -799,7 +863,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             var childrenRenderers = ScrollContainer.GetComponentsInChildren<Renderer>(true);
             if (childrenRenderers != null)
             {
-                contentMaxBounds = new Bounds
+                contentBounds = new Bounds
                 {
                     size = Vector3.zero,
                     center = ClipBox.transform.position
@@ -807,51 +871,62 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                 foreach (var renderer in childrenRenderers)
                 {
-                    contentMaxBounds.Encapsulate(renderer.bounds);
+                    contentBounds.Encapsulate(renderer.bounds);
                 }
+               
+                Vector3 localSize;
+
+                localSize.y = SafeDivisionFloat(contentBounds.size.y, transform.lossyScale.y);
+                localSize.x = SafeDivisionFloat(contentBounds.size.x, transform.lossyScale.x);
+                localSize.z = SafeDivisionFloat(contentBounds.size.z, transform.lossyScale.z);
+
+                contentBounds.size = localSize;
             }
 
             transform.rotation = originalRotation;
         }
 
-        // Setting up a collider and a near interaction touchable to allow interaction with empty spaces like corners or in between children items
-        private void SetupScrollingBackground()
+        // Setting  up the initial transform values for the scrolling interaction collider and near touchable.
+        private void SetupScrollingInteractionCollider()
         {
-            scrollingBackground = gameObject.EnsureComponent<BoxCollider>();
+            // Boundaries will be defined by direct manipulation of the scroll interaction components
+            if (colliderEditMode == EditMode.Manual)
+            {
+                return;
+            }
 
             if (scrollDirection == ScrollDirectionType.UpAndDown)
             {
-                scrollingBackground.size = new Vector3(CellWidth * CellsPerTier, CellHeight * TiersPerPage, ScrollingBackgroundDepth);
+                ScrollingCollider.size = new Vector3(CellWidth * CellsPerTier, CellHeight * TiersPerPage, ScrollingColliderDepth);
             }
             else
             {
-                scrollingBackground.size = new Vector3(CellWidth * TiersPerPage, CellHeight * CellsPerTier, ScrollingBackgroundDepth);
+                ScrollingCollider.size = new Vector3(CellWidth * TiersPerPage, CellHeight * CellsPerTier, ScrollingColliderDepth);
             }
 
             Vector3 colliderPosition;
-            colliderPosition.x = scrollingBackground.size.x / 2;
-            colliderPosition.y = -scrollingBackground.size.y / 2;
-            colliderPosition.z = cellDepth / 2 + ScrollingBackgroundDepth;
-            scrollingBackground.center = colliderPosition;
+            colliderPosition.x = ScrollingCollider.size.x / 2;
+            colliderPosition.y = - ScrollingCollider.size.y / 2;
+            colliderPosition.z = cellDepth / 2 + ScrollingColliderDepth;
+            ScrollingCollider.center = colliderPosition;
 
-            var touchable = gameObject.EnsureComponent<NearInteractionTouchable>();
             Vector2 size = new Vector2(
-                        Math.Abs(Vector3.Dot(scrollingBackground.size, touchable.LocalRight)),
-                        Math.Abs(Vector3.Dot(scrollingBackground.size, touchable.LocalUp)));
+                        Math.Abs(Vector3.Dot(ScrollingCollider.size, ScrollingTouchable.LocalRight)),
+                        Math.Abs(Vector3.Dot(ScrollingCollider.size, ScrollingTouchable.LocalUp)));
 
             Vector3 touchablePosition = colliderPosition;
-            touchablePosition.z = -cellDepth / 2;
+            touchablePosition.z = - cellDepth / 2;
 
-            touchable.SetBounds(size);
-            touchable.SetLocalCenter(touchablePosition);
+            ScrollingTouchable.SetBounds(size);
+            ScrollingTouchable.SetLocalCenter(touchablePosition);
         }
 
         /// <summary>
-        /// Sets up the initial position of the scroller object as well as the configuration for the clippingBox.
+        /// Setting up the initial transform values for the clippingBox.
         /// </summary>
-        private void ResolveClippingLayout()
+        private void SetupClippingObject()
         {
-            // Clipping box boundaries will be defined by direct manipulation of the clipping object if mask edit mode set to manual
+            // Boundaries will be defined by direct manipulation of the clipping object
             if (maskEditMode == EditMode.Manual)
             {
                 return;
@@ -900,18 +975,17 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void OnEnable()
         {
-            CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);
-            CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityPointerHandler>(this, PropagationPhase.TrickleDown);
-
             // Register for global input events
             CoreServices.InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
+            CoreServices.InputSystem?.RegisterHandler<IMixedRealityTouchHandler>(this);
+            CoreServices.InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
 
             if (useOnPreRender)
             {
                 ClipBox.UseOnPreRender = true;
 
                 // Subscribe to the preRender callback on the main camera so we can intercept it and make sure we catch
-                // any dynamically created children in our list
+                // any dynamically added content
                 cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
                 cameraMethods.OnCameraPreRender += OnCameraPreRender;
             }
@@ -1024,8 +1098,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                 // Apply our position
                 ApplyPosition(workingScrollerPos);
-
-
             }
 
             // Setting HasMomentum to true if scroll velocity state has changed or any movement happend during this update
@@ -1044,31 +1116,20 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void LateUpdate()
         {
-            // Manage content visibility if any movement has ocurred on last update or during editor mode
-            if (HasMomentum || !Application.isPlaying)
-            {
-                HideItems();
-            }
-
             if (!UseOnPreRender)
             {
-                ReconcileClippingNodes();
+                ManageVisibility();
             }
         }
 
         private void OnDisable()
         {
-            CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);
-            CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityPointerHandler>(this, PropagationPhase.TrickleDown);
-
             // Unregister global input events
             CoreServices.InputSystem?.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
+            CoreServices.InputSystem?.UnregisterHandler<IMixedRealityTouchHandler>(this);
+            CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
 
-            if (isRegisteredForGlobalPointerEvents)
-            {
-                CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
-                isRegisteredForGlobalPointerEvents = false;
-            }
+            RestoreContentVisibility();
 
             if (useOnPreRender && cameraMethods != null)
             {
@@ -1087,11 +1148,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// <param name="router">The active <see cref="CameraEventRouter"/> on the camera.</param>
         private void OnCameraPreRender(CameraEventRouter router)
         {
-            ReconcileClippingNodes();
+            ManageVisibility();
         }
 
         // Add or remove renderers from clipping primitive
-        private void ReconcileClippingNodes()
+        private void ReconcileClippingContent()
         {
             if (renderersToClip.Count > 0)
             {
@@ -1233,7 +1294,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         CurrentVelocityState = VelocityState.Resolving;
                     }
 
-                    workingScrollerPos = Solver.SmoothTo(scrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, ReleaseLerpInterval);
+                    workingScrollerPos = Solver.SmoothTo(scrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, BounceLerpInterval);
 
                     // Clear the velocity now that we've applied a new position
                     avgVelocity = 0.0f;
@@ -1252,7 +1313,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         }
                         else
                         {
-                            workingScrollerPos = Solver.SmoothTo(ScrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, ReleaseLerpInterval);
+                            workingScrollerPos = Solver.SmoothTo(ScrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, BounceLerpInterval);
 
                             SnapVelocityFinish();
                         }
@@ -1268,7 +1329,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         }
                         else
                         {
-                            workingScrollerPos = Solver.SmoothTo(ScrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, ReleaseLerpInterval);
+                            workingScrollerPos = Solver.SmoothTo(ScrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, BounceLerpInterval);
 
                             SnapVelocityFinish();
                         }
@@ -1515,20 +1576,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <summary>
-        /// Adds all content renderers to ClippingBox
-        /// </summary>
-        private void AddAllRenderersToClippingObject()
-        {
-            foreach (var renderer in ScrollContainer.GetComponentsInChildren<Renderer>(true))
-            {
-                if (renderer.gameObject.activeInHierarchy)
-                {
-                    ClipBox.AddRenderer(renderer);
-                }
-            }
-        }
-
-        /// <summary>
         /// Removes list of renderers from the ClippingBox
         /// </summary>
         private void RemoveRenderersFromClippingObject(List<Renderer> renderers)
@@ -1540,11 +1587,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <summary>
-        /// Helper to perform modulo operation and prevent division by 0.
+        /// Removes all renderers currently being clipped by the clipping box
         /// </summary>
-        private static int SafeModulo(int numerator, int denominator)
+        private void ClearClippingBox()
         {
-            return (denominator > 0) ? numerator % denominator : 0;
+            ClipBox.ClearRenderers();
         }
 
         /// <summary>
@@ -1562,25 +1609,31 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         /// <summary>
         /// Checks visibility of scroll content by iterating through all content renderers and colliders.
+        /// All inactive content objects and colliders are reactivated during visibility restoration. 
         /// </summary>
-        private void HideItems()
+        private void ManageVisibility(bool isRestoring = false)
         {
-            // Setting up temporary collider for checking intersection of the scroll visible area with content collider and renderer bounds
-            var tempClippingCollider = ClipBox.gameObject.AddComponent<BoxCollider>();
-            Bounds clippingThresholdBounds = tempClippingCollider.bounds;
+            if (!MaskEnabled)
+            {
+                return;
+            }
 
-            // Inner clipping bound to ensure minimum visibility in order to keep content collider active
-            Bounds innerClippingThresholdBounds = tempClippingCollider.bounds;
-            innerClippingThresholdBounds.size *= innerClippingBoundsRatio;
+            ClippingBoundsCollider.enabled = true;
+            Bounds clippingThresholdBounds = ClippingBoundsCollider.bounds;
 
             Renderer[] contentRenderers = ScrollContainer.GetComponentsInChildren<Renderer>(true);
-            List<Renderer> clippedRenderers = ClipBox.GetRenderersCopy().ToList();
+            List<Renderer> clippedRenderers = ClipBox.GetRenderersCopy().ToList(); 
 
             // Remove all renderers from clipping primitive that are not part of scroll content
             foreach (var clippedRenderer in clippedRenderers)
             {
-                if (clippedRenderers != null && !clippedRenderer.transform.IsChildOf(ScrollContainer.transform))
+                if (clippedRenderer != null && !clippedRenderer.transform.IsChildOf(ScrollContainer.transform))
                 {
+                    if (!clippedRenderer.gameObject.activeSelf)
+                    {
+                        clippedRenderer.gameObject.SetActive(true);
+                    }
+
                     renderersToUnclip.Add(clippedRenderer);
                 }
             }
@@ -1588,26 +1641,28 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             // Check render visibility
             foreach (var renderer in contentRenderers)
             {
-                // Complete or partialy visible renderers should be enabled and clipped 
-                if (clippingThresholdBounds.ContainsBounds(renderer.bounds) || clippingThresholdBounds.Intersects(renderer.bounds))
+                if (MaskEnabled && !clippedRenderers.Contains(renderer))
                 {
-                    if (!renderer.enabled)
-                    {
-                        renderer.enabled = true;
-                    }
+                    renderersToClip.Add(renderer);
+                }
 
-                    if (!clippedRenderers.Contains(renderer))
+                // Complete or partialy visible renders should be clipped and its game object should be active
+                if (isRestoring
+                    || clippingThresholdBounds.ContainsBounds(renderer.bounds) 
+                    || clippingThresholdBounds.Intersects(renderer.bounds)) 
+                {
+                    if (!renderer.gameObject.activeSelf)
                     {
-                        renderersToClip.Add(renderer);
+                        renderer.gameObject.SetActive(true);
                     }
                 }
 
-                // Hidden renderers should be disabled and should not be clipped
+                // Hidden renderer game objects should be inactive
                 else
                 {
-                    if (renderer.enabled)
+                    if (renderer.gameObject.activeSelf)
                     {
-                        renderer.enabled = false;
+                        renderer.gameObject.SetActive(false);
                     }
                 }
             }
@@ -1615,10 +1670,30 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             // Check collider visibility
             if (Application.isPlaying)
             {
-                var colliders = ScrollContainer.GetComponentsInChildren<Collider>(true);
+                // Outer clipping bounds is used to ensure collider has minimum visibility to stay enabled
+                Bounds outerClippingThresholdBounds = ClippingBoundsCollider.bounds;
+                outerClippingThresholdBounds.size *= contentVisibilityThresholdRatio;
 
+                var colliders = ScrollContainer.GetComponentsInChildren<Collider>(true);
                 foreach (var collider in colliders)
                 {
+                    // Disabling content colliders during drag to stop interaction even if game object is inactive
+                    if (!isRestoring && IsDragging)
+                    {
+                        if (collider.enabled)
+                        {
+                            collider.enabled = false;
+                        }
+
+                        continue;
+                    }
+
+                    // No need to manage collider visibility in case game object is inactive and no pointer is dragging the scroll
+                    if (!isRestoring && !collider.gameObject.activeSelf)
+                    {
+                        continue;
+                    }
+
                     // Temporary activating for getting bounds
                     var wasColliderEnabled = collider.enabled;
 
@@ -1627,25 +1702,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         collider.enabled = true;
                     }
 
-                    // Completely visible colliders should be enabled if scroll is not drag engaged
-                    // Inner clipping bounds is used to catch partially visible colliders with enouth visible area
-                    if (clippingThresholdBounds.ContainsBounds(collider.bounds)
-                        || innerClippingThresholdBounds.Intersects(collider.bounds)
-                        || collider.bounds.ContainsBounds(innerClippingThresholdBounds))
+                    // Completely or partially visible colliders should be enabled if scroll is not drag engaged
+                    if (isRestoring || outerClippingThresholdBounds.ContainsBounds(collider.bounds))
                     {
-                        if (IsDragging)
-                        {
-                            if (wasColliderEnabled)
-                            {
-                                wasColliderEnabled = false;
-                            }
-                        }
-                        else if (!wasColliderEnabled)
+                        if (!wasColliderEnabled)
                         {
                             wasColliderEnabled = true;
                         }
                     }
-                    // Hidden or partially visible colliders should be disabled
+                    // Hidden colliders should be disabled
                     else
                     {
                         if (wasColliderEnabled)
@@ -1659,7 +1724,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 }
             }
 
-            GameObject.DestroyImmediate(tempClippingCollider);
+            ClippingBoundsCollider.enabled = false;
+
+            if(!isRestoring)
+            {
+                ReconcileClippingContent();
+            }
         }
 
         /// <summary>
@@ -1712,7 +1782,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <summary>
-        /// Resets the interaction state of the ScrollingObjectCollection for the next scroll
+        /// Resets the interaction state of the ScrollingObjectCollection for the next scroll.
         /// </summary>
         private void ResetInteraction()
         {
@@ -1730,13 +1800,22 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <summary>
-        /// Resets the scroll offset state of the ScrollingObjectCollection
+        /// Resets the scroll offset state of the ScrollingObjectCollection.
         /// </summary>
         private void ResetScrollOffset()
         {
             MoveToIndex(0, false);
             workingScrollerPos = Vector3.zero;
             ApplyPosition(workingScrollerPos);
+        }
+
+        /// <summary>
+        /// All inactive content objects and colliders are reactivated and renderers are unclipped.
+        /// </summary>
+        private void RestoreContentVisibility()
+        {
+            ClearClippingBox();
+            ManageVisibility(true);
         }
 
         /// <summary>
@@ -1914,24 +1993,17 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 return;
             }
 
-            if (IsEngaged && isRegisteredForGlobalPointerEvents)
-            {
-                CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
-                isRegisteredForGlobalPointerEvents = false;
-            }
+            // Release the pointer
+            currentPointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
 
             if (!IsTouched && IsEngaged && animateScroller == null)
             {
                 if (IsDragging)
                 {
-                    eventData.Use();
                     // Its a drag release
                     initialScrollerPos = workingScrollerPos;
                     CurrentVelocityState = VelocityState.Calculating;
                 }
-
-                // Release the pointer
-                currentPointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
 
                 ResetInteraction();
             }
@@ -1940,28 +2012,27 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// <inheritdoc/>
         void IMixedRealityPointerHandler.OnPointerDown(MixedRealityPointerEventData eventData)
         {
-            currentPointer = eventData.Pointer;
-            oldIsTargetPositionLockedOnFocusLock = currentPointer.IsTargetPositionLockedOnFocusLock;
-
-            if (initialFocusedObject != null)
+            if (currentPointer != null)
             {
                 return;
             }
 
-            // Registering for global to listen for pointerups if focused child is disabled after dragged out of view
-            // Temporary workaround. Trying to fix bad performance of pointer and node focus checks when subscribing globally on the on enable callback
-            if (!isRegisteredForGlobalPointerEvents)
+            var selectedObject = eventData.Pointer.Result?.CurrentPointerTarget;
+
+            if (selectedObject == null || !selectedObject.transform.IsChildOf(transform))
             {
-                CoreServices.InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
-                isRegisteredForGlobalPointerEvents = true;
+                return;
             }
+
+            currentPointer = eventData.Pointer;
+            oldIsTargetPositionLockedOnFocusLock = currentPointer.IsTargetPositionLockedOnFocusLock;
 
             if (!(currentPointer is IMixedRealityNearPointer) && currentPointer.Controller.IsRotationAvailable)
             {
                 currentPointer.IsTargetPositionLockedOnFocusLock = false;
             }
 
-            initialFocusedObject = currentPointer.Result?.CurrentPointerTarget;
+            initialFocusedObject = selectedObject;
             currentPointer.IsFocusLocked = false; // Unwanted focus locked on children items
 
             // Reset the scroll state
@@ -1981,10 +2052,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <inheritdoc/>
-        void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData)
-        {
-            // We ignore this event and calculate click in the Update() loop;
-        }
+        /// Pointer Click handled during Update.
+        void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData) { }
 
         /// <inheritdoc/>
         void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData) { }
@@ -1996,16 +2065,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchStarted(HandTrackingInputEventData eventData)
         {
-            PokePointer pokePointer = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
-
-            if (pokePointer == null || !HasPassedThroughFrontPlane(pokePointer))
+            if (currentPointer != null)
             {
                 return;
             }
 
-            if (IsDragging || initialFocusedObject)
+            PokePointer pokePointer = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
+
+            var selectedObject = pokePointer.Result?.CurrentPointerTarget;
+            if (selectedObject == null || !selectedObject.transform.IsChildOf(transform))
             {
-                eventData.Use();
+                return;
+            }
+
+            if (!HasPassedThroughFrontPlane(pokePointer))
+            {
                 return;
             }
 
@@ -2018,7 +2092,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             if (!IsTouched && !IsEngaged)
             {
                 initialPointerPos = currentPointer.Position;
-                initialFocusedObject = currentPointer.Result?.CurrentPointerTarget;
+                initialFocusedObject = selectedObject;
                 initialScrollerPos = ScrollContainer.transform.localPosition;
 
                 IsTouched = true;
@@ -2030,20 +2104,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <inheritdoc/>
-        void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData)
-        {
-            if (IsDragging)
-            {
-                eventData.Use();
-            }
-        }
+        /// Touch release handled during Update.
+        void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData) { }
 
         /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchUpdated(HandTrackingInputEventData eventData)
         {
-            IMixedRealityPointer pointer = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
+            if (currentPointer == null || eventData.SourceId != currentPointer.InputSourceParent.SourceId)
+            {
+                return;
+            }
 
-            if (pointer == currentPointer && IsDragging)
+            if (IsDragging)
             {
                 eventData.Use();
             }
@@ -2057,18 +2129,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         void IMixedRealitySourceStateHandler.OnSourceLost(SourceStateEventData eventData)
         {
+            if (currentPointer == null || eventData.SourceId != currentPointer.InputSourceParent.SourceId)
+            {
+                return;
+            }
+
             // We'll consider this a drag release
-            if (IsEngaged && animateScroller == null && currentPointer != null && currentPointer.InputSourceParent.SourceId == eventData.SourceId)
+            if (IsEngaged && animateScroller == null)
             {
                 if (IsTouched || IsDragging)
                 {
                     // Its a drag release
                     initialScrollerPos = workingScrollerPos;
-                }
-
-                if (isRegisteredForGlobalPointerEvents)
-                {
-                    CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
                 }
 
                 ResetInteraction();

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -19,10 +19,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         private Material mrtkMaterial = new Material(StandardShaderUtility.MrtkStandardShader);
 
-        //Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2_32x96_NoLabel.prefab
+        // Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2_32x96_NoLabel.prefab
         private const string PressableHololens2_32x96_PrefabGuid = "eb36a4319b6be77409716f5a41e6da51";
 
-        //Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2_NoLabel.prefab
+        // Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2_NoLabel.prefab
         private const string PressableHololens2PrefabGuid = "b20573eb9bf8a914882fa4a571d2e8dc";
 
 

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -19,8 +19,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         private Material mrtkMaterial = new Material(StandardShaderUtility.MrtkStandardShader);
 
-        // SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2_32x96.prefab
-        private const string PressableHololens2_32x96_PrefabGuid = "4f44c0d070528944c9bff425c6932763";
+        //Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2_32x96_NoLabel.prefab
+        private const string PressableHololens2_32x96_PrefabGuid = "eb36a4319b6be77409716f5a41e6da51";
+
+        //Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2_NoLabel.prefab
+        private const string PressableHololens2PrefabGuid = "b20573eb9bf8a914882fa4a571d2e8dc";
+
 
         [SetUp]
         public override void Setup()
@@ -39,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator ScrollEngageResetsNearInteractionWithChildren()
         {
             // Setting up a vertical 1x2 scroll view with three pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 3);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 3);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -181,7 +185,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator ScrollEngageResetsFarInteractionWithChildren()
         {
             // Setting up a vertical 1x1 scroll view with two pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 2);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 2);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -268,7 +272,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator NoJumpsWhenInteractingWithChildren()
         {
             // Setting up a vertical 1x2 scroll view with three pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 3);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 3);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -319,7 +323,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator InteractionWithBackgroundEmptySpace()
         {
             // Setting up a vertical 2x1 scroll view with three pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 3);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 3);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -379,7 +383,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator ChildrenCanBeAddedAndDeleted()
         {
             // Setting up a vertical 1x1 scroll view with three pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 3);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 3);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -400,7 +404,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             scrollView.AddContent(objectCollection.gameObject);
 
             // This button will be added later to the scroll collection
-            GameObject button4 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            GameObject button4 = InstantiatePrefab(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid));
 
             PressableButton button1Component = contentItems[0].GetComponentInChildren<PressableButton>();
             PressableButton button3Component = contentItems[2].GetComponentInChildren<PressableButton>();
@@ -527,7 +531,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator ScrollEngageResetsWhenOutOfBoundaryThreshold()
         {
             // Setting up a vertical 1x1 scroll view with two pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 2);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 2);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -667,7 +671,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator ScrollEngageOnlyFromFrontInteraction()
         {
             // Setting up a vertical 1x1 scroll view with two pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 2);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 2);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -762,7 +766,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator ScrollViewCanBeScaled()
         {
             // Setting up a vertical 1x1 scroll view with one single pressable button item
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 1);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 1);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -812,7 +816,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator ScrollViewCanbeRotated()
         {
             // Setting up a vertical 1x1 scroll view with two pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 2);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 2);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -870,7 +874,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator CanBeScrolledByTierOrIndexOrPage()
         {
             // Setting up a horizontal 2x2 scroll view with nine pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 9);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 9);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.RowThenColumn,
@@ -983,7 +987,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
 
             // Setting up a horizontal 1x1 scroll view with two pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 2);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 2);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -1027,7 +1031,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator ContentClickHappensOnTouchUp()
         {
             // Setting up a horizontal 1x1 scroll view with two pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 2);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 2);
 
             GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
                                                                                 LayoutOrder.ColumnThenRow,
@@ -1136,20 +1140,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var collider1 = contentItems[1].GetComponent<Collider>();
             var collider2 = contentItems[2].GetComponent<Collider>();
 
-            // Completely visible items should have renderers enabled. Colliders should remain enabled for interaction.
+            // Completely visible objects should be active and have renderers clipped. Colliders should be enabled for interaction
             Assert.IsTrue(clippedRenderers.Contains(renderer0), "Renderer 0 is not being clipped");
-            Assert.IsTrue(renderer0.enabled, "Renderer 0 is disabled");
+            Assert.IsTrue(contentItems[0].activeSelf, "Sphere 0 is not active");
             Assert.IsTrue(collider0.enabled, "Collider 0 is disabled");
 
-            // Barelly visible content should still have renderers enabled. Colliders should be disabled for interaction.
+            // Barelly visible objects should be active and have renderers clipped. Colliders should be disabled for interaction
             Assert.IsTrue(clippedRenderers.Contains(renderer1), "Renderer 1 is not being clipped");
-            Assert.IsTrue(renderer1.enabled, "Renderer 1 is disabled");
+            Assert.IsTrue(contentItems[1].activeSelf, "Sphere 1 is not active");
             Assert.IsFalse(collider1.enabled, "Collider 1 is enabled");
 
-            // Hidden content should have renderers disabled. Colliders should be disabled for interaction.
-            Assert.IsTrue(clippedRenderers.Contains(renderer2), "Renderer 2 is being clipped");
-            Assert.IsFalse(renderer2.enabled, "Renderer 2 is enabled");
-            Assert.IsFalse(collider2.enabled, "Collider 2 is enabled");
+            // Hidden objects should be inactive and have renderers clipped. Collider state not important if scroll is not drag engaged
+            Assert.IsTrue(clippedRenderers.Contains(renderer2), "Renderer 2 is not being clipped");
+            Assert.IsFalse(contentItems[2].activeSelf, "Sphere 2 is active");
 
             // Scrolling half item up
             yield return hand.MoveTo(preTouchPos);
@@ -1159,25 +1162,24 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             clippedRenderers = scrollView.ClipBox.GetRenderersCopy().ToList();
 
-            // Partially visible content should have renderers enabled. Colliders should be enabled for interaction.
+            // Partially visible objects should be active and have renderers clipped. Colliders should be disabled for interaction
             Assert.IsTrue(clippedRenderers.Contains(renderer0), "Renderer 0 is not being clipped");
-            Assert.IsTrue(renderer0.enabled, "Renderer 0 is disabled");
-            Assert.IsTrue(collider0.enabled, "Collider 0 is disabled");
+            Assert.IsTrue(contentItems[0].activeSelf, "Sphere 0 is not active");
+            Assert.IsFalse(collider0.enabled, "Collider 0 is enabled");
 
             Assert.IsTrue(clippedRenderers.Contains(renderer1), "Renderer 1 is not being clipped");
-            Assert.IsTrue(renderer1.enabled, "Renderer 1 is disabled");
-            Assert.IsTrue(collider1.enabled, "Collider 1 is disabled");
+            Assert.IsTrue(contentItems[1].activeSelf, "Sphere 1 is not active");
+            Assert.IsFalse(collider1.enabled, "Collider 1 is enabled");
 
-            // Hidden content should have renderers disabled. Colliders should be disabled for interaction.
+            // Hidden objects should be inactive and have renderers clipped. Collider state not important if scroll is not drag engaged
             Assert.IsTrue(clippedRenderers.Contains(renderer2), "Renderer 2 is not being clipped");
-            Assert.IsFalse(renderer2.enabled, "Renderer 2 is enabled");
-            Assert.IsFalse(collider2.enabled, "Collider 2 is enabled");
+            Assert.IsFalse(contentItems[2].activeSelf, "Sphere 2 is active");
 
-            // Removing content from scroll content should also remove its renderers from the scroll clipping box.
+            // Removing content from scroll content should also remove its renderers from the scroll clipping box
             scrollView.RemoveItem(contentItems[0]);
             clippedRenderers = scrollView.ClipBox.GetRenderersCopy().ToList();
 
-            // Object is still visible, but renderer should not be clipped.
+            // Object is still visible but renderer should not be clipped
             Assert.IsFalse(clippedRenderers.Contains(renderer0), "Renderer 0 is being clipped");
         }
 
@@ -1188,7 +1190,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator CanScrollNonCollectionContent()
         {
             // Setting up a vertical 1x1 scroll view with two pressable buttons items
-            var contentItems = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 2);
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 2);
 
             var cellWidth = contentItems[0].GetComponent<NearInteractionTouchable>().Bounds.x;
             var cellHeight = contentItems[0].GetComponent<NearInteractionTouchable>().Bounds.y;
@@ -1241,7 +1243,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             // Setting up a vertical 1x1 scroll view with four pressable buttons items with two different sizes
             // Buttons are layouted in two grid object collection
-            var contentItems1 = InstantiatePrefabItems(TestButtonUtilities.PressableHoloLens2PrefabPath, 2);
+            var contentItems1 = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 2);
             var contentItems2 = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2_32x96_PrefabGuid), 2);
 
             GridObjectCollection objectCollection1 = InstantiateObjectCollection(contentItems1,


### PR DESCRIPTION
## Overview
This PR is part of the Scroll graduation and addresses the following issues:

**Revert input event subscription to global.** In order to get the graduation into MRTK 2.5 without the latest changes on the Event Propagation branch, we are reverting the scroll event handlers to globally subscribe to pointer and touch events. 

**Enabling mask disabled.** While upgrading the demo scene it became important to have this feature to make the process of editing and layouting of scroll content easier. 

**Inspector and Tests adjusted to the changes.**

**Example Scripts.** Added a pagination example of how to use the scroll pagination methods from unity events in the inspector. Used for demo scene pagination buttons.

**Further reformats.** Some fields / methods were renamed or moved moved in the class.

## Changes
- Fixes: #8431  
- Fixes: #8433 


## Verification
Demo scene coming in next PR