### PR TITLE
Skip rendering build entries when their folder was deleted

### DIFF
--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -891,6 +891,11 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
                         foreach (var fullBuildLocation in Builds)
                         {
+                            if (!Directory.Exists(fullBuildLocation))
+                            {
+                                continue;
+                            }
+
                             int lastBackslashIndex = fullBuildLocation.LastIndexOf("\\", StringComparison.Ordinal);
 
                             var directoryDate = Directory.GetLastWriteTime(fullBuildLocation).ToString("yyyy/MM/dd HH:mm:ss");


### PR DESCRIPTION
## Overview
When looking at the "Deploy Options" tab, if we delete a build from the AppPackages folder, the entry for that build will keep being rendered until the build list is refreshed. The only noticeable change is that the build date will change to a default value.

We can see this behavior here:
![Unity_LIU9JHcxaV](https://user-images.githubusercontent.com/2981116/99159584-6dfb3000-26d5-11eb-804e-3a8e83d83880.png)

This pull request just adds a check to skip rendering entries whose folder were deleted. It doesn't actually remove them from the build list. However, if you feel that we should remove those folders from the list I can make that change.

## Changes
- Fixes: Test whether the package build folder exists and skip rendering a build entry when it doesn't.
