### PR TITLE
Fix scaling issue of bounding box

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1225,6 +1225,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             ResetHandleVisibility();
             rigRoot.gameObject.SetActive(active);
             UpdateRigVisibilityInInspector();
+            CaptureInitialState();
         }
 
         #endregion
@@ -2041,7 +2042,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 #pragma warning restore 0618
                 }
 
-                scaleConstraint.Initialize(new MixedRealityTransform(transform));
+                scaleConstraint.Initialize(new MixedRealityTransform(target.transform));
             }
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -45,44 +45,23 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// Instantiates a bounding box at 0, 0, -1.5f
         /// box is at scale .5, .5, .5
+        /// Target is set to its child if targetIsChild is true
         /// </summary>
-        private BoundingBox InstantiateSceneAndDefaultBbox()
+        private BoundingBox InstantiateSceneAndDefaultBbox(bool targetIsChild = false)
         {
-            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = boundingBoxStartCenter;
-            cube.transform.localScale = boundingBoxStartScale;
-            BoundingBox bbox = cube.AddComponent<BoundingBox>();
-
-            MixedRealityPlayspace.PerformTransformation(
-            p =>
-            {
-                p.position = Vector3.zero;
-                p.LookAt(cube.transform.position);
-            });
-
-            bbox.Target = cube;
-            bbox.Active = true;
-
-            return bbox;
-        }
-
-        /// <summary>
-        /// Instantiates a bounding box at 0, 0, -1.5f
-        /// box is at scale .5, .5, .5
-        /// Target is set to its child
-        /// </summary>
-        private BoundingBox InstantiateSceneAndDefaultBboxWithChildTarget()
-        {
-            
-            var bboxGameObject = new GameObject();
+            var bboxGameObject = targetIsChild ? new GameObject() : GameObject.CreatePrimitive(PrimitiveType.Cube);
             bboxGameObject.transform.position = boundingBoxStartCenter;
             bboxGameObject.transform.localScale = boundingBoxStartScale;
             BoundingBox bbox = bboxGameObject.AddComponent<BoundingBox>();
-            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.parent = bboxGameObject.transform;
-            cube.transform.localScale = Vector3.one;
-            cube.transform.localPosition = Vector3.zero;
-            cube.transform.localRotation = Quaternion.identity;
+            GameObject cube = null;
+            if (targetIsChild)
+            {
+                cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                cube.transform.parent = bboxGameObject.transform;
+                cube.transform.localScale = Vector3.one;
+                cube.transform.localPosition = Vector3.zero;
+                cube.transform.localRotation = Quaternion.identity;
+            }
 
             MixedRealityPlayspace.PerformTransformation(
             p =>
@@ -91,7 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 p.LookAt(bboxGameObject.transform.position);
             });
 
-            bbox.Target = cube;
+            bbox.Target = targetIsChild ? cube : bboxGameObject;
             bbox.Active = true;
 
             return bbox;
@@ -367,7 +346,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             float minScale = 0.5f;
             float maxScale = 2f;
 
-            var bbox = InstantiateSceneAndDefaultBboxWithChildTarget();
+            var bbox = InstantiateSceneAndDefaultBbox(targetIsChild: true);
             var scaleHandler = bbox.EnsureComponent<MinMaxScaleConstraint>();
             scaleHandler.ScaleMinimum = minScale;
             scaleHandler.ScaleMaximum = maxScale;
@@ -401,11 +380,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Assert scale at min
             Assert.AreEqual(Vector3.one * scaleHandler.ScaleMinimum, bbox.Target.transform.localScale);
-
-            GameObject.Destroy(bbox.gameObject);
-            // Wait for a frame to give Unity a change to actually destroy the object
-            yield return null;
-
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -47,20 +47,26 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// box is at scale .5, .5, .5
         /// Target is set to its child if targetIsChild is true
         /// </summary>
-        private BoundingBox InstantiateSceneAndDefaultBbox(bool targetIsChild = false)
+        private BoundingBox InstantiateSceneAndDefaultBbox(GameObject target = null)
         {
-            var bboxGameObject = targetIsChild ? new GameObject() : GameObject.CreatePrimitive(PrimitiveType.Cube);
+            GameObject bboxGameObject;
+            if (target != null)
+            {
+                bboxGameObject = new GameObject();
+            }
+            else
+            {
+                bboxGameObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            }
             bboxGameObject.transform.position = boundingBoxStartCenter;
             bboxGameObject.transform.localScale = boundingBoxStartScale;
             BoundingBox bbox = bboxGameObject.AddComponent<BoundingBox>();
-            GameObject cube = null;
-            if (targetIsChild)
+            if (target != null)
             {
-                cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                cube.transform.parent = bboxGameObject.transform;
-                cube.transform.localScale = Vector3.one;
-                cube.transform.localPosition = Vector3.zero;
-                cube.transform.localRotation = Quaternion.identity;
+                target.transform.parent = bboxGameObject.transform;
+                target.transform.localScale = Vector3.one;
+                target.transform.localPosition = Vector3.zero;
+                bbox.Target = target;
             }
 
             MixedRealityPlayspace.PerformTransformation(
@@ -70,7 +76,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 p.LookAt(bboxGameObject.transform.position);
             });
 
