### PR TITLE
Various GGV pointer related fixes

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -196,6 +196,41 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                 }
 
+                // Check for far interactions
+                // Any far pointer other than GGV has priority over GGV
+                foreach (IMixedRealityPointer pointer in farInteractPointers)
+                {
+                    if (!unassignedPointers.Contains(pointer))
+                    {
+                        continue;
+                    }
+
+                    if (pointer.BaseCursor != null)
+                    {
+                        pointer.IsActive = true;
+                        unassignedPointers.Remove(pointer);
+
+                        if (pointer.InputSourceParent != null)
+                        {
+                            foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
+                            {
+                                if (!unassignedPointers.Contains(otherPointer))
+                                {
+                                    continue;
+                                }
+                                // If GGV pointer
+                                if (otherPointer.BaseCursor == null)
+                                {
+                                    // Disable the GGV pointer of an input source
+                                    // when there is another far pointer belonging to the same source
+                                    otherPointer.IsActive = false;
+                                    unassignedPointers.Remove(otherPointer);
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // All other pointers that have not been assigned this frame
                 // have no reason to be disabled, so make sure they are active
                 foreach (IMixedRealityPointer unassignedPointer in unassignedPointers)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -205,7 +205,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         continue;
                     }
 
-                    if (pointer.BaseCursor != null)
+                    if (!(pointer is GGVPointer))
                     {
                         pointer.IsActive = true;
                         unassignedPointers.Remove(pointer);
@@ -214,12 +214,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         {
                             foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
                             {
-                                if (!unassignedPointers.Contains(otherPointer))
+                                if (!unassignedPointers.Contains(otherPointer) || !farInteractPointers.Contains(otherPointer))
                                 {
                                     continue;
                                 }
-                                // If GGV pointer
-                                if (otherPointer.BaseCursor == null)
+                                
+                                if (otherPointer is GGVPointer)
                                 {
                                     // Disable the GGV pointer of an input source
                                     // when there is another far pointer belonging to the same source

--- a/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1InputSystemProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1InputSystemProfile.asset
@@ -100,7 +100,7 @@ MonoBehaviour:
     type: 2}
   inputActionRulesProfile: {fileID: 11400000, guid: 03945385d89102f41855bc8f5116b199,
     type: 2}
-  pointerProfile: {fileID: 11400000, guid: 48aa63a9725047b28d4137fd0834bc31, type: 2}
+  pointerProfile: {fileID: 11400000, guid: 0a376f3c898c61d40a2b819e32ff0edd, type: 2}
   gesturesProfile: {fileID: 11400000, guid: bd7829a9b29409045a745b5a18299291, type: 2}
   speechCommandsProfile: {fileID: 11400000, guid: e8d0393e66374dae9646851a57dc6bc1,
     type: 2}

--- a/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1PointerProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1PointerProfile.asset
@@ -1,0 +1,66 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db393d206eab4604ab74278cb6cda355, type: 3}
+  m_Name: DefaultHoloLens1PointerProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 0
+  pointingExtent: 10
+  pointingRaycastLayerMasks:
+  - serializedVersion: 2
+    m_Bits: 4294967291
+  debugDrawPointingRays: 1
+  debugDrawPointingRayColors:
+  - {r: 1, g: 0.58280706, b: 0, a: 1}
+  - {r: 0.86426115, g: 1, b: 0, a: 1}
+  - {r: 0, g: 1, b: 0.2163105, a: 1}
+  - {r: 0, g: 0.3028021, b: 1, a: 1}
+  - {r: 0.44855833, g: 0, b: 1, a: 1}
+  gazeCursorPrefab: {fileID: 1000012072213228, guid: 5b3e2856904e43c680f84f326861032a,
+    type: 3}
+  gazeProviderType:
+    reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
+  useHeadGazeOverride: 0
+  isEyeTrackingEnabled: 0
+  pointerOptions:
+  - controllerType: 0
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: d5b94136462644c9873bb3347169ae7e,
+      type: 3}
+  - controllerType: 1071
+    handedness: 7
+    pointerPrefab: {fileID: 1196247974088106, guid: c4fd3c6fc7ff484eb434775066e7f327,
+      type: 3}
+  - controllerType: 256
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,
+      type: 3}
+  - controllerType: 512
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: 31d81f88cf3f71d4b8392ded50df3f05,
+      type: 3}
+  - controllerType: 0
+    handedness: 7
+    pointerPrefab: {fileID: 1507865967819406, guid: 38b548c6a2c270545a383296ad2bc4d5,
+      type: 3}
+  - controllerType: 0
+    handedness: 7
+    pointerPrefab: {fileID: 1507865967819406, guid: c2fde7a8938065b459cff79b8ed89393,
+      type: 3}
+  - controllerType: 3119
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
+      type: 3}
+  pointerMediator:
+    reference: Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator, Microsoft.MixedReality.Toolkit.SDK
+  primaryPointerSelector:
+    reference: Microsoft.MixedReality.Toolkit.Input.DefaultPrimaryPointerSelector,
+      Microsoft.MixedReality.Toolkit.SDK

--- a/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1PointerProfile.asset.meta
+++ b/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1PointerProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a376f3c898c61d40a2b819e32ff0edd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Currently there are some issues with HoloLens 1 style interaction on HoloLens 2 and other devices:

- Using the DefaultHoloLens1ConfigurationProfile on HL2 does not bring HL1 style interaction as the DefaultMixedRealityInputPointerProfile is used for both HL1 and HL2 configuration profiles.
- Without profile switching, one should be able to switch between those two interaction styles by specifying articulated hand for both default controller pointer and the GGV pointer and then toggle the hand ray on or off at runtime. However the existing pointer mediator does not include logic for prioritizing non-GGV far pointer of an input source over a GGV pointer causing unexpected behavior. 

## Changes
- Add a new pointer profile and associate it with the HL1 configuration profile
- Add logic to handle both GGV and default controller pointer to the default pointer mediator

## Screenshot
The behavior when articulated hand is enabled for both default controller pointer and GGV pointer. Note after turning off hand rays the interaction becomes HL1 style.

![gif](https://user-images.githubusercontent.com/68253937/97511606-b3cd9f80-1944-11eb-8f7c-056b410d9910.gif)

Previously with the same pointer settings when hand ray is on both GGV and default controller pointers are enabled for a hand causing unexpected behavior (e.g. if the center of FoV is on a button even if the hand ray is pointing somewhere else the button will still be highlighted and even triggered if the user performs an air tap).