### PR TITLE
Fix for #8733: Limit migration tool to Assets folder tree

### DIFF
--- a/Assets/MRTK/SDK/Editor/Migration/Tools/MigrationTool.cs
+++ b/Assets/MRTK/SDK/Editor/Migration/Tools/MigrationTool.cs
@@ -397,7 +397,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             var filter = string.Join(" ", types
                                           .Select(x => string.Format("t:{0}", x.Name))
                                           .ToArray());
-            return AssetDatabase.FindAssets(filter).Select(x => AssetDatabase.GUIDToAssetPath(x)).ToList();
+            return AssetDatabase.FindAssets(filter, new[] {"Assets"}).Select(x => AssetDatabase.GUIDToAssetPath(x)).ToList();
         }
 
         private static bool IsSceneGameObject(Object selectedObject)

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -1,4 +1,4 @@
-# Microsoft Mixed Reality Toolkit 2.5.0 draft release notes
+# Microsoft Mixed Reality Toolkit 2.5.0 release notes
 
 - [What's new](#whats-new)
 - [Breaking changes](#breaking-changes)


### PR DESCRIPTION
#8733 identified a bug in the migration tool in which it is searching for assets in immutable folders. With the MRTK being provided as UPM packages, this causes a failure to load scene error when the scene system scenes (ex: DefaultLightingScene) are encountered.

This change limits the migration tool to only work on files in the Assets folder tree.

It does _not_ fix the inability to load the scenes (that change is forthcoming in a new PR_)

**_This change should be considered for a 2.5.1 UPM release as it prevents customers from using the Migration Tool._**

Fixes: #8733