### PR TITLE
Only run 2019 daily on a machine with VS2019

### DIFF
--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -14,6 +14,7 @@ jobs:
     - ${{ variables.Unity2019Version }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
+    - VS2019 -equals TRUE
   steps:
   - template: templates/common-Unity2019.yml
     parameters:


### PR DESCRIPTION
## Overview

Like the 2019 PR validation pipeline, our daily 2019 build also depends on VS 2019 existing on the VM it's running on. Not all of our VMs have 2019 installed, so this ensures it'll only run on a supported machine.