### PR TITLE
Various BoundsControl fixes

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/BoundsControl/BoundsControlInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/BoundsControl/BoundsControlInspector.cs
@@ -22,6 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializedProperty activationType;
         private SerializedProperty controlPadding;
         private SerializedProperty flattenAxis;
+        private SerializedProperty uniformScaleOnFlattenedAxis;
 
         private SerializedProperty smoothingActive;
         private SerializedProperty rotateLerpTime;
@@ -70,6 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             boundsOverride = serializedObject.FindProperty("boundsOverride");
             boundsCalculationMethod = serializedObject.FindProperty("boundsCalculationMethod");
             flattenAxis = serializedObject.FindProperty("flattenAxis");
+            uniformScaleOnFlattenedAxis = serializedObject.FindProperty("uniformScaleOnFlattenedAxis");
             controlPadding = serializedObject.FindProperty("boxPadding");
 
             smoothingActive = serializedObject.FindProperty("smoothingActive");
@@ -123,6 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     EditorGUILayout.PropertyField(boundsCalculationMethod);
                     EditorGUILayout.PropertyField(controlPadding);
                     EditorGUILayout.PropertyField(flattenAxis);
+                    EditorGUILayout.PropertyField(uniformScaleOnFlattenedAxis);
 
                     EditorGUILayout.Space();
                     EditorGUILayout.LabelField(new GUIContent("Smoothing"), EditorStyles.boldLabel);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     if (rigRoot != null)
                     {
                         rigRoot.parent = targetObject.transform;
-                        OnTargetBoundsChanged();
+                        UpdateBounds();
                     }
                 }
             }
@@ -82,7 +82,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     {
                         prevBoundsOverride = new Bounds();
                     }
-                    OnTargetBoundsChanged();
+                    UpdateBounds();
                 }
             }
         }
@@ -102,7 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 if (boundsCalculationMethod != value)
                 {
                     boundsCalculationMethod = value;
-                    OnTargetBoundsChanged();
+                    UpdateBounds();
                 }
             }
         }
@@ -178,7 +178,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 if (Vector3.Distance(boxPadding, value) > float.Epsilon)
                 {
                     boxPadding = value;
-                    OnTargetBoundsChanged();
+                    UpdateBounds();
                 }
             }
         }
@@ -634,6 +634,17 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             ResetVisuals();
             rigRoot.gameObject.SetActive(active);
             UpdateRigVisibilityInInspector();
+        }
+
+        /// <summary>
+        /// Update the bounds.
+        /// Call this function after modifying the transform of the target externally to make sure the bounds are also updated accordingly.
+        /// </summary>
+        public void UpdateBounds()
+        {
+            DetermineTargetBounds();
+            UpdateExtents();
+            UpdateVisuals();
         }
 
         #endregion
@@ -1251,13 +1262,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     } 
                 }
             }
-        }
-        
-        private void OnTargetBoundsChanged()
-        {
-            DetermineTargetBounds();
-            UpdateExtents();
-            UpdateVisuals();
         }
 
         #endregion Private Methods

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -151,6 +151,19 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         }
 
         [SerializeField]
+        [Tooltip("Whether scale the flattened axis when uniform scale is used.")]
+        private bool uniformScaleOnFlattenedAxis = true;
+
+        /// <summary>
+        /// Whether scale the flattened axis when uniform scale is used.
+        /// </summary>
+        public bool UniformScaleOnFlattenedAxis
+        {
+            get => uniformScaleOnFlattenedAxis;
+            set => uniformScaleOnFlattenedAxis = value;
+        }
+
+        [SerializeField]
         [Tooltip("Extra padding added to the actual Target bounds")]
         private Vector3 boxPadding = Vector3.zero;
 
@@ -1174,6 +1187,24 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                         Vector3 currentDist = (currentGrabPoint - oppositeCorner);
                         Vector3 grabDiff = (currentDist - initialDist);
                         scaleFactor = Vector3.one + grabDiff.Div(initialDist);
