### PR TITLE
Fixed occasional warning on null size collider when instantiating bounds control with activation on start

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
@@ -256,10 +256,11 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             else
             {
                 midpointVisual = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                if (config.HandlePrefabColliderType != HandlePrefabCollider.Sphere)
-                {
-                    Object.Destroy(midpointVisual.GetComponent<SphereCollider>());
-                }
+                // deactivate collider on visuals and register for deletion - actual collider
+                // of handle is attached to the handle gameobject, not the visual
+                var collider = midpointVisual.GetComponent<SphereCollider>();
+                collider.enabled = false;
+                Object.Destroy(collider);
             }
 
             Quaternion realignment = GetRotationRealignment(handleIndex);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
@@ -137,11 +137,15 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             GameObject prefabType = isFlattened ? config.HandleSlatePrefab : config.HandlePrefab;
             if (prefabType == null)
             {
-                // instantiate default prefab, a cube. Remove the box collider from it
+                // instantiate default prefab, a cube with box collider
                 cornerVisual = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 cornerVisual.transform.parent = parent.transform;
                 cornerVisual.transform.localPosition = Vector3.zero;
-                GameObject.Destroy(cornerVisual.GetComponent<BoxCollider>());
+                // deactivate collider on visuals and register for deletion - actual collider
+                // of handle is attached to the handle gameobject, not the visual
+                var collider = cornerVisual.GetComponent<BoxCollider>();
+                collider.enabled = false;
+                Object.Destroy(collider);
             }
             else
             {

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -155,8 +155,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator BoundsControlInstantiate()
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            Assert.IsNotNull(boundsControl, "Bounds control creation failed!");
             yield return VerifyInitialBoundsCorrect(boundsControl);
-            Assert.IsNotNull(boundsControl);
 
             GameObject.Destroy(boundsControl.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object
@@ -170,8 +170,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator HandleColliderInstantiation([ValueSource("handleTestData")] HandleTestData testData)
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            Assert.IsNotNull(boundsControl, "Bounds control creation failed!");
             yield return VerifyInitialBoundsCorrect(boundsControl);
-            Assert.IsNotNull(boundsControl);
             boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateOnStart;
             yield return null;
 

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -164,6 +164,33 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Verify correct collider attachment for handles after bounds control instantiation
+        /// </summary>
+        [UnityTest]
+        public IEnumerator HandleColliderInstantiation([ValueSource("handleTestData")] HandleTestData testData)
+        {
+            BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            Assert.IsNotNull(boundsControl);
+            boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateOnStart;
+            yield return null;
+
+            // get handle and their visuals and check if collider is only attached to the handle gameobject
+            // but not the handle visuals
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+            Transform handle = rigRoot.transform.Find(testData.handleName);
+            Assert.IsNotNull(handle, "couldn't find handle");
+            Transform handleVisual = rigRoot.transform.Find(testData.handleVisualPath);
+            Assert.IsNotNull(handleVisual, "couldn't find handle visual");
+
+            Assert.IsNotNull(handle.GetComponent<Collider>(), "Handle should have collider.");
+            Assert.IsNull(handleVisual.GetComponent<Collider>(), "Visual should not have collider.");
+
+            yield return null;
+        }
+
+        /// <summary>
         /// Test that if we update the bounds of a box collider, that the corners will move correctly
         /// </summary>
         [UnityTest]


### PR DESCRIPTION
## Overview
- disabled collider on visuals before removing them in case they get updated before they're removed at the end of the frame (could cause a warning)
- readded unconditional collider removal on rotation handles as colliders for handles are directly attached to the handle object itself and not the visuals
- added test to verify that handles will always attach the handle collider on the handle gameobject and not the visual




## Changes
- Fixes:  #8550 


## Verification
added test