### PR TITLE
Update the prefab spawner to have an option that actually honors vanishDelay

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -257,7 +257,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private Boolean HasVanishDelayElapsed()
         {
-            return Time.time - focusExitTime > vanishDelay;
+            return Time.unscaledTime - focusExitTime > vanishDelay;
         }
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Serialization;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -20,8 +21,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
     {
         private enum VanishType
         {
+            /// <summary>
+            /// Causes the tooltip to vanish immediately after disappearing. Ignores vanishDelay.
+            /// </summary>
             VanishOnFocusExit = 0,
             VanishOnTap,
+
+            /// <summary>
+            /// Equivalent to VanishOnFocusExit. but honors vanishDelay and will only disappear
+            /// after that many seconds elapses after focus loss.
+            /// </summary>
+            VanishOnFocusExitWithDelay,
         }
 
         private enum AppearType
@@ -57,6 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private float appearDelay = 0.0f;
         [SerializeField]
         [Range(0f, 5f)]
+        [Tooltip("The number of seconds that must elapse before the tooltip will disappear. Only used when vanishType is VanishOnFocusExitWithDelay.")]
         private float vanishDelay = 2.0f;
         [SerializeField]
         [Range(0.5f, 10.0f)]
@@ -148,13 +159,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                         break;
 
+                    case VanishType.VanishOnFocusExitWithDelay:
                     default:
-                        if (!HasFocus)
+                        if (!HasFocus && HasVanishDelayElapsed())
                         {
-                            if (Time.time - focusExitTime > vanishDelay)
-                            {
-                                spawnable.gameObject.SetActive(false);
-                            }
+                            spawnable.gameObject.SetActive(false);
                         }
                         break;
                 }
@@ -244,6 +253,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private void HandleFocusExit()
         {
             focusExitTime = Time.unscaledTime;
+        }
+
+        private Boolean HasVanishDelayElapsed()
+        {
+            return Time.time - focusExitTime > vanishDelay;
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7467

As I was looking at issues that were set to the 2.5 milestone, I noticed this one which seemed like a fun break from other work. There's a few things to note here:

1. vanishDelay is not used in the code prior to this, because the default case never ran.
2. I couldn't just update the VanishOnFocusExit to use vanishDelay, because other consumers may already be dependent on the immediate vanish behavior.
3. So I ended up adding another option (that actually honors vanishDelay), so that people can opt into this correct behavior while not breaking existing users.
4. Opted not to write a test for this specific case because it involves timers, and I don't want to add sleeps to our tests without having some system of parallel-zing them first