### PR TITLE
Change the input simulation mode in InputActions.MixedRealityInputSimulationProfile

### DIFF
--- a/Assets/MRTK/Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityInputSimulationProfile.asset
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityInputSimulationProfile.asset
@@ -42,22 +42,22 @@ MonoBehaviour:
   lookHorizontal: AXIS_4
   lookVertical: AXIS_5
   defaultEyeGazeSimulationMode: 0
-  defaultHandSimulationMode: 2
-  toggleLeftHandKey:
+  defaultControllerSimulationMode: 1
+  toggleLeftControllerKey:
     bindingType: 2
     code: 116
-  toggleRightHandKey:
+  toggleRightControllerKey:
     bindingType: 2
     code: 121
-  handHideTimeout: 0.2
-  leftHandManipulationKey:
+  controllerHideTimeout: 0.2
+  leftControllerManipulationKey:
     bindingType: 2
     code: 304
-  rightHandManipulationKey:
+  rightControllerManipulationKey:
     bindingType: 2
     code: 32
-  mouseHandRotationSpeed: 30
-  handRotateButton:
+  mouseControllerRotationSpeed: 30
+  controllerRotateButton:
     bindingType: 2
     code: 306
   defaultHandGesture: 2
@@ -67,6 +67,15 @@ MonoBehaviour:
   handGestureAnimationSpeed: 8
   holdStartDuration: 0.5
   navigationStartThreshold: 0.03
-  defaultHandDistance: 0.5
-  handDepthMultiplier: 0.03
-  handJitterAmount: 0
+  defaultControllerDistance: 0.5
+  controllerDepthMultiplier: 0.03
+  controllerJitterAmount: 0
+  motionControllerTriggerKey:
+    bindingType: 1
+    code: 0
+  motionControllerGrabKey:
+    bindingType: 2
+    code: 103
+  motionControllerMenuKey:
+    bindingType: 2
+    code: 109


### PR DESCRIPTION
## Overview

This PR changes the input simulation mode of InputActions.MixedRealityInputSimulationProfile.asset from articulated hand to gesture hand to match the description shown in the InputActionsExample scene.

## Changes
- Fixes: #8476.