### PR TITLE
Keep the ui camera during active profile switch

### DIFF
--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// Set the active profile prior to the initialization (i.e. Awake()) of <see cref="MixedRealityToolkit"/>
         /// </summary>
         /// <remarks>
-        /// If changing the Active profile during runtime is desired, modify <see cref="ActiveProfile"/> of the active instance directly.
+        /// If changing the Active profile after <see cref="MixedRealityToolkit"/> has been initialized, modify <see cref="ActiveProfile"/> of the active instance directly.
         /// This function requires the caller script to be executed earlier than the <see cref="MixedRealityToolkit"/> script, which can be achieved by setting 
         /// <see href="https://docs.unity3d.com/Manual/class-MonoManager.html">Script Execution Order settings</see>.
         /// You are strongly recommended to see 
@@ -139,6 +139,13 @@ namespace Microsoft.MixedReality.Toolkit
         /// <summary>
         /// When a configuration Profile is replaced with a new configuration, force all services to reset and read the new values
         /// </summary>
+        /// <remarks>
+        /// This function should only be used by editor code in most cases.
+        /// Do not call this function if resetting profile at runtime.
+        /// Instead see 
+        /// <see href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">here</see> 
+        /// for more information on profile switching at runtime.
+        /// </remarks>
         public void ResetConfiguration(MixedRealityToolkitConfigurationProfile profile)
         {
             RemoveCurrentProfile(profile);

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -38,7 +38,10 @@ namespace Microsoft.MixedReality.Toolkit
         private static bool internalShutdown = false;
         private const string NoMRTKProfileErrorMessage = "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit";
 
-        private bool isProfileSwitching = false;
+        /// <summary>
+        /// Whether an active profile switching is currently in progress
+        /// </summary>
+        public bool IsProfileSwitching { get; private set; }
 
         #region Mixed Reality Toolkit Profile configuration
 
@@ -708,11 +711,11 @@ namespace Microsoft.MixedReality.Toolkit
             {
                 // Before any Update() of a service is performed check to see if we need to switch profile
                 // If so we instantiate and initialize the services associated with the new profile.
-                if (newProfile != null && isProfileSwitching)
+                if (newProfile != null && IsProfileSwitching)
                 {
                     InitializeNewProfile(newProfile);
                     newProfile = null;
-                    isProfileSwitching = false;
+                    IsProfileSwitching = false;
                 }
                 UpdateAllServices();
             }
@@ -727,8 +730,8 @@ namespace Microsoft.MixedReality.Toolkit
                 // If so we destroy currently running services.
                 if (newProfile != null)
                 {
+                    IsProfileSwitching = true;
                     RemoveCurrentProfile(newProfile);
-                    isProfileSwitching = true;
                 }
             }
         }

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// of all services, and the instantiation and initialization of the services associated with the new profile will happen before the
         /// first Update() of all services.
         /// A noticable application hesitation may occur during this process. Also any script with higher priority than this can enter its Update
-        /// before the new profile is properly setup. Special handling required for Unity UI.
+        /// before the new profile is properly setup.
         /// You are strongly recommended to see 
         /// <see href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">here</see> 
         /// for more information on profile switching.

--- a/Assets/MRTK/Examples/Common/Scripts/LoadProfilesOnStartup.cs
+++ b/Assets/MRTK/Examples/Common/Scripts/LoadProfilesOnStartup.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         [SerializeField]
         private MixedRealityToolkitConfigurationProfile configProfile = null;
 
-        private void LateUpdate()
+        private void Update()
         {
             if ((configProfile != null) && (MixedRealityToolkit.Instance != null))
             {

--- a/Assets/MRTK/Examples/Common/Scripts/LoadProfilesOnStartup.cs
+++ b/Assets/MRTK/Examples/Common/Scripts/LoadProfilesOnStartup.cs
@@ -15,17 +15,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         [SerializeField]
         private MixedRealityToolkitConfigurationProfile configProfile = null;
 
-        private void Start()
-        {
-            MixedRealityToolkit.Instance.ActiveProfile = null;
-        }
-
         private void LateUpdate()
         {
-            if ((configProfile != null) && (MixedRealityToolkit.Instance != null) && (MixedRealityToolkit.Instance.ActiveProfile == null))
+            if ((configProfile != null) && (MixedRealityToolkit.Instance != null))
             {
                 MixedRealityToolkit.Instance.ActiveProfile = configProfile;
                 Debug.Log($"Loading new MRTK configuration profile: {configProfile.name}");
+                configProfile = null;
             }
         }
     }

--- a/Assets/MRTK/Examples/Experimental/ExamplesHub/Scenes/MRTKExamplesHub.unity
+++ b/Assets/MRTK/Examples/Experimental/ExamplesHub/Scenes/MRTKExamplesHub.unity
@@ -628,7 +628,6 @@ GameObject:
   - component: {fileID: 941829593}
   - component: {fileID: 941829598}
   - component: {fileID: 941829597}
-  - component: {fileID: 941829596}
   - component: {fileID: 941829595}
   - component: {fileID: 941829599}
   - component: {fileID: 941829594}
@@ -695,18 +694,6 @@ MonoBehaviour:
   m_InputActionsPerSecond: 10
   m_RepeatDelay: 0.5
   m_ForceModuleActive: 0
---- !u!114 &941829596
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 941829592}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!81 &941829597
 AudioListener:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -698,8 +698,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             GameObject cameraObject = null;
 
             var existingUiRaycastCameraObject = GameObject.Find("UIRaycastCamera");
