### PR TITLE
Cherry pick some recent docs changes to 2.5.1

### DIFF
--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -1,57 +1,69 @@
 # Roadmap
 
-This document outlines the roadmap of the Mixed Reality Toolkit.
+This document outlines the roadmap of the Mixed Reality Toolkit. Please note that the following reflects work that is in development and target dates reflect estimates.
 
 ## Current release
 
-[Microsoft Mixed Reality Toolkit v2.4.0](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v2.4.0)
+[Microsoft Mixed Reality Toolkit v2.5.1](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v2.5.1)
 
 ## Upcoming releases
 
 | Product | Description | Timeline | Project board |
 | --- | --- | --- | --- |
-| [MRTK V2.5](#250) | Next iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/12 |
+| [MRTK V2.6](#250) | Next iteration of MRTK | January 2021 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/13 |
 
-Releases are centered around themes (ex: large feature areas) and are scheduled to occur approximately every 8 weeks.
+Releases are centered around themes (ex: large feature areas) and are scheduled to occur approximately every 8-12 weeks.
 
 Release details, including backlog items, can be found on the [GitHub milestone pages](https://github.com/Microsoft/MixedRealityToolkit-Unity/milestones). The complete set of open issues can also be found on [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/issues).
 
 ## Mixed Reality Toolkit (MRTK) roadmap
 
-The Mixed Reality Toolkit is an all-new product, built to be cross MR/AR/VR/XR platform by design. There are two planned pre-releases after which the Mixed Reality Toolkit will become the primary product.
+The Mixed Reality Toolkit is built to be cross MR/AR/VR/XR platform by design. The toolkit currently supports Unity 2019.4.x and Unity 2018.4.x.
 
-The Mixed Reality Toolkit will require Unity 2018.4.x
+> When Unity releases an LTS (Long Term Support) product, the Mixed Reality Toolkit will update to the LTS release. Although the Mixed Reality Toolkit runs on the latest non-beta (ex: 2020.1) tech branch version of Unity, it is not officially supported.
 
-> When Unity releases an LTS (Long Term Support) product, the Mixed Reality Toolkit will update to the LTS release. MRTK will also support the latest non-beta (ex: 2020.1) tech branch version of Unity, at the time at which MRTK was released.
+### 2.6.0
 
-### 2.5.0
-
-For the latest status of the release, please visit the [milestone page]( https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/12).
+For the latest status of the release, please visit the [milestone page]( https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/13).
 
 Status: In development
 
-Timeline: TBD 2020
+Target Timeline: January 2021
 
 Themes:
 
 - Stability
-- Developer education
 - User Experience
+- Platform Expansion: OpenXR
+- Developer Education
+- Packaging
 
 **Stability**
 
 Quality and stability are the top priority for this and all Microsoft Mixed Reality Toolkit releases. We will continue to prioritize customer and partner issues that impact the stability of MRTK components.
 
-**Developer education**
-
-[Developer documentation](https://microsoft.github.io/MixedRealityToolkit-Unity) and example scenes are, like stability, an ongoing priority for the MRTK team.
-
 **User Experience**
 
+We're listening to your feedback about MRTK and have continued plans for:
 - Bug fixes
+- Making MRTK UX controls easier to understand
 - HoloLens Shell parity
-- Graduating experimental features
 - Tests to ensure features do not regress
+
+**Platform Expansion: OpenXR**
+
+The MRTK team supports the open future of mixed reality through [OpenXR](https://techcommunity.microsoft.com/t5/mixed-reality-blog/moving-forward-to-openxr/ba-p/1825672). Support for OpenXR is currently under development. 
+
+**Developer Education**
+
+[Developer documentation](https://microsoft.github.io/MixedRealityToolkit-Unity) and example scenes are an ongoing priority for the MRTK team. 
+
+With continued investments in [MRTK tutorials](https://docs.microsoft.com/en-us/windows/mixed-reality/develop/unity/tutorials), the MRTK team seeks to accelerate the getting started experience for developers and improve instructions on how to leverage Azure Services and other extensions with the MRTK.
+
+**Packaging**
+
+In MRTK 2.5.0 we released support for Unity Package Manager (UPM). We are continuing to make improvements so it's even easier for you to download packages with UPM.
+
 
 ## Backlog
 
@@ -62,6 +74,5 @@ The following list highlights some of the key investments the MRTK team intends 
 - Modularity
 - Accessibility features
 - Globalization enhancements
-- Packaging
 - Cloud service support
 - Tools

--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -10,7 +10,7 @@ This document outlines the roadmap of the Mixed Reality Toolkit. Please note tha
 
 | Product | Description | Timeline | Project board |
 | --- | --- | --- | --- |
-| [MRTK V2.6](#250) | Next iteration of MRTK | January 2021 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/13 |
+| [MRTK V2.6](#260) | Next iteration of MRTK | January 2021 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/13 |
 
 Releases are centered around themes (ex: large feature areas) and are scheduled to occur approximately every 8-12 weeks.
 

--- a/Documentation/usingupm.md
+++ b/Documentation/usingupm.md
@@ -42,7 +42,7 @@ To add an MRTK package, modify the dependencies section of the `Packages/manifes
 
 ```
   "dependencies": {
-    "com.microsoft.mixedreality.toolkit.foundation": "2.5.1,
+    "com.microsoft.mixedreality.toolkit.foundation": "2.5.1",
     "com.microsoft.mixedreality.toolkit.tools": "2.5.1",
     "com.microsoft.mixedreality.toolkit.examples": "2.5.1",
 ```


### PR DESCRIPTION
## Overview

#8825 fixed an error in the sample we give for people to copy and paste into their manifest.json, which feels important to have on our default docs version.
#8862 retooled our roadmap, which also feels important to have on our default docs version.