### PR TITLE
Add a workaround for the ARM64 issue for IL2CPP + WSA builds

### DIFF
--- a/Assets/MRTK/Tools/BuildWindow/Arm64Workaround.cs
+++ b/Assets/MRTK/Tools/BuildWindow/Arm64Workaround.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This file contains a build post processor that adds a specific compiler flag to avoid
+// the ARM64 compiler issue described in this issue:
+// https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7624
+// It works by updating the specific .vxcproj file and only modifying the ARM64 compiler
+// option to turn off the specific optmization that leads to the ARM64 issue
+
+// This build post processor should only after during UWP player build.
+// This ifdef exists so that we don't add extra overhead to other platform builds.
+#if UNITY_WSA && UNITY_2019_4_OR_NEWER
+using System.IO;
+using System.Xml.Linq;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+
+public class Arm64Workaround : IPostprocessBuildWithReport
+{
+    private const string VcxProjectRelativeFilePath = "Il2CppOutputProject/Il2CppOutputProject.vcxproj";
+    private const string Arm64Condtion = "'$(Platform)'=='ARM64'";
+    private const string WorkaroundCompilerFlags = " --compiler-flags=\"-d2ssa-cfg-jt-\"";
+
+    // Arbitrary callback order, chosen to be larger so that it runs after other things that
+    // a developer may have already.
+    public int callbackOrder => 100;
+
+    public void OnPostprocessBuild(BuildReport report)
+    {
+        EnsureWorkaround(Path.Combine(report.summary.outputPath, VcxProjectRelativeFilePath));
+    }
+
+    private static void EnsureWorkaround(string path)
+    {
+        XElement root = XElement.Load(path);
+
+        // Adding the workaround is basically a two-step process:
+        // 1) Finding the actual build command line (the thing we will append --compiler-flags="-d2ssa-cfg-jt-"
+        // to.
+        // 2) Appending a new PropertyGroup that is conditional on Arm64Condtion, which appends those
+        // compiler flags.
+        // If this code discovers that the work was already done (i.e. there's already some conditional there
+        // with a build command line override, or there's a command line with compiler flags, then
+        // we abort.
+        string buildCommandLineText = "";
+        string rebuildCommandLineText = "";
+        foreach (XElement propertyGroup in root.Elements(root.GetDefaultNamespace() + "PropertyGroup"))
+        {
+            XAttribute condition = propertyGroup.Attribute("Condition");
+
+            // We look for both, even though we actually only use one (i.e. this is to provide another layer
+            // of assurance that we actually got the right PropertyGroup element).
+            XElement buildCommandLine = propertyGroup.Element(root.GetDefaultNamespace() + "NMakeBuildCommandLine");
+            XElement rebuildCommandLine = propertyGroup.Element(root.GetDefaultNamespace() + "NMakeReBuildCommandLine");
+            if (buildCommandLine != null && rebuildCommandLine != null)
+            {
+                // It's possible that we have already had the workaround in this file, in which case there will be
+                // an ARM64 condition with the buildCommandLine value present. In that case, we just return and
+                // don't do anything. It's also possible there are already compiler flags set which is not the default
+                // and if this happens, avoid doing anything (so as to not cause a problem in untested scenarios)
+                if (condition != null && condition.Value == Arm64Condtion || buildCommandLine.Value.Contains("--compiler-flags"))
+                {
+                    return;
+                }
+
+                buildCommandLineText = buildCommandLine.Value;
+                rebuildCommandLineText = rebuildCommandLine.Value;
+            }
+        }
+
+        // This is unexpected for the workaround but if this happens, we should abort.
+        if (buildCommandLineText.Length == 0)
+        {
+            return;
+        }
+
+        buildCommandLineText += WorkaroundCompilerFlags;
+
+        // The newly added node has to be appended to the end of the Project node, otherwise
+        // its values will not take effect (i.e. the last setter of the given values will win)
+        XElement newPropertyGroup = new XElement(root.GetDefaultNamespace() + "PropertyGroup");
+        newPropertyGroup.SetAttributeValue("Condition", Arm64Condtion);
+
+        XElement newBuildCommandLine = new XElement(root.GetDefaultNamespace() + "NMakeBuildCommandLine");
+        XElement newRebuildCommandLine = new XElement(root.GetDefaultNamespace() + "NMakeReBuildCommandLine");
+        newBuildCommandLine.SetValue(buildCommandLineText);
+        newRebuildCommandLine.SetValue(rebuildCommandLineText);
+
+        newPropertyGroup.Add(newBuildCommandLine);
+        newPropertyGroup.Add(newRebuildCommandLine);
+
+        root.Add(newPropertyGroup);
+        root.Save(path);
+    }
+}
+#endif // UNITY_WSA && UNITY_2019_4_OR_NEWER

