### PR TITLE
Fix test utilities access in 2019.4 when imported via UPM

### DIFF
--- a/Assets/MRTK/Tests/TestUtilities/Microsoft.MixedReality.Toolkit.Tests.Utilities.asmdef
+++ b/Assets/MRTK/Tests/TestUtilities/Microsoft.MixedReality.Toolkit.Tests.Utilities.asmdef
@@ -10,9 +10,7 @@
         "Microsoft.MixedReality.Toolkit.Services.InputSystem",
         "Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem"
     ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
-    ],
+    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -13,7 +13,6 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
 using UnityEngine;
-using NUnit.Framework;
 using System.Collections;
 using System.IO;
 using Microsoft.MixedReality.Toolkit.Diagnostics;
@@ -96,7 +95,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </remarks>
         public static void Setup(MixedRealityToolkitConfigurationProfile profile = null)
         {
-            Assert.True(Application.isPlaying, "This setup method should only be used during play mode tests. Use TestUtilities.");
+            Debug.Assert(Application.isPlaying, "This setup method should only be used during play mode tests. Use TestUtilities.");
 
             // See comments for UseSlowTestController for why this is reset to false on each test case.
             UseSlowTestController = false;
@@ -191,7 +190,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         public static IMixedRealityInputSystem GetInputSystem()
         {
-            Assert.IsNotNull(CoreServices.InputSystem, "MixedRealityInputSystem is null!");
+            Debug.Assert((CoreServices.InputSystem != null), "MixedRealityInputSystem is null!");
             return CoreServices.InputSystem;
         }
 
@@ -202,7 +201,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public static InputSimulationService GetInputSimulationService()
         {
             InputSimulationService inputSimulationService = CoreServices.GetInputSystemDataProvider<InputSimulationService>();
-            Assert.IsNotNull(inputSimulationService, "InputSimulationService is null!");
+            Debug.Assert((inputSimulationService != null), "InputSimulationService is null!");
             return inputSimulationService;
         }
 
@@ -255,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 yield break;
             }
 
-            Assert.IsNotNull(CoreServices.InputSystem, "Input system must be initialized");
+            Debug.Assert((CoreServices.InputSystem != null), "Input system must be initialized");
 
             // Let input system to register all cursors and managers.
             yield return null;
@@ -292,8 +291,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
 
             // Check that input system is clean
-            CollectionAssert.IsEmpty(((BaseEventSystem)CoreServices.InputSystem).EventListeners, "Input event system handler registry is not empty in the beginning of the test.");
-            CollectionAssert.IsEmpty(((BaseEventSystem)CoreServices.InputSystem).EventHandlersByType, "Input event system handler registry is not empty in the beginning of the test.");
+            Debug.Assert(((BaseEventSystem)CoreServices.InputSystem).EventListeners.Count == 0, "Input event system handler registry is not empty in the beginning of the test.");
+            Debug.Assert(((BaseEventSystem)CoreServices.InputSystem).EventHandlersByType.Count == 0, "Input event system handler registry is not empty in the beginning of the test.");
 
             yield return null;
         }
@@ -480,8 +479,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             yield return null;
 
-            Assert.That(inputSimulationService.ControllerSimulationMode == ControllerSimulationMode.HandGestures || 
-                inputSimulationService.ControllerSimulationMode == ControllerSimulationMode.ArticulatedHand, "The current ControllerSimulationMode must be HandGestures or ArticulatedHand!");
+            Debug.Assert(
+                ((inputSimulationService.ControllerSimulationMode == ControllerSimulationMode.HandGestures) || 
+                (inputSimulationService.ControllerSimulationMode == ControllerSimulationMode.ArticulatedHand)), 
+                "The current ControllerSimulationMode must be HandGestures or ArticulatedHand!");
             SimulatedHandData handData = handedness == Handedness.Right ? inputSimulationService.HandDataRight : inputSimulationService.HandDataLeft;
             handData.Update(true, false, GenerateHandPose(handPose, handedness, handLocation, Quaternion.identity));
 
@@ -502,7 +503,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             yield return null;
 
-            Assert.AreEqual(ControllerSimulationMode.MotionController, inputSimulationService.ControllerSimulationMode, "The current ControllerSimulationMode must be MotionController!");
+            Debug.Assert((ControllerSimulationMode.MotionController == inputSimulationService.ControllerSimulationMode), "The current ControllerSimulationMode must be MotionController!");
             SimulatedMotionControllerData motionControllerData = handedness == Handedness.Right ? inputSimulationService.MotionControllerDataRight : inputSimulationService.MotionControllerDataLeft;
             motionControllerData.Update(true, buttonState, UpdateMotionControllerPose(handedness, motionControllerLocation, Quaternion.identity));
 

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -10,7 +10,6 @@ using UnityEngine.SceneManagement;
 
 #if UNITY_EDITOR
 using Microsoft.MixedReality.Toolkit.Editor;
