### PR TITLE
Add super sampling option for mrtk standard shader

### DIFF
--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -476,7 +476,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 materialEditor.ShaderProperty(triplanarMappingBlendSharpness, Styles.triplanarMappingBlendSharpness, 2);
             }
 
-
+            // SSAA implementation based off this article: https://medium.com/@bgolus/sharper-mipmapping-using-shader-based-supersampling-ed7aadb47bec
             materialEditor.ShaderProperty(enableSSAA, Styles.enableSSAA);
             if (PropertyEnabled(enableSSAA))
             {

--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent enableEmission = new GUIContent("Emission", "Enable Emission");
             public static GUIContent emissiveColor = new GUIContent("Color");
             public static GUIContent enableTriplanarMapping = new GUIContent("Triplanar Mapping", "Enable Triplanar Mapping, a technique which programmatically generates UV coordinates");
-            public static GUIContent enableMSAA = new GUIContent("Multi Sample Anti-Aliasing", "Enable Multi Sample Anti-Aliasing, a technique improves texture clarity at long distances");
+            public static GUIContent enableSSAA = new GUIContent("Super Sample Anti-Aliasing", "Enable Super Sample Anti-Aliasing, a technique improves texture clarity at long distances");
             public static GUIContent mipmapBias = new GUIContent("Mipmap Bias", "Degree to bias the mip map. A more negative value increases aliasing but gives a clearer image");
             public static GUIContent enableLocalSpaceTriplanarMapping = new GUIContent("Local Space", "If True Triplanar Mapping is Calculated in Local Space");
             public static GUIContent triplanarMappingBlendSharpness = new GUIContent("Blend Sharpness", "The Power of the Blend with the Normal");
@@ -137,7 +137,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         protected MaterialProperty enableEmission;
         protected MaterialProperty emissiveColor;
         protected MaterialProperty enableTriplanarMapping;
-        protected MaterialProperty enableMSAA;
+        protected MaterialProperty enableSSAA;
         protected MaterialProperty mipmapBias;
         protected MaterialProperty enableLocalSpaceTriplanarMapping;
         protected MaterialProperty triplanarMappingBlendSharpness;
@@ -229,7 +229,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             enableEmission = FindProperty("_EnableEmission", props);
             emissiveColor = FindProperty("_EmissiveColor", props);
             enableTriplanarMapping = FindProperty("_EnableTriplanarMapping", props);
-            enableMSAA = FindProperty("_EnableMSAA", props);
+            enableSSAA = FindProperty("_EnableSSAA", props);
             mipmapBias = FindProperty("_MipmapBias", props);
             enableLocalSpaceTriplanarMapping = FindProperty("_EnableLocalSpaceTriplanarMapping", props);
             triplanarMappingBlendSharpness = FindProperty("_TriplanarMappingBlendSharpness", props);
@@ -477,8 +477,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
 
 
-            materialEditor.ShaderProperty(enableMSAA, Styles.enableMSAA);
-            if (PropertyEnabled(enableMSAA))
+            materialEditor.ShaderProperty(enableSSAA, Styles.enableSSAA);
+            if (PropertyEnabled(enableSSAA))
             {
                 materialEditor.ShaderProperty(mipmapBias, Styles.mipmapBias, 2);
             }

--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -468,6 +468,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 materialEditor.ShaderProperty(emissiveColor, Styles.emissiveColor, 2);
             }
 
+            GUI.enabled = !PropertyEnabled(enableSSAA);
             materialEditor.ShaderProperty(enableTriplanarMapping, Styles.enableTriplanarMapping);
 
             if (PropertyEnabled(enableTriplanarMapping))
@@ -475,13 +476,17 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 materialEditor.ShaderProperty(enableLocalSpaceTriplanarMapping, Styles.enableLocalSpaceTriplanarMapping, 2);
                 materialEditor.ShaderProperty(triplanarMappingBlendSharpness, Styles.triplanarMappingBlendSharpness, 2);
             }
+            GUI.enabled = true;
 