-            bool uiRaycastCameraObjectExists = existingUiRaycastCameraObject != null;
-            Debug.Assert(uiRaycastCameraObjectExists == MixedRealityToolkit.Instance.IsProfileSwitching);
             if (existingUiRaycastCameraObject != null)
             {
                 cameraObject = existingUiRaycastCameraObject;

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -540,8 +540,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 primaryPointerSelector.Destroy();
             }
+            if (!MixedRealityToolkit.Instance.IsProfileSwitching)
+            {
+                CleanUpUiRaycastCamera();
+            }
 
-            CleanUpUiRaycastCamera();
             base.Destroy();
         }
 
@@ -695,6 +698,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             GameObject cameraObject = null;
 
             var existingUiRaycastCameraObject = GameObject.Find("UIRaycastCamera");
+            bool uiRaycastCameraObjectExists = existingUiRaycastCameraObject != null;
+            Debug.Assert(uiRaycastCameraObjectExists == MixedRealityToolkit.Instance.IsProfileSwitching);
             if (existingUiRaycastCameraObject != null)
             {
                 cameraObject = existingUiRaycastCameraObject;

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
@@ -422,10 +422,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     if (pointer.InputSourceParent == inputSource)
                     {
                         int pointerId = (int)pointer.PointerId;
-                        Debug.Assert(pointerDataToUpdate.ContainsKey(pointerId));
+                        if (!pointerDataToUpdate.ContainsKey(pointerId))
+                        {
+                            // During runtime profile switch this may happen but we can ignore
+                            if (!MixedRealityToolkit.Instance.IsProfileSwitching)
+                            {
+                                Debug.LogError("The pointer you are trying to remove does not exist in the mapping dict!");
+                            }
+                            return;
+                        }
 
-                        PointerData pointerData = null;
-                        if (pointerDataToUpdate.TryGetValue(pointerId, out pointerData))
+                        if (pointerDataToUpdate.TryGetValue(pointerId, out PointerData pointerData))
                         {
                             Debug.Assert(!pointerDataToRemove.Contains(pointerData));
                             pointerDataToRemove.Add(pointerData);

--- a/Assets/MRTK/Tests/PlayModeTests/PointerProfileTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerProfileTests.cs
@@ -34,8 +34,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         // <summary>
         /// Verifies if eye tracking configuration is correctly applied at gaze provider initialization.
         /// </summary>
-        [Test]
-        public void TestGazeProviderEyeTrackingConfiguration()
+        [UnityTest]
+        public IEnumerator TestGazeProviderEyeTrackingConfiguration()
         {
             // Default configuration profile should set head based gaze
             var eyeGazeProvider = CoreServices.InputSystem.GazeProvider as IMixedRealityEyeGazeProvider;
@@ -44,7 +44,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Eye tracking configuration profile should set eye based gaze
             var profile = AssetDatabase.LoadAssetAtPath(eyeTrackingConfigurationProfilePath, typeof(MixedRealityToolkitConfigurationProfile)) as MixedRealityToolkitConfigurationProfile;
-            MixedRealityToolkit.Instance.ResetConfiguration(profile);
+            MixedRealityToolkit.Instance.ActiveProfile = profile;
+            yield return null;
+            yield return null;
+            eyeGazeProvider = CoreServices.InputSystem.GazeProvider as IMixedRealityEyeGazeProvider;
 
             Assert.IsTrue(eyeGazeProvider.IsEyeTrackingEnabled, "Use eye tracking should be set to true");
         }


### PR DESCRIPTION
## Overview
As @keveleigh pointed out in #8787, it might be preferable to keep the UI camera during active profile switch process. The advantage includes reasigning ui camera to Unity UI(UGUI) canvas will no longer be necessary. However the existing approach makes sure the ui camera life cycle is in sync with the services of a profile.

Also modified `LoadProfilesOnStartup.cs` to make sure it no longer generates error messages.

## Changes
- Continuation of #8787

## Note
Tested in editor play mode, editor remoting and HL2 device.