### PR TITLE
Fixed missing gameobject references on xrsdk device manager profile

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/Profiles/OculusXRSDKDeviceManagerProfile.asset
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Profiles/OculusXRSDKDeviceManagerProfile.asset
@@ -13,19 +13,15 @@ MonoBehaviour:
   m_Name: OculusXRSDKDeviceManagerProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
-  ovrCameraRigPrefab: {fileID: 2343937678421323989, guid: 69a746aa83d0d0e45b4e2d33eab0fff4,
+  ovrCameraRigPrefab: {fileID: -6479404110534306751, guid: 69a746aa83d0d0e45b4e2d33eab0fff4,
     type: 3}
   renderAvatarHandsInsteadOfControllers: 1
-  localAvatarPrefab: {fileID: 6297684789857299957, guid: 5357c8e6c4495c04f90e97272375c294,
+  localAvatarPrefab: {fileID: 1703282039130822552, guid: 5357c8e6c4495c04f90e97272375c294,
     type: 3}
   useCustomHandMaterial: 1
   customHandMaterial: {fileID: 2100000, guid: 46180a965b426614f97a7239d1248a1a, type: 2}
   updateMaterialPinchStrengthValue: 1
   pinchStrengthMaterialProperty: _PressIntensity
-  minimumHandConfidence: 0
   lowConfidenceTimeThreshold: 0.2
   defaultCpuLevel: 2
   defaultGpuLevel: 2
-  resolutionScale: 1.25
-  useDynamicFixedFoveatedRendering: 1
-  fixedFoveatedRenderingLevel: 3


### PR DESCRIPTION
## Overview

Missing gameobject references on the xrsdk device manager profile caused CI breaks, fixing it here
