### PR TITLE
Remove collider from MRTK logo on example hub button

### DIFF
--- a/Assets/MRTK/Examples/Experimental/ExamplesHub/Prefabs/ExampleHubButton.prefab
+++ b/Assets/MRTK/Examples/Experimental/ExamplesHub/Prefabs/ExampleHubButton.prefab
@@ -771,7 +771,6 @@ GameObject:
   - component: {fileID: 8040640385906350904}
   - component: {fileID: 8115061322601606439}
   - component: {fileID: 6294259050204340425}
-  - component: {fileID: 8665082625485886343}
   m_Layer: 0
   m_Name: Quad
   m_TagString: Untagged
@@ -838,17 +837,3 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!64 &8665082625485886343
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5704342747490533093}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
## Overview
This PR removes the non-convex mesh collider from the logo so that when a hand touches the button the ClosestPoint warnings will no longer appear.

## Changes
- Fixes: #8649.