--- a/Assets/MRTK/Tools/BuildWindow/Arm64Workaround.cs
+++ b/Assets/MRTK/Tools/BuildWindow/Arm64Workaround.cs
@@ -5,9 +5,9 @@
 // the ARM64 compiler issue described in this issue:
 // https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7624
 // It works by updating the specific .vxcproj file and only modifying the ARM64 compiler
-// option to turn off the specific optmization that leads to the ARM64 issue
+// option to turn off the specific optimization that leads to the ARM64 issue
 
-// This build post processor should only after during UWP player build.
+// This build post processor should only run after a UWP player build.
 // This ifdef exists so that we don't add extra overhead to other platform builds.
 #if UNITY_WSA && UNITY_2019_4_OR_NEWER
 using System.IO;
@@ -15,82 +15,85 @@ using System.Xml.Linq;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 
-public class Arm64Workaround : IPostprocessBuildWithReport
+namespace Microsoft.MixedReality.Toolkit.Build.Editor
 {
-    private const string VcxProjectRelativeFilePath = "Il2CppOutputProject/Il2CppOutputProject.vcxproj";
-    private const string Arm64Condtion = "'$(Platform)'=='ARM64'";
-    private const string WorkaroundCompilerFlags = " --compiler-flags=\"-d2ssa-cfg-jt-\"";
-
-    // Arbitrary callback order, chosen to be larger so that it runs after other things that
-    // a developer may have already.
-    public int callbackOrder => 100;
-
-    public void OnPostprocessBuild(BuildReport report)
+    public class Arm64Workaround : IPostprocessBuildWithReport
     {
-        EnsureWorkaround(Path.Combine(report.summary.outputPath, VcxProjectRelativeFilePath));
-    }
+        private const string VcxProjectRelativeFilePath = "Il2CppOutputProject/Il2CppOutputProject.vcxproj";
+        private const string Arm64Condition = "'$(Platform)'=='ARM64'";
+        private const string WorkaroundCompilerFlags = " --compiler-flags=\"-d2ssa-cfg-jt-\"";
 
-    private static void EnsureWorkaround(string path)
-    {
-        XElement root = XElement.Load(path);
+        // Arbitrary callback order, chosen to be larger so that it runs after other things that
+        // a developer may have already.
+        public int callbackOrder => 100;
 
-        // Adding the workaround is basically a two-step process:
-        // 1) Finding the actual build command line (the thing we will append --compiler-flags="-d2ssa-cfg-jt-"
-        // to.
-        // 2) Appending a new PropertyGroup that is conditional on Arm64Condtion, which appends those
-        // compiler flags.
-        // If this code discovers that the work was already done (i.e. there's already some conditional there
-        // with a build command line override, or there's a command line with compiler flags, then
-        // we abort.
-        string buildCommandLineText = "";
-        string rebuildCommandLineText = "";
-        foreach (XElement propertyGroup in root.Elements(root.GetDefaultNamespace() + "PropertyGroup"))
+        public void OnPostprocessBuild(BuildReport report)
         {
-            XAttribute condition = propertyGroup.Attribute("Condition");
+            EnsureWorkaround(Path.Combine(report.summary.outputPath, VcxProjectRelativeFilePath));
+        }
 
-            // We look for both, even though we actually only use one (i.e. this is to provide another layer
-            // of assurance that we actually got the right PropertyGroup element).
-            XElement buildCommandLine = propertyGroup.Element(root.GetDefaultNamespace() + "NMakeBuildCommandLine");
-            XElement rebuildCommandLine = propertyGroup.Element(root.GetDefaultNamespace() + "NMakeReBuildCommandLine");
-            if (buildCommandLine != null && rebuildCommandLine != null)
+        private static void EnsureWorkaround(string path)
+        {
+            XElement root = XElement.Load(path);
+
+            // Adding the workaround is basically a two-step process:
+            // 1) Finding the actual build command line (the thing we will append --compiler-flags="-d2ssa-cfg-jt-"
+            // to.
+            // 2) Appending a new PropertyGroup that is conditional on Arm64Condition, which appends those
+            // compiler flags.
+            // If this code discovers that the work was already done (i.e. there's already some conditional there
+            // with a build command line override, or there's a command line with compiler flags, then
+            // we abort.
+            string buildCommandLineText = "";
+            string rebuildCommandLineText = "";
+            foreach (XElement propertyGroup in root.Elements(root.GetDefaultNamespace() + "PropertyGroup"))
             {
-                // It's possible that we have already had the workaround in this file, in which case there will be
-                // an ARM64 condition with the buildCommandLine value present. In that case, we just return and
-                // don't do anything. It's also possible there are already compiler flags set which is not the default
-                // and if this happens, avoid doing anything (so as to not cause a problem in untested scenarios)
-                if (condition != null && condition.Value == Arm64Condtion || buildCommandLine.Value.Contains("--compiler-flags"))
+                XAttribute condition = propertyGroup.Attribute("Condition");
+
+                // We look for both, even though we actually only use one (i.e. this is to provide another layer
+                // of assurance that we actually got the right PropertyGroup element).
+                XElement buildCommandLine = propertyGroup.Element(root.GetDefaultNamespace() + "NMakeBuildCommandLine");
+                XElement rebuildCommandLine = propertyGroup.Element(root.GetDefaultNamespace() + "NMakeReBuildCommandLine");
+                if (buildCommandLine != null && rebuildCommandLine != null)
                 {
-                    return;
+                    // It's possible that we have already had the workaround in this file, in which case there will be
+                    // an ARM64 condition with the buildCommandLine value present. In that case, we just return and
+                    // don't do anything. It's also possible there are already compiler flags set which is not the default
+                    // and if this happens, avoid doing anything (so as to not cause a problem in untested scenarios)
+                    if (condition != null && condition.Value == Arm64Condition || buildCommandLine.Value.Contains("--compiler-flags"))
+                    {
+                        return;
+                    }
+
+                    buildCommandLineText = buildCommandLine.Value;
+                    rebuildCommandLineText = rebuildCommandLine.Value;
                 }
-
-                buildCommandLineText = buildCommandLine.Value;
-                rebuildCommandLineText = rebuildCommandLine.Value;
             }
+
+            // This is unexpected for the workaround but if this happens, we should abort.
+            if (buildCommandLineText.Length == 0)
+            {
+                return;
+            }
+
+            buildCommandLineText += WorkaroundCompilerFlags;
+
+            // The newly added node has to be appended to the end of the Project node, otherwise
+            // its values will not take effect (i.e. the last setter of the given values will win)
+            XElement newPropertyGroup = new XElement(root.GetDefaultNamespace() + "PropertyGroup");
+            newPropertyGroup.SetAttributeValue("Condition", Arm64Condition);
+
+            XElement newBuildCommandLine = new XElement(root.GetDefaultNamespace() + "NMakeBuildCommandLine");
+            XElement newRebuildCommandLine = new XElement(root.GetDefaultNamespace() + "NMakeReBuildCommandLine");
+            newBuildCommandLine.SetValue(buildCommandLineText);
+            newRebuildCommandLine.SetValue(rebuildCommandLineText);
+
+            newPropertyGroup.Add(newBuildCommandLine);
+            newPropertyGroup.Add(newRebuildCommandLine);
+
+            root.Add(newPropertyGroup);
+            root.Save(path);
         }
-
-        // This is unexpected for the workaround but if this happens, we should abort.
-        if (buildCommandLineText.Length == 0)
-        {
-            return;
-        }
-
-        buildCommandLineText += WorkaroundCompilerFlags;
-
-        // The newly added node has to be appended to the end of the Project node, otherwise
-        // its values will not take effect (i.e. the last setter of the given values will win)
-        XElement newPropertyGroup = new XElement(root.GetDefaultNamespace() + "PropertyGroup");
-        newPropertyGroup.SetAttributeValue("Condition", Arm64Condtion);
-
-        XElement newBuildCommandLine = new XElement(root.GetDefaultNamespace() + "NMakeBuildCommandLine");
-        XElement newRebuildCommandLine = new XElement(root.GetDefaultNamespace() + "NMakeReBuildCommandLine");
-        newBuildCommandLine.SetValue(buildCommandLineText);
-        newRebuildCommandLine.SetValue(rebuildCommandLineText);
-
-        newPropertyGroup.Add(newBuildCommandLine);
-        newPropertyGroup.Add(newRebuildCommandLine);
-
-        root.Add(newPropertyGroup);
-        root.Save(path);
     }
 }
 #endif // UNITY_WSA && UNITY_2019_4_OR_NEWER

