### PR TITLE
Missing text mesh pro dependency in Foundation

### DIFF
--- a/Assets/MRTK/packagetemplate.json
+++ b/Assets/MRTK/packagetemplate.json
@@ -24,7 +24,8 @@
         "url": "https://github.com/microsoft/MixedRealityToolkit-Unity/issues"
      },
     "dependencies": { 
-        "com.microsoft.mixedreality.toolkit.standardassets": "%version%"
+        "com.microsoft.mixedreality.toolkit.standardassets": "%version%",
+        "com.unity.textmeshpro": "2.1.1"
     },
     "files": [
         "Core*",


### PR DESCRIPTION
Sorry for the PR's on individual files...I'm just using the github web-based file editor to make patches.

Foundation contains asset SDK\Features\UX\Interactable\Prefabs\PressableButtonHoloLens2_NoLabel.prefab, that depends on Packages/com.unity.textmeshpro/Scripts/Runtime/TextMeshPro.cs, but package dependency is missing.