### PR TITLE
Fix up some Unity behavioral warnings

### DIFF
--- a/Assets/MRTK/Core/Extensions/GameObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/GameObjectExtensions.cs
@@ -140,7 +140,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <typeparam name="T">Component Type</typeparam>
         /// <param name="gameObject">this gameObject</param>
         /// <param name="action">Action to perform.</param>
-        public static void ForEachComponent<T>(this GameObject gameObject, Action<T> action)
+        public static void ForEachComponent<T>(this GameObject gameObject, Action<T> action) where T : Component
         {
             foreach (T i in gameObject.GetComponents<T>())
             {

--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -52,15 +52,15 @@ namespace Microsoft.MixedReality.Toolkit
 
         /// <summary>
         /// Tests if an interface is null, taking potential UnityEngine.Object derived class implementers into account
-        /// which require their overridden operators to be called
+        /// which require their overridden operators to be called.
         /// </summary>
-        /// <returns>True if either the managed or native object is null, false otherwise</returns>
+        /// <returns>True if either the managed or native object is null, false otherwise.</returns>
         public static bool IsNull<T>(this T @interface) where T : class => @interface == null || @interface.Equals(null);
 
         /// <summary>
-        /// Properly checks an interface for null and returns the MonoBehaviour implementing it
+        /// Properly checks an interface for null and returns the MonoBehaviour implementing it.
         /// </summary>
-        /// <returns> True if the implementer of the interface is not a MonoBehaviour or the MonoBehaviour is null</returns>
+        /// <returns>True if the implementer of the interface is a MonoBehaviour and the MonoBehaviour is not null.</returns>
         public static bool TryGetMonoBehaviour<T>(this T @interface, out MonoBehaviour monoBehaviour) where T : class => (monoBehaviour = @interface as MonoBehaviour) != null;
     }
 }

