### PR TITLE
Remove WaitingForSceneObserverAccess from BaseSpatialObserver

### DIFF
--- a/Assets/MRTK/Core/Providers/BaseSpatialObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialObserver.cs
@@ -177,9 +177,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         public bool IsRunning { get; protected set; } = false;
 
         /// <inheritdoc />
-        public bool WaitingForSceneObserverAccess { get; protected set; } = true;
-
-        /// <inheritdoc />
         public bool IsStationaryObserver { get; set; } = false;
 
         /// <inheritdoc />

--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
@@ -90,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         /// <inheritdoc />
         public override void Update()
         {
-            if (!WaitingForSceneObserverAccess) 
+            if (!IsRunning) 
             {
                 return;
             }
@@ -129,36 +129,34 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         /// <inheritdoc />
         public override void ClearObservations()
         {
-            if (WaitingForSceneObserverAccess)
+            if (IsRunning)
             {
-                if (IsRunning)
-                {
-                    Debug.Log("Cannot clear observations while the observer is running. Suspending this observer.");
-                    Suspend();
-                }
-
-                foreach (int id in Meshes.Keys)
-                {
-                    RemoveMeshObject(id);
-                }
-
-                // Resend file observations when resumed.
-                sendObservations = true;
+                Debug.Log("Cannot clear observations while the observer is running. Suspending this observer.");
+                Suspend();
             }
+
+            foreach (int id in Meshes.Keys)
+            {
+                RemoveMeshObject(id);
+            }
+
+            // Resend file observations when resumed.
+            sendObservations = true;
+            
         }
 
         /// <inheritdoc />
         public override void Resume()
         {
-            if (WaitingForSceneObserverAccess) { return; }
-            WaitingForSceneObserverAccess = true;
+            if (IsRunning) { return; }
+            IsRunning = true;
         }
 
         /// <inheritdoc />
         public override void Suspend()
         {
-            if (!WaitingForSceneObserverAccess) { return; }
-            WaitingForSceneObserverAccess = false;
+            if (!IsRunning) { return; }
+            IsRunning = false;
         }
 
         #endregion IMixedRealitySpatialAwarenessObserver Implementation

--- a/Assets/MRTK/Tests/PlayModeTests/SpatialObserverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpatialObserverTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             var spatialObserver = CoreServices.GetSpatialAwarenessSystemDataProvider<SpatialObjectMeshObserver.SpatialObjectMeshObserver>();
             Assert.IsNotNull(spatialObserver, "No SpatialObjectMeshObserver data provider created or found");
-            Assert.IsTrue(spatialObserver.WaitingForSceneObserverAccess);
+            Assert.IsTrue(spatialObserver.IsRunning);
             Assert.IsNotEmpty(spatialObserver.Meshes);
 
             CoreServices.SpatialAwarenessSystem.Disable();
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             CoreServices.SpatialAwarenessSystem.Enable();
             spatialObserver = CoreServices.GetSpatialAwarenessSystemDataProvider<SpatialObjectMeshObserver.SpatialObjectMeshObserver>();
             Assert.IsNotNull(spatialObserver, "No SpatialObjectMeshObserver data provider created or found");
-            Assert.IsTrue(spatialObserver.WaitingForSceneObserverAccess);
+            Assert.IsTrue(spatialObserver.IsRunning);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
             Assert.IsNotEmpty(spatialObserver.Meshes);
         }
@@ -75,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var spatialAwarenesssDataProvider = CoreServices.SpatialAwarenessSystem as IMixedRealityDataProviderAccess;
             var spatialObserver = spatialAwarenesssDataProvider.GetDataProvider<SpatialObjectMeshObserver.SpatialObjectMeshObserver>();
             Assert.IsNotNull(spatialObserver, "No SpatialObjectMeshObserver data provider created or found");
-            Assert.IsFalse(spatialObserver.WaitingForSceneObserverAccess);
+            Assert.IsFalse(spatialObserver.IsRunning);
             Assert.IsEmpty(spatialObserver.Meshes);
 
             CoreServices.SpatialAwarenessSystem.Disable();
@@ -85,11 +85,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             CoreServices.SpatialAwarenessSystem.Enable();
             spatialObserver = spatialAwarenesssDataProvider.GetDataProvider<SpatialObjectMeshObserver.SpatialObjectMeshObserver>();
             Assert.IsNotNull(spatialObserver, "No SpatialObjectMeshObserver data provider created or found");
-            Assert.IsFalse(spatialObserver.WaitingForSceneObserverAccess);
+            Assert.IsFalse(spatialObserver.IsRunning);
             Assert.IsEmpty(spatialObserver.Meshes);
 
             CoreServices.SpatialAwarenessSystem.ResumeObservers();
-            Assert.IsTrue(spatialObserver.WaitingForSceneObserverAccess);
+            Assert.IsTrue(spatialObserver.IsRunning);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
             Assert.IsNotEmpty(spatialObserver.Meshes);
 
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             CoreServices.SpatialAwarenessSystem.Enable();
             spatialObserver = spatialAwarenesssDataProvider.GetDataProvider<SpatialObjectMeshObserver.SpatialObjectMeshObserver>();
             Assert.IsNotNull(spatialObserver, "No SpatialObjectMeshObserver data provider created or found");
-            Assert.IsFalse(spatialObserver.WaitingForSceneObserverAccess);
+            Assert.IsFalse(spatialObserver.IsRunning);
             Assert.IsEmpty(spatialObserver.Meshes);
         }
 


### PR DESCRIPTION
## Overview
Remove the WaitingForSceneObserverAccess bool from BaseSpatialObserver and related files. References are replaced with the IsRunning flag.