### PR TITLE
Remove link.xml from build targets since it is now generated

### DIFF
--- a/Assets/MRTK/Core/MixedReality.Toolkit.targets
+++ b/Assets/MRTK/Core/MixedReality.Toolkit.targets
@@ -36,11 +36,6 @@
       <Link>MRTK\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
 
-    <Content Include="$(MSBuildThisFileDirectory)..\link.xml" Condition=" '$(MRTKIncludeContent)' == 'true' ">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>MRTK\link.xml</Link>
-    </Content>
-
     <!-- Get all the dlls for the target player, and store the Identity in a custom OriginalPath metadata.
          If Identity is used directly as the HintPath in the Reference, Visual Studio generates a warning
          indicating the assemblies are not found, even though the build succeeds. -->


### PR DESCRIPTION
## Overview
When the checked-in link.xml was removed, this build target that copies link.xml from the nuget package into the Unity project was not removed. It is no longer necessary, as the link.xml file is generated inside the Unity project. This unblocks Remote Assist from ingesting new nuget packages.