### PR TITLE
Refactor SpatialInteractionManager access and conversions from Unity to native SpatialInteractionSource

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -90,11 +90,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         {
             using (UpdateHandMeshPerfMarker.Auto())
             {
-                if (sourceState == null)
-                {
-                    return;
-                }
-
                 MixedRealityHandTrackingProfile handTrackingProfile = null;
                 MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
                 if (inputSystemProfile != null)

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -90,6 +90,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         {
             using (UpdateHandMeshPerfMarker.Auto())
             {
+                if (sourceState == null)
+                {
+                    return;
+                }
+
                 MixedRealityHandTrackingProfile handTrackingProfile = null;
                 MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
                 if (inputSystemProfile != null)
@@ -174,7 +179,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 
                             /// Hands should follow the Playspace to accommodate teleporting, so fold in the Playspace transform.
                             Vector3 positionUnity = MixedRealityPlayspace.TransformPoint(translation.ToUnityVector3());
-                            Quaternion rotationUnity = MixedRealityPlayspace.Rotation * rotation.ToUnityQuaternion(); 
+                            Quaternion rotationUnity = MixedRealityPlayspace.Rotation * rotation.ToUnityQuaternion();
 
                             HandMeshInfo handMeshInfo = new HandMeshInfo
                             {

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
@@ -13,7 +13,7 @@ using Microsoft.Windows.Graphics.Holographic;
 #else
 using Windows.Graphics.Holographic;
 #endif
-#elif DOTNETWINRT_PRESENT
+#else
 using Microsoft.Windows.Graphics.Holographic;
 using Microsoft.Windows.Perception.Spatial;
 using Microsoft.Windows.UI.Input.Spatial;

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
@@ -12,12 +12,12 @@ using Windows.UI.Input.Spatial;
 using Microsoft.Windows.Graphics.Holographic;
 #else
 using Windows.Graphics.Holographic;
-#endif
+#endif // DOTNETWINRT_PRESENT
 #else
 using Microsoft.Windows.Graphics.Holographic;
 using Microsoft.Windows.Perception.Spatial;
 using Microsoft.Windows.UI.Input.Spatial;
-#endif
+#endif // WINDOWS_UWP
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
@@ -35,6 +35,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         private static SpatialInteractionManager spatialInteractionManager = null;
+
+        /// <summary>
+        /// Provides access to the current native SpatialInteractionManager.
+        /// </summary>
         public static SpatialInteractionManager SpatialInteractionManager
         {
             get

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
@@ -7,6 +7,7 @@ using System;
 using System.Runtime.InteropServices;
 #if WINDOWS_UWP
 using Windows.Perception.Spatial;
+using Windows.UI.Input.Spatial;
 #if DOTNETWINRT_PRESENT
 using Microsoft.Windows.Graphics.Holographic;
 #else
@@ -15,6 +16,7 @@ using Windows.Graphics.Holographic;
 #elif DOTNETWINRT_PRESENT
 using Microsoft.Windows.Graphics.Holographic;
 using Microsoft.Windows.Perception.Spatial;
+using Microsoft.Windows.UI.Input.Spatial;
 #endif
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
@@ -32,6 +34,23 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         public static IWindowsMixedRealityUtilitiesProvider UtilitiesProvider { get; set; } = null;
 
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+        private static SpatialInteractionManager spatialInteractionManager = null;
+        public static SpatialInteractionManager SpatialInteractionManager
+        {
+            get
+            {
+                if (spatialInteractionManager == null)
+                {
+                    UnityEngine.WSA.Application.InvokeOnUIThread(() =>
+                    {
+                        spatialInteractionManager = SpatialInteractionManager.GetForCurrentView();
+                    }, true);
+                }
+
+                return spatialInteractionManager;
+            }
+        }
+
 #if ENABLE_DOTNET
         [DllImport("DotNetNativeWorkaround.dll", EntryPoint = "MarshalIInspectable")]
         private static extern void GetSpatialCoordinateSystem(IntPtr nativePtr, out SpatialCoordinateSystem coordinateSystem);
@@ -66,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         /// </summary>
         /// <remarks>
         /// Changing the state of the native objects received via this API may cause unpredictable
-        /// behaviour and rendering artifacts, especially if Unity also reasons about that same state.
+        /// behavior and rendering artifacts, especially if Unity also reasons about that same state.
         /// </remarks>
         public static SpatialCoordinateSystem SpatialCoordinateSystem
         {

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
@@ -118,6 +118,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
                 SpatialInteractionSourceState sourceState = interactionSourceState.source.GetSpatialInteractionSourceState();
 
+                if (sourceState == null)
+                {
+                    return;
+                }
+
 #if WINDOWS_UWP
                 handMeshProvider?.UpdateHandMesh(sourceState);
 #endif // WINDOWS_UWP

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
@@ -10,14 +10,12 @@ using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine.XR.WSA.Input;
 #if WINDOWS_UWP || DOTNETWINRT_PRESENT
-using System;
+using Microsoft.MixedReality.Toolkit.Windows.Input;
 using UnityEngine;
 #if WINDOWS_UWP
-using Windows.Perception;
 using Windows.Perception.People;
 using Windows.UI.Input.Spatial;
 #elif DOTNETWINRT_PRESENT
-using Microsoft.Windows.Perception;
 using Microsoft.Windows.Perception.People;
 using Microsoft.Windows.UI.Input.Spatial;
 #endif
@@ -70,26 +68,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public override bool IsInPointingPose => handDefinition.IsInPointingPose;
 
 #if UNITY_WSA
-#if WINDOWS_UWP || DOTNETWINRT_PRESENT
-        private SpatialInteractionManager spatialInteractionManager = null;
-        private SpatialInteractionManager SpatialInteractionManager
-        {
-            get
-            {
-                if (spatialInteractionManager == null)
-                {
-                    UnityEngine.WSA.Application.InvokeOnUIThread(() =>
-                    {
-                        spatialInteractionManager = SpatialInteractionManager.GetForCurrentView();
-                    }, true);
-                }
-
-                return spatialInteractionManager;
-            }
-        }
-
-#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
-
         #region Update data functions
 
         private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityArticulatedHand.UpdateController");
@@ -138,44 +116,37 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     return;
                 }
 
-                PerceptionTimestamp perceptionTimestamp = PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now);
-                IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager?.GetDetectedSourcesAtTimestamp(perceptionTimestamp);
-                foreach (SpatialInteractionSourceState sourceState in sources)
-                {
-                    if (sourceState.Source.Id.Equals(interactionSourceState.source.id))
-                    {
+                SpatialInteractionSourceState sourceState = interactionSourceState.source.GetSpatialInteractionSourceState();
+
 #if WINDOWS_UWP
-                        handMeshProvider?.UpdateHandMesh(sourceState);
+                handMeshProvider?.UpdateHandMesh(sourceState);
 #endif // WINDOWS_UWP
 
-                        HandPose handPose = sourceState.TryGetHandPose();
+                HandPose handPose = sourceState.TryGetHandPose();
 
-                        if (handPose != null && handPose.TryGetJoints(WindowsMixedRealityUtilities.SpatialCoordinateSystem, jointIndices, jointPoses))
+                if (handPose != null && handPose.TryGetJoints(WindowsMixedRealityUtilities.SpatialCoordinateSystem, jointIndices, jointPoses))
+                {
+                    for (int i = 0; i < jointPoses.Length; i++)
+                    {
+                        Vector3 jointPosition = jointPoses[i].Position.ToUnityVector3();
+                        Quaternion jointOrientation = jointPoses[i].Orientation.ToUnityQuaternion();
+
+                        // We want the joints to follow the playspace, so fold in the playspace transform here to 
+                        // put the joint pose into world space.
+                        jointPosition = MixedRealityPlayspace.TransformPoint(jointPosition);
+                        jointOrientation = MixedRealityPlayspace.Rotation * jointOrientation;
+
+                        TrackedHandJoint handJoint = ConvertHandJointKindToTrackedHandJoint(jointIndices[i]);
+
+                        if (handJoint == TrackedHandJoint.IndexTip)
                         {
-                            for (int i = 0; i < jointPoses.Length; i++)
-                            {
-                                Vector3 jointPosition = jointPoses[i].Position.ToUnityVector3();
-                                Quaternion jointOrientation = jointPoses[i].Orientation.ToUnityQuaternion();
-
-                                // We want the joints to follow the playspace, so fold in the playspace transform here to 
-                                // put the joint pose into world space.
-                                jointPosition = MixedRealityPlayspace.TransformPoint(jointPosition);
-                                jointOrientation = MixedRealityPlayspace.Rotation * jointOrientation;
-
-                                TrackedHandJoint handJoint = ConvertHandJointKindToTrackedHandJoint(jointIndices[i]);
-
-                                if (handJoint == TrackedHandJoint.IndexTip)
-                                {
-                                    lastIndexTipRadius = jointPoses[i].Radius;
-                                }
-
-                                unityJointPoses[handJoint] = new MixedRealityPose(jointPosition, jointOrientation);
-                            }
-
-                            handDefinition?.UpdateHandJoints(unityJointPoses);
+                            lastIndexTipRadius = jointPoses[i].Radius;
                         }
-                        break;
+
+                        unityJointPoses[handJoint] = new MixedRealityPose(jointPosition, jointOrientation);
                     }
+
+                    handDefinition?.UpdateHandJoints(unityJointPoses);
                 }
             }
 #endif // WINDOWS_UWP || DOTNETWINRT_PRESENT

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <returns></returns>
         public static SpatialInteractionSourceState GetSpatialInteractionSourceState(this InteractionSource interactionSource)
         {
-            IReadOnlyList<SpatialInteractionSourceState> sources = WindowsMixedRealityUtilities.SpatialInteractionManager?.GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
+            IReadOnlyList<SpatialInteractionSourceState> sources = WindowsMixedRealityUtilities.SpatialInteractionManager?.GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.UtcNow));
 
             for (var i = 0; i < sources?.Count; i++)
             {

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -1,15 +1,24 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if WINDOWS_UWP
-using Microsoft.MixedReality.Toolkit.Windows.Utilities;
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
+using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 using System;
 using System.Collections.Generic;
 using UnityEngine.XR.WSA.Input;
-using Windows.Foundation;
+#if WINDOWS_UWP
 using Windows.Perception;
-using Windows.Storage.Streams;
 using Windows.UI.Input.Spatial;
+#elif DOTNETWINRT_PRESENT
+using Microsoft.Windows.Perception;
+using Microsoft.Windows.UI.Input.Spatial;
+#endif
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
+
+#if WINDOWS_UWP
+using Microsoft.MixedReality.Toolkit.Windows.Utilities;
+using Windows.Foundation;
+using Windows.Storage.Streams;
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.Windows.Input
@@ -19,30 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
     /// </summary>
     public static class InteractionSourceExtensions
     {
-#if WINDOWS_UWP
-        /// <summary>
-        /// Attempts to call the Windows API for loading the controller renderable model at runtime.
-        /// </summary>
-        /// <param name="interactionSource">The source to try loading the model for.</param>
-        /// <returns>A stream of the glTF model for loading.</returns>
-        /// <remarks>Doesn't work in-editor.</remarks>
-        public static IAsyncOperation<IRandomAccessStreamWithContentType> TryGetRenderableModelAsync(this InteractionSource interactionSource)
-        {
-            IAsyncOperation<IRandomAccessStreamWithContentType> returnValue = null;
-
-            // GetForCurrentView and GetDetectedSourcesAtTimestamp were both introduced in the same Windows version.
-            // We need only check for one of them.
-            if (WindowsApiChecker.IsMethodAvailable(
-                "Windows.UI.Input.Spatial",
-                "SpatialInteractionManager",
-                "GetForCurrentView"))
-            {
-                returnValue = interactionSource.GetSpatialInteractionSource()?.Controller.TryGetRenderableModelAsync();
-            }
-
-            return returnValue;
-        }
-
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
         /// <summary>
         /// Gets the current native SpatialInteractionSourceState for this InteractionSource.
         /// </summary>
@@ -69,6 +55,31 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <param name="interactionSource">This InteractionSource to search for via the native Windows APIs.</param>
         /// <returns>The current native SpatialInteractionSource.</returns>
         public static SpatialInteractionSource GetSpatialInteractionSource(this InteractionSource interactionSource) => interactionSource.GetSpatialInteractionSourceState()?.Source;
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
+
+#if WINDOWS_UWP
+        /// <summary>
+        /// Attempts to call the Windows API for loading the controller renderable model at runtime.
+        /// </summary>
+        /// <param name="interactionSource">The source to try loading the model for.</param>
+        /// <returns>A stream of the glTF model for loading.</returns>
+        /// <remarks>Doesn't work in-editor.</remarks>
+        public static IAsyncOperation<IRandomAccessStreamWithContentType> TryGetRenderableModelAsync(this InteractionSource interactionSource)
+        {
+            IAsyncOperation<IRandomAccessStreamWithContentType> returnValue = null;
+
+            // GetForCurrentView and GetDetectedSourcesAtTimestamp were both introduced in the same Windows version.
+            // We need only check for one of them.
+            if (WindowsApiChecker.IsMethodAvailable(
+                "Windows.UI.Input.Spatial",
+                "SpatialInteractionManager",
+                "GetForCurrentView"))
+            {
+                returnValue = interactionSource.GetSpatialInteractionSource()?.Controller.TryGetRenderableModelAsync();
+            }
+
+            return returnValue;
+        }
 #endif // WINDOWS_UWP
     }
 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -44,10 +44,10 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         }
 
         /// <summary>
-        /// 
+        /// Gets the current native SpatialInteractionSourceState for this InteractionSource.
         /// </summary>
-        /// <param name="interactionSource"></param>
-        /// <returns></returns>
+        /// <param name="interactionSource">This InteractionSource to search for via the native Windows APIs.</param>
+        /// <returns>The current native SpatialInteractionSourceState.</returns>
         public static SpatialInteractionSourceState GetSpatialInteractionSourceState(this InteractionSource interactionSource)
         {
             IReadOnlyList<SpatialInteractionSourceState> sources = WindowsMixedRealityUtilities.SpatialInteractionManager?.GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.UtcNow));
@@ -64,10 +64,10 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         }
 
         /// <summary>
-        /// 
+        /// Gets the current native SpatialInteractionSource for this InteractionSource.
         /// </summary>
-        /// <param name="interactionSource"></param>
-        /// <returns></returns>
+        /// <param name="interactionSource">This InteractionSource to search for via the native Windows APIs.</param>
+        /// <returns>The current native SpatialInteractionSource.</returns>
         public static SpatialInteractionSource GetSpatialInteractionSource(this InteractionSource interactionSource) => interactionSource.GetSpatialInteractionSourceState()?.Source;
 #endif // WINDOWS_UWP
     }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -56,6 +56,12 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
 #if WINDOWS_UWP
+        private const string SpatialNamespace = "Windows.UI.Input.Spatial";
+        private const string SpatialInteractionController = "SpatialInteractionController";
+        private const string TryGetRenderableModelAsyncName = "TryGetRenderableModelAsync";
+
+        private static readonly bool IsTryGetRenderableModelAvailable = WindowsApiChecker.IsMethodAvailable(SpatialNamespace, SpatialInteractionController, TryGetRenderableModelAsyncName);
+
         /// <summary>
         /// Attempts to call the Windows API for loading the controller renderable model at runtime.
         /// </summary>
@@ -64,19 +70,12 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <remarks>Doesn't work in-editor.</remarks>
         public static IAsyncOperation<IRandomAccessStreamWithContentType> TryGetRenderableModelAsync(this InteractionSource interactionSource)
         {
-            IAsyncOperation<IRandomAccessStreamWithContentType> returnValue = null;
-
-            // GetForCurrentView and GetDetectedSourcesAtTimestamp were both introduced in the same Windows version.
-            // We need only check for one of them.
-            if (WindowsApiChecker.IsMethodAvailable(
-                "Windows.UI.Input.Spatial",
-                "SpatialInteractionManager",
-                "GetForCurrentView"))
+            if (IsTryGetRenderableModelAvailable)
             {
-                returnValue = interactionSource.GetSpatialInteractionSource()?.Controller.TryGetRenderableModelAsync();
+                return interactionSource.GetSpatialInteractionSource()?.Controller.TryGetRenderableModelAsync();
             }
 
-            return returnValue;
+            return null;
         }
 #endif // WINDOWS_UWP
     }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -1,24 +1,22 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if WINDOWS_UWP || DOTNETWINRT_PRESENT
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 using System;
 using System.Collections.Generic;
 using UnityEngine.XR.WSA.Input;
-#if WINDOWS_UWP
-using Windows.Perception;
-using Windows.UI.Input.Spatial;
-#elif DOTNETWINRT_PRESENT
-using Microsoft.Windows.Perception;
-using Microsoft.Windows.UI.Input.Spatial;
-#endif
-#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
 #if WINDOWS_UWP
 using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using Windows.Foundation;
+using Windows.Perception;
 using Windows.Storage.Streams;
+using Windows.UI.Input.Spatial;
+#elif (UNITY_WSA && DOTNETWINRT_PRESENT)
+using Microsoft.Windows.Perception;
+using Microsoft.Windows.UI.Input.Spatial;
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.Windows.Input
@@ -28,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
     /// </summary>
     public static class InteractionSourceExtensions
     {
-#if WINDOWS_UWP || DOTNETWINRT_PRESENT
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         /// <summary>
         /// Gets the current native SpatialInteractionSourceState for this InteractionSource.
         /// </summary>
@@ -55,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <param name="interactionSource">This InteractionSource to search for via the native Windows APIs.</param>
         /// <returns>The current native SpatialInteractionSource.</returns>
         public static SpatialInteractionSource GetSpatialInteractionSource(this InteractionSource interactionSource) => interactionSource.GetSpatialInteractionSourceState()?.Source;
-#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
 #if WINDOWS_UWP
         /// <summary>


### PR DESCRIPTION
## Overview

1. Getting the SpatialInteractionManager, which involves jumping over to the UI thread, is something we do in a couple places, so it makes sense to provide that alongside the other native resources we provide in WindowsMixedRealityUtilities.
1. Typically when the manager is needed, it's to iterate through all `SpatialInteractionSource`s and find the one that represents the current Unity `InteractionSource`. This logic has also been refactored out, provided as an `InteractionSource` extension method.