-using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 #endif
@@ -69,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // In playmode the scene needs to be set up manually.
 
 #if UNITY_EDITOR
-            Assert.False(EditorApplication.isPlaying, "This method should only be called during edit mode tests. Use PlaymodeTestUtilities.");
+            Debug.Assert(!EditorApplication.isPlaying, "This method should only be called during edit mode tests. Use PlaymodeTestUtilities.");
 
             List<Scene> additiveTestScenesList = new List<Scene>();
 
@@ -306,12 +305,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 BaseEventSystem.enableDanglingHandlerDiagnostics = true;
             }
 
-            Assert.IsTrue(MixedRealityToolkit.IsInitialized);
-            Assert.IsNotNull(MixedRealityToolkit.Instance);
+            Debug.Assert(MixedRealityToolkit.IsInitialized);
+            Debug.Assert(MixedRealityToolkit.Instance != null);
 
 
             MixedRealityToolkit.Instance.ActiveProfile = configuration;
-            Assert.IsTrue(MixedRealityToolkit.Instance.ActiveProfile != null);
+            Debug.Assert(MixedRealityToolkit.Instance.ActiveProfile != null);
         }
 
         public static void InitializeMixedRealityToolkit(bool useDefaultProfile = false)
@@ -320,7 +319,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 ? GetDefaultMixedRealityProfile<MixedRealityToolkitConfigurationProfile>()
                 : ScriptableObject.CreateInstance<MixedRealityToolkitConfigurationProfile>();
 
-            Assert.IsTrue(configuration != null, "Failed to find the Default Mixed Reality Configuration Profile");
+            Debug.Assert(configuration != null, "Failed to find the Default Mixed Reality Configuration Profile");
             InitializeMixedRealityToolkit(configuration);
         }
 
@@ -377,7 +376,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </remarks>
         public static void AssertLessOrEqual(float observed, float expected, float tolerance = 0.01f)
         {
-            Assert.That(observed, Is.EqualTo(expected).Within(tolerance).Or.LessThan(expected));
+            Debug.Assert((Mathf.Abs(observed - expected) <= tolerance) || (observed < expected));
         }
 
         /// <summary>
@@ -389,7 +388,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </remarks>
         public static void AssertLessOrEqual(float observed, float expected, string message, float tolerance = 0.01f)
         {
-            Assert.That(observed, Is.EqualTo(expected).Within(tolerance).Or.LessThan(expected), message);
+            Debug.Assert((Mathf.Abs(observed - expected) <= tolerance) || (observed < expected), message);
         }
 
         /// <summary>
@@ -401,7 +400,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </remarks>
         public static void AssertGreaterOrEqual(float observed, float expected, float tolerance = 0.01f)
         {
-            Assert.That(observed, Is.EqualTo(expected).Within(tolerance).Or.GreaterThan(expected));
+            Debug.Assert((Mathf.Abs(observed - expected) <= tolerance) || (observed > expected));
         }
         /// <summary>
         /// Equvalent to NUnit.Framework.Assert.GreaterOrEqual, except this also
@@ -412,7 +411,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </remarks>
         public static void AssertGreaterOrEqual(float observed, float expected, string message, float tolerance = 0.01f)
         {
-            Assert.That(observed, Is.EqualTo(expected).Within(tolerance).Or.GreaterThan(expected), message);
+            Debug.Assert((Mathf.Abs(observed - expected) <= tolerance) || (observed > expected), message);
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
During UPM pre-release testing, it was found that there was an issue with accessing the MRTK test utilities assembly when it was imported as a UPM package. When the files were copied into the Assets folder, or imported via a .unitypackage file, it succeeded.

After quite a bit of investigation, it appears that there is behavior where an assembly marked as a test assembly, is not auto-added and does not appear able to be used if it is in the Library/PackageCache.

This change removes the dependency on NUnit and marks the assembly as NOT being a test asm. As part of this change, existing NUnit assertions have been replaced with UnityEngine assertions.

This was validated by spot-running some play mode tests as well as verifying that the assembly was referenceable via a custom script.

Special thanks to @keveleigh for helping to figure this one out.

Fixes #8436 