### PR TITLE
Small fixes for Unity 2020.1

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -654,7 +654,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                         if (prefabStage != null)
                         {
                             var instancePath = AssetDatabase.GetAssetPath(scriptable.objectReferenceValue);
-                            isNestedInCurrentPrefab = (instancePath != "" && instancePath == prefabStage.prefabAssetPath);
+                            isNestedInCurrentPrefab = instancePath != "" &&
+#if UNITY_2020_1_OR_NEWER
+                                instancePath == prefabStage.assetPath
+#else
+                                instancePath == prefabStage.prefabAssetPath
+#endif
+                            ;
                         }
                         
                         

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -304,11 +304,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         public static bool IsVisibleMetaFiles()
         {
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
             return VersionControlSettings.mode.Equals("Visible Meta Files");
 #else
             return EditorSettings.externalVersionControl.Equals("Visible Meta Files");
-#endif // UNITY_2020_2_OR_NEWER
+#endif // UNITY_2020_1_OR_NEWER
         }
 
         /// <summary>
@@ -316,11 +316,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         public static void SetVisibleMetaFiles()
         {
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
             VersionControlSettings.mode = "Visible Meta Files";
 #else
             EditorSettings.externalVersionControl = "Visible Meta Files";
-#endif // UNITY_2020_2_OR_NEWER
+#endif // UNITY_2020_1_OR_NEWER
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
Opening MRTK in Unity 2020.1 highlights some issues regarding the new Unity 2020.1 API changes.

## Changes
- use Unity 2020.1 C# directive 


## Verification
Open MRTK in a Unity 2020.1 and you should not see any errors.
