### PR TITLE
Fix a DeleteArrayElementAtIndex related issue

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Constraints/ConstraintManagerInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Constraints/ConstraintManagerInspector.cs
@@ -278,9 +278,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     EditorGUILayout.LabelField("ComponentId: " + constraintManager.GetInstanceID(), EditorStyles.miniLabel);
 
                     // deferred delete elements from array to not break unity layout
-                    foreach (int i in indicesToRemove)
+                    for (int i = indicesToRemove.Count - 1; i > -1; i--)
                     {
-                        selectedConstraints.DeleteArrayElementAtIndex(i);
+                        var currentArraySize = selectedConstraints.arraySize;
+                        selectedConstraints.DeleteArrayElementAtIndex(indicesToRemove[i]);
+                        if (currentArraySize == selectedConstraints.arraySize)
+                        {
+                            selectedConstraints.DeleteArrayElementAtIndex(indicesToRemove[i]);
+                        }
                     }
 
                     indicesToRemove.Clear();


### PR DESCRIPTION
## Overview
Currently there is a bug associated with the constraint manager. To reproduce:
1. Add a cube to a scene with MRTK properly set up
2. Add `BoundsControl` to the cube
3. Go to the constraint manager component, switch to manual mode, add a constraint and then remove it
4. Click play and try to scale the cube. Note `NullReferenceException`s appear in the console

The bug is related to a call to `SerializedProperty.DeleteArrayElementAtIndex`, which supposedly should "delete the element at the specified index in the array", but instead it actually sets the element to null if it is not already null at the time of the call (otherwise it removes the element). Some on the Internet said this behavior ensured such removal did not break the indexing of the array and should "just work" when being applied back to the object behind the SerializedObject. However that differs from the behavior I am currently seeing on Unity 2018.4.26f1 and Unity 2019.4.12f1.


## Changes
- Call `DeleteArrayElementAtIndex` a second time if the size of the array does not change after the first call.


## Verification
Repeat the steps above and observe no such error.