### PR TITLE
Add support for reducing the UPM preview version length

### DIFF
--- a/pipelines/templates/tasks/upmpackages.yml
+++ b/pipelines/templates/tasks/upmpackages.yml
@@ -29,7 +29,7 @@ steps:
         -ProjectRoot ${{ parameters.projectRoot }}
         -OutputDirectory ${{ parameters.outputDirectory }}
         -Version ${{ parameters.version }}
-        -BuildNumber $(parameters.previewVersion)
+        -BuildNumber $(previewVersion)
 
 - ${{ if eq(parameters.excludeBuildNumber, 1) }}:
   - task: PowerShell@2

--- a/pipelines/templates/tasks/upmpackages.yml
+++ b/pipelines/templates/tasks/upmpackages.yml
@@ -41,7 +41,7 @@ steps:
         -ProjectRoot ${{ parameters.projectRoot }}
         -OutputDirectory ${{ parameters.outputDirectory }}
         -Version ${{ parameters.version }}
-        -BuildNumber $(parameters.previewVersion)
+        -BuildNumber $(previewVersion)
         -ExcludeBuildNumber
 
 - task: PublishBuildArtifacts@1

--- a/pipelines/templates/tasks/upmpackages.yml
+++ b/pipelines/templates/tasks/upmpackages.yml
@@ -16,7 +16,8 @@ steps:
     versionSpec: '12.18.0'
 
 - powershell: |
-  $previewVersion = ${{ parameters.buildNumber }}.Substring(4)
+    $previewVersion = ${{ parameters.buildNumber }}.Substring(4)
+    echo "##vso[task.setvariable variable=previewVersion"]$previewVersion
 
 - ${{ if eq(parameters.excludeBuildNumber, 0) }}:
   - task: PowerShell@2

--- a/pipelines/templates/tasks/upmpackages.yml
+++ b/pipelines/templates/tasks/upmpackages.yml
@@ -6,11 +6,18 @@ parameters:
   buildNumber: $(Build.BuildNumber)
   excludeBuildNumber: 0
 
+variables:
+- name: previewVersion
+  value: ""
+
 steps:
 - task: NodeTool@0
   inputs:
     versionSpec: '12.18.0'
-    
+
+- powershell: |
+  $previewVersion = ${{ parameters.buildNumber }}.Substring(4)
+
 - ${{ if eq(parameters.excludeBuildNumber, 0) }}:
   - task: PowerShell@2
     displayName: 'Build PREVIEW UPM packages'
@@ -21,7 +28,7 @@ steps:
         -ProjectRoot ${{ parameters.projectRoot }}
         -OutputDirectory ${{ parameters.outputDirectory }}
         -Version ${{ parameters.version }}
-        -BuildNumber ${{ parameters.buildNumber }}
+        -BuildNumber $(parameters.previewVersion)
 
 - ${{ if eq(parameters.excludeBuildNumber, 1) }}:
   - task: PowerShell@2
@@ -33,7 +40,7 @@ steps:
         -ProjectRoot ${{ parameters.projectRoot }}
         -OutputDirectory ${{ parameters.outputDirectory }}
         -Version ${{ parameters.version }}
-        -BuildNumber ${{ parameters.buildNumber }}
+        -BuildNumber $(parameters.previewVersion)
         -ExcludeBuildNumber
 
 - task: PublishBuildArtifacts@1

--- a/scripts/packaging/createupmpackages.ps1
+++ b/scripts/packaging/createupmpackages.ps1
@@ -14,6 +14,10 @@
 .PARAMETER ExcludeBuildNumber
     Indicates that the build number should be excluded from the generated artifacts. If this parameter is specified, the version
     of the artifacts will be formatted as "<$Version>", if omitted, the artifact version will be "<$Version>-preview.<BuildNumber>".
