### PR TITLE
Use variable expansion for CI/PR demands

### DIFF
--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -11,7 +11,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2019.4.8f1
+    - ${{ variables.Unity2019Version }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
@@ -26,7 +26,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.26f1
+    - ${{ variables.Unity2018Version }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-packaging-dontpublish.yml
+++ b/pipelines/ci-packaging-dontpublish.yml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.26f1
+    - ${{ variables.Unity2018Version }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: Analog N-1
     demands:
-    - Unity2018.4.23f1
+    - ${{ variables.Unity2018VersionInternal }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.26f1
+    - ${{ variables.Unity2018Version }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -19,7 +19,7 @@ jobs:
   pool:
     name: Analog N-1
     demands:
-    - Unity2018.4.23f1
+    - ${{ variables.Unity2018VersionInternal }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-weekly-internal.yml
+++ b/pipelines/ci-weekly-internal.yml
@@ -21,7 +21,7 @@ jobs:
   pool:
     name: Analog N-1
     demands:
-    - Unity2018.4.23f1
+    - ${{ variables.Unity2018VersionInternal }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.26f1
+    - ${{ variables.Unity2018Version }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.26f1
+    - ${{ variables.Unity2018Version }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:


### PR DESCRIPTION
## Overview

I think this didn't used to work or something? But I found while working on a different repo's pipeline that I could do this now. Helps reduce the number of places we need to update version numbers to one for the pipelines.