### PR TITLE
Update Leap Configuration Checker for 2020 Support

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/MRTK.LeapMotion.asmdef
+++ b/Assets/MRTK/Providers/LeapMotion/MRTK.LeapMotion.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "Microsoft.MixedReality.Toolkit.Providers.LeapMotion",
     "references": [
-        "Microsoft.MixedReality.Toolkit"
+        "Microsoft.MixedReality.Toolkit",
+        "LeapMotion",
+        "LeapMotion.LeapCSharp"
     ],
     "includePlatforms": [
         "Editor",


### PR DESCRIPTION
## Overview
- Removes the editing of the formerly named `Microsoft.MixedReality.Toolkit.Providers.LeapMotion` asmdef in the configuration checker because Unity 2020 does not support editing asmdefs for UPM 
- Adds placeholders to the root leap asmdef now named `MRTK.Leap`


## Verification

- [x] Unity 2019.4 with the 4.5.1 assets
- [x] Unity 2019.4 with the 4.5.0 assets

- [x] Unity 2018.4 with the 4.5.0 assets
- [x] Unity 2018.4 with the 4.5.1 assets
