### PR TITLE
Add additional references to the ARM64 workaround to ReleaseNotes and UsingUpm articles

### DIFF
--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -5,6 +5,12 @@
 - [Updating guidance](Updating.md#upgrading-to-a-new-version-of-mrtk)
 - [Known issues](#known-issues)
 
+> [!IMPORTANT]
+> There is a known compiler issue that impacts applications built for Microsoft HoloLens 2 using
+> ARM64. This issue is addressed in the forthcoming 16.8 update for Visual Studio 2019. Until the 
+> update is available, please import the `com.microsoft.mixedreality.toolkit.tools` package to apply 
+> a workaround.
+
 ## What's new
 
 > [!NOTE]

--- a/Documentation/usingupm.md
+++ b/Documentation/usingupm.md
@@ -46,6 +46,11 @@ To add an MRTK package, modify the dependencies section of the `Packages/manifes
     "com.microsoft.mixedreality.toolkit.tools": "2.5.1",
     "com.microsoft.mixedreality.toolkit.examples": "2.5.1",
 ```
+> [!IMPORTANT]
+> There is a known compiler issue that impacts applications built for Microsoft HoloLens 2 using
+> ARM64. This issue is addressed in the forthcoming 16.8 update for Visual Studio 2019. Until the 
+> update is available, please import the `com.microsoft.mixedreality.toolkit.tools` package to apply 
+> a workaround.
 
 ## Managing Mixed Reality features with the Unity Package Manager
 


### PR DESCRIPTION
This change adds the following note to ReleaseNotes.md and usingupm.md

> [!IMPORTANT]
> There is a known compiler issue that impacts applications built for Microsoft HoloLens 2 using
> ARM64. This issue is addressed in the forthcoming 16.8 update for Visual Studio 2019. Until the 
> update is available, please import the `com.microsoft.mixedreality.toolkit.tools` package to apply 
> a workaround.