--- a/Assets/MRTK/Tools/BuildWindow/Arm64Workaround.cs.meta
+++ b/Assets/MRTK/Tools/BuildWindow/Arm64Workaround.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 17d5a9b7aaf3c964eb7749d1aafa3911
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
With some of our recent testing, we found that the ARM64 compiler bug described here https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7624 is actually affecting some new code that was introduced in the 2.5 timeframe. This time around, it's actually a lot worse because it's leading to crashes.

While there's been a fix to the VS compiler that should be coming in a future VS update, there's still going to be some time between the latest MRTK 2.5 release and the VS compiler update, during which things will be a lot worse.

There's a workaround that was identified in the linked issue, and I figured it would be best to add some auto-magic to the build process that will automatically update your IL2CPP project to add this compiler flag ONLY to the ARM64 build option.

This code will only run:
1. Unity 2019 and above (i.e. ARM64 supporting and above)
2. When building UWP/WSA (i.e. HL2, HL1 should no-op when it doesn't find the ARM64 option)
3. If the workaround hasn't run before

This code will also NOT run if someone has already customized their compiler options (I didn't want to blow existing customizations away) or if someone had their own ARM64 NMakeBuildCommandLine customization. Basically this will only do work in the default IL2CPP build, and if you've done work to heavily customize it this should no-op.