-            bbox.Target = targetIsChild ? cube : bboxGameObject;
             bbox.Active = true;
 
             return bbox;
@@ -346,7 +351,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             float minScale = 0.5f;
             float maxScale = 2f;
 
-            var bbox = InstantiateSceneAndDefaultBbox(targetIsChild: true);
+            var target = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var bbox = InstantiateSceneAndDefaultBbox(target);
             var scaleHandler = bbox.EnsureComponent<MinMaxScaleConstraint>();
             scaleHandler.ScaleMinimum = minScale;
             scaleHandler.ScaleMaximum = maxScale;

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -50,6 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.transform.position = boundingBoxStartCenter;
+            cube.transform.localScale = boundingBoxStartScale;
             BoundingBox bbox = cube.AddComponent<BoundingBox>();
 
             MixedRealityPlayspace.PerformTransformation(
@@ -60,7 +61,37 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             });
 
             bbox.Target = cube;
-            bbox.transform.localScale = boundingBoxStartScale;
+            bbox.Active = true;
+
+            return bbox;
+        }
+
+        /// <summary>
+        /// Instantiates a bounding box at 0, 0, -1.5f
+        /// box is at scale .5, .5, .5
+        /// Target is set to its child
+        /// </summary>
+        private BoundingBox InstantiateSceneAndDefaultBboxWithChildTarget()
+        {
+            
+            var bboxGameObject = new GameObject();
+            bboxGameObject.transform.position = boundingBoxStartCenter;
+            bboxGameObject.transform.localScale = boundingBoxStartScale;
+            BoundingBox bbox = bboxGameObject.AddComponent<BoundingBox>();
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.parent = bboxGameObject.transform;
+            cube.transform.localScale = Vector3.one;
+            cube.transform.localPosition = Vector3.zero;
+            cube.transform.localRotation = Quaternion.identity;
+
+            MixedRealityPlayspace.PerformTransformation(
+            p =>
+            {
+                p.position = Vector3.zero;
+                p.LookAt(bboxGameObject.transform.position);
+            });
+
+            bbox.Target = cube;
             bbox.Active = true;
 
             return bbox;
@@ -328,6 +359,56 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// This tests the minimum and maximum scaling for the bounding box when target is a child of the box.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScaleChildTargetMinMax()
+        {
+            float minScale = 0.5f;
+            float maxScale = 2f;
+
+            var bbox = InstantiateSceneAndDefaultBboxWithChildTarget();
+            var scaleHandler = bbox.EnsureComponent<MinMaxScaleConstraint>();
+            scaleHandler.ScaleMinimum = minScale;
+            scaleHandler.ScaleMaximum = maxScale;
+            yield return null;
+
+            Vector3 initialScale = bbox.Target.transform.localScale;
+
+            const int numHandSteps = 1;
+
+            Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
+            var frontRightCornerPos = bbox.ScaleCorners[3].transform.position; // front right corner is corner 3
+            TestHand hand = new TestHand(Handedness.Right);
+
+            // Hands grab object at initial position
+            yield return hand.Show(initialHandPosition);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+            yield return hand.MoveTo(frontRightCornerPos, numHandSteps);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            // No change to scale yet
+            Assert.AreEqual(initialScale, bbox.Target.transform.localScale);
+
+            // Move hands beyond max scale limit
+            yield return hand.MoveTo(new Vector3(scaleHandler.ScaleMaximum * 2, scaleHandler.ScaleMaximum * 2, 0) + frontRightCornerPos, numHandSteps);
+            
+            // Assert scale at max
+            Assert.AreEqual(Vector3.one * scaleHandler.ScaleMaximum, bbox.Target.transform.localScale);
+
+            // Move hands beyond min scale limit
+            yield return hand.MoveTo(new Vector3(-scaleHandler.ScaleMinimum * 2, -scaleHandler.ScaleMinimum * 2, 0) + frontRightCornerPos, numHandSteps);
+
+            // Assert scale at min
+            Assert.AreEqual(Vector3.one * scaleHandler.ScaleMinimum, bbox.Target.transform.localScale);
+
+            GameObject.Destroy(bbox.gameObject);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+
+        }
+
+        /// <summary>
         /// Uses far interaction (HoloLens 1 style) to scale the bounding box
         /// </summary>
         [UnityTest]
@@ -363,7 +444,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return rightHand.Move(delta);
 
             var endBounds = bbox.GetComponent<BoxCollider>().bounds;
-            TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center");
+            TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center", 0.02f);
             TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .561f, "endBounds incorrect size", 0.02f);
 
             GameObject.Destroy(bbox.gameObject);
