### PR TITLE
Add Active property and Touch state to Interactive Element 

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -431,7 +431,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             Color prevColor = GUI.color;
 
-            GUI.color = ColorTint100;
+            GUI.color = ColorTint50;
             using (new EditorGUILayout.VerticalScope(EditorStyles.textArea))
             {
                 EditorGUILayout.LabelField(notice, EditorStyles.wordWrappedMiniLabel);

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/BaseInteractiveElementInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/BaseInteractiveElementInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License
 
+using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI.Interaction;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System;
@@ -20,6 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     {
         private BaseInteractiveElement instance;
         private SerializedProperty states;
+        private SerializedProperty active;
 
         private static GUIContent RemoveStateButtonLabel;
 
@@ -27,40 +29,74 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static string newStateName = "New State Name";
         private const string newCoreStateName = "New Core State";
         private const string createNewStateName = "Create New State";
-        private const string defaultStateName = "Default";
         private const string removeStateLabel = "Remove State";
         private const string statesLabel = "States";
+        private const string settingsLabel = "Settings";
+        private const string setStateNameLabel = "Set State Name";
+        private const string addCoreStateLabel = "Add Core State";
 
         private const int stateValueDisplayWidth = 20;
         private const int stateValueDisplayContainerWidth = 10;
 
+        private bool previousActiveStatus;
+
+        private string defaultStateName = CoreInteractionState.Default.ToString();
+        private string touchStateName = CoreInteractionState.Touch.ToString();
+        
         protected virtual void OnEnable()
         {
             instance = (BaseInteractiveElement)target;
 
+            active = serializedObject.FindProperty("active");
             states = serializedObject.FindProperty("states");
 
             RemoveStateButtonLabel = new GUIContent(InspectorUIUtility.Minus, removeStateLabel);
+
+            previousActiveStatus = active.boolValue;
         }
 
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
 
-            InspectorUIUtility.DrawTitle(statesLabel);
+            RenderSettings();
 
             RenderStates();
-
-            EditorGUILayout.Space();
-            EditorGUILayout.Space();
 
             RenderAddStateButtons();
 
             serializedObject.ApplyModifiedProperties();
         }
 
+        private void RenderSettings()
+        {
+            // Draw a title for the Settings section 
+            InspectorUIUtility.DrawTitle(settingsLabel);
+
+            EditorGUILayout.PropertyField(active);
+
+            if (Application.isPlaying)
+            {
+                if (!active.boolValue)
+                {
+                    // Add a notice in the inspector to let the user know that they have disabled internal updates, i.e. state values will not update
+                    InspectorUIUtility.DrawNotice("Internal updates to this Interactive Element have been disabled.");
+                }
+                
+                if (previousActiveStatus != active.boolValue)
+                {
+                    ResetAllStates();
+                }
+
+                previousActiveStatus = active.boolValue;
+            }
+        }
+
         private void RenderStates()
         {
+            // Draw a States title for the State list section 
+            InspectorUIUtility.DrawTitle(statesLabel);
+
             for (int i = 0; i < states.arraySize; i++)
             {
                 SerializedProperty state = states.GetArrayElementAtIndex(i);
@@ -159,7 +195,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 // If the state is already being tracked then do not display the state name as an option to add
                 foreach (string coreState in coreInteractionStateNames.ToList())
                 {
-                    if (IsStatePresent(coreState))
+                    if (instance.IsStatePresentEditMode(coreState))
                     {
                         coreInteractionStateNames.Remove(coreState);
                     }
@@ -183,6 +219,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     serializedObject.ApplyModifiedProperties();
 
                     instance.SetEventConfigurationInstance(stateName.stringValue);
+
+                    if (stateName.stringValue == touchStateName)
+                    {
+                        instance.AddNearInteractionTouchable();
+                    }
                 }
             }
         }
@@ -194,9 +235,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 newStateName = EditorGUILayout.TextField("New State Name", newStateName);
 
-                if (GUILayout.Button("Set State Name"))
+                if (GUILayout.Button(setStateNameLabel))
                 {
-                    if (newStateName != string.Empty && !IsStatePresent(newStateName) && newStateName != "New State Name")
+                    if (newStateName != string.Empty && !instance.IsStatePresentEditMode(newStateName) && newStateName != "New State Name")
                     {
                         stateName.stringValue = newStateName;
 
@@ -234,24 +275,39 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         // Draw the buttons for adding or creating a new state at the bottom of the inspector window side by side
         private void RenderAddStateButtons()
         {
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+
             using (new EditorGUILayout.HorizontalScope())
             {
-                if (GUILayout.Button("Add Core State"))
+                if (GUILayout.Button(addCoreStateLabel))
                 {
                     AddNewState(newCoreStateName);
                 }
 
-                if (GUILayout.Button("Create New State"))
+                if (GUILayout.Button(createNewStateName))
                 {
                     AddNewState(createNewStateName);
                 }
             }
         }
 
-        // Checks if a given state is already in the States list
-        private bool IsStatePresent(string stateName)
+        // Reset all the state values if the Active property is set to false via inspector
+        private void ResetAllStates()
         {
-            return instance.States.Find((state) => state.Name == stateName) != null;
+            for (int i = 0; i < states.arraySize; i++)
+            {
+                SerializedProperty state = states.GetArrayElementAtIndex(i);
+                SerializedProperty stateName = state.FindPropertyRelative("stateName");
+                SerializedProperty stateValue = state.FindPropertyRelative("stateValue");
+                SerializedProperty stateActive = state.FindPropertyRelative("active");
+
+                if (stateName.stringValue != defaultStateName)
+                {
+                    stateValue.intValue = 0;
+                    stateActive.boolValue = false;
+                }
+            }
         }
     }
 }

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/BaseInteractiveElementInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/BaseInteractiveElementInspector.cs
@@ -85,7 +85,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 
                 if (previousActiveStatus != active.boolValue)
                 {
-                    ResetAllStates();
+                    // Only reset all states when Active is set to false
+                    if (!active.boolValue)
+                    {
+                        ResetAllStates();
+                    }
                 }
 
                 previousActiveStatus = active.boolValue;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/TouchEvents.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/TouchEvents.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The event configuration for the Touch InteractionState.
+    /// </summary>
+    public class TouchEvents : BaseInteractionEventConfiguration
+    {
+        /// <summary>
+        /// A Unity event with HandTrackingInputEventData. This event is fired when Touch enters an object.
+        /// </summary>
+        public TouchInteractionEvent OnTouchStarted = new TouchInteractionEvent();
+
+        /// <summary>
+        /// A Unity event with HandTrackingInputEventData. This event is fired when Touch exits an object.
+        /// </summary>
+        public TouchInteractionEvent OnTouchCompleted = new TouchInteractionEvent();
+
+        /// <summary>
+        /// A Unity event with HandTrackingInputEventData. This event is fired when Touch is updated.
+        /// </summary>
+        public TouchInteractionEvent OnTouchUpdated = new TouchInteractionEvent();
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/TouchEvents.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/TouchEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6117ae08e3122b94093b49f3f1828c5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceiverManager.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceiverManager.cs
@@ -60,11 +60,12 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         {
             BaseEventReceiver receiver = EventReceivers[stateName];
 
-            if (receiver != null)
+            // Only invoke state events if Interactive Element is Active
+            if (receiver != null && stateManager.InteractiveElement.Active)
             {
                 receiver.OnUpdate(stateManager, eventData);
             }
-            else
+            else if (receiver == null)
             {
                 Debug.LogError($"The event receiver for the {stateName} state does not exist");
             }
@@ -122,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
             // For example, the Focus state is associated with the FocusEvents class which has BaseInteractionEventConfiguration as its base class.
             // The FocusEvents class contains unity events with FocusEventData.
             // This pattern continues with states that have events with specific event data, i.e. the Touch state
-            // is associated with the serialized class TouchEvents which contians unity events with TouchEventData
+            // is associated with the serialized class TouchEvents which contains unity events with TouchEventData
             var eventConfigTypes = TypeCacheUtility.GetSubClasses<BaseInteractionEventConfiguration>();
             Type eventConfigType = eventConfigTypes.Find((type) => type.Name.StartsWith(stateName));
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/FocusReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/FocusReceiver.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         /// <inheritdoc />
         public override void OnUpdate(StateManager stateManager, BaseEventData eventData)
         {
-            bool hasFocus = stateManager.GetState(CoreInteractionState.Focus.ToString()).Value > 0;
+            bool hasFocus = stateManager.GetState(StateName).Value > 0;
 
             if (hadFocus != hasFocus)
             {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/TouchReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/TouchReceiver.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The internal event receiver for the events defined in the TouchEvents Configuration.
+    /// </summary>
+    public class TouchReceiver : BaseEventReceiver
+    {
+        public TouchReceiver(BaseInteractionEventConfiguration eventConfiguration) : base(eventConfiguration) { }
+
+        private TouchEvents touchEventConfig => EventConfiguration as TouchEvents;
+
+        private TouchInteractionEvent onTouchStarted => touchEventConfig.OnTouchStarted;
+
+        private TouchInteractionEvent onTouchCompleted => touchEventConfig.OnTouchCompleted;
+
+        private TouchInteractionEvent onTouchUpdated => touchEventConfig.OnTouchUpdated;
+
+        private bool wasTouching;
+
+        /// <inheritdoc />
+        public override void OnUpdate(StateManager stateManager, BaseEventData eventData)
+        {
+            bool isTouching = stateManager.GetState(StateName).Value > 0;
+
+            if (wasTouching != isTouching)
+            {
+                if (isTouching)
+                {
+                    onTouchStarted.Invoke(eventData as HandTrackingInputEventData);
+                }
+                else
+                {
+                    onTouchCompleted.Invoke(eventData as HandTrackingInputEventData);
+                }
+            }
+
+            if (isTouching)
+            {
+                onTouchUpdated.Invoke(eventData as HandTrackingInputEventData);
+            }
+
+            wasTouching = isTouching;
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/TouchReceiver.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/TouchReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f0b8a9958a55424ea1fec9041158594
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/TouchInteractionEvent.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/TouchInteractionEvent.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine.Events;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// A Unity event with HandTrackingInputEventData. This event is used in the event configuration for the 
+    /// Touch state.
+    /// </summary>
+    [System.Serializable]
+    public class TouchInteractionEvent : UnityEvent<HandTrackingInputEventData> { }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/TouchInteractionEvent.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/TouchInteractionEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a5c35dc3c14966458845e03a45547cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

Added the `Active` property and support for the Touch state to Interactive Element.  

Also added 2 new tests.

#### Touch State
When the Touch state is added via inspector, a Near Interaction Touchable Volume is also added as a Near Interaction Touchable is required for touch input.  If a user adds the Touch state during runtime, a Near Interaction Touchable is added as well. 

Once a button class is added, a Near Interaction Touchable will be attached instead of a Near Interaction Touchable Volume.

![AddTouchState](https://user-images.githubusercontent.com/53493796/99316499-54fb9780-2819-11eb-995f-1e5ac87397e5.gif)

#### Active Property
The `Active` property controls whether or not the Interactive Element updates state changes internally.  The `Active` property maps to Interactable's `Enabled` property.  The naming was changed from `Enabled` to `Active` to limit the confusion between a Monobehaviour's `Enabled` property and Interactable's internal `Enabled` property.

### Interactive Element State Values Runtime Inspector View

Watch the state values change in the inspector for the Focus and Touch state as the input simulation hand moves.
![Focus+TouchState](https://user-images.githubusercontent.com/53493796/99317953-b58bd400-281b-11eb-99d4-01f711da9338.gif)

## Changes
- Completes the add Active property item on this checklist #8883 

## Verification
How to test:
1. Checkout the branch
2. Open new unity scene
3. Add MRTK to the scene
4. Add a cube to the scene
5. Attach the `Interactive Element` component
6. Select Add Core State button in the Interactive Element inspector
7. Select Touch 
8. Press play and observe the state value changes in the inspector
