### PR TITLE
update the docs list and default to 2.5.1

### DIFF
--- a/scripts/docs/web/version.js
+++ b/scripts/docs/web/version.js
@@ -1,7 +1,7 @@
 function createDropdown()
 {
 	// configurable values:
-	var defaultTitle = "releases/2.5.0"; // title in the dropdown for the root version of the docs - alternatively put a version from the version array as a default
+	var defaultTitle = "releases/2.5.1"; // title in the dropdown for the root version of the docs - alternatively put a version from the version array as a default
 	
 	// list of all versions in the version folder
 	var versionArray = [
@@ -12,6 +12,7 @@ function createDropdown()
 		"releases/2.3.0",
 		"releases/2.4.0",
 		"releases/2.5.0",
+		"releases/2.5.1"
 	];
 	
 	var ignoreDefaultInVersionFolder = true;


### PR DESCRIPTION
This change adds 2.5.1 to the available docs list and sets the default version displayed to 2.5.1