### PR TITLE
Missing foundation and TMP dep in standard assets

### DIFF
--- a/Assets/MRTK/StandardAssets/packagetemplate.json
+++ b/Assets/MRTK/StandardAssets/packagetemplate.json
@@ -25,5 +25,9 @@
     },
     "bugs": {
         "url": "https://github.com/microsoft/MixedRealityToolkit-Unity/issues"
+    },
+    "dependencies": {
+        "com.thirdparty.mrtk.foundation": "2.5.0",
+        "com.unity.textmeshpro": "2.1.1"
     }
 }


### PR DESCRIPTION
Sorry for the PR's on individual files...I'm just using the github web-based file editor to make patches.

Standardassets contains asset FontsSDFTextures\seguisb SDF.asset, that depends on Packages/com.unity.textmeshpro/Scripts/Runtime/TMP_FontAsset.cs, but package dependency is missing.

Standardassets contains asset Materials\MRTK_Standard_GlowingCyan.mat, that depends on Foundation/SDK/StandardAssets/Textures/IridescentSpectrum.png, but package dependency is missing.
