### PR TITLE
Initial workflow for syncing stabilization and development

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: GitHub Pull Request Action
+        # This is synced directly to the v2.3's commit hash, to avoid cases where a tag gets added/removed
+        # and the tag itself is now pointing at a different commit.
         uses: repo-sync/pull-request@ea6773388b83b337e4da9a223293309f2c3670e7
         with:
           source_branch: "prerelease/2.5.0_stabilization"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+# This is a scheduled workflow that will run daily to keep mrtk_development with the
+# latest in the stabilization branch. This will create a PR every day if there commits
+# that haven't been made to mrtk_development.
+
+name: Stabilization to mrtk_development sync
+
+# This schedules a run to occur at 4AM UTC every day
+on:  
+  schedule:
+    - cron: "0 4 * * *"
+
+jobs:
+  synchronization_job:
+    runs-on: ubuntu-latest
+    
+    # Since this is a scheduled cron job and is a checked in workflow, this has
+    # the capability of running in any forks of this project. This line ensures that
+    # this workflow only runs on the main repo, not forks.
+    if: ${{ github.repository == "microsoft/MixedRealityToolkit-Unity" }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: GitHub Pull Request Action
+        uses: repo-sync/pull-request@v2.3
+        with:
+          source_branch: "prerelease/2.5.0_stabilization"
+          destination_branch: "mrtk_development"
+          pr_title: "Automated: stabilization to mrtk_development synchronization"
+          pr_body: "This an automated pull request to merge latest changes in stabilization back into mrtk_development"
+          # This workflow will not create a PR if the change set is empty (i.e. if mrtk_development already contains
+          # everything in stabilization, there's no need to create a PR)
+          pr_allow_empty: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: GitHub Pull Request Action
-        uses: repo-sync/pull-request@v2.3
+        uses: repo-sync/pull-request@ea6773388b83b337e4da9a223293309f2c3670e7
         with:
           source_branch: "prerelease/2.5.0_stabilization"
           destination_branch: "mrtk_development"


### PR DESCRIPTION
During the stabilization process, we have to periodically (usually daily) create PRs to merge the latest prerelease/*stabilization branch into mrtk_development, to ensure that our mainline doesn't get out of sync with the 'true latest' (i.e. more people are working out of stabilization than mrtk_development during the earlier phases of stabilization).

This is somewhat onerous, so this change sets up a github actions workflow to automate this process every day (i.e. every morning we'll have a PR if there are changes between stabilization and development)