### PR TITLE
Update the CI process to log a warning/error when there's an unknown project failure

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -164,6 +164,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             if (!asmDefInfoMap.TryGetValue(projectKey, out AssemblyDefinitionInfo assemblyDefinitionInfo))
             {
+                Debug.LogError($"Can't find an asmdef for project: {projectKey}, this project may need to be to added to the PackageReferencesUnity2019 exclusion list");
                 throw new InvalidOperationException($"Can't find an asmdef for project: {projectKey}");
             }
 

--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -164,7 +164,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             if (!asmDefInfoMap.TryGetValue(projectKey, out AssemblyDefinitionInfo assemblyDefinitionInfo))
             {
-                Debug.LogError($"Can't find an asmdef for project: {projectKey}, this project may need to be to added to the PackageReferencesUnity2019 exclusion list");
+                Debug.LogError($"Can't find an asmdef for project: {projectKey}, this project may need to be to added to the PackageReferencesUnity2019 or ExcludedPackageReferences exclusion list");
                 throw new InvalidOperationException($"Can't find an asmdef for project: {projectKey}");
             }
 


### PR DESCRIPTION
With some of the Generate SDK Project failures that we've encountered, there's an error in CI but no error actually logged there.

The exception doesn't appear to be captured and logged (i.e. it just kills the process). This updates the code to actually log before killing off the process, so hopefully future errors that we encounter, we can have more immediately actionable build logs.