--- a/Assets/MRTK/Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
@@ -24,14 +24,15 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
             {
                 if (newPointer != null)
                 {
-                    GameObject gameObjectReference = newPointer.BaseCursor?.GameObjectReference;
-                    Transform parentTransform = (gameObjectReference != null) ? gameObjectReference.transform : null;
+                    Transform parentTransform = newPointer.BaseCursor.TryGetMonoBehaviour(out MonoBehaviour baseCursor) ? baseCursor.transform : null;
 
                     // If there's no cursor try using the controller pointer transform instead
                     if (parentTransform == null)
                     {
-                        var controllerPointer = newPointer as BaseControllerPointer;
-                        parentTransform = controllerPointer?.transform;
+                        if (newPointer.TryGetMonoBehaviour(out MonoBehaviour controllerPointer))
+                        {
+                            parentTransform = controllerPointer.transform;
+                        }
                     }
 
                     if (parentTransform != null)

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
@@ -147,7 +147,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             for (int i = 0; i < toggleActions.Count; ++i)
             {
-                ToggleList[i]?.OnClick.RemoveListener(toggleActions[i]);
+                Interactable toggle = ToggleList[i];
+                if (toggle != null)
+                {
+                    toggle.OnClick.RemoveListener(toggleActions[i]);
+                }
             }
 
             toggleActions.Clear();

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1126,7 +1126,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 if (active != value)
                 {
                     active = value;
-                    rigRoot?.gameObject.SetActive(value);
+                    if (rigRoot != null)
+                    {
+                        rigRoot.gameObject.SetActive(value);
+                    }
                     ResetHandleVisibility();
 
                     if (value && proximityEffectActive)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -543,7 +543,10 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 if (active != value)
                 {
                     active = value;
-                    rigRoot?.gameObject.SetActive(value);
+                    if (rigRoot != null)
+                    {
+                        rigRoot.gameObject.SetActive(value);
+                    }
                     ResetVisuals();
 
                     if (active)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
@@ -188,9 +188,16 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         }
 
         #region BoundsControlHandlerBase
+
         protected override Transform GetVisual(Transform handle)
         {
-            Transform visual = handle.GetChild(0)?.GetChild(0);
+            Transform firstChild = handle.GetChild(0);
+            if (firstChild == null)
+            {
+                return null;
+            }
+
+            Transform visual = firstChild.GetChild(0);
             if (visual != null && visual.name == visualsName)
             {
                 return visual;
@@ -208,6 +215,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         {
             return HandleType.Scale;
         }
+
         #endregion BoundsControlHandlerBase
 
         #region IProximityScaleObjectProvider 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public string MainLabelText
         {
-            get { return mainLabelText?.text; }
+            get { return mainLabelText != null ? mainLabelText.text : null; }
             set
             {
                 if (mainLabelText == null)
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public string SeeItSayItLabelText
         {
-            get { return seeItSatItLabelText?.text; }
+            get { return seeItSayItLabelText != null ? seeItSayItLabelText.text : null; }
             set
             {
                 if (seeItSatItLabelText == null)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
@@ -4,7 +4,8 @@
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
-using System;
+using UnityEngine.Serialization;
+
 #if UNITY_EDITOR
 using UnityEditor;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
@@ -45,13 +46,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get { return seeItSayItLabelText != null ? seeItSayItLabelText.text : null; }
             set
             {
-                if (seeItSatItLabelText == null)
+                if (seeItSayItLabelText == null)
                 {
                     Debug.LogWarning("No see it / say it label set in " + name + " - not setting see it / say it label text.");
                     return;
                 }
 
-                seeItSatItLabelText.text = value;
+                seeItSayItLabelText.text = value;
             }
         }
 
@@ -132,8 +133,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private Interactable interactable = null;
         [SerializeField, Tooltip("Optional see it / say it object.")]
         private GameObject seeItSayItLabel = null;
-        [SerializeField, Tooltip("Optional see it / say it label used by the button. Should be subsumed under the seeItSayItLabel object.")]
-        private TextMeshPro seeItSatItLabelText = null;
+        [SerializeField, Tooltip("Optional see it / say it label used by the button. Should be subsumed under the seeItSayItLabel object."), FormerlySerializedAs("seeItSatItLabelText")]
+        private TextMeshPro seeItSayItLabelText = null;
         [SerializeField, Tooltip("How the button icon should be rendered.")]
         private ButtonIconStyle iconStyle = ButtonIconStyle.Quad;
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -375,7 +375,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 foreach (var pointer in currentInputSources[currentInputSources.Count - 1].Pointers)
                 {
-                    GameObject cursorGameObject = pointer.BaseCursor?.GameObjectReference;
+                    if (!pointer.BaseCursor.TryGetMonoBehaviour(out MonoBehaviour baseCursor))
+                    {
+                        return;
+                    }
+
+                    GameObject cursorGameObject = baseCursor.gameObject;
                     if (cursorGameObject == null)
                     {
                         return;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -375,7 +375,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 foreach (var pointer in currentInputSources[currentInputSources.Count - 1].Pointers)
                 {
-                    ProximityLight[] proximityLights = pointer.BaseCursor?.GameObjectReference?.GetComponentsInChildren<ProximityLight>();
+                    GameObject cursorGameObject = pointer.BaseCursor?.GameObjectReference;
+                    if (cursorGameObject == null)
+                    {
+                        return;
+                    }
+
+                    ProximityLight[] proximityLights = cursorGameObject.GetComponentsInChildren<ProximityLight>();
 
                     if (proximityLights != null)
                     {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTip.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTip.cs
@@ -377,13 +377,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 toolTipText = " ";
 
             backgrounds.Clear();
-            foreach (IToolTipBackground background in GetComponents(typeof(IToolTipBackground)))
+            foreach (IToolTipBackground background in GetComponents<IToolTipBackground>())
             {
                 backgrounds.Add(background);
             }
 
             highlights.Clear();
-            foreach (IToolTipHighlight highlight in GetComponents(typeof(IToolTipHighlight)))
+            foreach (IToolTipHighlight highlight in GetComponents<IToolTipHighlight>())
             {
                 highlights.Add(highlight);
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
@@ -25,7 +25,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private void UpdateHandVisibility()
         {
-            MixedRealityHandTrackingProfile handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile;
+            MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
+            if (inputSystemProfile == null)
+            {
+                return;
+            }
+
+            MixedRealityHandTrackingProfile handTrackingProfile = inputSystemProfile.HandTrackingProfile;
             if (handTrackingProfile != null)
             {
                 handTrackingProfile.EnableHandMeshVisualization = isHandMeshVisible;

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -444,9 +444,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private void OnDestroy()
         {
             // Because GazeCursor is not derived from UnityEngine.Object, we need to manually perform null check against Unity's null
-            if (GazeCursor != null && !GazeCursor.Equals(null))
+            if (GazeCursor.TryGetMonoBehaviour(out MonoBehaviour gazeCursor))
             {
-                Destroy(GazeCursor.GameObjectReference);
+                Destroy(gazeCursor.gameObject);
             }
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
@@ -397,7 +397,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private static T CreatePointerPrefab<T>(string prefabPath,
                                                 out IMixedRealityInputSource inputSource,
                                                 out IMixedRealityController controller)
-            where T : IMixedRealityPointer
+            where T : MonoBehaviour, IMixedRealityPointer
         {
             var pointerPrefab = AssetDatabase.LoadAssetAtPath<Object>(prefabPath);
             var result = PrefabUtility.InstantiatePrefab(pointerPrefab) as GameObject;


### PR DESCRIPTION
## Overview

Using https://github.com/microsoft/Microsoft.Unity.Analyzers (which I think is included in VS by default? or maybe the [extension](https://docs.microsoft.com/en-us/visualstudio/cross-platform/using-visual-studio-tools-for-unity?view=vs-2019)?), a few common cases were flagged.

Fixes:

1. [UNT0003 Usage of non generic GetComponent](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/doc/UNT0003.md)
1. [UNT0008 Null propagation on Unity objects](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/doc/UNT0008.md)
1. [UNT0014 GetComponent called with non-Component or non-Interface Type](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/doc/UNT0014.md)

I wouldn't be surprised if I missed some (especially UNT0008), but it'd be good to clean these up when they pop up!