+            GUI.enabled = !PropertyEnabled(enableTriplanarMapping);
             // SSAA implementation based off this article: https://medium.com/@bgolus/sharper-mipmapping-using-shader-based-supersampling-ed7aadb47bec
             materialEditor.ShaderProperty(enableSSAA, Styles.enableSSAA);
+
             if (PropertyEnabled(enableSSAA))
             {
                 materialEditor.ShaderProperty(mipmapBias, Styles.mipmapBias, 2);
             }
+            GUI.enabled = true;
 
             EditorGUILayout.Space();
             materialEditor.TextureScaleOffsetProperty(albedoMap);

--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -52,6 +52,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent enableEmission = new GUIContent("Emission", "Enable Emission");
             public static GUIContent emissiveColor = new GUIContent("Color");
             public static GUIContent enableTriplanarMapping = new GUIContent("Triplanar Mapping", "Enable Triplanar Mapping, a technique which programmatically generates UV coordinates");
+            public static GUIContent enableMSAA = new GUIContent("Multi Sample Anti-Aliasing", "Enable Multi Sample Anti-Aliasing, a technique improves texture clarity at long distances");
+            public static GUIContent mipmapBias = new GUIContent("Mipmap Bias", "Degree to bias the mip map. A more negative value increases aliasing but gives a clearer image");
             public static GUIContent enableLocalSpaceTriplanarMapping = new GUIContent("Local Space", "If True Triplanar Mapping is Calculated in Local Space");
             public static GUIContent triplanarMappingBlendSharpness = new GUIContent("Blend Sharpness", "The Power of the Blend with the Normal");
             public static GUIContent directionalLight = new GUIContent("Directional Light", "Affected by One Unity Directional Light");
@@ -135,6 +137,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         protected MaterialProperty enableEmission;
         protected MaterialProperty emissiveColor;
         protected MaterialProperty enableTriplanarMapping;
+        protected MaterialProperty enableMSAA;
+        protected MaterialProperty mipmapBias;
         protected MaterialProperty enableLocalSpaceTriplanarMapping;
         protected MaterialProperty triplanarMappingBlendSharpness;
         protected MaterialProperty metallic;
@@ -225,6 +229,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             enableEmission = FindProperty("_EnableEmission", props);
             emissiveColor = FindProperty("_EmissiveColor", props);
             enableTriplanarMapping = FindProperty("_EnableTriplanarMapping", props);
+            enableMSAA = FindProperty("_EnableMSAA", props);
+            mipmapBias = FindProperty("_MipmapBias", props);
             enableLocalSpaceTriplanarMapping = FindProperty("_EnableLocalSpaceTriplanarMapping", props);
             triplanarMappingBlendSharpness = FindProperty("_TriplanarMappingBlendSharpness", props);
             directionalLight = FindProperty("_DirectionalLight", props);
@@ -468,6 +474,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 materialEditor.ShaderProperty(enableLocalSpaceTriplanarMapping, Styles.enableLocalSpaceTriplanarMapping, 2);
                 materialEditor.ShaderProperty(triplanarMappingBlendSharpness, Styles.triplanarMappingBlendSharpness, 2);
+            }
+
+
+            materialEditor.ShaderProperty(enableMSAA, Styles.enableMSAA);
+            if (PropertyEnabled(enableMSAA))
+            {
+                materialEditor.ShaderProperty(mipmapBias, Styles.mipmapBias, 2);
             }
 
             EditorGUILayout.Space();

--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent emissiveColor = new GUIContent("Color");
             public static GUIContent enableTriplanarMapping = new GUIContent("Triplanar Mapping", "Enable Triplanar Mapping, a technique which programmatically generates UV coordinates");
             public static GUIContent enableSSAA = new GUIContent("Super Sample Anti-Aliasing", "Enable Super Sample Anti-Aliasing, a technique improves texture clarity at long distances");