+                    }
+
+                    // If non-uniform scaling or uniform scaling only on the non-flattened axes
+                    if (ScaleHandlesConfig.ScaleBehavior != HandleScaleMode.Uniform || !UniformScaleOnFlattenedAxis)
+                    {
+                        FlattenModeType determinedType = FlattenAxis == FlattenModeType.FlattenAuto ? VisualUtils.DetermineAxisToFlatten(TargetBounds.bounds.extents) : FlattenAxis;
+                        if (determinedType == FlattenModeType.FlattenX)
+                        {
+                            scaleFactor.x = 1;
+                        }
+                        if (determinedType == FlattenModeType.FlattenY)
+                        {
+                            scaleFactor.y = 1;
+                        }
+                        if (determinedType == FlattenModeType.FlattenZ)
+                        {
+                            scaleFactor.z = 1;
+                        }
                     }
 
                     Vector3 newScale = initialScaleOnGrabStart.Mul(scaleFactor);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Links.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Links.cs
@@ -113,7 +113,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 }
 
                 List<int> flattenedHandles = VisualUtils.GetFlattenedIndices(cachedFlattenAxis, VisualUtils.EdgeAxisType);
-                if (flattenedHandles != null)
+                if (flattenedHandles != null && VisualUtils.EdgeAxisType.Length == links.Count)
                 {
                     for (int i = 0; i < flattenedHandles.Count; ++i)
                     {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
@@ -157,7 +157,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         {
             IsActive = areHandlesActive;
             ResetHandles();
-            if (IsActive)
+            if (IsActive && handleAxes.Length == handles.Count)
             {
                 List<int> flattenedHandles = VisualUtils.GetFlattenedIndices(flattenAxis, handleAxes);
                 if (flattenedHandles != null)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/VisualUtils.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/VisualUtils.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
 {
     /// <summary>
-    /// Helper class providing some static utility functions for <see cref="BoundsControl"/> <see cref="BoundsControlHandlesBase">handles</see>/>
+    /// Helper class providing some static utility functions for <see cref="BoundsControl"/> <see cref="HandlesBase">handles</see>
     /// </summary>
     internal class VisualUtils
     {
@@ -146,18 +146,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             {
                 if (flattenAxis == FlattenModeType.FlattenAuto)
                 {
-                    if (boundsExtents.x < boundsExtents.y && boundsExtents.x < boundsExtents.z)
-                    {
-                        flattenAxis = FlattenModeType.FlattenX;
-                    }
-                    else if (boundsExtents.y < boundsExtents.z)
-                    {
-                        flattenAxis = FlattenModeType.FlattenY;
-                    }
-                    else
-                    {
-                        flattenAxis = FlattenModeType.FlattenZ;
-                    }
+                    flattenAxis = DetermineAxisToFlatten(boundsExtents);
                 }
 
                 boundsExtents.x = (flattenAxis == FlattenModeType.FlattenX) ? flattenValue : boundsExtents.x;
@@ -166,6 +155,30 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             }
 
             return boundsExtents;
+        }
+
+        /// <summary>
+        /// Determine the axis to flatten based on the bound extents. Useful when <see cref="FlattenModeType"/> is set to <see cref="FlattenModeType.FlattenAuto"/> instead of an explicit axis.
+        /// </summary>
+        /// <param name="boundsExtents">The current bound extents.</param>
+        /// <returns>Determined axis to be flattened.</returns>
+        internal static FlattenModeType DetermineAxisToFlatten(Vector3 boundsExtents)
+        {
+            FlattenModeType axisToFlatten;
+            if (boundsExtents.x < boundsExtents.y && boundsExtents.x < boundsExtents.z)
+            {
+                axisToFlatten = FlattenModeType.FlattenX;
+            }
+            else if (boundsExtents.y < boundsExtents.z)
+            {
+                axisToFlatten = FlattenModeType.FlattenY;
+            }
+            else
+            {
+                axisToFlatten = FlattenModeType.FlattenZ;
+            }
+
+            return axisToFlatten;
         }
 
         /// <summary>

--- a/Documentation/README_BoundsControl.md
+++ b/Documentation/README_BoundsControl.md
@@ -16,7 +16,7 @@ You can find examples of bounds control configurations in the `BoundsControlExam
 
 ### Target object
 
-This property specifies which object will get transformed by the bounds control manipulation. If no object is setit defaults to the owner object.
+This property specifies which object will get transformed by the bounds control manipulation. If no object is set, it defaults to the owner object.
 
 ### Activation behavior
 
@@ -40,6 +40,9 @@ Adds a padding to the collider bounds used to calculate the extents of the contr
 Indicates whether the control is flattened in one of the axes, making it 2 dimensional and disallowing manipulation along that axis. This feature can be used for thin objects like slates.
 If flatten axis is set to *Flatten Auto* the script will automatically pick the axis with the smallest extent as flatten axis.
 
+### Uniform Scale On Flattened Axis
+Indicates whether to scale along the flattened axis when uniform scale is used. If set to false, uniform scaling will not happen along the flattened axis. Note when using non-uniform scaling, the flattened axis is never scaled along.
+
 ### Smoothing
 The smoothing section allows to configure smoothing behavior for scale and rotate of the control.
 
@@ -50,7 +53,7 @@ Visual configurations are either linked or inlined scriptable objects and are de
 ## Configuration Objects
 The control comes with a set of configuration objects that can be stored as scriptable objects and shared between different instances or prefabs. Configurations can be shared and linked either as individual scriptable asset files or nested scriptable assets inside of prefabs. Further configurations can also be defined directly on the instance without linking to an external or nested scriptable asset. 
 
-The bounds control inspector will indicate whether a configuration is shared or inlined as part of the current instance by showing a message in the property inspector. In addition shared instances won't be editable directly in the bounds control property window itself, but instead the asset it's linking to has to be directly modfied to avoid any accidental changes on shared configurations.
+The bounds control inspector will indicate whether a configuration is shared or inlined as part of the current instance by showing a message in the property inspector. In addition shared instances won't be editable directly in the bounds control property window itself, but instead the asset it's linking to has to be directly modified to avoid any accidental changes on shared configurations.
 
 Currently bounds control offers configuration objects options for the following features:
 - Handles

--- a/Documentation/README_BoundsControl.md
+++ b/Documentation/README_BoundsControl.md
@@ -41,7 +41,9 @@ Indicates whether the control is flattened in one of the axes, making it 2 dimen
 If flatten axis is set to *Flatten Auto* the script will automatically pick the axis with the smallest extent as flatten axis.
 
 ### Uniform Scale On Flattened Axis
-Indicates whether to scale along the flattened axis when uniform scale is used. If set to false, uniform scaling will not happen along the flattened axis. Note when using non-uniform scaling, the flattened axis is never scaled along.
+Only applies when uniform scale is used. The default behavior (set to true) leads to the flattened axis being scaled along with other axes. If set to false, uniform scaling will not happen along the flattened axis.
+
+Note when using non-uniform scaling, the flattened axis is never scaled along.
 
 ### Smoothing
 The smoothing section allows to configure smoothing behavior for scale and rotate of the control.


### PR DESCRIPTION
## Overview
This PR addresses the following problems:

1. Currently setting flatten axis to anything other than nothing or auto creates exceptions at scene start if bounds control is set to active on start.
2. After setting the flattened axis a user can still scale the bounded gameObject along that axis. This PR changes the behavior to the following: if uniform scaling is used, the user can choose whether the flattened axis is also uniformly scaled with the other axes through `UniformScaleOnFlattenedAxis`; if non-uniform scaling is used, the user cannot scale along the flattened axis.
3. If the target's transform is modified externally, the bounds does not update to correctly reflect the change. This PR renames `OnTargetBoundsChanged` to `UpdateBounds` and makes it public so that developers can invoke the function after external transform modifications.

## Changes
- Fixes: #8904, #8921