### PR TITLE
Added check for hand data count in EndAllTouches before calling RaisePanEnded

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -789,8 +789,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void EndAllTouches()
         {
-            handDataMap.Clear();
-            RaisePanEnded(0);
+            if (handDataMap.Count > 0)
+            {
+                handDataMap.Clear();
+                RaisePanEnded(0);
+            }
         }
 
         private void MoveTouch(uint sourceId)


### PR DESCRIPTION
## Overview
HandInteractionPanZoom.EndAllTouches no longer calls RaisePanEnded when there is no hand data in the map.

## Changes
- Fixes: #8874 