### PR TITLE
Remove 2019 test dependencies when building on 2018

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -191,6 +191,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 #if !UNITY_2019_3_OR_NEWER
                 if(PackageReferencesUnity2019.Contains(reference))
                 {
+                    Debug.LogWarning($"Skipping processing {reference} for {toReturn.Name}, as it's for Unity 2019.3+");
                     continue;
                 }
 #endif

--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -27,6 +27,18 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         };
 
         /// <summary>
+        /// These package refernces are only for Unity 2019.3+ and shouldn't be included when using older versions
+        /// </summary>
+        private static readonly HashSet<string> PackageReferencesUnity2019 = new HashSet<string>()
+        {
+            "Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus",
+            "Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.Editor",
+            "Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.Handtracking.Editor",
+            "Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality",
+            "Microsoft.MixedReality.Toolkit.Providers.XRSDK"
+        };
+
+        /// <summary>
         /// Gets the name of this Unity Project.
         /// </summary>
         public string UnityProjectName { get; }
@@ -175,6 +187,14 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                     Debug.LogWarning($"Skipping processing {reference} for {toReturn.Name}, as it's marked as excluded.");
                     continue;
                 }
+
+#if !UNITY_2019_3_OR_NEWER
+                if(PackageReferencesUnity2019.Contains(reference))
+                {
+                    continue;
+                }
+#endif
+
                 string packageCandidate = $"com.{reference.ToLower()}";
                 if (builtInPackagesWithoutSource.Any(t => packageCandidate.StartsWith(t)))
                 {

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -602,7 +602,6 @@ $AsmDefExceptions = [System.Collections.Generic.HashSet[String]]@(
     "Assets/MRTK/Providers/Oculus/XRSDK/Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.asmdef",
     "Assets/MRTK/Providers/Oculus/XRSDK/Editor/Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.Editor.asmdef",
     "Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.Handtracking.Editor.asmdef",
-    "Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Utils/Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.Handtracking.Utilities.asmdef",
     "Assets/MRTK/Providers/OpenVR/Microsoft.MixedReality.Toolkit.Providers.OpenVR.asmdef",
     "Assets/MRTK/Providers/UnityAR/Microsoft.MixedReality.Toolkit.Providers.UnityAR.asmdef",
     "Assets/MRTK/Providers/UnityAR/Editor/Microsoft.MixedReality.Toolkit.UnityAR.Editor.asmdef",


### PR DESCRIPTION
## Overview
Unit tests for the Oculus Integration tool have dependencies on asmdefs that are for Unity 2019.3+ 

This caused breaks in the CI pipeline. We're removing those dependencies when building the nuget packages as those tests are disabled for Unity 2018 versions anyways.