### PR TITLE
Oculus Device Manager initialized with Oculus Prefabs

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/Profiles/DefaultOculusXRSDKDeviceManagerProfile.asset
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Profiles/DefaultOculusXRSDKDeviceManagerProfile.asset
@@ -13,9 +13,11 @@ MonoBehaviour:
   m_Name: DefaultOculusXRSDKDeviceManagerProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
-  ovrCameraRigPrefab: {fileID: 0}
+  ovrCameraRigPrefab: {fileID: 2343937678421323989, guid: 69a746aa83d0d0e45b4e2d33eab0fff4,
+    type: 3}
   renderAvatarHandsInsteadOfControllers: 1
-  localAvatarPrefab: {fileID: 0}
+  localAvatarPrefab: {fileID: 6297684789857299957, guid: 5357c8e6c4495c04f90e97272375c294,
+    type: 3}
   useCustomHandMaterial: 1
   customHandMaterial: {fileID: 2100000, guid: 46180a965b426614f97a7239d1248a1a, type: 2}
   updateMaterialPinchStrengthValue: 1


### PR DESCRIPTION
## Overview
When using UPM, changes made to the default profiles are not saved due to using existing inside the Packages directory. Thus, we have to ensure that the DeviceManager is initialized with the relevant prefabs at startup, even if those prefabs contain missing references that require the Oculus Integration package.

Previous iterations of this solution broke CI, but the latest Unity versions seem to not raise those CI errors, so trying this fix once again.

## Changes
- Partially Fixes: #8849

