### PR TITLE
Pull in the analytics update into the latest release (i.e. default github.io page)

### DIFF
--- a/scripts/docs/templates/mrtk/styles/main.js
+++ b/scripts/docs/templates/mrtk/styles/main.js
@@ -30,6 +30,18 @@ function createSharedTags()
 	link.href = rootDir+'web/version.css';
 	link.media = 'all';
 	head.appendChild(link);
+
+	var analytics = `<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-177859076-1"></script>
+	<script>
+	  window.dataLayer = window.dataLayer || [];
+	  function gtag(){dataLayer.push(arguments);}
+	  gtag('js', new Date());
+	
+	  gtag('config', 'UA-177859076-1');
+	</script>
+	`
+	head.insertAdjacentHTML('afterbegin', analytics);
 }
 
 createSharedTags();


### PR DESCRIPTION
This change cherry-picks the analytics change in https://github.com/microsoft/MixedRealityToolkit-Unity/pull/8532 into the latest release.

So the reason we have to do this is interesting:

Prior to last month-ish, the default branch that showed up on our github.io was mrtk_development, which meant that the previous change would have worked about a month ago. We recently made a change to switch our default github.io branch (https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html) to point to the latest release (i.e. right now, 2.4), which means that the previous change didn't actually show up in the default/root folder.

In order to make this change show up, we need to cherry pick the change and then rebuild the docs (which will happen automatically once this gets submitted)