### PR TITLE
Revert "Merge pull request #8190 from MaxWang-MS/AxisFlags_fix"

### DIFF
--- a/Assets/MRTK/Core/Definitions/Utilities/AxisFlags.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/AxisFlags.cs
@@ -9,7 +9,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     [System.Flags]
     public enum AxisFlags
     {
-        None = 0,
         XAxis = 1 << 0,
         YAxis = 1 << 1,
         ZAxis = 1 << 2

--- a/Assets/MRTK/Core/Definitions/Utilities/RotationConstraintType.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/RotationConstraintType.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 case RotationConstraintType.ZAxisOnly:
                     return AxisFlags.XAxis | AxisFlags.YAxis;
                 default:
-                    return AxisFlags.None;
+                    return 0;
             }
         }
     }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/MoveAxisConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/MoveAxisConstraint.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [EnumFlags]
         [Tooltip("Constrain movement along an axis")]
-        private AxisFlags constraintOnMovement = AxisFlags.None;
+        private AxisFlags constraintOnMovement = 0;
 
         /// <summary>
         /// Constrain movement along an axis

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/RotationAxisConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/RotationAxisConstraint.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [EnumFlags]
         [Tooltip("Constrain rotation about an axis")]
-        private AxisFlags constraintOnRotation = AxisFlags.None;
+        private AxisFlags constraintOnRotation = 0;
 
         /// <summary>
         /// Constrain rotation about an axis


### PR DESCRIPTION
This reverts commit 121c4573f2ffb4dc5853f2571f5f74905e572273, reversing
changes made to 5730fa18cbe5f300a5145ebd1013d35e203ef9b9.

## Overview
reverted the changes to axis flag as it's breaking user asset files (and mrtk example scenes)
there needs to be more investigation on android side to tackle the original issue. 

- Reopens: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7463
- Fixes parts of: #8555 


