### PR TITLE
Make oculus hand rendering controled by the hand visualization profile

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -69,6 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
 #endif
         
         private OculusXRSDKDeviceManagerProfile settingsProfile;
+        private MixedRealityHandTrackingProfile handTrackingProfile;
         private int pinchStrengthProp;
 
 
@@ -110,6 +111,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         public void InitializeHand(OVRHand ovrHand, OculusXRSDKDeviceManagerProfile deviceManagerSettings)
         {
             settingsProfile = deviceManagerSettings;
+            handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile.HandTrackingProfile;
 
             handRenderer = ovrHand.GetComponent<Renderer>();
             UpdateHandMaterial(settingsProfile.CustomHandMaterial);
@@ -403,7 +405,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             // Disable hand if not tracked
             if (handRenderer != null)
             {
-                MixedRealityHandTrackingProfile handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile.HandTrackingProfile;
                 bool showHandMesh = handTrackingProfile.EnableHandMeshVisualization;
                 handRenderer.enabled = isTracked && showHandMesh;
             }

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -403,7 +403,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             // Disable hand if not tracked
             if (handRenderer != null)
             {
-                handRenderer.enabled = isTracked;
+                MixedRealityHandTrackingProfile handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile.HandTrackingProfile;
+                bool showHandMesh = handTrackingProfile.EnableHandMeshVisualization;
+                handRenderer.enabled = isTracked && showHandMesh;
             }
 
             if (ovrSkeleton != null)

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -194,14 +194,14 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         /// Update the controller data from the provided platform state
         /// </summary>
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform</param>
-        public void UpdateController(OVRHand hand, OVRSkeleton ovrSkeleton, Transform trackingOrigin)
+        public void UpdateController(OVRHand hand, OVRSkeleton ovrSkeleton, OVRMeshRenderer ovrMeshRenderer, Transform trackingOrigin)
         {
             if (!Enabled || hand == null || ovrSkeleton == null)
             {
                 return;
             }
 
-            bool isTracked = UpdateHandData(hand, ovrSkeleton);
+            bool isTracked = UpdateHandData(hand, ovrSkeleton, ovrMeshRenderer);
             IsPositionAvailable = IsRotationAvailable = isTracked;
 
             if (isTracked)
@@ -369,7 +369,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         };
 
         private float _lastHighConfidenceTime = 0f;
-        protected bool UpdateHandData(OVRHand ovrHand, OVRSkeleton ovrSkeleton)
+        protected bool UpdateHandData(OVRHand ovrHand, OVRSkeleton ovrSkeleton, OVRMeshRenderer ovrMeshRenderer)
         {
             bool isTracked = ovrHand.IsTracked;
             if (ovrHand.HandConfidence == OVRHand.TrackingConfidence.High)
@@ -402,11 +402,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
                 settingsProfile.CurrentRightHandTrackingConfidence = ovrHand.HandConfidence;
             }
 
-            // Disable hand if not tracked
+            // Managing hand visuals based on the handtracking visualization profile and if the hand is tracked
             if (handRenderer != null)
             {
-                bool showHandMesh = handTrackingProfile.EnableHandMeshVisualization;
+                bool showHandMesh = handTrackingProfile.IsNull() ? false : handTrackingProfile.EnableHandMeshVisualization;
+                bool showHandJoints = handTrackingProfile.IsNull() ? false : handTrackingProfile.EnableHandJointVisualization;
+
+                ovrMeshRenderer.enabled = isTracked && showHandMesh;
                 handRenderer.enabled = isTracked && showHandMesh;
+                Visualizer.GameObjectProxy.SetActive(isTracked && showHandJoints);
             }
 
             if (ovrSkeleton != null)

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -50,7 +50,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         private OVRCameraRig cameraRig;
 
         private OVRHand rightHand;
-        private OVRMeshRenderer righMeshRenderer;
+        private OVRMeshRenderer rightMeshRenderer;
         private OVRSkeleton rightSkeleton;
 
         private OVRHand leftHand;
@@ -230,7 +230,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
                     case OVRSkeleton.SkeletonType.HandRight:
                         rightHand = ovrHand;
                         rightSkeleton = ovrSkeleton;
-                        righMeshRenderer = meshRenderer;
+                        rightMeshRenderer = meshRenderer;
                         break;
                 }
             }
