### PR TITLE
Fix XRSubsystemHelpers on 2019.2

### DIFF
--- a/Assets/MRTK/Core/Utilities/XRSubsystemHelpers.cs
+++ b/Assets/MRTK/Core/Utilities/XRSubsystemHelpers.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
 #else
+#if UNITY_2019_2_OR_NEWER
+using UnityEngine.XR;
+#endif
 using UnityEngine.Experimental.XR;
 #endif
 

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -9,7 +9,7 @@ The Mixed Reality Toolkit (MRTK) is a cross-platform toolkit for building Mixed 
 To get started with the Mixed Reality Toolkit, you will need:
 
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/)
-* [Unity 2018.4.x, Unity 2019](https://unity3d.com/get-unity/download/archive)
+* [Unity 2018.4 or Unity 2019.4](https://unity3d.com/get-unity/download/archive)
 
   MRTK supports both IL2CPP and .NET scripting backends on Unity 2018
 
@@ -21,7 +21,7 @@ To get started with the Mixed Reality Toolkit, you will need:
 ## Add MRTK to your Unity project
 
 > [!Note]
-> Users of Unity 2019.4, and newer, can use the Unity Package Manager to import MRTK. Please see [Using the Unity Package Manager](usingupm.md) for more information.
+> Users of Unity 2019.4 and newer, can use the Unity Package Manager to import MRTK. Please see [Using the Unity Package Manager](usingupm.md) for more information.
 
 ### Required
 

--- a/Documentation/Performance/PerfGettingStarted.md
+++ b/Documentation/Performance/PerfGettingStarted.md
@@ -207,7 +207,7 @@ MRTK Standard shader statistics example
 
 - [Unity Performance Optimization for Beginners](https://www.youtube.com/watch?v=1e5WY2qf600)
 - [Unity Performance Optimization Tutorials](https://unity3d.com/learn/tutorials/topics/performance-optimization)
-- [Unity Optimization Best Practices](https://docs.unity3d.com/2019.1/Documentation/Manual/BestPracticeUnderstandingPerformanceInUnity.html)
+- [Unity Optimization Best Practices](https://docs.unity3d.com/Documentation/Manual/BestPracticeUnderstandingPerformanceInUnity.html)
 - [Optimizing graphics performance](https://docs.unity3d.com/Manual/OptimizingGraphicsPerformance.html)
 - [Mobile Optimization Practical Guide](https://docs.unity3d.com/Manual/MobileOptimizationPracticalGuide.html)
 
@@ -225,5 +225,5 @@ MRTK Standard shader statistics example
 
 ### Mesh optimization
 
-- [Optimize 3D models](https://docs.microsoft.com/en-us/dynamics365/mixed-reality/import-tool/optimize-models#performance-targets)
-- [Best practices for converting and optimizing real-time 3D models](https://docs.microsoft.com/en-us/dynamics365/mixed-reality/import-tool/best-practices)
+- [Optimize 3D models](https://docs.microsoft.com/dynamics365/mixed-reality/import-tool/optimize-models#performance-targets)
+- [Best practices for converting and optimizing real-time 3D models](https://docs.microsoft.com/dynamics365/mixed-reality/import-tool/best-practices)


### PR DESCRIPTION
## Overview

2019.2 appears to have moved one subsystem definition while leaving the others in the experimental namespace. We don't want the actually functionality here, since most of it isn't stable or fully usable until 2019.3, but I'm adding this so it still builds.

## Changes
- Fixes: #8501 
