### PR TITLE
Added common issue for OculusXRSDKDeviceManagerProfile Prefab 

### DIFF
--- a/Documentation/CrossPlatform/OculusQuestMRTK.md
+++ b/Documentation/CrossPlatform/OculusQuestMRTK.md
@@ -33,7 +33,7 @@ This data provider does **NOT** use Unity's **XR Pipeline** or **Legacy XR Pipel
 work is 20.0.0. Older versions can be found from this [archive](https://developer.oculus.com/downloads/package/unity-integration-archive/)
 
 1. Navigate to Mixed Reality Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules and run it. Doing this will update the asmdefs with definitions and references needed for the
-relevant Oculus Quest code to function. Additionally, it should populate the **Prefab reference** fields of the **OculusXRSDKDeviceManagerProfile** at */Assets/MRTK/Providers/Oculus/XRSDK/Profiles*.
+relevant Oculus Quest code to function. Additionally, it should populate the **Prefab reference** fields of the **OculusXRSDKDeviceManagerProfile**.
 It will also update the csc file to filter out the obsolete warnings produced by the Oculus Integration assets. The MRTK repo contains a csc file that converts warnings to errors, this conversion halts the MRTK-Quest configuration process.
 
     ![OculusIntegrationAsmdef](../Images/CrossPlatform/OculusQuest/OculusIntegrationAsmdef.png)
@@ -118,4 +118,4 @@ If you encounter an error that looks like this
 **UnassignedReferenceException: The variable ovrCameraRigPrefab of OculusXRSDKDeviceManagerProfile has not been assigned. You probably need to assign the ovrCameraRigPrefab variable of the OculusXRSDKDeviceManagerProfile script in the inspector.**
 
 Then the project is not fully integrated with the Oculus Unity Modules. Navigate to Mixed Reality Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules and run it. 
-Doing so populate the **Prefab reference** fields of the **OculusXRSDKDevicemanagerProfile** at */Assets/MRTK/Providers/Oculus/XRSDK/Profiles*.
+Doing so populate the **Prefab reference** fields of the **OculusXRSDKDeviceManagerProfile**.

--- a/Documentation/CrossPlatform/OculusQuestMRTK.md
+++ b/Documentation/CrossPlatform/OculusQuestMRTK.md
@@ -32,8 +32,9 @@ This data provider does **NOT** use Unity's **XR Pipeline** or **Legacy XR Pipel
 1. Download and import [Oculus Integration](https://assetstore.unity.com/packages/tools/integration/oculus-integration-82022) from the Unity Asset Store. The latest version tested to
 work is 20.0.0. Older versions can be found from this [archive](https://developer.oculus.com/downloads/package/unity-integration-archive/)
 
-1. Navigate to Mixed Reality Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules. Doing this will update the asmdefs with definitions and references needed for the
-relevant Oculus Quest code to function. It will also update the csc file to filter out the obsolete warnings produced by the Oculus Integration assets. The MRTK repo contains a csc file that converts warnings to errors, this conversion halts the MRTK-Quest configuration process.
+1. Navigate to Mixed Reality Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules and run it. Doing this will update the asmdefs with definitions and references needed for the
+relevant Oculus Quest code to function. Additionally, it should populate the **Prefab reference** fields of the **OculusXRSDKDevicemanagerProfile** at */Assets/MRTK/Providers/Oculus/XRSDK/Profiles*.
+It will also update the csc file to filter out the obsolete warnings produced by the Oculus Integration assets. The MRTK repo contains a csc file that converts warnings to errors, this conversion halts the MRTK-Quest configuration process.
 
     ![OculusIntegrationAsmdef](../Images/CrossPlatform/OculusQuest/OculusIntegrationAsmdef.png)
 
@@ -109,3 +110,12 @@ Make sure your Android paths are properly configured. If you continue to encount
 **Edit > Preferences > External Tools > Android**
 
 ![AndroidToolsConfig](../Images/CrossPlatform/OculusQuest/AndroidToolsConfig.png)
+
+### The ovrCameraRigPrefab of OculusXRSDKDeviceManagerProfile has not been assigned.
+
+If you encounter an error that looks like this
+
+**UnassignedReferenceException: The variable ovrCameraRigPrefab of OculusXRSDKDeviceManagerProfile has not been assigned. You probably need to assign the ovrCameraRigPrefab variable of the OculusXRSDKDeviceManagerProfile script in the inspector.**
+
+Then the project is not fully integrated with the Oculus Unity Modules. Navigate to Mixed Reality Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules and run it. 
+Doing so populate the **Prefab reference** fields of the **OculusXRSDKDevicemanagerProfile** at */Assets/MRTK/Providers/Oculus/XRSDK/Profiles*.

--- a/Documentation/CrossPlatform/OculusQuestMRTK.md
+++ b/Documentation/CrossPlatform/OculusQuestMRTK.md
@@ -33,7 +33,7 @@ This data provider does **NOT** use Unity's **XR Pipeline** or **Legacy XR Pipel
 work is 20.0.0. Older versions can be found from this [archive](https://developer.oculus.com/downloads/package/unity-integration-archive/)
 
 1. Navigate to Mixed Reality Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules and run it. Doing this will update the asmdefs with definitions and references needed for the
-relevant Oculus Quest code to function. Additionally, it should populate the **Prefab reference** fields of the **OculusXRSDKDevicemanagerProfile** at */Assets/MRTK/Providers/Oculus/XRSDK/Profiles*.
+relevant Oculus Quest code to function. Additionally, it should populate the **Prefab reference** fields of the **OculusXRSDKDeviceManagerProfile** at */Assets/MRTK/Providers/Oculus/XRSDK/Profiles*.
 It will also update the csc file to filter out the obsolete warnings produced by the Oculus Integration assets. The MRTK repo contains a csc file that converts warnings to errors, this conversion halts the MRTK-Quest configuration process.
 
     ![OculusIntegrationAsmdef](../Images/CrossPlatform/OculusQuest/OculusIntegrationAsmdef.png)


### PR DESCRIPTION
#8359  Overview

Updated docs to more clearly indicate that the prefab references for the OculusXRSDKDeviceManager should get populated.