### PR TITLE
Fix input axis mappings in 2.5

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializedProperty useServiceInspectors;
         private SerializedProperty renderDepthBuffer;
 
-        private Func<bool>[] RenderProfileFuncs;
+        private Func<bool>[] renderProfileFuncs;
 
         private static readonly string[] ProfileTabTitles = {
             "Camera",
@@ -138,9 +138,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             SelectedProfileTab = SessionState.GetInt(SelectedTabPreferenceKey, SelectedProfileTab);
 
-            if (RenderProfileFuncs == null)
+            if (renderProfileFuncs == null)
             {
-                RenderProfileFuncs = new Func<bool>[]
+                renderProfileFuncs = new Func<bool>[]
                 {
                     () => {
                         bool changed = false;
@@ -440,7 +440,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
             using (new EditorGUI.IndentLevelScope())
             {
-                changed |= RenderProfileFuncs[SelectedProfileTab]();
+                changed |= renderProfileFuncs[SelectedProfileTab]();
             }
             EditorGUILayout.EndVertical();
             EditorGUILayout.EndHorizontal();

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -126,6 +126,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             useServiceInspectors = serializedObject.FindProperty("useServiceInspectors");
             renderDepthBuffer = serializedObject.FindProperty("renderDepthBuffer");
 
+            if (enableInputSystem.boolValue)
+            {
+                // Make sure Unity axis mappings are set.
+                InputMappingAxisUtility.CheckUnityInputManagerMappings(ControllerMappingLibrary.UnityInputManagerAxes);
+            }
+            else
+            {
+                InputMappingAxisUtility.RemoveMappings(ControllerMappingLibrary.UnityInputManagerAxes);
+            }
+
             SelectedProfileTab = SessionState.GetInt(SelectedTabPreferenceKey, SelectedProfileTab);
 
             if (RenderProfileFuncs == null)
@@ -169,16 +179,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                                 EditorGUILayout.PropertyField(inputSystemType);
 
-                                // Make sure Unity axis mappings are set.
-                                InputMappingAxisUtility.CheckUnityInputManagerMappings(ControllerMappingLibrary.UnityInputManagerAxes);
-
                                 changed |= RenderProfile(inputSystemProfile, null, true, false, typeof(IMixedRealityInputSystem));
                             }
                             else
                             {
                                 RenderSystemDisabled(service);
-
-                                InputMappingAxisUtility.RemoveMappings(ControllerMappingLibrary.UnityInputManagerAxes);
                             }
 
                             changed |= c.changed;

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit.Boundary;
 using Microsoft.MixedReality.Toolkit.Diagnostics;
 using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Input.Editor;
 using Microsoft.MixedReality.Toolkit.Rendering;
 using Microsoft.MixedReality.Toolkit.SceneSystem;
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
@@ -125,16 +124,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             // Editor settings
             useServiceInspectors = serializedObject.FindProperty("useServiceInspectors");
             renderDepthBuffer = serializedObject.FindProperty("renderDepthBuffer");
-
-            if (enableInputSystem.boolValue)
-            {
-                // Make sure Unity axis mappings are set.
-                InputMappingAxisUtility.CheckUnityInputManagerMappings(ControllerMappingLibrary.UnityInputManagerAxes);
-            }
-            else
-            {
-                InputMappingAxisUtility.RemoveMappings(ControllerMappingLibrary.UnityInputManagerAxes);
-            }
 
             SelectedProfileTab = SessionState.GetInt(SelectedTabPreferenceKey, SelectedProfileTab);
 

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -18,6 +18,7 @@ using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Rendering;
 
 #if UNITY_EDITOR
+using Microsoft.MixedReality.Toolkit.Input.Editor;
 using UnityEditor;
 #endif
 
@@ -400,6 +401,11 @@ namespace Microsoft.MixedReality.Toolkit
             {
                 DebugUtilities.LogVerbose("Begin registration of the input system");
 
+#if UNITY_EDITOR
+                // Make sure unity axis mappings are set.	
+                InputMappingAxisUtility.CheckUnityInputManagerMappings(ControllerMappingLibrary.UnityInputManagerAxes);
+#endif
+
                 object[] args = { ActiveProfile.InputSystemProfile };
                 if (!RegisterService<IMixedRealityInputSystem>(ActiveProfile.InputSystemType, args: args) || CoreServices.InputSystem == null)
                 {
@@ -421,6 +427,12 @@ namespace Microsoft.MixedReality.Toolkit
                 }
 
                 DebugUtilities.LogVerbose("End registration of the input system");
+            }
+            else
+            {
+#if UNITY_EDITOR
+                InputMappingAxisUtility.RemoveMappings(ControllerMappingLibrary.UnityInputManagerAxes);
+#endif
             }
 
             // If the Boundary system has been selected for initialization in the Active profile, enable it in the project

--- a/Assets/MRTK/Core/Utilities/Editor/InputMappingAxisUtility.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/InputMappingAxisUtility.cs
@@ -9,11 +9,8 @@ using UnityEditor;
 namespace Microsoft.MixedReality.Toolkit.Input.Editor
 {
     /// <summary>
-    /// Utility class for Unity's Input Manager Mappings.
+    /// Utility class for Unity's Input Manager mappings.
     /// </summary>
-    /// <remarks>
-    /// Note, with any luck this will be temporary.  If it is to remain beyond Alpha, then this needs some refactoring to make a proper component.
-    /// </remarks>
     public static class InputMappingAxisUtility
     {
         #region Configuration elements

--- a/Assets/MRTK/Core/Utilities/Editor/InputMappingAxisUtility.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/InputMappingAxisUtility.cs
@@ -36,12 +36,16 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         /// Simple static function to check Unity InputManager Axis configuration, and apply if needed.
         /// </summary>
         /// <remarks>
-        /// This only exists as the Unity input manager CANNOT map Axis to an id, it has to be through a mapping
+        /// This only exists as the Unity input manager CANNOT map Axis to an id; it has to be through a mapping.
         /// </remarks>
-        /// <param name="axisMappings">Optional array of Axis Mappings, to configure your own custom set</param>
-        public static void CheckUnityInputManagerMappings(InputManagerAxis[] axisMappings)
+        /// <param name="axisMappings">Array of axis mappings, to configure your own custom set.</param>
+        /// <param name="updateMappings">If the mappings should be updated to match axisMappings or simply check that they match. Defaults to true.</param>
+        /// <returns>True if the mappings needed an update. False if they match axisMappings already.</returns>
+        public static bool CheckUnityInputManagerMappings(InputManagerAxis[] axisMappings, bool updateMappings = true)
         {
             EnsureInputManagerReference();
+
+            bool mappingsNeedUpdate = false;
 
             if (axisMappings != null)
             {
@@ -49,12 +53,21 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 {
                     if (!DoesAxisNameExist(axisMappings[i].Name))
                     {
-                        AddAxis(axisMappings[i]);
+                        if (updateMappings)
+                        {
+                            AddAxis(axisMappings[i]);
+                        }
+                        mappingsNeedUpdate = true;
                     }
                 }
 
-                inputManagerAsset.ApplyModifiedProperties();
+                if (mappingsNeedUpdate && updateMappings)
+                {
+                    inputManagerAsset.ApplyModifiedProperties();
+                }
             }
+
+            return mappingsNeedUpdate;
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

The change in #8315 inadvertantly moved it to an area that only runs when the input tab in the configuration profile is visible. Reverted this code to run when the MRTK initializes instead.

A larger PR to add this to the configurator and fix the core -> editor references will be opened on the dev branch, but that's a bit too much for the stabilization branch.

Also updated some code style capitalization of a private field and added an optional bool to the input axis setter method for future use.