### PR TITLE
Separate out if checks so we don't skip the continue and cause IndexOutOfRangeException

### DIFF
--- a/Assets/MRTK/Tools/RuntimeTools/Tools/InputFeatureUsageTool/ListInputFeatureUsages.cs
+++ b/Assets/MRTK/Tools/RuntimeTools/Tools/InputFeatureUsageTool/ListInputFeatureUsages.cs
@@ -55,9 +55,12 @@ namespace Microsoft.MixedReality.Toolkit.Tools.Runtime
                     continue;
                 }
 
-                if (i >= inputDevices.Count && textMesh.text != string.Empty)
+                if (i >= inputDevices.Count)
                 {
-                    textMesh.text = string.Empty;
+                    if (textMesh.text != string.Empty)
+                    {
+                        textMesh.text = string.Empty;
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
## Overview

There was an edge case where no input devices were detected _and_ the textMesh was already empty that caused this `if` and `continue` to be skipped, which led to an IndexOutOfRangeException a few lines lower. We want to always `continue` if no input devices are detected and clear the text if it's not already empty.