### PR TITLE
Object collection list accessibility, adding a read only list

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
@@ -26,6 +26,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             get { return nodeList; }
         }
 
+        /// <summary>
+        /// Read only list of objects with generated data on the object.
+        /// </summary>
         public IReadOnlyList<ObjectCollectionNode> NodeListReadOnly
         {
             get { return nodeList.AsReadOnly<ObjectCollectionNode>(); }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
@@ -26,6 +26,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             get { return nodeList; }
         }
 
+        public IReadOnlyList<ObjectCollectionNode> NodeListReadOnly
+        {
+            get { return nodeList.AsReadOnly<ObjectCollectionNode>(); }
+        }
+
         [Tooltip("Whether to include space for inactive transforms in the layout")]
         [SerializeField]
         private bool ignoreInactiveTransforms = true;
@@ -160,7 +165,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="node">The Transform belonging to <see cref="ObjectCollectionNode"/></param>
         /// <param name="nodeIndex">The index of the element in <see cref="NodeList"/></param>
         /// <returns>true when <paramref name="node"/> belongs to an element of the list.</returns>
-        protected bool ContainsNode(Transform node, out int nodeIndex)
+        public bool ContainsNode(Transform node, out int nodeIndex)
         {
             nodeIndex = 0;
             if (node == null)


### PR DESCRIPTION
## Overview
I've found myself making data driven lists with the built-in object collection implementations (specifically, the grid collection). What's nice about this approach is I can keep the list component completely separate from the app code driving the data binding. The only issue is the `ObjectCollectionNode` list isn't accessible to any other component. I completely understand why it shouldn't be _modified_, but the accessibility level prevents some simple tasks like "is this object a part of this collection?" My fix is to add a public, read only version of the  `ObjectCollectionNode` list. Additionally I've changed the Contains check method to public as well, for the same reasons above.

## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
