### PR TITLE
Remove the verbose hoverlight debug log messages

### DIFF
--- a/Assets/MRTK/Core/Utilities/StandardShader/HoverLight.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/HoverLight.cs
@@ -108,15 +108,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             if (activeHoverLights.Count == hoverLightCountLow)
             {
                 Shader.EnableKeyword(hoverLightCountMediumName);
-
-                Debug.LogFormat("Max hover light count increased to {0}.", hoverLightCountMedium);
             }
             else if (activeHoverLights.Count == hoverLightCountMedium)
             {
                 Shader.DisableKeyword(hoverLightCountMediumName);
                 Shader.EnableKeyword(hoverLightCountHighName);
-
-                Debug.LogFormat("Max hover light count increased to {0}.", hoverLightCountHigh);
             }
             else if (activeHoverLights.Count >= hoverLightCountHigh)
             {
@@ -133,15 +129,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             if (activeHoverLights.Count == hoverLightCountLow)
             {
                 Shader.DisableKeyword(hoverLightCountMediumName);
-
-                Debug.LogFormat("Max hover light count decreased to {0}.", hoverLightCountLow);
             }
             else if (activeHoverLights.Count == hoverLightCountMedium)
             {
                 Shader.EnableKeyword(hoverLightCountMediumName);
                 Shader.DisableKeyword(hoverLightCountHighName);
-
-                Debug.LogFormat("Max hover light count decreased to {0}.", hoverLightCountMedium);
             }
         }
 


### PR DESCRIPTION
The messages that were added for the hover light increase/decrease tends to clutter the console output - they're valuable for us as things increase/decrease, though probably less so for normal use cases like with leap hands.

https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8700

I'm removing the more routine logs and keeping the limit one (i.e. when you hit the max value)