### PR TITLE
Fix/menu update icons

### DIFF
--- a/Assets/MRTK/Tests/EditModeTests/Core/Extensions/BoundsExtensionsTests.cs.meta
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Extensions/BoundsExtensionsTests.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/ElasticTests.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/ElasticTests.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/TestCustomPointerMediator.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/TestCustomPointerMediator.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MRTK/Tests/TestUtilities/TestController.cs.meta
+++ b/Assets/MRTK/Tests/TestUtilities/TestController.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MRTK/Tests/TestUtilities/TestMotionController.cs.meta
+++ b/Assets/MRTK/Tests/TestUtilities/TestMotionController.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -420,7 +420,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             Texture2D icon = null;
 
-            foreach (string iconPath in MixedRealityToolkitFiles.GetFiles("StandardAssets/Icons"))
+            foreach (string iconPath in MixedRealityToolkitFiles.GetFiles(MixedRealityToolkitModuleType.StandardAssets, "Icons"))
             {
                 if (iconPath.EndsWith("test_icon.png"))
                 {


### PR DESCRIPTION
## Overview
Fixes regression issue with menu option **Mixed Reality Toolkit > Utilities > Update > Icons > Tests**
and updates test assets missing icon.

## Changes
- Fixes: #8635 
