### PR TITLE
Fix Shader import error seen on Mac editor

### DIFF
--- a/Assets/MRTK/StandardAssets/EditorUtilities/OnLoadUtilities.cs
+++ b/Assets/MRTK/StandardAssets/EditorUtilities/OnLoadUtilities.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private const string SessionStateKey = "StandardAssetsOnLoadUtilitiesSessionStateKey";
 
         private const string ShaderSentinelGuid = "05852dd420bb9ec4cb7318bfa529d37c";
-        private const string ShaderSentinelFile = "MRTK.Shaders.Sentinel";
+        private const string ShaderSentinelFile = "MRTK.Shaders.sentinel";
 
         private const string ShaderImportDestination = "MRTK/Shaders";
 


### PR DESCRIPTION
OnLoadUtilities.cs fails to copy shaders when running on MacOS due to a filename sensitivity issue.

The constant `ShaderSentinelFile = "MRTK.Shaders.Sentinel";` refers to a file that is actually named `MRTK.Shaders.sentinel` with a lowercase `s` on sentinel.

On MacOS DirectoryInfo.GetFiles appears to be case-sensitive even if the underlying filesystem is not. This causes the script to not find MRTK.Shaders.sentinel and thus not be able to copy the shaders.

Fix the issue by using a lowercase `s` in the constant.

Fixes #8826
