### PR TITLE
Hotfix reverting change breaking oculus quest camera

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKInputSystemProfile.asset
+++ b/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKInputSystemProfile.asset
@@ -27,7 +27,8 @@ MonoBehaviour:
     componentName: XRSDK Oculus Device Manager
     priority: 0
     runtimePlatform: 33
-    deviceManagerProfile: {fileID: 0}
+    deviceManagerProfile: {fileID: 11400000, guid: 8f48cb9c26fb518499c65c9f9e8bb4ed,
+      type: 2}
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation
     componentName: Input Simulation Service

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealityXRSDKControllerVisualizationProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealityXRSDKControllerVisualizationProfile.asset
@@ -64,7 +64,7 @@ MonoBehaviour:
   - description: Oculus Hand
     controllerType:
       reference: Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input.OculusHand, Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus
-    handedness: 1
+    handedness: 2
     useDefaultModel: 0
     defaultModelMaterial: {fileID: 0}
     overrideModel: {fileID: 3512491064599439886, guid: 7a857af0cb85b4a47b6ec8a1babcb73c,


### PR DESCRIPTION
## Overview
Mistaken profile change broke the camera on oculus quest. reverting
