### PR TITLE
Add a scroll view to the list of included scenes on the Build Window

### DIFF
--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -243,6 +243,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         private string[] targetIps;
         private readonly List<Version> windowsSdkVersions = new List<Version>();
 
+        private Vector2 buildSceneListScrollPosition;
         private Vector2 deployBuildListScrollPosition;
 
         private BuildDeployTab currentTab = BuildDeployTab.UnityBuildOptions;
@@ -425,12 +426,17 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             {
                 EditorGUILayout.LabelField("Scenes in Build", EditorStyles.boldLabel);
 
-                using (new EditorGUI.DisabledGroupScope(true))
+                using (var scrollView = new EditorGUILayout.ScrollViewScope(buildSceneListScrollPosition, GUILayout.ExpandHeight(true), GUILayout.ExpandWidth(true)))
                 {
-                    var scenes = EditorBuildSettings.scenes;
-                    for (int i = 0; i < scenes.Length; i++)
+                    buildSceneListScrollPosition = scrollView.scrollPosition;
+
+                    using (new EditorGUI.DisabledGroupScope(true))
                     {
-                        EditorGUILayout.ToggleLeft($"{i} {scenes[i].path}", scenes[i].enabled);
+                        var scenes = EditorBuildSettings.scenes;
+                        for (int i = 0; i < scenes.Length; i++)
+                        {
+                            EditorGUILayout.ToggleLeft($"{i} {scenes[i].path}", scenes[i].enabled);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Overview
When we had a big list of scenes to be included in the build, the layout of the "Unity Build Options" tab in the Build Window would keep growing. Thus, the buttons to open Visual Studio and build the Unity Project can easily become clipped and out of reach. This pull request adds a scroll view to surround the list of scenes in order to avoid this issue.

### Before
![Unity_zpKM31U6or](https://user-images.githubusercontent.com/2981116/95800539-80a5d200-0cef-11eb-852d-facf3651cf9f.png)

### After
![Unity_ra2IS2pw1d](https://user-images.githubusercontent.com/2981116/95800523-7aaff100-0cef-11eb-9389-866e399aef9f.png)

## Changes
- Fixes: Add a scroll view around the list of scenes to be included in the "Unity Build Options" tab of the Build and Deploy Window.
