### PR TITLE
Fix controller popup window when MRTK isn't initialized

### DIFF
--- a/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
@@ -196,6 +196,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             window = null;
 
+            if (!MixedRealityToolkit.IsInitialized)
+            {
+                throw new InvalidOperationException("Mixed Reality Toolkit hasn't been initialized yet! Open a scene with a Mixed Reality Toolkit to initialize it before editing the controller mappings.");
+            }
+
             window = CreateInstance<ControllerPopupWindow>();
             window.thisWindow = window;
             window.titleContent = new GUIContent($"{controllerMapping.Description} - Input Action Assignment");

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -113,11 +113,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 if (controllerType == null) { continue; }
 
                 Handedness handedness = controllerMapping.Handedness;
-                bool useCustomInteractionMappings = controllerMapping.HasCustomInteractionMappings;
                 SupportedControllerType supportedControllerType = controllerMapping.SupportedControllerType;
-
-                var controllerMappingProperty = controllerList.GetArrayElementAtIndex(i);
-                var handednessProperty = controllerMappingProperty.FindPropertyRelative("handedness");
 
                 ControllerMappingSignature currentSignature = new ControllerMappingSignature(supportedControllerType, handedness);
                 if(!controllersAffectedByMappingSignatures.ContainsKey(currentSignature))


### PR DESCRIPTION
## Overview

Adds a check before creating the `ControllerPopupWindow` that the MRTK object is initialized. If it's not initialized, we can't get the input action profile, and thus can't get the input actions to display in the window.
Also removed some unused variables.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8368
