### PR TITLE
Sanitize data provider array access

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
@@ -167,6 +167,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 using (new EditorGUILayout.HorizontalScope())
                 {
+                    if (index < 0 || index >= providerFoldouts.Count) index = 0;
                     providerFoldouts[index] = EditorGUILayout.Foldout(providerFoldouts[index], providerProperties.componentName.stringValue, true);
 
                     if (GUILayout.Button(removeContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))


### PR DESCRIPTION
## Changes

Partially fixes #8802 

Some of the error messages there seem to be "by design but misleading", e.g. a new data provider is created without a concrete type (type is "(None)") and then an error is logged that the type (obviously) is not a concrete type, so I'm not quite sure what the best approach would be – maybe this should be a warning in the editor and an error in a build?
