### PR TITLE
Clean up CI exceptions list

### DIFF
--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -365,11 +365,7 @@ $InitializeOnLoadExceptions = [System.Collections.Generic.HashSet[String]]@(
     "Assets/MRTK/Core/Utilities/WindowsApiChecker.cs",
     "Assets/MRTK/Core/Utilities/Async/Internal/SyncContextUtility.cs",
     "Assets/MRTK/Core/Utilities/Editor/EditorProjectUtilities.cs",
-    "Assets/MRTK/Core/Utilities/Editor/USB/USBDeviceListener.cs",
-    "Assets/MRTK/Providers/Oculus/XRSDK/Editor/OculusXRSDKConfigurationChecker.cs",
-    "Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs",
-    "Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Editor/WindowsMixedRealityXRSDKConfigurationChecker.cs",
-    "Assets/MRTK/Providers/XRSDK/Editor/XRSDKConfigurationChecker.cs"
+    "Assets/MRTK/Core/Utilities/Editor/USB/USBDeviceListener.cs"
 )
 
 <#

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -596,7 +596,6 @@ $AsmDefExceptions = [System.Collections.Generic.HashSet[String]]@(
     "Assets/MRTK/Providers/LeapMotion/MRTK.LeapMotion.asmdef",
     "Assets/MRTK/Providers/LeapMotion/Editor/MRTK.LeapMotion.Editor.asmdef",
     "Assets/MRTK/Providers/Oculus/XRSDK/MRTK.Oculus.asmdef",
-    "Assets/MRTK/Providers/Oculus/XRSDK/Editor/MRTK.Oculus.Editor.asmdef",
     "Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/MRTK.Oculus.Hands.Editor.asmdef",
     "Assets/MRTK/Providers/OpenVR/MRTK.OpenVR.asmdef",
     "Assets/MRTK/Providers/UnityAR/MRTK.UnityAR.asmdef",


### PR DESCRIPTION
## Overview

As part of #8574, several `[InitializeOnLoad]` tags and asmdefs were removed. We can go ahead and trim down the exceptions lists!