### PR TITLE
Improve scroll bar in input actions profile when not rendered as a sub profile

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                    profile == MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile;
         }
 
-        private static void RenderList(SerializedProperty list)
+        private void RenderList(SerializedProperty list)
         {
             using (new EditorGUILayout.VerticalScope())
             {
@@ -80,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     EditorGUIUtility.labelWidth = labelWidth;
                 }
 
-                scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition, GUILayout.Height(100f));
+                scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition, RenderAsSubProfile ? GUILayout.Height(100f) : GUILayout.ExpandHeight(true));
 
                 for (int i = 0; i < list.arraySize; i++)
                 {


### PR DESCRIPTION
## Overview

This height is good when rendered as a sub profile, so it doesn't take up the entire inspector.
However, when viewing as a standalone profile, it led to views like

![image](https://user-images.githubusercontent.com/3580640/99106686-79494100-2599-11eb-89b9-ebe693560860.png)

Now it looks like

![image](https://user-images.githubusercontent.com/3580640/99108033-9aab2c80-259b-11eb-8a87-db55e569b74f.png)
