### PR TITLE
Check the presence of XR device before dependent subsequent steps

### DIFF
--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -44,6 +44,11 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             CeilingPhysicsLayer = BoundaryProfile.CeilingPhysicsLayer;
         }
 
+        /// <summary>
+        /// Whether any XR device is present.
+        /// </summary>
+        protected virtual bool IsXRDevicePresent { get; } = true;
+
         #region IMixedRealityService Implementation
 
         private MixedRealityBoundaryVisualizationProfile BoundaryProfile { get; }
@@ -60,7 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             // after profile change reads the correct data.
             ReadProfile();
 
-            if (!Application.isPlaying) { return; }
+            if (!Application.isPlaying || !IsXRDevicePresent) { return; }
 
             boundaryEventData = new BoundaryEventData(EventSystem.current);
 

--- a/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
@@ -42,14 +42,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         /// <inheritdoc/>
         public override string Name { get; protected set; } = "XR SDK Boundary System";
 
-        /// <inheritdoc/>
-        public override void Initialize()
-        {
-            if (!Application.isPlaying || !IsXRDevicePresent) { return; }
-
-            base.Initialize();
-        }
-
         #endregion IMixedRealityService Implementation
 
         /// <inheritdoc/>

--- a/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
@@ -26,6 +26,17 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
         }
 
+        /// <inheritdoc/>
+        protected override bool IsXRDevicePresent
+        {
+            get
+            {
+                List<InputDevice> devices = new List<InputDevice>();
+                InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.HeadMounted, devices);
+                return devices.Count <= 0;
+            }
+        }
+
         #region IMixedRealityService Implementation
 
         /// <inheritdoc/>
@@ -34,12 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         /// <inheritdoc/>
         public override void Initialize()
         {
-            if (!Application.isPlaying) { return; }
-
-            List<InputDevice> devices = new List<InputDevice>();
-            InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.HeadMounted, devices);
-
-            if (devices.Count <= 0) { return; }
+            if (!Application.isPlaying || !IsXRDevicePresent) { return; }
 
             base.Initialize();
         }

--- a/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
@@ -33,7 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             {
                 List<InputDevice> devices = new List<InputDevice>();
                 InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.HeadMounted, devices);
-                return devices.Count <= 0;
+                return devices.Count > 0;
             }
         }
 

--- a/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
+++ b/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
@@ -24,20 +24,13 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             MixedRealityBoundaryVisualizationProfile profile,
             ExperienceScale scale) : base(profile, scale) { }
 
+        /// <inheritdoc/>
+        protected override bool IsXRDevicePresent => XRDevice.isPresent;
+
         #region IMixedRealityService Implementation
 
         /// <inheritdoc/>
         public override string Name { get; protected set; } = "Mixed Reality Boundary System";
-
-        /// <inheritdoc/>
-        public override void Initialize()
-        {
-            // The base class initialization should be run every time. This ensures
-            // that profile settings are read at the correct time.
-            base.Initialize();
-
-            if (!Application.isPlaying || !XRDevice.isPresent) { return; }
-        }
 
         #endregion IMixedRealityService Implementation
 


### PR DESCRIPTION
## Overview
This PR fixes warnings created by MixedRealityBoundarySystem by checking whether there is any XR device before performing subsequent steps that require such device (e.g. SetTrackingSpace()). Thanks @keveleigh for coming up with the idea of adding the virtual IsXRDevicePresent property in base class that defaults to true to prevent a breaking change.

## Changes
- Fixes: #8568.