### PR TITLE
Properly switch input simulation mode in tests

### DIFF
--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -687,8 +687,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             BoundsControl control = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(control);
-            PlayModeTestUtilities.PushControllerSimulationProfile();
-            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // move camera to look at rotation sphere
             CameraCache.Main.transform.LookAt(new Vector3(0.248f, 0.001f, 1.226f)); // rotation sphere front right
@@ -720,9 +721,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
 
-            // Restore the input simulation profile
-            PlayModeTestUtilities.PopControllerSimulationProfile();
-
+            iss.ControllerSimulationMode = oldSimMode;
             yield return null;
         }
 
@@ -857,8 +856,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
             BoxCollider boxCollider = boundsControl.GetComponent<BoxCollider>();
-            PlayModeTestUtilities.PushControllerSimulationProfile();
-            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             CameraCache.Main.transform.LookAt(boundsControl.gameObject.transform.Find("rigRoot/corner_3").transform);
 
@@ -884,9 +884,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
 
-            // Restore the input simulation profile
-            PlayModeTestUtilities.PopControllerSimulationProfile();
-
+            iss.ControllerSimulationMode = oldSimMode;
             yield return null;
         }
 
@@ -1024,8 +1022,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return VerifyInitialBoundsCorrect(control);
             control.TranslationHandlesConfig.ShowHandleForZ = true;
             control.SmoothingActive = false;
-            PlayModeTestUtilities.PushControllerSimulationProfile();
-            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // move camera to look at translation sphere
             Transform transformHandle = control.gameObject.transform.Find("rigRoot/faceCenter_2");
@@ -1052,9 +1051,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
 
-            // Restore the input simulation profile
-            PlayModeTestUtilities.PopControllerSimulationProfile();
-
+            iss.ControllerSimulationMode = oldSimMode;
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
@@ -54,8 +54,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestClickEvents()
         {
-            PlayModeTestUtilities.PushControllerSimulationProfile();
-            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             // Subscribe to interactable's on click so we know the click went through
             bool wasClicked = false;
@@ -71,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.True(wasClicked);
 
-            PlayModeTestUtilities.PopControllerSimulationProfile();
+            iss.ControllerSimulationMode = oldSimMode;
         }
 
         [UnityTest]
@@ -188,8 +189,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestToggleEvents()
         {
-            PlayModeTestUtilities.PushControllerSimulationProfile();
-            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();
             interactable.transform.position = Vector3.forward * 2f;
@@ -213,7 +215,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(didSelect, "Toggle select did not fire");
             Assert.True(didUnselect, "Toggle unselect did not fire");
 
-            PlayModeTestUtilities.PopControllerSimulationProfile();
+            iss.ControllerSimulationMode = oldSimMode;
         }
 
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
@@ -115,8 +115,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Debug.Assert(slider.SliderValue == 0.5, "Slider should have value 0.5 at start");
 
             // Set up ggv simulation
-            PlayModeTestUtilities.PushControllerSimulationProfile();
-            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             var rightHand = new TestHand(Handedness.Right);
             Vector3 initialPos = new Vector3(0.05f, 0, 1.0f);
@@ -131,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // clean up
             GameObject.Destroy(pinchSliderObject);
-            PlayModeTestUtilities.PopControllerSimulationProfile();
+            iss.ControllerSimulationMode = oldSimMode;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator Setup()
         {
             PlayModeTestUtilities.Setup();
-            PlayModeTestUtilities.PushControllerSimulationProfile();
             TestUtilities.PlayspaceToOriginLookingForward();
             yield return null;
         }
@@ -44,7 +43,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             GameObject.Destroy(panObject);
             GameObject.Destroy(panZoom);
-            PlayModeTestUtilities.PopControllerSimulationProfile();
             PlayModeTestUtilities.TearDown();
             yield return null;
         }
@@ -130,7 +128,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             InstantiateFromPrefab();
 
-            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             TestHand handRight = new TestHand(Handedness.Right);
             yield return handRight.Show(new Vector3(0.0f, 0.0f, 0.6f));
@@ -148,6 +148,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return handRight.Hide();
             yield return handLeft.Hide();
+
+            iss.ControllerSimulationMode = oldSimMode;
+            yield return null;
         }
 
         /// <summary>
@@ -226,7 +229,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <param name="expectedScroll">The amount panZoom is expected to scroll</param>
         private IEnumerator RunGGVScrollTest(float expectedScroll)
         {
-            PlayModeTestUtilities.SetControllerSimulationMode(ControllerSimulationMode.HandGestures);
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldSimMode = iss.ControllerSimulationMode;
+            iss.ControllerSimulationMode = ControllerSimulationMode.HandGestures;
 
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);
@@ -242,6 +247,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(expectedScroll, totalPanDelta.y, 0.1, "pan delta is not correct");
 
             yield return handRight.Hide();
+
+            iss.ControllerSimulationMode = oldSimMode;
+            yield return null;
         }
 
         private void InstantiateFromCode(Vector3? position = null, Quaternion? rotation = null)


### PR DESCRIPTION
## Overview
This PR removes the use of PushControllerSimulationProfile() and PopControllerSimulationProfile() when trying to switch input simulation mode in tests (e.g. from articulated hand to gesture hand). Those two functions manipulate the profile of input simulation service, which does not have any impact on simulation mode after the initialization of the service. In this PR the current simulation mode is cached before switching and will be restored after the test is finished. This technique has been used in some other existing tests.

## Changes
- Fixes: #8468.