### PR TITLE
Check if instancing is supported before attempting it in visual profiler

### DIFF
--- a/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -378,14 +378,14 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
                 {
                     Matrix4x4 parentLocalToWorldMatrix = window.localToWorldMatrix;
 
-                    if (defaultInstancedMaterial != null)
+                    if (defaultInstancedMaterial != null && SystemInfo.supportsInstancing)
                     {
                         frameInfoPropertyBlock.SetMatrix(parentMatrixID, parentLocalToWorldMatrix);
                         Graphics.DrawMeshInstanced(quadMesh, 0, defaultInstancedMaterial, frameInfoMatrices, frameInfoMatrices.Length, frameInfoPropertyBlock, UnityEngine.Rendering.ShadowCastingMode.Off, false);
                     }
                     else
                     {
-                        // If a instanced material is not available, fall back to non-instanced rendering.
+                        // If a instanced material is not available or instancing isn't supported, fall back to non-instanced rendering.
                         for (int i = 0; i < frameInfoMatrices.Length; ++i)
                         {
                             frameInfoPropertyBlock.SetColor(colorID, frameInfoColors[i]);


### PR DESCRIPTION
## Overview

Instancing isn't supported on all platforms, so the visual profiler should only attempt it if supported. See the fixed bug below for more info.

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8600
