### PR TITLE
Adjusted line pointer endpoint to match the cursor 1 to 1

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -150,7 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 lineBase.UpdateMatrix();
 
-                // Set our first and last points
+                // Set our first and last points on the Line Renderer
                 if (IsFocusLocked && IsTargetPositionLockedOnFocusLock && Result != null)
                 {
                     // Make the final point 'stick' to the target at the distance of the target
@@ -206,12 +206,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // Used to ensure the line doesn't extend beyond the cursor
                 float cursorOffsetWorldLength = (BaseCursor != null) ? BaseCursor.SurfaceCursorDistance : 0;
 
+                // Readjust the Line renderer's endpoint to match the the cursor's position if it is focus locked to a target
+                if (IsFocusLocked && IsTargetPositionLockedOnFocusLock && Result != null)
+                {
+                    SetLinePoints(Position, Result.Details.Point + Rotation * Vector3.back * cursorOffsetWorldLength);
+                }
+
                 // If focus is locked, we're sticking to the target
-                // So don't clamp the world length
+                // So don't clamp the world length, the line data's end point is already set to the world cursor
                 if (IsFocusLocked && IsTargetPositionLockedOnFocusLock)
                 {
-                    float cursorOffsetLocalLength = LineBase.GetNormalizedLengthFromWorldLength(cursorOffsetWorldLength);
-                    LineBase.LineEndClamp = 1 - cursorOffsetLocalLength;
+                    LineBase.LineEndClamp = 1;
                 }
                 else
                 {


### PR DESCRIPTION
## Overview
Updates the line pointer so that its endpoint now tracks the cursor one to 1 instead of lagging behind somewhat noticeably

old line pointer behavior:
![Cursorold](https://user-images.githubusercontent.com/39840334/101104670-7d58f500-3580-11eb-99cf-5398287803ce.gif)


new line pointer behavior:
![Cursornew](https://user-images.githubusercontent.com/39840334/101104675-7f22b880-3580-11eb-82ec-e8f1a3e0f656.gif)


## Changes
- Fixes: #8710


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
