### PR TITLE
Missing text mesh pro dependency in examples.

### DIFF
--- a/Assets/MRTK/Examples/packagetemplate.json
+++ b/Assets/MRTK/Examples/packagetemplate.json
@@ -25,7 +25,8 @@
       },
     "dependencies": {
         "com.microsoft.mixedreality.toolkit.foundation": "%version%",
-        "com.microsoft.mixedreality.toolkit.extensions": "%version%"
+        "com.microsoft.mixedreality.toolkit.extensions": "%version%",
+        "com.unity.textmeshpro": "2.1.1"
     },
     "files": [
         "Common*",


### PR DESCRIPTION
Sorry for the PR's on individual files...I'm just using the github web-based file editor to make patches.

My dependency walker found several issues such as:

Examples contains asset Common\Prefabs\HandMenu_Large_AutoWorldLock_On_HandDrop.prefab, that depends on Packages/com.unity.textmeshpro/Scripts/Runtime/TextMeshPro.cs, but package dependency is missing.

The asmdef does contain the reference, but that doesn't guarantee they have the package reference.
