### PR TITLE
Allow manipulation with the GazePointer for both ManipulationHandler and ObjectManipulator

### DIFF
--- a/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
@@ -973,8 +973,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool TryGetGripRotation(IMixedRealityPointer pointer, out Quaternion rotation)
         {
-
-            for (int i = 0; i < pointer.Controller.Interactions.Length; i++)
+            for (int i = 0; i < (pointer.Controller?.Interactions?.Length ?? 0); i++)
             {
                 if (pointer.Controller.Interactions[i].InputType == DeviceInputType.SpatialGrip)
                 {

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -936,7 +936,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool TryGetGripRotation(IMixedRealityPointer pointer, out Quaternion rotation)
         {
-            for (int i = 0; i < pointer.Controller.Interactions.Length; i++)
+            for (int i = 0; i < (pointer.Controller?.Interactions?.Length ?? 0); i++)
             {
                 if (pointer.Controller.Interactions[i].InputType == DeviceInputType.SpatialGrip)
                 {

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -433,6 +433,61 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         }
 
+        /// <summary>
+        /// This tests that the gaze pointer can be used to directly invoke the manipulation logic via simulated pointer events, used
+        /// for scenarios like voice-driven movement using the gaze pointer.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ObjectManipulatorGazePointerMove()
+        {
+            // set up cube with manipulation handler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.transform.localScale = Vector3.one * 0.2f;
+            Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
+            testObject.transform.position = initialObjectPosition;
+            var manipHandler = testObject.AddComponent<ObjectManipulator>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingFar = false;
+            manipHandler.SmoothingNear = false;
+            manipHandler.ManipulationType = ManipulationHandFlags.OneHanded;
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            var gazePointer = CoreServices.InputSystem.GazeProvider.GazePointer;
+            MixedRealityPointerEventData pointerDownData = new MixedRealityPointerEventData(UnityEngine.EventSystems.EventSystem.current);
+            pointerDownData.Initialize(gazePointer, MixedRealityInputAction.None, Microsoft.MixedReality.Toolkit.Utilities.Handedness.None);
+
+            manipHandler.OnPointerDown(pointerDownData);
+
+            Vector3 cameraMovement = new Vector3(2.1f, 0.4f, 0.2f);
+            CameraCache.Main.transform.position += cameraMovement;
+
+            yield return null;
+
+            MixedRealityPointerEventData pointerMoveData = new MixedRealityPointerEventData(UnityEngine.EventSystems.EventSystem.current);
+            pointerMoveData.Initialize(gazePointer, MixedRealityInputAction.None, Microsoft.MixedReality.Toolkit.Utilities.Handedness.None);
+            manipHandler.OnPointerDragged(pointerMoveData);
+
+            Vector3 expectedPosition = initialObjectPosition + cameraMovement;
+            TestUtilities.AssertAboutEqual(manipHandler.HostTransform.position, expectedPosition, "Camera movement translates to object movement from pointer updates");
+
+            MixedRealityPointerEventData pointerUpData = new MixedRealityPointerEventData(UnityEngine.EventSystems.EventSystem.current);
+            pointerUpData.Initialize(gazePointer, MixedRealityInputAction.None, Microsoft.MixedReality.Toolkit.Utilities.Handedness.None);
+            manipHandler.OnPointerUp(pointerUpData);
+
+            Vector3 cameraSecondMovement = new Vector3(-0.7f, 0.9f, 2.2f);
+            CameraCache.Main.transform.position += cameraSecondMovement;
+
+            yield return null;
+
+            TestUtilities.AssertAboutEqual(manipHandler.HostTransform.position, expectedPosition, "Camera movement after releasing pointer does not continue to affect object");
+        }
 
         /// <summary>
         /// This tests the one hand near rotation and applying different rotation constraints to the object.


### PR DESCRIPTION
## Overview

Remote Assist has a voice-based manipulation system for moving slates using a voice command and gaze pointer updates. This was blocked from working due to exceptions thrown by the ManipulationHandler (which didn't check the Controller of the pointer it was manipulated with to see in TryGetGripRotation). For the GazePointer, the controller is null.

This change updates both ManipulationHandler and ObjectManipulator to check these values for null. I've also added two playmode tests that emulate the logic that exists in Remote Assist today to prevent future regressions.