### PR TITLE
Added check to see if Pointer is a IMixedRealityNearPointer to HandInteractionPanZoom.OnPointerDown

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -870,7 +870,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             bool isNear = eventData.Pointer is IMixedRealityNearPointer;
             oldIsTargetPositionLockedOnFocusLock = eventData.Pointer.IsTargetPositionLockedOnFocusLock;
-            if (!(eventData.Pointer is IMixedRealityNearPointer) && eventData.Pointer.Controller.IsRotationAvailable)
+            if (!isNear && eventData.Pointer.Controller.IsRotationAvailable)
             {
                 eventData.Pointer.IsTargetPositionLockedOnFocusLock = false;
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -868,6 +868,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public void OnPointerDown(MixedRealityPointerEventData eventData)
         {
+            bool isNear = eventData.Pointer as IMixedRealityNearPointer != null;
             oldIsTargetPositionLockedOnFocusLock = eventData.Pointer.IsTargetPositionLockedOnFocusLock;
             if (!(eventData.Pointer is IMixedRealityNearPointer) && eventData.Pointer.Controller.IsRotationAvailable)
             {
@@ -875,7 +876,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             SetAffordancesActive(false);
             EndTouch(eventData.SourceId);
-            SetHandDataFromController(eventData.Pointer.Controller, eventData.Pointer, false);
+            SetHandDataFromController(eventData.Pointer.Controller, eventData.Pointer, isNear);
             eventData.Use();
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -868,7 +868,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public void OnPointerDown(MixedRealityPointerEventData eventData)
         {
-            bool isNear = eventData.Pointer as IMixedRealityNearPointer != null;
+            bool isNear = eventData.Pointer is IMixedRealityNearPointer;
             oldIsTargetPositionLockedOnFocusLock = eventData.Pointer.IsTargetPositionLockedOnFocusLock;
             if (!(eventData.Pointer is IMixedRealityNearPointer) && eventData.Pointer.Controller.IsRotationAvailable)
             {


### PR DESCRIPTION
## Overview
HandInteractionPanZoom should now properly work with NearInteractionGrabbable, and the texture should not jump after the initial pointer down event.

## Changes
- Fixes: #8869 