### PR TITLE
Update github.io documentation version list and default

### DIFF
--- a/scripts/docs/web/version.js
+++ b/scripts/docs/web/version.js
@@ -1,7 +1,8 @@
 function createDropdown()
 {
 	// configurable values:
-	var defaultTitle = "releases/2.4.0"; // title in the dropdown for the root version of the docs - alternatively put a version from the version array as a default
+	var defaultTitle = "releases/2.5.0"; // title in the dropdown for the root version of the docs - alternatively put a version from the version array as a default
+	
 	// list of all versions in the version folder
 	var versionArray = [
 		"mrtk_development",
@@ -10,7 +11,7 @@ function createDropdown()
 		"releases/2.2.0",
 		"releases/2.3.0",
 		"releases/2.4.0",
-		"prerelease/2.5.0_stabilization",
+		"releases/2.5.0",
 	];
 	
 	var ignoreDefaultInVersionFolder = true;


### PR DESCRIPTION
This change adds 2.5.0 to the collection of documentation versions and sets the default to the latest (2.5.0).

Do NOT merge this until the final release process is complete.