@@ -251,8 +251,8 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         #region Hand Utilities
         protected void UpdateHands()
         {
-            UpdateHand(leftHand, leftSkeleton, righMeshRenderer, Handedness.Left);
-            UpdateHand(rightHand, rightSkeleton, righMeshRenderer, Handedness.Right);
+            UpdateHand(leftHand, leftSkeleton, leftMeshRenderer, Handedness.Left);
+            UpdateHand(rightHand, rightSkeleton, rightMeshRenderer, Handedness.Right);
         }
 
         protected void UpdateHand(OVRHand ovrHand, OVRSkeleton ovrSkeleton, OVRMeshRenderer ovrMeshRenderer, Handedness handedness)

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -63,7 +63,6 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         /// Input > Input Data Providers > Oculus XRSDK Device Manager in the MixedRealityToolkit object in the hierarchy.
         /// </summary>
         private OculusXRSDKDeviceManagerProfile SettingsProfile => ConfigurationProfile as OculusXRSDKDeviceManagerProfile;
-        private MixedRealityHandTrackingProfile handTrackingProfile;
 #endif
 
         #region IMixedRealityCapabilityCheck Implementation
@@ -140,7 +139,6 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         public override void Enable()
         {
             base.Enable();
-            handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile.HandTrackingProfile;
 
             SetupInput();
             ConfigurePerformancePreferences();
@@ -267,14 +265,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
             if (ovrHand.IsTracked)
             {
                 var hand = GetOrAddHand(handedness, ovrHand);
-
-                bool showHandMesh = handTrackingProfile.EnableHandMeshVisualization;
-                bool showHandJoints = handTrackingProfile.EnableHandJointVisualization;
-
-                ovrMeshRenderer.enabled = showHandMesh;
-                hand.Visualizer.GameObjectProxy.SetActive(showHandJoints);
-
-                hand.UpdateController(ovrHand, ovrSkeleton, cameraRig.trackingSpace);
+                hand.UpdateController(ovrHand, ovrSkeleton, ovrMeshRenderer, cameraRig.trackingSpace);
             }
             else
             {

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -63,6 +63,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         /// Input > Input Data Providers > Oculus XRSDK Device Manager in the MixedRealityToolkit object in the hierarchy.
         /// </summary>
         private OculusXRSDKDeviceManagerProfile SettingsProfile => ConfigurationProfile as OculusXRSDKDeviceManagerProfile;
+        private MixedRealityHandTrackingProfile handTrackingProfile;
 #endif
 
         #region IMixedRealityCapabilityCheck Implementation
@@ -139,6 +140,8 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         public override void Enable()
         {
             base.Enable();
+            handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile.HandTrackingProfile;
+
             SetupInput();
             ConfigurePerformancePreferences();
             SettingsProfile.OnCustomHandMaterialUpdate += UpdateHandMaterial;
@@ -265,7 +268,6 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
             {
                 var hand = GetOrAddHand(handedness, ovrHand);
 
-                MixedRealityHandTrackingProfile handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile.HandTrackingProfile;
                 bool showHandMesh = handTrackingProfile.EnableHandMeshVisualization;
                 bool showHandJoints = handTrackingProfile.EnableHandJointVisualization;
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -251,8 +251,8 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         #region Hand Utilities
         protected void UpdateHands()
         {
-            UpdateHand(rightHand, rightSkeleton, righMeshRenderer, Handedness.Right);
             UpdateHand(leftHand, leftSkeleton, righMeshRenderer, Handedness.Left);
+            UpdateHand(rightHand, rightSkeleton, righMeshRenderer, Handedness.Right);
         }
 
         protected void UpdateHand(OVRHand ovrHand, OVRSkeleton ovrSkeleton, OVRMeshRenderer ovrMeshRenderer, Handedness handedness)
@@ -264,6 +264,14 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
             if (ovrHand.IsTracked)
             {
                 var hand = GetOrAddHand(handedness, ovrHand);
+
+                MixedRealityHandTrackingProfile handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile.HandTrackingProfile;
+                bool showHandMesh = handTrackingProfile.EnableHandMeshVisualization;
+                bool showHandJoints = handTrackingProfile.EnableHandJointVisualization;
+
+                ovrMeshRenderer.enabled = showHandMesh;
+                hand.Visualizer.GameObjectProxy.SetActive(showHandJoints);
+
                 hand.UpdateController(ovrHand, ovrSkeleton, cameraRig.trackingSpace);
             }
             else

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -757,9 +757,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             InputAction = ResolveInputAction(InputActionId);
 
-            CurrentDimension = startDimensionIndex;
-
             RefreshSetup();
+
+            CurrentDimension = startDimensionIndex;
+            IsToggled = CurrentDimension > 0;
 
             IsEnabled = enabledOnStart;
         }

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Panels/ToggleFeaturesPanel.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Panels/ToggleFeaturesPanel.prefab
@@ -54,6 +54,7 @@ MeshRenderer:
   m_MotionVectors: 2
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -65,6 +66,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -351,6 +353,7 @@ GameObject:
   - component: {fileID: 1900320861033997991}
   - component: {fileID: 4529492485766667979}
   - component: {fileID: 2487395089502843316}
+  - component: {fileID: 7937653309753903445}
   m_Layer: 0
   m_Name: ToggleFeaturesPanel
   m_TagString: Untagged
@@ -389,8 +392,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 210487fc9a02cd049bdd702b7cb8b977, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isHandMeshVisible: 1
-  isHandJointVisible: 1
 --- !u!114 &3673227729376072232
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -602,6 +603,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 63eaf86d83dad1241bea44bea33e29aa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &7937653309753903445
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4943773361295851263}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bed961c399800584ba77a743bcd9275c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  profilerButton: {fileID: 157292884975899652}
+  handRayButton: {fileID: 4257127838476300249}
+  handMeshButton: {fileID: 1869750914582395922}
+  handJointsButton: {fileID: 959061154081218648}
 --- !u!1 &5160907477204597137
 GameObject:
   m_ObjectHideFlags: 0
@@ -655,6 +672,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -666,6 +684,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -709,6 +728,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -859,6 +879,7 @@ MeshRenderer:
   m_MotionVectors: 2
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -870,6 +891,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -936,6 +958,7 @@ MeshRenderer:
   m_MotionVectors: 2
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -947,6 +970,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1047,6 +1071,7 @@ MeshRenderer:
   m_MotionVectors: 2
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1058,6 +1083,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1244,6 +1270,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 64790b91b91094d49942373c4e83c237, type: 3}
+--- !u!114 &4257127838476300249 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4238929520169732924, guid: 64790b91b91094d49942373c4e83c237,
+    type: 3}
+  m_PrefabInstance: {fileID: 128327052216247525}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1410eac1ae94b4d4492a09cc368e152c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &6653879039667128219 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6742094790733259646, guid: 64790b91b91094d49942373c4e83c237,
@@ -1424,6 +1462,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 64790b91b91094d49942373c4e83c237, type: 3}
+--- !u!114 &1869750914582395922 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4238929520169732924, guid: 64790b91b91094d49942373c4e83c237,
+    type: 3}
+  m_PrefabInstance: {fileID: 2531308298809341742}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1410eac1ae94b4d4492a09cc368e152c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &9129280237516723280 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6742094790733259646, guid: 64790b91b91094d49942373c4e83c237,
@@ -1604,6 +1654,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 64790b91b91094d49942373c4e83c237, type: 3}
+--- !u!114 &959061154081218648 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4238929520169732924, guid: 64790b91b91094d49942373c4e83c237,
+    type: 3}
+  m_PrefabInstance: {fileID: 4007349319291202404}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1410eac1ae94b4d4492a09cc368e152c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &7641567900979660826 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6742094790733259646, guid: 64790b91b91094d49942373c4e83c237,
@@ -1946,6 +2008,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 4106547266264571704}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &157292884975899652 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4238929520169732924, guid: 64790b91b91094d49942373c4e83c237,
+    type: 3}
+  m_PrefabInstance: {fileID: 4106547266264571704}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1410eac1ae94b4d4492a09cc368e152c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &4947511621099178455
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2265,9 +2339,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9215a7c858170d74fb2257375d5feaf1, type: 3}
---- !u!1 &2924503655918868814 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7988634196090784245, guid: 9215a7c858170d74fb2257375d5feaf1,
+--- !u!23 &1262640991058816982 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 6326842415924641645, guid: 9215a7c858170d74fb2257375d5feaf1,
     type: 3}
   m_PrefabInstance: {fileID: 5064501110533230779}
   m_PrefabAsset: {fileID: 0}
