### PR TITLE
Make sure NearInteraction triggers CanInteract check

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1229,11 +1229,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         /// <summary>
         /// A public way to trigger or route an onClick event from an external source, like PressableButton
-        /// <param name="force">Force the click without checking CanInteract()</param>
         /// </summary>
+        /// <param name="force">Force the click without checking CanInteract(). Does not override enabled and only applies to toggle.</param>
         public void TriggerOnClick(bool force = false)
         {
-            if (!force && !CanInteract())
+            if (!enabled || (!force && !CanInteract()))
             {
                 return;
             }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1230,10 +1230,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// A public way to trigger or route an onClick event from an external source, like PressableButton
         /// </summary>
-        /// <param name="force">Force the click without checking CanInteract(). Does not override enabled and only applies to toggle.</param>
+        /// <param name="force">Force the click without checking CanInteract(). Does not override IsEnabled and only applies to toggle.</param>
         public void TriggerOnClick(bool force = false)
         {
-            if (!enabled || (!force && !CanInteract()))
+            if (!IsEnabled || (!force && !CanInteract()))
             {
                 return;
             }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1229,10 +1229,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         /// <summary>
         /// A public way to trigger or route an onClick event from an external source, like PressableButton
+        /// <param name="force">Force the click without checking CanInteract()</param>
         /// </summary>
-        public void TriggerOnClick()
+        public void TriggerOnClick(bool force = false)
         {
-            if (!CanInteract())
+            if (!force && !CanInteract())
             {
                 return;
             }
@@ -1509,7 +1510,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return;
             }
 
-            if (eventData.Command.Keyword == VoiceCommand && (!VoiceRequiresFocus || HasFocus))
+            if (eventData.Command.Keyword == VoiceCommand && (!VoiceRequiresFocus || HasFocus) && CanInteract())
             {
                 StartGlobalVisual(true);
                 HasVoiceCommand = true;

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1232,7 +1232,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public void TriggerOnClick()
         {
-            if (!IsEnabled)
+            if (!CanInteract())
             {
                 return;
             }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 if (fireOnClick)
                 {
-                    ToggleList[index].TriggerOnClick();
+                    ToggleList[index].TriggerOnClick(true);
                 }
             }
         }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
@@ -106,6 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 if (fireOnClick)
                 {
+                    // Trigger the OnClick event without checking CanInteract as we did not check when setting the index earlier
                     ToggleList[index].TriggerOnClick(true);
                 }
             }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Simulation/InteractablePointerSimulator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Simulation/InteractablePointerSimulator.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (isClicked != Clicked)
             {
-                Button.TriggerOnClick();
+                Button.TriggerOnClick(true);
                 Clicked = isClicked;
             }
         }

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
@@ -625,6 +625,90 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test the TriggerOnClick API for Interactable in toggle mode both when Can(De)Select and not.
+        /// Also test the force parameter of TriggerOnClick.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestToggleTriggerOnClick()
+        {
+            TestButtonUtilities.InstantiateDefaultButton(
+                TestButtonUtilities.DefaultButtonType.DefaultPushButton,
+                out Interactable toggle,
+                out Transform innerCylinderTransform);
+
+            toggle.NumOfDimensions = 2;
+            toggle.IsToggled = false;
+
+            // Subscribe to toggle's on click so we know the click went through
+            bool wasClicked = false;
+            toggle.OnClick.AddListener(() => { wasClicked = true; });
+
+            // Test TriggerOnClick when CanSelect is false
+            toggle.CanSelect = false;
+
+            toggle.TriggerOnClick();
+            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+
+            Assert.False(wasClicked, "Toggle was clicked.");
+            Assert.False(toggle.IsToggled, "Toggle was selected.");
+
+            // Test TriggerOnClick when CanSelect is true
+            toggle.CanSelect = true;
+
+            toggle.TriggerOnClick();
+            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+
+            Assert.True(wasClicked, "Toggle was not clicked.");
+            Assert.True(toggle.IsToggled, "Toggle was not selected.");
+
+            toggle.IsToggled = false;
+            wasClicked = false;
+
+            // Test force TriggerOnClick when CanSelect is false
+            toggle.CanSelect = false;
+
+            toggle.TriggerOnClick(true);
+            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+
+            Assert.True(wasClicked, "Toggle was not clicked.");
+            Assert.True(toggle.IsToggled, "Toggle was not selected.");
+
+            wasClicked = false;
+
+            // Test TriggerOnClick when CanDeselect is false
+            toggle.CanDeselect = false;
+
+            toggle.TriggerOnClick();
+            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+
+            Assert.False(wasClicked, "Toggle was clicked.");
+            Assert.True(toggle.IsToggled, "Toggle was not selected.");
+
+            // Test TriggerOnClick when CanDeselect is true
+            toggle.CanDeselect = true;
+
+            toggle.TriggerOnClick();
+            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+
+            Assert.True(wasClicked, "Toggle was not clicked.");
+            Assert.False(toggle.IsToggled, "Toggle was selected.");
+
+            toggle.IsToggled = true;
+            wasClicked = false;
+
+            // Test force TriggerOnClick when CanDeselect is false
+            toggle.CanDeselect = false;
+
+            toggle.TriggerOnClick(true);
+            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+
+            Assert.True(wasClicked, "Toggle was not clicked.");
+            Assert.False(toggle.IsToggled, "Toggle was selected.");
+
+            GameObject.Destroy(toggle.gameObject);
+        }
+
+        /// <summary>
         /// Tests that radial buttons can be selected and deselected, and that a radial button
         /// set allows just one button to be selected at a time
         /// </summary>


### PR DESCRIPTION
## Overview
Interactable should always check for `CanInteract` no matter it is responding to far interaction or near interaction.

Thanks @rfurmaniak for proposing the change!

## Changes
- Fixes #8479 