### PR TITLE
Upgrading documentation fixes/updates

### DIFF
--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -7,13 +7,11 @@
 - [2.0.0 to 2.1.0](#updating-200-to-210)
 - [RC2 to 2.0.0](#updating-rc2-to-200)
 
-## Upgrading to a new version of MRTK
+## Upgrading new version of MRTK
 
-The 2.4.0 release has some changes that may impact application projects. Breaking change details, including mitigation guidance, can be found in the [**Updating 2.3.0 to 2.4.0**](Updating.md#updating-230-to-240) article.
-
-*Starting with 2.4.0, it is strongly recommended to run the [migration tool](Tools/MigrationWindow.md)
-after getting the MRTK update** to auto-fix and upgrade from deprecated components and adjust to
-breaking changes. The migration tool is part of the **Tools** package.
+*It is strongly recommended to run the [migration tool](Tools/MigrationWindow.md) after getting the MRTK update*
+to auto-fix and upgrade from deprecated components and adjust to breaking changes. The migration tool is part of
+the **Tools** package.
 
 ### Unity asset (.unitypackage) files
 
@@ -21,7 +19,7 @@ For the smoothest upgrade path, please use the following steps.
 
 1. Save a copy of your current project, in case you hit any snags at any point in the upgrade steps.
 1. Close Unity
-1. Inside the *Assets* folder, delete most of the **MixedRealityToolkit** folders, along with their .meta files (the project may not have all listed folders)
+1. Inside the *Assets* folder, delete the following **MixedRealityToolkit** folders, along with their .meta files (the project may not have all listed folders)
     - MixedRealityToolkit
     - MixedRealityToolkit.Examples
     - MixedRealityToolkit.Extensions

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -7,7 +7,7 @@
 - [2.0.0 to 2.1.0](#updating-200-to-210)
 - [RC2 to 2.0.0](#updating-rc2-to-200)
 
-## Upgrading new version of MRTK
+## Upgrading to a new version of MRTK
 
 *It is strongly recommended to run the [migration tool](Tools/MigrationWindow.md) after getting the MRTK update*
 to auto-fix and upgrade from deprecated components and adjust to breaking changes. The migration tool is part of


### PR DESCRIPTION
This PR contains a couple of tweaks to the updating guide to make things a little clearer:

Removes specific references to 2.4.0 as being the latest (we generally just recommend using the migration tool from here on out, so there's no reason to call out 2.4.0 in the 2.5.0 release)
Changes the phrase "most of" to "the following" because the instructions actually say which folders to delete, and "most of" is terribly, terribly imprecise when it comes to telling people to delete things ("delete most of it, it's fine!")