+.PARAMETER TrimPreview
+    Indicates that the build number should be trimmed to remove the leading year (ex: 20200925.1 -> 0925.1). This parameter is ignored
+    if ExcludeBuildNumber is also used.
+    NOTE: TrimPreview does not attempt to evaluate the format of BuildNumber. It simply removes the first four characters.
 #>
 param(
     [string]$ProjectRoot,

--- a/scripts/packaging/createupmpackages.ps1
+++ b/scripts/packaging/createupmpackages.ps1
@@ -23,7 +23,9 @@ param(
     [ValidatePattern("^\d+?[\.\d+]*$")]
     [string]$BuildNumber,
     [Parameter(Mandatory=$false)]
-    [Switch]$ExcludeBuildNumber
+    [Switch]$ExcludeBuildNumber,
+    [Parameter(Mandatory=$false)]
+    [Switch]$TrimPreview
 )
 
 [string]$startPath = $(Get-Location)
@@ -41,9 +43,17 @@ if ((-not $BuildNumber) -and (-not $ExcludeBuildNumber)) {
     throw "Missing required parameter: -BuildNumber. This parameter is required when -ExcludeBuildNumber is not specified."
 }
 if (-not $ExcludeBuildNumber) {
-    $Version = "$Version-preview.$BuildNumber"
+    $previewNumber = $BuildNumber
+
+    if ($TrimPreview -and ($previewNumber.Length -gt 8)) {
+        # Trim off the first four characters, the build system uses YYYYMMDD.# for the build number.
+        $previewNumber = $previewNumber.Substring(4)
+    }
+
+    $Version = "$Version-preview.$previewNumber"
 }
 Write-Output "Package version: $Version"
+throw
 
 if (-not (Test-Path $OutputDirectory -PathType Container)) {
     New-Item $OutputDirectory -ItemType Directory | Out-Null

--- a/scripts/packaging/createupmpackages.ps1
+++ b/scripts/packaging/createupmpackages.ps1
@@ -57,7 +57,6 @@ if (-not $ExcludeBuildNumber) {
     $Version = "$Version-preview.$previewNumber"
 }
 Write-Output "Package version: $Version"
-throw
 
 if (-not (Test-Path $OutputDirectory -PathType Container)) {
     New-Item $OutputDirectory -ItemType Directory | Out-Null

--- a/scripts/packaging/createupmpackages.ps1
+++ b/scripts/packaging/createupmpackages.ps1
@@ -14,10 +14,6 @@
 .PARAMETER ExcludeBuildNumber
     Indicates that the build number should be excluded from the generated artifacts. If this parameter is specified, the version
     of the artifacts will be formatted as "<$Version>", if omitted, the artifact version will be "<$Version>-preview.<BuildNumber>".
-.PARAMETER TrimPreview
-    Indicates that the build number should be trimmed to remove the leading year (ex: 20200925.1 -> 0925.1). This parameter is ignored
-    if ExcludeBuildNumber is also used.
-    NOTE: TrimPreview does not attempt to evaluate the format of BuildNumber. It simply removes the first four characters.
 #>
 param(
     [string]$ProjectRoot,
@@ -27,9 +23,7 @@ param(
     [ValidatePattern("^\d+?[\.\d+]*$")]
     [string]$BuildNumber,
     [Parameter(Mandatory=$false)]
-    [Switch]$ExcludeBuildNumber,
-    [Parameter(Mandatory=$false)]
-    [Switch]$TrimPreview
+    [Switch]$ExcludeBuildNumber
 )
 
 [string]$startPath = $(Get-Location)
@@ -47,14 +41,7 @@ if ((-not $BuildNumber) -and (-not $ExcludeBuildNumber)) {
     throw "Missing required parameter: -BuildNumber. This parameter is required when -ExcludeBuildNumber is not specified."
 }
 if (-not $ExcludeBuildNumber) {
-    $previewNumber = $BuildNumber
-
-    if ($TrimPreview -and ($previewNumber.Length -gt 8)) {
-        # Trim off the first four characters, the build system uses YYYYMMDD.# for the build number.
-        $previewNumber = $previewNumber.Substring(4)
-    }
-
-    $Version = "$Version-preview.$previewNumber"
+    $Version = "$Version-preview.$BuildNumber"
 }
 Write-Output "Package version: $Version"
 


### PR DESCRIPTION
This change reduces the length of the UPM preview version by trimming the year from the build number.

Before:  4.3.2-preview.20200925.1
After: 4.3.2-preview.0925.1
