### PR TITLE
Lock tests to run on StandaloneWindows to try to improve daily CI

### DIFF
--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -40,14 +40,14 @@ steps:
       scopedValidation: ${{ parameters.scopedValidation }}
       changesFile: '$(Build.ArtifactStagingDirectory)\build\changedfiles.txt'
 
-# Build Standalone x86.
+# Build Standalone x64.
 # This must happen before tests run, because if the build fails and tests attempt
 # to get run, Unity will hang showing a dialog (even when in batch mode).
 # This is the fastest build, since it doesn't produce an AppX.
 - ${{ if eq(parameters.buildStandalone, true) }}:
   - template: tasks/unitybuild.yml
     parameters:
-      Arch: 'x86'
+      Arch: 'x64'
       Platform: 'Standalone'
       UnityVersion: ${{ parameters.UnityVersion }}
 

--- a/pipelines/templates/tests.yml
+++ b/pipelines/templates/tests.yml
@@ -12,7 +12,7 @@ steps:
    
    $logFile = New-Item -Path .\editmode-test-run.log -ItemType File -Force
    
-   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform editmode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform EditMode -batchMode -buildTarget StandaloneWindows -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
    $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
    
    while (-not $proc.HasExited -and $ljob.HasMoreData)
@@ -37,7 +37,7 @@ steps:
    
    $logFile = New-Item -Path .\playmode-test-run.log -ItemType File -Force
    
-   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform playmode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-playmode-default.xml" -PassThru
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform PlayMode -batchMode -buildTarget StandaloneWindows -logFile $($logFile.Name) -editorTestsResultFile .\test-playmode-default.xml" -PassThru
    $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
    
    while (-not $proc.HasExited -and $ljob.HasMoreData)


### PR DESCRIPTION
## Overview

Our daily 2019 build has been failing tests for a long time. @CDiaz-MS recently added a Unity 2019 PR validation pipeline, which...doesn't fail tests 😲 PR validation runs tests after a Standalone build, while the daily 2019 pipeline builds UWP ARM64 first, which means the tests then attempt to run in the context of UWP, which attempts to start-up VR and seems to be the cause of many of the failures.

This PR

1. Adds `-buildTarget StandaloneWindows` to our test running command, which should reset the editor out of UWP
1. Updates our existing standalone build from x86 to x64, the more common architecture target for standalone