### PR TITLE
Update mapping profile serialization for Oculus types

### DIFF
--- a/Assets/MRTK/Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityControllerMappingProfile.asset
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityControllerMappingProfile.asset
@@ -3080,7 +3080,7 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.OculusXRSDKTouchController,
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input.OculusXRSDKTouchController,
         Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
     handedness: 1
     interactions:
@@ -3306,7 +3306,7 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.OculusXRSDKTouchController,
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input.OculusXRSDKTouchController,
         Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
     handedness: 2
     interactions:
@@ -3519,7 +3519,7 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.OculusHand, Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input.OculusHand, Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
     handedness: 1
     interactions:
     - id: 0
@@ -3588,7 +3588,7 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.OculusHand, Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input.OculusHand, Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
     handedness: 2
     interactions:
     - id: 0

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
@@ -3080,7 +3080,7 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.OculusXRSDKTouchController,
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input.OculusXRSDKTouchController,
         Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
     handedness: 1
     interactions:
@@ -3306,7 +3306,7 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.OculusXRSDKTouchController,
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input.OculusXRSDKTouchController,
         Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
     handedness: 2
     interactions:
@@ -3519,7 +3519,7 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.OculusHand, Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input.OculusHand, Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
     handedness: 1
     interactions:
     - id: 0
@@ -3588,7 +3588,7 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.OculusHand, Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input.OculusHand, Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
     handedness: 2
     interactions:
     - id: 0


### PR DESCRIPTION
## Overview

The Oculus controller types had their types changed but the profile serialization wasn't committed. This _should_ be a non-issue for users, as these profiles can be pretty aggressive at reserializing locally, but we may as well check them in correctly.

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/fecccf9e3bdadd67cd21409667a65f3843c83afd/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs#L15-L21

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/fecccf9e3bdadd67cd21409667a65f3843c83afd/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs#L42-L50