### PR TITLE
Add Microsoft copyright header to scripts contributed by Microsoft

### DIFF
--- a/scripts/ci/common.psm1
+++ b/scripts/ci/common.psm1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Given the path to the list of raw git changes, returns an array of

--- a/scripts/ci/githubchanges.ps1
+++ b/scripts/ci/githubchanges.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     This script generates a list of changed files in a given pull request and outputs

--- a/scripts/ci/validatebuildlog.ps1
+++ b/scripts/ci/validatebuildlog.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Validates a build log to check for the presence of non-build related warnings

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Validates the code and assets to check for common patterns and usage that shouldn't be

--- a/scripts/ci/validatedocs.ps1
+++ b/scripts/ci/validatedocs.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Validates the docs to check for common patterns and usage that shouldn't be

--- a/scripts/lint/prettyjson.ps1
+++ b/scripts/lint/prettyjson.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
  # Recursively finds a .json files in the current working directory
  # and pretty-formats them.

--- a/scripts/packaging/createnugetpackages.ps1
+++ b/scripts/packaging/createnugetpackages.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Builds the Mixed Reality Toolkit nuget packacges.

--- a/scripts/packaging/createupmpackages.ps1
+++ b/scripts/packaging/createupmpackages.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Builds the Mixed Reality Toolkit Unity Package Manager (UPM) packacges.

--- a/scripts/packaging/examplesfolderpreupm.ps1
+++ b/scripts/packaging/examplesfolderpreupm.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Prepares the MRTK\Examples folder for UPM packaging.

--- a/scripts/packaging/extensionsfolderpreupm.ps1
+++ b/scripts/packaging/extensionsfolderpreupm.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Prepares the MRTK\Extensions folder for UPM packaging.

--- a/scripts/packaging/foundationpreupm.ps1
+++ b/scripts/packaging/foundationpreupm.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Prepares the MRTK foundation for UPM packaging.

--- a/scripts/packaging/publishupmpackages.ps1
+++ b/scripts/packaging/publishupmpackages.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Publishes the Mixed Reality Toolkit Unity Package Manager (UPM) packacges.

--- a/scripts/packaging/unitypackage.ps1
+++ b/scripts/packaging/unitypackage.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Builds .unitypackage artifacts for the Mixed Reality Toolkit

--- a/scripts/packaging/updateMRTKVersion.ps1
+++ b/scripts/packaging/updateMRTKVersion.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Updates Mixed Reality Toolkit version (i.e. major.minor.patch) across all known files.

--- a/scripts/packaging/versionmetadata.ps1
+++ b/scripts/packaging/versionmetadata.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Adds version metadata to the MRTK prior to building and packagine.

--- a/scripts/test/generate_repeat_tests.py
+++ b/scripts/test/generate_repeat_tests.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Prints code that can be copy / pasted to run multiple Unity Playmode tests
 """
 

--- a/scripts/test/run_playmode_tests.ps1
+++ b/scripts/test/run_playmode_tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
  # Runs the playmode tests in batch mode. This is the same technique as 
  # used by the MRTK PR validation when you do "/azp run mrtk_pr" on github.

--- a/scripts/test/run_repeat_tests.ps1
+++ b/scripts/test/run_repeat_tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
  # Runs the playmode tests in batch mode, repeatedly.
  #>


### PR DESCRIPTION
## Overview

To make sure we're in compliance with the [copyright header rules](https://docs.opensource.microsoft.com/content/releasing/copyright-headers.html), this adds the header to any Powershell or Python script that was contributed by a Microsoft employee. Most of these are custom to do with our CI.

We normally keep on top of this for C# scripts well, but seems we've overlooked some non-C# scripts.

Follow-up to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/8102.