### PR TITLE
enabled diagnostics / disabled spatial awareness for default xrsdk config

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/Profiles/DefaultHololens2XRSDKConfigurationProfile.asset
+++ b/Assets/MRTK/Providers/XRSDK/Profiles/DefaultHololens2XRSDKConfigurationProfile.asset
@@ -32,7 +32,7 @@ MonoBehaviour:
   teleportSystemType:
     reference: Microsoft.MixedReality.Toolkit.Teleport.MixedRealityTeleportSystem,
       Microsoft.MixedReality.Toolkit.Services.TeleportSystem
-  enableSpatialAwarenessSystem: 1
+  enableSpatialAwarenessSystem: 0
   spatialAwarenessSystemType:
     reference: Microsoft.MixedReality.Toolkit.SpatialAwareness.MixedRealitySpatialAwarenessSystem,
       Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem
@@ -40,7 +40,7 @@ MonoBehaviour:
     type: 2}
   diagnosticsSystemProfile: {fileID: 11400000, guid: 478436bd1083882479a52d067e98e537,
     type: 2}
-  enableDiagnosticsSystem: 0
+  enableDiagnosticsSystem: 1
   diagnosticsSystemType:
     reference: Microsoft.MixedReality.Toolkit.Diagnostics.MixedRealityDiagnosticsSystem,
       Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem

--- a/Assets/MRTK/Providers/XRSDK/Profiles/DefaultHololens2XRSDKConfigurationProfile.asset.meta
+++ b/Assets/MRTK/Providers/XRSDK/Profiles/DefaultHololens2XRSDKConfigurationProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e3716acf2b8f684aba2d69548e29c52
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKConfigurationProfile.asset
+++ b/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKConfigurationProfile.asset
@@ -32,7 +32,7 @@ MonoBehaviour:
   teleportSystemType:
     reference: Microsoft.MixedReality.Toolkit.Teleport.MixedRealityTeleportSystem,
       Microsoft.MixedReality.Toolkit.Services.TeleportSystem
-  enableSpatialAwarenessSystem: 1
+  enableSpatialAwarenessSystem: 0
   spatialAwarenessSystemType:
     reference: Microsoft.MixedReality.Toolkit.SpatialAwareness.MixedRealitySpatialAwarenessSystem,
       Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem

--- a/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKConfigurationProfile.asset
+++ b/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKConfigurationProfile.asset
@@ -40,7 +40,7 @@ MonoBehaviour:
     type: 2}
   diagnosticsSystemProfile: {fileID: 11400000, guid: 478436bd1083882479a52d067e98e537,
     type: 2}
-  enableDiagnosticsSystem: 0
+  enableDiagnosticsSystem: 1
   diagnosticsSystemType:
     reference: Microsoft.MixedReality.Toolkit.Diagnostics.MixedRealityDiagnosticsSystem,
       Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem


### PR DESCRIPTION
## Overview
fixes missing profiler in hand interaction scene if you're starting the examples with xr sdk default profile (unity 2019.4)
disabled spatial awareness setting

both flags now match the hl2 profile