-            public static GUIContent mipmapBias = new GUIContent("Mipmap Bias", "Degree to bias the mip map. A more negative value increases aliasing but gives a clearer image");
+            public static GUIContent mipmapBias = new GUIContent("Mipmap Bias", "Degree to bias the mip map. A larger negative value reduces aliasing and improves clarity, but may decrease performance");
             public static GUIContent enableLocalSpaceTriplanarMapping = new GUIContent("Local Space", "If True Triplanar Mapping is Calculated in Local Space");
             public static GUIContent triplanarMappingBlendSharpness = new GUIContent("Blend Sharpness", "The Power of the Blend with the Normal");
             public static GUIContent directionalLight = new GUIContent("Directional Light", "Affected by One Unity Directional Light");

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Materials/HolographicButtonIconFontMaterial.mat
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Materials/HolographicButtonIconFontMaterial.mat
@@ -123,7 +123,7 @@ Material:
     - _IridescenceIntensity: 0.5
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
-    - _MipmapBias: -5
+    - _MipmapBias: -2
     - _Mode: 1
     - _NearLightFade: 0
     - _NearPlaneFade: 0

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Materials/HolographicButtonIconFontMaterial.mat
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Materials/HolographicButtonIconFontMaterial.mat
@@ -10,6 +10,7 @@ Material:
   m_Name: HolographicButtonIconFontMaterial
   m_Shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
   m_ShaderKeywords: _ALPHATEST_ON _SPECULAR_HIGHLIGHTS _USECOLOR_ON _USEMAINTEX_ON
+    _USE_SSAA
   m_LightmapFlags: 5
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -102,6 +103,7 @@ Material:
     - _EnableLocalSpaceTriplanarMapping: 0
     - _EnableNormalMap: 0
     - _EnableProximityLightColorOverride: 0
+    - _EnableSSAA: 1
     - _EnableTriplanarMapping: 0
     - _EnvironmentColorIntensity: 0.5
     - _EnvironmentColorThreshold: 1.5
@@ -121,6 +123,7 @@ Material:
     - _IridescenceIntensity: 0.5
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
+    - _MipmapBias: -5
     - _Mode: 1
     - _NearLightFade: 0
     - _NearPlaneFade: 0

--- a/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -789,19 +789,19 @@ Shader "Mixed Reality Toolkit/Standard"
                                 tex2D(_MainTex, uvZ) * triplanarBlend.z;
 #else
 #if defined(_USE_SSAA)
-				// Does SSAA on the texture, implementation based off this article: https://medium.com/@bgolus/sharper-mipmapping-using-shader-based-supersampling-ed7aadb47bec
-				// per pixel screen space partial derivatives
-				float2 dx = ddx(i.uv.xy) * 0.25; // horizontal offset
-				float2 dy = ddy(i.uv.xy) * 0.25; // vertical offset
-				// supersampled 2x2 ordered grid
-				fixed4 albedo = 0;
-				albedo += tex2Dbias(_MainTex, float4(i.uv.xy + dx + dy, 0.0, _MipmapBias));
-				albedo += tex2Dbias(_MainTex, float4(i.uv.xy - dx + dy, 0.0, _MipmapBias));
-				albedo += tex2Dbias(_MainTex, float4(i.uv.xy + dx - dy, 0.0, _MipmapBias));
-				albedo += tex2Dbias(_MainTex, float4(i.uv.xy - dx - dy, 0.0, _MipmapBias));
-				albedo *= 0.25;
+                // Does SSAA on the texture, implementation based off this article: https://medium.com/@bgolus/sharper-mipmapping-using-shader-based-supersampling-ed7aadb47bec
+                // per pixel screen space partial derivatives
+                float2 dx = ddx(i.uv.xy) * 0.25; // horizontal offset
+                float2 dy = ddy(i.uv.xy) * 0.25; // vertical offset
+                // supersampled 2x2 ordered grid
+                fixed4 albedo = 0;
+                albedo += tex2Dbias(_MainTex, float4(i.uv.xy + dx + dy, 0.0, _MipmapBias));
+                albedo += tex2Dbias(_MainTex, float4(i.uv.xy - dx + dy, 0.0, _MipmapBias));
+                albedo += tex2Dbias(_MainTex, float4(i.uv.xy + dx - dy, 0.0, _MipmapBias));
+                albedo += tex2Dbias(_MainTex, float4(i.uv.xy - dx - dy, 0.0, _MipmapBias));
+                albedo *= 0.25;
 #else
