### PR TITLE
Add state sorting menu and the FocusNear/FocusFar states to Interactive Element

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/StateSelectionMenu.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/StateSelectionMenu.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+using Microsoft.MixedReality.Toolkit.UI.Interaction;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    /// <summary>
+    /// The state selection menu for an Interactive Element. Utilized by the BaseInteractiveElementInspector class. 
+    /// </summary>
+    internal class StateSelectionMenu : EditorWindow
+    {
+        internal bool stateSelected;
+        internal string state;
+
+        private const string Near = "Near";
+        private const string Far = "Far";
+        private const string Both = "Both";
+        private const string SelectStateButtonLabel = "Select State";
+
+        private string touchStateName = CoreInteractionState.Touch.ToString();
+
+        /// <summary>
+        /// Display the state selection menu.
+        /// </summary>
+        public void DisplayMenu(BaseInteractiveElement instance)
+        {
+            if (GUILayout.Button(SelectStateButtonLabel))
+            {
+                GenericMenu menu = new GenericMenu();
+
+                CreateStateSelectionMenu(instance, menu);
+
+                menu.ShowAsContext();
+            }
+        }
+
+        /// <summary>
+        /// Add state menu items and sort them by interaction type (Near, Far, Both).
+        /// </summary>
+        public void CreateStateSelectionMenu(BaseInteractiveElement instance, GenericMenu statesMenu)
+        {
+            List<string> coreInteractionStateNames = Enum.GetNames(typeof(CoreInteractionState)).ToList();
+
+            // If the state is already being tracked then do not display the state name as an option to add
+            foreach (string coreState in coreInteractionStateNames.ToList())
+            {
+                if (instance.IsStatePresentEditMode(coreState))
+                {
+                    coreInteractionStateNames.Remove(coreState);
+                }
+            }
+
+            // Sort the states in the menu based on name
+            foreach (var stateName in coreInteractionStateNames)
+            {
+                // Add special case for touch because it is a near interaction state that does not contain "Near" in the name
+                if (stateName.Contains(Near) || stateName == touchStateName)
+                {
+                    // Near Interaction States
+                    AddStateToMenu(statesMenu, Near + "/" + stateName, stateName);
+                }
+                else if (stateName.Contains(Far))
+                {
+                    // Far Interaction States
+                    AddStateToMenu(statesMenu, Far + "/" + stateName, stateName);
+                }
+                else if (!stateName.Contains(Far) && !stateName.Contains(Near))
+                {
+                    // Both Near and Far Interaction States
+                    AddStateToMenu(statesMenu, Both + "/" + stateName, stateName);
+                }
+            }
+        }
+
+        // Add a single item to the state selection menu
+        private void AddStateToMenu(GenericMenu menu, string menuPath, string stateName)
+        {
+            menu.AddItem(new GUIContent(menuPath), false, OnStateSelected, stateName);
+        }
+
+        // Set internal properties when a state is selected from the menu
+        private void OnStateSelected(object stateName)
+        {
+            stateSelected = true;
+            state = stateName.ToString();
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/StateSelectionMenu.cs.meta
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/StateSelectionMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdbbf3d36cbb697469115101a44426a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceiverManager.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceiverManager.cs
@@ -119,13 +119,15 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         {
             BaseInteractionEventConfiguration eventConfiguration;
 
+            string subStateName = stateManager.GetState(stateName).GetSubStateName();
+
             // Check if the state has an associated event configuration by state name.
             // For example, the Focus state is associated with the FocusEvents class which has BaseInteractionEventConfiguration as its base class.
             // The FocusEvents class contains unity events with FocusEventData.
             // This pattern continues with states that have events with specific event data, i.e. the Touch state
             // is associated with the serialized class TouchEvents which contains unity events with TouchEventData
             var eventConfigTypes = TypeCacheUtility.GetSubClasses<BaseInteractionEventConfiguration>();
-            Type eventConfigType = eventConfigTypes.Find((type) => type.Name.StartsWith(stateName));
+            Type eventConfigType = eventConfigTypes.Find((type) => type.Name.StartsWith(subStateName));
 
             if (eventConfigType != null)
             {
@@ -149,10 +151,12 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
             InteractionState state = stateManager.GetState(stateName);
 
             BaseInteractionEventConfiguration eventConfiguration = (BaseInteractionEventConfiguration)state.EventConfiguration;
-            
+
+            string subStateName = state.GetSubStateName();
+
             // Find the associated event receiver for the state if it has one
             var eventReceiverTypes = TypeCacheUtility.GetSubClasses<BaseEventReceiver>();
-            Type eventReceiver = eventReceiverTypes.Find((type) => type.Name.StartsWith(stateName));
+            Type eventReceiver = eventReceiverTypes.Find((type) => type.Name.StartsWith(subStateName));
 
             if (eventReceiver != null)
             {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/CoreInteractionState.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/CoreInteractionState.cs
@@ -14,15 +14,24 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         Default = 0,
 
         /// <summary>
-        /// Represents the Focus state.
+        /// Represents the Focus state. This state supports both near and far interaction.
         /// </summary>
         Focus,
 
         /// <summary>
-        /// Represents the Touch state.  THIS STATE DOES NOT HAVE LOGIC DEFINED YET.
+        /// Represents the Focus Near state. This is a near interaction state
+        /// </summary>
+        FocusNear,
+
+        /// <summary>
+        /// Represents the Focus state. This is a far interaction state. 
+        /// </summary>
+        FocusFar,
+
+        /// <summary>
+        /// Represents the Touch state. This is a near interaction state that also requires the attachment of a NearInteractionTouchable 
+        /// component to register touch input. 
         /// </summary>
         Touch
-
-        // Add more core states as the state logic is defined: Click, Grab, Speech Keyword, Pressed
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/InteractionType.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/InteractionType.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The type of interaction an InteractionState is associated with. Utilized by the InteractionState
+    /// class.  
+    /// </summary>
+    public enum InteractionType
+    {
+        /// <summary>
+        /// Does not support any form of input interaction.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Near interaction support. Input is considered near interaction when an articulated hand has 
+        /// direct contact with another game object, i.e. the position the articulated hand is 
+        /// close to the position of the game object in world space.
+        /// </summary>
+        Near = 1,
+
+        /// <summary>
+        /// Far interaction support. Input is considered far interaction when direct contact with 
+        /// the game object is not required. For example, input via controller ray or gaze is considered
+        /// far interaction input.
+        /// </summary>
+        Far = 2,
+        
+        /// <summary>
+        /// Encompasses both near and far interaction support. 
+        /// </summary>
+        Both = 3
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/InteractionType.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/InteractionType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04fb540d07a609b4590422259ad2f161
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/StateManager.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/StateManager.cs
@@ -95,7 +95,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
             }
             catch 
             {
-                Debug.LogError($"{stateName} state was not found, please check the spelling or add a new state with {stateName} as the name.");
                 return null;
             }
         }
@@ -294,8 +293,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
                 // Set the event configuration if one exists for the core interaction state
                 EventReceiverManager.SetEventConfiguration(newState);
 
-                // If the Touch state is added, check if a Near Interaction Touchable component attached to the game object
-                if (stateName == touchStateName)
+                // If a near interaction state is added, check if a Near Interaction Touchable component attached to the game object
+                if (newState.InteractionType == InteractionType.Near)
                 {
                     // A Near Interaction Touchable component is required for an object to receive touch events
                     InteractiveElement.AddNearInteractionTouchable();


### PR DESCRIPTION
## Overview

#### State Selection Menu
Adds a state sorting menu to Interactive Element.  When a user selects "Add Core State", the states are now sorted based on the Interaction Type. 

![SortingStatesMenuPR](https://user-images.githubusercontent.com/53493796/99713338-06d4d700-2a59-11eb-947a-c230a395fb52.gif)

#### Active state inspector highlight

During play mode, when a state is active, it is highlighted with cyan in the inspector.  This makes a state change more obvious to the user. 

#### Added new FocusNear and FocusFar states

The Focus state encompasses both near and far interaction but the addition of FocusNear and FocusFar allows users to track whether an object is in near focus or far focus.  For example, if an object comes into focus with the controller ray pointer, that is considered far interaction.  If an object comes into Focus with the poke pointer, that is considered near interaction.   Added a test for these states. 

The gif below demonstrates the state value highlight in the inspector and how the object responds to Focus.

![FocusNearFocusFarPR](https://user-images.githubusercontent.com/53493796/99715296-81065b00-2a5b-11eb-9bca-ee771171e2a5.gif)

#### Added the InteractionType property 

Added a property to the InteractionState class that defines the `InteractionType` of a state as Near, Far, Both, None.  This property is used to label states with the goal of reducing confusion on the type of interaction each state supports. 


## Changes
- Checks off 2 item in this to do list: #8883 


## Verification
1. Checkout the branch
1. Open new unity scene
1. Add MRTK to the scene
1. Add a cube to the scene
1. Attach the Interactive Element component
1. Select Add Core State button in the Interactive Element inspector
1. Add the FocusNear and FocusFar state
1. Press play and observe the state value changes in the inspector
