### PR TITLE
Re-add haptics to InteractionSourceExtensions

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -19,6 +19,7 @@ using Windows.Perception;
 using Windows.Storage.Streams;
 using Windows.UI.Input.Spatial;
 #elif (UNITY_WSA && DOTNETWINRT_PRESENT)
+using Microsoft.Windows.Devices.Haptics;
 using Microsoft.Windows.Perception;
 using Microsoft.Windows.UI.Input.Spatial;
 #endif
@@ -64,6 +65,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         private const string SimpleHapticsController = "SimpleHapticsController";
         private const string SendHapticFeedback = "SendHapticFeedback";
 
+        /// <summary>
+        /// This value is standardized according to https://www.usb.org/sites/default/files/hutrr63b_-_haptics_page_redline_0.pdf.
+        /// </summary>
+        private const ushort ContinuousBuzzWaveform = 0x1004;
+
         private static readonly bool IsHapticsAvailable = WindowsApiChecker.IsMethodAvailable(HapticsNamespace, SimpleHapticsController, SendHapticFeedback);
 
         /// <summary>
@@ -71,7 +77,6 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// </summary>
         /// <param name="interactionSource"></param>
         /// <param name="intensity"></param>
-        /// <remarks>Doesn't work in-editor.</remarks>
         public static void StartHaptics(this InteractionSource interactionSource, float intensity) => interactionSource.StartHaptics(intensity, float.MaxValue);
 
         /// <summary>
@@ -80,7 +85,6 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <param name="interactionSource"></param>
         /// <param name="intensity"></param>
         /// <param name="durationInSeconds"></param>
-        /// <remarks>Doesn't work in-editor.</remarks>
         public static void StartHaptics(this InteractionSource interactionSource, float intensity, float durationInSeconds)
         {
             if (!IsHapticsAvailable)
@@ -88,11 +92,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 return;
             }
 
-#if WINDOWS_UWP
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
             SimpleHapticsController simpleHapticsController = interactionSource.GetSpatialInteractionSource()?.Controller.SimpleHapticsController;
             foreach (SimpleHapticsControllerFeedback hapticsFeedback in simpleHapticsController?.SupportedFeedback)
             {
-                if (hapticsFeedback.Waveform.Equals(KnownSimpleHapticsControllerWaveforms.BuzzContinuous))
+                if (hapticsFeedback.Waveform.Equals(ContinuousBuzzWaveform))
                 {
                     if (durationInSeconds.Equals(float.MaxValue))
                     {
@@ -105,14 +109,13 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                     return;
                 }
             }
-#endif // WINDOWS_UWP
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
         }
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="interactionSource"></param>
-        /// <remarks>Doesn't work in-editor.</remarks>
         public static void StopHaptics(this InteractionSource interactionSource)
         {
             if (!IsHapticsAvailable)
@@ -120,9 +123,9 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 return;
             }
 
-#if WINDOWS_UWP
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
             interactionSource.GetSpatialInteractionSource()?.Controller.SimpleHapticsController.StopFeedback();
-#endif // WINDOWS_UWP
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
         }
 #endif // UNITY_WSA
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <summary>
         /// Gets the current native SpatialInteractionSource for this InteractionSource.
         /// </summary>
-        /// <param name="interactionSource">This InteractionSource to search for via the native Windows APIs.</param>
+        /// <param name="interactionSource">The InteractionSource to search for via the native Windows APIs.</param>
         /// <returns>The current native SpatialInteractionSource.</returns>
         public static SpatialInteractionSource GetSpatialInteractionSource(this InteractionSource interactionSource) => interactionSource.GetSpatialInteractionSourceState()?.Source;
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
@@ -73,18 +73,18 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         private static readonly bool IsHapticsAvailable = WindowsApiChecker.IsMethodAvailable(HapticsNamespace, SimpleHapticsController, SendHapticFeedback);
 
         /// <summary>
-        /// 
+        /// Start haptic feedback on the interaction source with the specified intensity.
         /// </summary>
-        /// <param name="interactionSource"></param>
-        /// <param name="intensity"></param>
+        /// <param name="interactionSource">The source to start haptics on.</param>
+        /// <param name="intensity">The strength of the haptic feedback from 0.0 (no haptics) to 1.0 (maximum strength).</param>
         public static void StartHaptics(this InteractionSource interactionSource, float intensity) => interactionSource.StartHaptics(intensity, float.MaxValue);
 
         /// <summary>
-        /// 
+        /// Start haptic feedback on the interaction source with the specified intensity and continue for the specified amount of time.
         /// </summary>
-        /// <param name="interactionSource"></param>
-        /// <param name="intensity"></param>
-        /// <param name="durationInSeconds"></param>
+        /// <param name="interactionSource">The source to start haptics on.</param>
+        /// <param name="intensity">The strength of the haptic feedback from 0.0 (no haptics) to 1.0 (maximum strength).</param>
+        /// <param name="durationInSeconds">The time period expressed in seconds.</param>
         public static void StartHaptics(this InteractionSource interactionSource, float intensity, float durationInSeconds)
         {
             if (!IsHapticsAvailable)
@@ -113,9 +113,9 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         }
 
         /// <summary>
-        /// 
+        /// Stops haptics feedback on the specified interaction source.
         /// </summary>
-        /// <param name="interactionSource"></param>
+        /// <param name="interactionSource">The source to stop haptics for.</param>
         public static void StopHaptics(this InteractionSource interactionSource)
         {
             if (!IsHapticsAvailable)


### PR DESCRIPTION
## Overview

Follow-up to #8592. Re-adds the haptics extensions that were removed in https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6364, and additional adds in-editor support via DotNetWinRT.