@@ -418,7 +499,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             var endBounds = bbox.GetComponent<BoxCollider>().bounds;
-            TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center");
+            TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center", 0.02f);
             TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .561f, "endBounds incorrect size", 0.02f);
 
             GameObject.Destroy(bbox.gameObject);

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -105,12 +105,27 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Instantiates a bounds control at boundsControlStartCenter
         /// transform is at scale boundsControlStartScale
         /// </summary>
-        private BoundsControl InstantiateSceneAndDefaultBoundsControl()
+        private BoundsControl InstantiateSceneAndDefaultBoundsControl(GameObject target = null)
         {
-            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = boundsControlStartCenter;
-            cube.transform.localScale = boundsControlStartScale;
-            BoundsControl boundsControl = cube.AddComponent<BoundsControl>();
+            GameObject boundsControlGameObject;
+            if(target != null)
+            {
+                boundsControlGameObject = new GameObject();
+            }
+            else
+            {
+                boundsControlGameObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            }
+            boundsControlGameObject.transform.position = boundsControlStartCenter;
+            boundsControlGameObject.transform.localScale = boundsControlStartScale;
+            BoundsControl boundsControl = boundsControlGameObject.AddComponent<BoundsControl>();
+            if (target != null)
+            {
+                target.transform.parent = boundsControlGameObject.transform;
+                target.transform.localScale = Vector3.one;
+                target.transform.localPosition = Vector3.zero;
+                boundsControl.Target = target;
+            }
             TestUtilities.PlayspaceToOriginLookingForward();
             boundsControl.Active = true;
 
@@ -125,7 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             yield return null;
             yield return new WaitForFixedUpdate();
-            BoxCollider boxCollider = boundsControl.GetComponent<BoxCollider>();
+            BoxCollider boxCollider = boundsControl.Target.GetComponent<BoxCollider>();
             var bounds = boxCollider.bounds;
             TestUtilities.AssertAboutEqual(bounds.center, boundsControlStartCenter, "bounds control incorrect center at start");
             TestUtilities.AssertAboutEqual(bounds.size, boundsControlStartScale, "bounds control incorrect size at start");
@@ -846,6 +861,52 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
 
+        }
+
+        /// <summary>
+        /// This tests the minimum and maximum scaling for the bounds control when target is its child.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScaleChildTargetMinMax()
+        {
+            float minScale = 0.5f;
+            float maxScale = 2f;
+
+            var target = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl(target);
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            var scaleHandler = boundsControl.EnsureComponent<MinMaxScaleConstraint>();
+            scaleHandler.ScaleMinimum = minScale;
+            scaleHandler.ScaleMaximum = maxScale;
+
+            Vector3 initialScale = boundsControl.Target.transform.localScale;
+
+            const int numHandSteps = 1;
+
+            Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
+            var frontRightCornerPos = boundsControl.Target.gameObject.transform.Find("rigRoot/corner_3").position; // front right corner is corner 3
+            TestHand hand = new TestHand(Handedness.Right);
+
+            // Hands grab object at initial position
+            yield return hand.Show(initialHandPosition);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+            yield return hand.MoveTo(frontRightCornerPos, numHandSteps);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            // No change to scale yet
+            Assert.AreEqual(initialScale, boundsControl.Target.transform.localScale);
+
+            // Move hands beyond max scale limit
+            yield return hand.MoveTo(new Vector3(scaleHandler.ScaleMaximum * 2, scaleHandler.ScaleMaximum * 2, 0) + frontRightCornerPos, numHandSteps);
+
+            // Assert scale at max
+            Assert.AreEqual(Vector3.one * scaleHandler.ScaleMaximum, boundsControl.Target.transform.localScale);
+
+            // Move hands beyond min scale limit
+            yield return hand.MoveTo(new Vector3(-scaleHandler.ScaleMinimum * 2, -scaleHandler.ScaleMinimum * 2, 0) + frontRightCornerPos, numHandSteps);
+
+            // Assert scale at min
+            Assert.AreEqual(Vector3.one * scaleHandler.ScaleMinimum, boundsControl.Target.transform.localScale);
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
This PR addresses two related issues:
1. The bounding box script does not allow proper scaling when the its target is set to a child of the GameObject the script is attached to. This issue is resolved by making sure target.transform instead of transform is used when initializing scale constraint. A test is added to help verify the fix.
2. The existing test utility seems to work (tests pass), but the way it is working is unintended. The change of bounding box's scale in InstantiateSceneAndDefaultBbox() happens after the instantiation of bounding box and the assignment of its target, which causes scale constraint never getting the correct "initial scale" information. The location of scale change is now moved so that scale constraint now gets the correct value. Also, the "initial scale" information is now updated after switching the target of bounding box.

## Changes
- Fixes: #8458.