### PR TITLE
Update release notes, fix authors formatting

### DIFF
--- a/Documentation/Authors.md
+++ b/Documentation/Authors.md
@@ -45,7 +45,7 @@ The Microsoft Mixed Reality Toolkit is a collaborative project containing contri
 - JoeyBytes
 - julenka
 - julesra
- -julianloehr-kg
+- julianloehr-kg
 - jwittner
 - Kent1LG
 - keveleigh

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -13,9 +13,6 @@
 
 ## What's new
 
-> [!NOTE]
-> The Mixed Reality Toolkit 2.5.1 release is available exclusively via the [Unity Package Manager](usingupm.md).
-
 ### Package dependency errors fixed
 
 This release fixes incorrect inter-package file dependencies (ex: files in Standard Assets no longer incorrectly reference files in Foundation). Version 2.5.1 also adds an explicit dependency on Text Mesh Pro.


### PR DESCRIPTION
This change removes the note that 2.5.1 is a UPM only release. It also fixes an authors list formatting issue.