### PR TITLE
(Fix CI) Make a missing asmdef a warning instead of an exception in MSBuild scripts

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         };
 
         /// <summary>
-        /// These package refernces are only for Unity 2019.3+ and shouldn't be included when using older versions
+        /// These package references are only for Unity 2019.3+ and shouldn't be included when using older versions
         /// </summary>
         private static readonly HashSet<string> PackageReferencesUnity2019 = new HashSet<string>()
         {
@@ -35,7 +35,8 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             "Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.Editor",
             "Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.Handtracking.Editor",
             "Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality",
-            "Microsoft.MixedReality.Toolkit.Providers.XRSDK"
+            "Microsoft.MixedReality.Toolkit.Providers.XRSDK",
+            "UnityEngine.SpatialTracking"
         };
 
         /// <summary>
@@ -190,9 +191,9 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 }
 
 #if !UNITY_2019_3_OR_NEWER
-                if(PackageReferencesUnity2019.Contains(reference))
+                if (PackageReferencesUnity2019.Contains(reference))
                 {
-                    Debug.LogWarning($"Skipping processing {reference} for {toReturn.Name}, as it's for Unity 2019.3+");
+                    Debug.LogWarning($"Skipping processing {reference} for {toReturn.Name}, as it's for Unity 2019.3+.");
                     continue;
                 }
 #endif

--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -164,8 +164,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             if (!asmDefInfoMap.TryGetValue(projectKey, out AssemblyDefinitionInfo assemblyDefinitionInfo))
             {
-                Debug.LogWarning($"Can't find an asmdef for project: {projectKey}.");
-                return null;
+                throw new InvalidOperationException($"Can't find an asmdef for project: {projectKey}");
             }
 
             CSProjectInfo toReturn = new CSProjectInfo(this, assemblyDefinitionInfo, projectOutputPath);
@@ -205,11 +204,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                     continue;
                 }
 
-                CSProjectInfo projectInfo = GetProjectInfo(projectsMap, asmDefInfoMap, builtInPackagesWithoutSource, reference, projectOutputPath);
-                if (projectInfo != null)
-                {
-                    toReturn.AddDependency(projectInfo);
-                }
+                toReturn.AddDependency(GetProjectInfo(projectsMap, asmDefInfoMap, builtInPackagesWithoutSource, reference, projectOutputPath));
             }
 
             return toReturn;

--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -163,7 +163,8 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             if (!asmDefInfoMap.TryGetValue(projectKey, out AssemblyDefinitionInfo assemblyDefinitionInfo))
             {
-                throw new InvalidOperationException($"Can't find an asmdef for project: {projectKey}");
+                Debug.LogWarning($"Can't find an asmdef for project: {projectKey}.");
+                return null;
             }
 
             CSProjectInfo toReturn = new CSProjectInfo(this, assemblyDefinitionInfo, projectOutputPath);
@@ -203,7 +204,11 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                     continue;
                 }
 
-                toReturn.AddDependency(GetProjectInfo(projectsMap, asmDefInfoMap, builtInPackagesWithoutSource, reference, projectOutputPath));
+                CSProjectInfo projectInfo = GetProjectInfo(projectsMap, asmDefInfoMap, builtInPackagesWithoutSource, reference, projectOutputPath);
+                if (projectInfo != null)
+                {
+                    toReturn.AddDependency(projectInfo);
+                }
             }
 
             return toReturn;


### PR DESCRIPTION
## Overview

Since we're only using this script to build packages for Unity 2018, where certain projects might not exist, we can safely skip it. Since we're also migrating off support for the NuGet packages (no longer publishing publicly), this is an okay scenario.
Still logs, in case we need to debug any issues. This will resolve any asmdef references that only exist in Unity 2019 for https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8574.