### PR TITLE
Rename RimOutline so there's only one 'Mixed Reality Toolkit' item in the Shader list.

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Art/Shaders/RimOutline.shader
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Art/Shaders/RimOutline.shader
@@ -26,7 +26,7 @@
 //SOFTWARE.
 //------------------------------------------------------------------------------ -
 
-Shader "MixedRealityToolkit/RimOutline"
+Shader "Mixed Reality Toolkit/RimOutline"
 {
     Properties{
         _Color("Color", Color) = (1,1,1,1)


### PR DESCRIPTION
## Overview
Renamed the path for the shader so it fell under the same folder.

## Changes

Previously:
![image](https://user-images.githubusercontent.com/12958442/97043770-d23c3100-1527-11eb-970a-38fe476d0b1a.png)

Now:
![image](https://user-images.githubusercontent.com/12958442/97043730-c3557e80-1527-11eb-9c1b-510a8bb8f80f.png)

## Verification

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
