### PR TITLE
Remove duplicate EventSystem in LeapMotion Hand Tracking Example

### DIFF
--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/LeapMotionHandTrackingExample.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/LeapMotionHandTrackingExample.unity
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 512
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 512
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -87,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -684,7 +693,6 @@ GameObject:
   - component: {fileID: 712999893}
   - component: {fileID: 712999896}
   - component: {fileID: 712999898}
-  - component: {fileID: 712999899}
   - component: {fileID: 712999897}
   m_Layer: 0
   m_Name: Main Camera
@@ -713,9 +721,10 @@ Camera:
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -814,21 +823,6 @@ MonoBehaviour:
   m_InputActionsPerSecond: 10
   m_RepeatDelay: 0.5
   m_ForceModuleActive: 0
---- !u!114 &712999899
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 712999892}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
 --- !u!1 &736454870
 GameObject:
   m_ObjectHideFlags: 0
@@ -1089,6 +1083,8 @@ MonoBehaviour:
   rotateLerpTime: 0.001
   scaleLerpTime: 0.001
   translateLerpTime: 0.001
+  enableConstraints: 1
+  constraintsManager: {fileID: 0}
   rotateStarted:
     m_PersistentCalls:
       m_Calls: []
@@ -1120,6 +1116,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a98de877dee5fc341b4eb59dfdab266c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  autoConstraintSelection: 1
+  selectedConstraints: []
 --- !u!65 &823646993
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1147,6 +1145,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1158,6 +1157,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1433,29 +1433,35 @@ PrefabInstance:
       value: '<size=42><b>Leap Motion Hand Tracking</b></size>
 
 
-        MRTK supports articulated hand tracking for VR using the Leap Motion Controller.  The
-        Leap Motion Controller is required to use this data provider.
+        MRTK supports
+        articulated hand tracking for VR using the Leap Motion Controller.  The Leap
+        Motion Controller is required to use this data provider.
 
 
-        This scene uses the DefaultLeapMotionConfigurationProfile which is a clone
-        of the DefaultMixedRealityConfigurationProfile with the addition of the Leap
-        Data Provider under the Input Data Providers section.
+        This scene
+        uses the DefaultLeapMotionConfigurationProfile which is a clone of the DefaultMixedRealityConfigurationProfile
+        with the addition of the Leap Data Provider under the Input Data Providers
+        section.
 
 
         - Make sure the Leap Motion Orion SDK 4.0.0 is installed
 
-        - Import the latest version of the Leap Motion Unity Modules
+        -
+        Import the latest version of the Leap Motion Unity Modules
 
-        - Navigate to Mixed Reality Toolkit > Utilities > Leap Motion > Connect Leap
-        Motion Assets
+        - Navigate
+        to Mixed Reality Toolkit > Utilities > Leap Motion > Connect Leap Motion
+        Assets
 
-        - Make sure the assets are connected to MRTK by navigating to Mixed Reality
-        Toolkit > Utilities > Leap Motion > Check Connection Status
+        - Make sure the assets are connected to MRTK by navigating
+        to Mixed Reality Toolkit > Utilities > Leap Motion > Check Connection Status
 
-        - Make sure the Leap Controller is plugged in
+        -
+        Make sure the Leap Controller is plugged in
 
-        - Press Play and move your hand in front of the Leap Controller to see the
-        joint representation of a tracked hand.
+        - Press Play and move
+        your hand in front of the Leap Controller to see the joint representation
+        of a tracked hand.
 
 '
       objectReference: {fileID: 0}
@@ -1907,12 +1913,14 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1410962402}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -1922,6 +1930,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -1929,12 +1955,15 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 4
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &1410962404


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8654

Basic example scene cleanup - opening example scenes shouldn't show warnings in the Unity editor. I was already looking at https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8720, this was in the same neighborhood so I opted to fix this one as well.

Basically, the main camera had two EventSystems on it (so we deleted the duplicate one)