-				fixed4 albedo = tex2D(_MainTex, i.uv);
+                fixed4 albedo = tex2D(_MainTex, i.uv);
 #endif
 #endif
 #endif

--- a/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -21,7 +21,7 @@ Shader "Mixed Reality Toolkit/Standard"
         [Toggle(_EMISSION)] _EnableEmission("Enable Emission", Float) = 0.0
         [HDR]_EmissiveColor("Emissive Color", Color) = (0.0, 0.0, 0.0, 1.0)
         [Toggle(_TRIPLANAR_MAPPING)] _EnableTriplanarMapping("Triplanar Mapping", Float) = 0.0
-		[Toggle(_USE_MSAA)] _EnableMSAA("Multi Sample Anti Aliasing", Float) = 0.0
+		[Toggle(_USE_SSAA)] _EnableSSAA("Super Sample Anti Aliasing", Float) = 0.0
 		_MipmapBias("Mipmap Bias", Range(-1.0, 0.0)) = 0.0
 		[Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
         _TriplanarMappingBlendSharpness("Blend Sharpness", Range(1.0, 16.0)) = 4.0
@@ -151,6 +151,7 @@ Shader "Mixed Reality Toolkit/Standard"
             #pragma shader_feature _EMISSION
             #pragma shader_feature _TRIPLANAR_MAPPING
             #pragma shader_feature _LOCAL_SPACE_TRIPLANAR_MAPPING
+			#pragma shader_feature _USE_SSAA
             #pragma shader_feature _DIRECTIONAL_LIGHT
             #pragma shader_feature _SPECULAR_HIGHLIGHTS
             #pragma shader_feature _SPHERICAL_HARMONICS
@@ -348,7 +349,7 @@ Shader "Mixed Reality Toolkit/Standard"
             fixed4 _EmissiveColor;
 #endif
 
-#if defined(_USE_MSAA)
+#if defined(_USE_SSAA)
 			float _MipmapBias;
 #endif
 
@@ -783,11 +784,11 @@ Shader "Mixed Reality Toolkit/Standard"
                 fixed4 albedo = fixed4(1.0, 1.0, 1.0, 1.0);
 #else
 #if defined(_TRIPLANAR_MAPPING)
-                //fixed4 albedo = tex2D(_MainTex, uvX) * triplanarBlend.x + 
-                //                tex2D(_MainTex, uvY) * triplanarBlend.y + 
-                //                tex2D(_MainTex, uvZ) * triplanarBlend.z;
+                fixed4 albedo = tex2D(_MainTex, uvX) * triplanarBlend.x + 
+                                tex2D(_MainTex, uvY) * triplanarBlend.y + 
+                                tex2D(_MainTex, uvZ) * triplanarBlend.z;
 #else
-#if defined(_USE_MSAA)
+#if defined(_USE_SSAA)
 				// per pixel screen space partial derivatives
 				float2 dx = ddx(i.uv.xy) * 0.25; // horizontal offset
 				float2 dy = ddy(i.uv.xy) * 0.25; // vertical offset

--- a/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -22,7 +22,7 @@ Shader "Mixed Reality Toolkit/Standard"
         [HDR]_EmissiveColor("Emissive Color", Color) = (0.0, 0.0, 0.0, 1.0)
         [Toggle(_TRIPLANAR_MAPPING)] _EnableTriplanarMapping("Triplanar Mapping", Float) = 0.0
         [Toggle(_USE_SSAA)] _EnableSSAA("Super Sample Anti Aliasing", Float) = 0.0
-        _MipmapBias("Mipmap Bias", Range(-1.0, 0.0)) = 0.0
+        _MipmapBias("Mipmap Bias", Range(-10.0, 0.0)) = -5.0
         [Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
         _TriplanarMappingBlendSharpness("Blend Sharpness", Range(1.0, 16.0)) = 4.0
 

--- a/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -789,6 +789,7 @@ Shader "Mixed Reality Toolkit/Standard"
                                 tex2D(_MainTex, uvZ) * triplanarBlend.z;
 #else
 #if defined(_USE_SSAA)
+				// Does SSAA on the texture, implementation based off this article: https://medium.com/@bgolus/sharper-mipmapping-using-shader-based-supersampling-ed7aadb47bec
 				// per pixel screen space partial derivatives
 				float2 dx = ddx(i.uv.xy) * 0.25; // horizontal offset
 				float2 dy = ddy(i.uv.xy) * 0.25; // vertical offset

--- a/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -22,7 +22,7 @@ Shader "Mixed Reality Toolkit/Standard"
         [HDR]_EmissiveColor("Emissive Color", Color) = (0.0, 0.0, 0.0, 1.0)
         [Toggle(_TRIPLANAR_MAPPING)] _EnableTriplanarMapping("Triplanar Mapping", Float) = 0.0
         [Toggle(_USE_SSAA)] _EnableSSAA("Super Sample Anti Aliasing", Float) = 0.0
-        _MipmapBias("Mipmap Bias", Range(-10.0, 0.0)) = -5.0
+        _MipmapBias("Mipmap Bias", Range(-5.0, 0.0)) = -2.0
         [Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
         _TriplanarMappingBlendSharpness("Blend Sharpness", Range(1.0, 16.0)) = 4.0
 

--- a/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MRTK/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -21,9 +21,9 @@ Shader "Mixed Reality Toolkit/Standard"
         [Toggle(_EMISSION)] _EnableEmission("Enable Emission", Float) = 0.0
         [HDR]_EmissiveColor("Emissive Color", Color) = (0.0, 0.0, 0.0, 1.0)
         [Toggle(_TRIPLANAR_MAPPING)] _EnableTriplanarMapping("Triplanar Mapping", Float) = 0.0
-		[Toggle(_USE_SSAA)] _EnableSSAA("Super Sample Anti Aliasing", Float) = 0.0
-		_MipmapBias("Mipmap Bias", Range(-1.0, 0.0)) = 0.0
-		[Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
+        [Toggle(_USE_SSAA)] _EnableSSAA("Super Sample Anti Aliasing", Float) = 0.0
+        _MipmapBias("Mipmap Bias", Range(-1.0, 0.0)) = 0.0
+        [Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
         _TriplanarMappingBlendSharpness("Blend Sharpness", Range(1.0, 16.0)) = 4.0
 
         // Rendering options.
@@ -151,7 +151,7 @@ Shader "Mixed Reality Toolkit/Standard"
             #pragma shader_feature _EMISSION
             #pragma shader_feature _TRIPLANAR_MAPPING
             #pragma shader_feature _LOCAL_SPACE_TRIPLANAR_MAPPING
-			#pragma shader_feature _USE_SSAA
+            #pragma shader_feature _USE_SSAA
             #pragma shader_feature _DIRECTIONAL_LIGHT
             #pragma shader_feature _SPECULAR_HIGHLIGHTS
             #pragma shader_feature _SPHERICAL_HARMONICS
@@ -350,7 +350,7 @@ Shader "Mixed Reality Toolkit/Standard"
 #endif
 
 #if defined(_USE_SSAA)
-			float _MipmapBias;
+            float _MipmapBias;
 #endif
 
 #if defined(_TRIPLANAR_MAPPING)


### PR DESCRIPTION
## Overview
Icon rendering is noticeably blurry on VR devices Hololens 2 (slightly less so for the latter). By adding super sampling (https://medium.com/@bgolus/sharper-mipmapping-using-shader-based-supersampling-ed7aadb47bec) we can improve the icon rendering quality without too much performance impact.

## Changes
- Fixes: #8713
