### PR TITLE
Fix the titlebar in the HandInteractionExamples scene

### DIFF
--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -23892,6 +23892,11 @@ PrefabInstance:
       propertyPath: m_textInfo.pageCount
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7614231226395134405, guid: 18470d71939382448be2ecd06efa9662,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 18470d71939382448be2ecd06efa9662, type: 3}
 --- !u!4 &1672675964 stripped

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -24217,7 +24217,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1698852960}
-  - component: {fileID: 1698852961}
   m_Layer: 0
   m_Name: SceneContent
   m_TagString: Untagged
@@ -24249,14 +24248,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!362 &1698852961
-WorldAnchor:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1698852959}
-  serializedVersion: 2
 --- !u!114 &1700502666 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4448574576992466704, guid: ffbe4bef620a0a542bb77fe2f765c905,


### PR DESCRIPTION
## Overview
This PR removes a non-working close button from the "Grab to manipulate the entire scene" TitleBar. Further more the world anchor is removed from SceneContent to enable grab titlebar manipulation in remoting mode and on HL2 device.

## Changes
- Fixes: #8553.