### PR TITLE
Fix tooltip in the Examples Hub Tooltip scene

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -78,18 +78,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private async Task UpdateSpawnable(float focusEnterTimeOnStart, float tappedTimeOnStart)
         {
+            if (spawnable == null)
+            {
+                spawnable = Instantiate(prefab);
+                spawnable.transform.parent = transform;
+                spawnable.transform.localPosition = Vector3.zero;
+                if (!keepWorldRotation)
+                {
+                    spawnable.transform.localRotation = Quaternion.identity;
+                }
+                spawnable.gameObject.SetActive(false);
+            }
             if (appearType == AppearType.AppearOnFocusEnter)
             {
-                if (spawnable == null)
-                {
-                    spawnable = Instantiate(prefab, transform, false);
-                    spawnable.transform.localPosition = Vector3.zero;
-                    if (!keepWorldRotation)
-                    {
-                        spawnable.transform.localRotation = Quaternion.identity;
-                    }
-                    spawnable.gameObject.SetActive(false);
-                }
                 // Wait for the appear delay
                 await new WaitForSeconds(appearDelay);
                 // If we don't have focus any more, get out of here


### PR DESCRIPTION
## Overview
This PR fixes two issues in the Examples Hub Tooltip scene:
1. The blue platonic now shows a tooltip when pressed as expected
2. The scale of tooltip generated after looking at the green platonic is now correct

## Changes
- Fixes: #8578 