### PR TITLE
Prevent exception when using Oculus Quest with hand tracking and the TeleportCursor

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/TeleportCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/TeleportCursor.cs
@@ -116,7 +116,10 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 
         public override void SetVisibility(bool visible)
         {
-            this.PrimaryCursorVisual.gameObject.SetChildrenActive(visible);
+            if (this.PrimaryCursorVisual != null)
+            {
+                this.PrimaryCursorVisual.gameObject.SetChildrenActive(visible);
+            }
         }
 
         #endregion IMixedRealityCursor Implementation


### PR DESCRIPTION
## Overview
Added a null check to prevent an exception that occurs when using Oculus Quest and moving the hands in and out of view.  This can be especially problematic when testing in the editor and being forced to remove the headset and unpause to allow execution to continue.