@@ -2277,9 +2351,9 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5064501110533230779}
   m_PrefabAsset: {fileID: 0}
---- !u!23 &1262640991058816982 stripped
-MeshRenderer:
-  m_CorrespondingSourceObject: {fileID: 6326842415924641645, guid: 9215a7c858170d74fb2257375d5feaf1,
+--- !u!1 &2924503655918868814 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7988634196090784245, guid: 9215a7c858170d74fb2257375d5feaf1,
     type: 3}
   m_PrefabInstance: {fileID: 5064501110533230779}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Diagnostics;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.UI
+{
+    /// <summary>
+    /// Class that initializes the appearance of the features panel according to the toggled states of the associated features
+    /// </summary>
+    internal class FeaturesPanelVisuals : MonoBehaviour
+    {
+        [SerializeField]
+        private Interactable profilerButton = null;
+        [SerializeField]
+        private Interactable handRayButton = null;
+        [SerializeField]
+        private Interactable handMeshButton = null;
+        [SerializeField]
+        private Interactable handJointsButton = null;
+
+        // Start is called before the first frame update
+        void Start()
+        {
+            profilerButton.IsToggled = (CoreServices.DiagnosticsSystem?.ShowProfiler).GetValueOrDefault(false);
+            handRayButton.IsToggled = PointerUtils.GetPointerBehavior<ShellHandRayPointer>(Handedness.Any, InputSourceType.Hand) != PointerBehavior.AlwaysOff;
+            handMeshButton.IsToggled = (CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile.EnableHandMeshVisualization).GetValueOrDefault(false);
+            handJointsButton.IsToggled = (CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile.EnableHandJointVisualization).GetValueOrDefault(false);
+        }
+
+        private void Update()
+        {
+            if(UnityEngine.Input.GetKeyDown(KeyCode.Q))
+            {
+                handJointsButton.IsToggled = !handJointsButton.IsToggled;
+            }
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
@@ -30,13 +30,5 @@ namespace Microsoft.MixedReality.Toolkit.UI
             handMeshButton.IsToggled = (CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile.EnableHandMeshVisualization).GetValueOrDefault(false);
             handJointsButton.IsToggled = (CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile.EnableHandJointVisualization).GetValueOrDefault(false);
         }
-
-        private void Update()
-        {
-            if(UnityEngine.Input.GetKeyDown(KeyCode.Q))
-            {
-                handJointsButton.IsToggled = !handJointsButton.IsToggled;
-            }
-        }
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bed961c399800584ba77a743bcd9275c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
@@ -13,14 +13,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public bool isHandJointVisible = false;
 
         /// <summary>
-        /// Initial setting of hand mesh visualization - default is disabled
-        /// </summary>
-        private void Start()
-        {
-            UpdateHandVisibility();
-        }
-
-        /// <summary>
         /// Updates the hand tracking profile with the current local visualization settings
         /// </summary>
         private void UpdateHandVisibility()
@@ -38,8 +30,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public void OnToggleHandMesh()
         {
-            isHandMeshVisible = !isHandMeshVisible;
-            UpdateHandVisibility();
+            MixedRealityHandTrackingProfile handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile;
+            if (handTrackingProfile != null)
+            {
+                handTrackingProfile.EnableHandMeshVisualization = !handTrackingProfile.EnableHandMeshVisualization;
+            }
         }
 
         /// <summary>
@@ -47,8 +42,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public void OnToggleHandJoint()
         {
-            isHandJointVisible = !isHandJointVisible;
-            UpdateHandVisibility();
+            MixedRealityHandTrackingProfile handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile;
+            if (handTrackingProfile != null)
+            {
+                handTrackingProfile.EnableHandJointVisualization = !handTrackingProfile.EnableHandJointVisualization;
+            }
         }
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
@@ -9,22 +9,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
     [AddComponentMenu("Scripts/MRTK/SDK/ToggleHandVisualisation")]
     public class ToggleHandVisualisation : MonoBehaviour
     {
-        public bool isHandMeshVisible = false;
-        public bool isHandJointVisible = false;
-
-        /// <summary>
-        /// Updates the hand tracking profile with the current local visualization settings
-        /// </summary>
-        private void UpdateHandVisibility()
-        {
-            MixedRealityHandTrackingProfile handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile;
-            if (handTrackingProfile != null)
-            {
-                handTrackingProfile.EnableHandMeshVisualization = isHandMeshVisible;
-                handTrackingProfile.EnableHandJointVisualization = isHandJointVisible;
-            }
-        }
-
         /// <summary>
         /// Toggles hand mesh visualization
         /// </summary>


### PR DESCRIPTION
## Overview
Makes the Oculus hand mesh rendering controlled by the Hand Visualization Profile

## Changes
- Fixes: #8793


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
