### PR TITLE
Missing text mesh pro dependency in Extensions.

### DIFF
--- a/Assets/MRTK/Extensions/packagetemplate.json
+++ b/Assets/MRTK/Extensions/packagetemplate.json
@@ -25,7 +25,8 @@
         "url": "https://github.com/microsoft/MixedRealityToolkit-Unity/issues"
       },
     "dependencies": {
-        "com.microsoft.mixedreality.toolkit.foundation": "%version%"
+        "com.microsoft.mixedreality.toolkit.foundation": "%version%",
+        "com.unity.textmeshpro": "2.1.1"
     },
     %samples%
 }


### PR DESCRIPTION
Sorry for the PR's on individual files...I'm just using the github web-based file editor to make patches.

Extensions contains asset LostTrackingService\Assets\LostTrackingVisualPrefab.prefab, that depends on Packages/com.unity.textmeshpro/Scripts/Runtime/TextMeshPro.cs, but package dependency is missing.
