### PR TITLE
Mark MixedRealityInputModule as always supported

### DIFF
--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
@@ -148,6 +148,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
+        public override bool IsModuleSupported()
+        {
+            return true;
+        }
+
         private static readonly ProfilerMarker ProcessMrtkPointerLostPerfMarker = new ProfilerMarker("[MRTK] MixedRealityInputModule.ProcessMrtkPointerLost");
 
         private void ProcessMrtkPointerLost(PointerData pointerData)


### PR DESCRIPTION
## Overview
The input module is required by MRTK but in Windows Mixed Reality headset builds the module sometimes cannot be correctly activated due to the `IsModuleSupported` function not being properly overridden.

## Changes
- Fixes #4821