### PR TITLE
Clean up some inheritdoc tags

### DIFF
--- a/Assets/MRTK/Core/Definitions/Utilities/MixedRealityPose.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/MixedRealityPose.cs
@@ -108,6 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         #region IEqualityComparer Implementation
 
+        /// <inheritdoc />
         bool IEqualityComparer.Equals(object left, object right)
         {
             if (ReferenceEquals(null, left) || ReferenceEquals(null, right)) { return false; }
@@ -127,12 +128,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return obj is MixedRealityPose && Equals((MixedRealityPose)obj);
         }
 
+        /// <inheritdoc />
         int IEqualityComparer.GetHashCode(object obj)
         {
             return obj is MixedRealityPose ? ((MixedRealityPose)obj).GetHashCode() : 0;
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return base.GetHashCode();

--- a/Assets/MRTK/Core/Definitions/Utilities/MixedRealityTransform.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/MixedRealityTransform.cs
@@ -118,6 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         #region IEqualityComparer Implementation
 
+        /// <inheritdoc />
         bool IEqualityComparer.Equals(object left, object right)
         {
             if (ReferenceEquals(null, left) || ReferenceEquals(null, right)) { return false; }
@@ -137,12 +138,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return obj is MixedRealityTransform && Equals((MixedRealityTransform)obj);
         }
 
+        /// <inheritdoc />
         int IEqualityComparer.GetHashCode(object obj)
         {
             return obj is MixedRealityTransform ? ((MixedRealityTransform)obj).GetHashCode() : 0;
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return base.GetHashCode();

--- a/Assets/MRTK/Core/Providers/BaseGenericInputSource.cs
+++ b/Assets/MRTK/Core/Providers/BaseGenericInputSource.cs
@@ -50,7 +50,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return left.Equals(right);
         }
 
-        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) { return false; }
@@ -71,7 +70,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return obj.GetHashCode();
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             unchecked

--- a/Assets/MRTK/Core/Providers/BaseSpatialObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialObserver.cs
@@ -132,7 +132,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             return x.Equals(y);
         }
 
-        /// <inheritdoc /> 
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) { return false; }
@@ -155,7 +154,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             return obj.GetHashCode();
         }
 
-        /// <inheritdoc /> 
         public override int GetHashCode()
         {
             return Mathf.Abs(SourceName.GetHashCode());

--- a/Assets/MRTK/Core/Providers/GenericPointer.cs
+++ b/Assets/MRTK/Core/Providers/GenericPointer.cs
@@ -144,6 +144,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return left.Equals(right);
         }
 
+        /// <inheritdoc />
         bool IEqualityComparer.Equals(object left, object right)
         {
             return left.Equals(right);
@@ -163,12 +164,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return other != null && PointerId == other.PointerId && string.Equals(PointerName, other.PointerName);
         }
 
+        /// <inheritdoc />
         int IEqualityComparer.GetHashCode(object obj)
         {
             return obj.GetHashCode();
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             unchecked

--- a/Assets/MRTK/Core/Providers/InputSimulation/KeyBinding.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/KeyBinding.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using UnityEngine;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using UnityEngine;
 
 [assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor")]
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -92,6 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         private KeyType bindingType;
+
         /// <summary>
         /// Type of input this binding maps to.
         /// </summary>
@@ -102,7 +103,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         private int code;
 
-        /// <inheritdoc />
         public override string ToString()
         {
             string s = "";

--- a/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DataStructures/DeviceInfo.cs
+++ b/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DataStructures/DeviceInfo.cs
@@ -90,7 +90,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             CsrfToken = string.Empty;
         }
 
-        /// <inheritdoc/>
         public override string ToString()
         {
             return IP + (string.IsNullOrEmpty(MachineName) ? string.Empty : $" [{MachineName}]");

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/State.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/State.cs
@@ -34,7 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public int ActiveIndex;
 
-        /// <inheritdoc/>
         public override string ToString()
         {
             return Name;

--- a/Assets/MRTK/Tests/PlayModeTests/EventCatcherTestUtilities.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/EventCatcherTestUtilities.cs
@@ -31,7 +31,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             return gameObject.AddComponent<T>();
         }
 
-        /// <inheritdoc />
         public void Dispose()
         {
             Destroy(this);
@@ -52,10 +51,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             return go.AddComponent<T>();
         }
 
-        /// <inheritdoc />
         public void Dispose()
         {
-            Destroy(this.gameObject);
+            Destroy(gameObject);
         }
     }
 
@@ -146,7 +144,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             button.onClick.AddListener(OnClick);
         }
 
-        /// <inheritdoc />
         public void Dispose()
         {
             button.onClick.RemoveListener(OnClick);
@@ -175,7 +172,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             toggle.onValueChanged.AddListener(OnValueChanged);
         }
 
-        /// <inheritdoc />
         public void Dispose()
         {
             toggle.onValueChanged.RemoveListener(OnValueChanged);


### PR DESCRIPTION
## Overview

Looks like when running the latest docfx (our pipeline was recently updated) with VS 2019 (our pipeline was recently updated), some in-box overridden methods aren't able to have their docs inherited. This cleans those tags up.