### PR TITLE
Fix implied install of legacy Windows Mixed Reality package with config dlg

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -172,11 +172,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 RenderToggle(MRConfig.VisibleMetaFiles, "Enable visible meta files");
                 if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS() && XRSettingsUtilities.IsLegacyXRActive)
                 {
-#if UNITY_2019_3_OR_NEWER
-                    RenderToggle(MRConfig.VirtualRealitySupported, "Enable legacy XR");
-#else
+#if !UNITY_2019_3_OR_NEWER
                     RenderToggle(MRConfig.VirtualRealitySupported, "Enable VR supported");
-#endif // UNITY_2019_3_OR_NEWER
+#endif // !UNITY_2019_3_OR_NEWER
                 }
 #if UNITY_2019_3_OR_NEWER
                 RenderToggle(MRConfig.OptimalRenderingPath, "Set Single Pass Instanced rendering path (legacy XR API)");

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -117,7 +117,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.LatestScriptingRuntime, new ConfigGetter(IsLatestScriptingRuntime) },
             { Configurations.ForceTextSerialization, new ConfigGetter(IsForceTextSerialization) },
             { Configurations.VisibleMetaFiles, new ConfigGetter(IsVisibleMetaFiles) },
+#if !UNITY_2019_3_OR_NEWER
             { Configurations.VirtualRealitySupported, new ConfigGetter(() => XRSettingsUtilities.LegacyXREnabled) },
+#endif // !UNITY_2019_3_OR_NEWER
             { Configurations.OptimalRenderingPath, new ConfigGetter(MixedRealityOptimizeUtils.IsOptimalRenderingPath) },
             { Configurations.SpatialAwarenessLayer, new ConfigGetter(HasSpatialAwarenessLayer) },
             { Configurations.AudioSpatializer, new ConfigGetter(SpatializerUtilities.CheckSettings) },
@@ -151,7 +153,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.LatestScriptingRuntime, SetLatestScriptingRuntime },
             { Configurations.ForceTextSerialization, SetForceTextSerialization },
             { Configurations.VisibleMetaFiles, SetVisibleMetaFiles },
+#if !UNITY_2019_3_OR_NEWER
             { Configurations.VirtualRealitySupported, () => XRSettingsUtilities.LegacyXREnabled = true },
+#endif // !UNITY_2019_3_OR_NEWER
             { Configurations.OptimalRenderingPath, MixedRealityOptimizeUtils.SetOptimalRenderingPath },
             { Configurations.SpatialAwarenessLayer,  SetSpatialAwarenessLayer },
             { Configurations.AudioSpatializer, SetAudioSpatializer },

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -93,17 +93,11 @@ With the introduction of Unity Package Manger MRTK, MRTK now writes a `link.xml`
 
 More information on the MRTK link.xml file can be found in the [MRTK and managed code stripping](MRTK_and_managed_code_stripping.md) article.
 
-**Enable MSBuild for Unity removed from the configuration dialog**
+**Unity 2019.3+: MRTK configuration dialog no longer attempts to enable legacy XR support**
 
-To prevent the MRTK configuration dialog from repeatedly displaying when `Enable MSBuild for Unity` is unchecked, it has been moved to the `Mixed Reality Toolkit' menu as shown in the following image.
-
-![MSBuild for Unity menu items](Images/ConfigurationDialog/MSB4UMenuItems.png)
-
-This change also adds the ability to remove MSBulid for Unity.
-
-There is a confirmation dialog that will be displayed when selecting `Use MSBuild for Unity dependency resolution`.
-
-![MSBuild for Unity confirmation](Images/ConfigurationDialog/EnableMSB4UPrompt.png)
+To avoid potential conflicts when using Unity's XR Platform, the option to enable legacy XR support has been removed
+from the MRTK configuration dialog. If desired, legacy XR support can be enabled, in Unity 2019, using **Edit** > **Project Settings** >
+**Player** > **XR Settings** > **Virtual Reality Supported**.
 
 **Reduction in InitializeOnLoad overhead**
 We've been doing work to reduce the amount of work that runs in InitializeOnLoad handlers, which should lead to


### PR DESCRIPTION
During testing, it was discovered that a duplication of AudioSpatializerMSHRTF.dll occurs in the following scenario:

* Unity 2019.4
* XR SDK
* Click "Apply" on MRTK Configuration dialog.

This was caused by the configuration dialog attempting to check the legacy XR option, which was triggering the installation of the legacy Windows Mixed Reality UPM package.

Unfortunately, this install is not reflected in Packages/manifest.json which makes it difficult for customers to identify a means of resolving the duplication.

This change suppresses attempts to enable legacy XR on Unity 2019 and newer and was verified by creating and importing a local version of the foundation package.