### PR TITLE
Add SelectFar, Clicked and Toggle states to Interactive Element 

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/BaseInteractiveElementInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/BaseInteractiveElementInspector.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         // Used to set the default name for the text input field when a user creates a new state
         private static string newStateName = "New State Name";
         private const string newCoreStateName = "New Core State";
-        private const string createNewStateName = "Create Custom State";
+        private const string createCustomStateName = "Create Custom State";
         private const string removeStateLabel = "Remove State";
         private const string statesLabel = "States";
         private const string settingsLabel = "Settings";
@@ -160,9 +160,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                         SetCoreStateType(state, stateName);
                                     }
 
-                                    // When a new state is added via inspector, the name is initialized to "Create New State" and then changed
+                                    // When a new state is added via inspector, the name is initialized to "Create Custom State" and then changed
                                     // to the name the user enters a name in the text field and then selects the "Set State Name" button
-                                    if (stateName.stringValue == createNewStateName)
+                                    if (stateName.stringValue == createCustomStateName)
                                     {
                                         SetUserDefinedState(stateName);
                                     }
@@ -203,8 +203,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         // Render the event configuration of a state
         private void RenderStateEventConfiguration(SerializedProperty stateName, SerializedProperty stateEventConfiguration)
         {
-            // Do not draw the state events if the state is in the selection process, i.e. the state name is "New Core State" or "Create New State"
-            if (stateEventConfiguration.managedReferenceFullTypename != string.Empty && stateName.stringValue != newCoreStateName && stateName.stringValue != createNewStateName)
+            // Do not draw the state events if the state is in the selection process, i.e. the state name is "New Core State" or "Create Custom State"
+            if (stateEventConfiguration.managedReferenceFullTypename != string.Empty && stateName.stringValue != newCoreStateName && stateName.stringValue != createCustomStateName)
             {
                 using (new EditorGUI.IndentLevelScope())
                 {
@@ -300,9 +300,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         AddNewState(newCoreStateName);
                     }
 
-                    if (GUILayout.Button(createNewStateName))
+                    if (GUILayout.Button(createCustomStateName))
                     {
-                        AddNewState(createNewStateName);
+                        AddNewState(createCustomStateName);
                     }
                 }
             }

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/StateSelectionMenu.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/StateSelectionMenu.cs
@@ -18,12 +18,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         internal bool stateSelected;
         internal string state;
 
-        private const string Near = "Near";
-        private const string Far = "Far";
-        private const string Both = "Both";
+        private string Near = InteractionType.Near.ToString();
+        private string Far = InteractionType.Far.ToString();
+        private string NearAndFar = InteractionType.NearAndFar.ToString();
+        private string Other = InteractionType.Other.ToString();
         private const string SelectStateButtonLabel = "Select State";
 
         private string touchStateName = CoreInteractionState.Touch.ToString();
+        private string focusStateName = CoreInteractionState.Focus.ToString();
 
         /// <summary>
         /// Display the state selection menu.
@@ -70,10 +72,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     // Far Interaction States
                     AddStateToMenu(statesMenu, Far + "/" + stateName, stateName);
                 }
-                else if (!stateName.Contains(Far) && !stateName.Contains(Near))
+                else if (stateName == focusStateName)
                 {
-                    // Both Near and Far Interaction States
-                    AddStateToMenu(statesMenu, Both + "/" + stateName, stateName);
+                    // Focus is a special case state because it supports both near and far interaction
+                    AddStateToMenu(statesMenu, NearAndFar + "/" + stateName, stateName);
+                }
+                else
+                {
+                    AddStateToMenu(statesMenu, Other + "/" + stateName, stateName);
                 }
             }
         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/BaseInteractiveElement.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/BaseInteractiveElement.cs
@@ -6,9 +6,11 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
+[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.SDK.Editor")]
 namespace Microsoft.MixedReality.Toolkit.UI.Interaction
 {
     /// <summary>
@@ -18,7 +20,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
     public abstract class BaseInteractiveElement :
         MonoBehaviour,
         IMixedRealityFocusHandler,
-        IMixedRealityTouchHandler
+        IMixedRealityTouchHandler,
+        IMixedRealityPointerHandler
     {
         [SerializeField]
         [Tooltip("Whether or not this interactive element will react to input and update internally. If true, the " +
@@ -70,6 +73,10 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         protected string FocusNearStateName = CoreInteractionState.FocusNear.ToString();
         protected string FocusFarStateName = CoreInteractionState.FocusFar.ToString();
         protected string TouchStateName = CoreInteractionState.Touch.ToString();
+        protected string SelectFarStateName = CoreInteractionState.SelectFar.ToString();
+        protected string ClickedStateName = CoreInteractionState.Clicked.ToString();
+        protected string ToggleOnStateName = CoreInteractionState.ToggleOn.ToString();
+        protected string ToggleOffStateName = CoreInteractionState.ToggleOff.ToString();
 
         public virtual void OnValidate()
         {
@@ -88,6 +95,35 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
 
             // Initially set the default state to on
             SetStateOn(DefaultStateName);
+        }
+
+        public virtual void Start()
+        {
+            // If the SelectFar state is in the States list at start and the Global property is true, then
+            // register the IMixedRealityPointerHandler for global usage
+            RegisterSelectFarHandler(true);
+
+            // If the SelectFar state is present, add listeners for the Global property for runtime property modification
+            StateManager.AddSelectFarListeners();
+
+            // If the Toggle states are present, ensure the set up is correct and check initial values
+            if (IsStatePresent(ToggleOnStateName) || IsStatePresent(ToggleOffStateName))
+            {
+                // Ensure both the ToggleOn and ToggleOff states are added if either state is present
+                // The Toggle behavior only works if both the ToggleOn and ToggleOff states are present
+                AddToggleStates();
+
+                var toggleOn = GetStateEvents<ToggleOnEvents>(ToggleOnStateName);
+
+                // Set the initial toggle states according to the value of ToggleOn's IsActiveOnStart property
+                ForceSetToggleStates(toggleOn.IsSelectedOnStart);
+            }
+        }
+
+        private void OnDisable()
+        {
+            // Unregister the IMixedRealityPointerHandler if it was registered
+            RegisterSelectFarHandler(false);
         }
 
         // Add the Default and the Focus state as the initial states in the States list
@@ -142,13 +178,40 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
 
         public void OnTouchUpdated(HandTrackingInputEventData eventData)
         {
-            if (IsStatePresent(TouchStateName))
-            {
-                EventReceiverManager.InvokeStateEvent(TouchStateName, eventData);
-            }
+            EventReceiverManager.InvokeStateEvent(TouchStateName, eventData);
         }
 
         #endregion
+
+        #region SelectFar
+
+        public void OnPointerDown(MixedRealityPointerEventData eventData)
+        {
+            SetStateAndInvokeEvent(SelectFarStateName, 1, eventData);
+        }
+
+        public void OnPointerDragged(MixedRealityPointerEventData eventData)
+        {
+            EventReceiverManager.InvokeStateEvent(SelectFarStateName, eventData);
+        }
+
+        public void OnPointerClicked(MixedRealityPointerEventData eventData)
+        {
+            EventReceiverManager.InvokeStateEvent(SelectFarStateName, eventData);
+
+            TriggerClickedState();
+
+            SetToggleStates();
+        }
+
+        public void OnPointerUp(MixedRealityPointerEventData eventData)
+        {
+            SetStateAndInvokeEvent(SelectFarStateName, 0, eventData);
+        }
+
+        #endregion
+
+        #region Event Utilities
 
         /// <summary>
         /// Sets a state to a given state value and invokes an event with associated event data. 
@@ -156,7 +219,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         /// <param name="stateName">The name of the state to set</param>
         /// <param name="stateValue">The state value. A value of 0 = set the state off, 1 = set the state on</param>
         /// <param name="eventData">Event data to pass into the event</param>
-        public void SetStateAndInvokeEvent(string stateName, int stateValue, BaseEventData eventData)
+        public void SetStateAndInvokeEvent(string stateName, int stateValue, BaseEventData eventData = null)
         {
             if (IsStatePresent(stateName))
             {
@@ -165,8 +228,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
                 EventReceiverManager.InvokeStateEvent(stateName, eventData);
             }
         }
-
-        #region Event Utilities
 
         public T GetStateEvents<T>(string stateName) where T : BaseInteractionEventConfiguration
         {
@@ -270,17 +331,101 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
 
         #endregion
 
+        #region Button Setting Utilities
+
+        /// <summary>
+        /// Set the Clicked state and invoke the OnClicked event
+        /// </summary>
+        public void TriggerClickedState()
+        {
+            // Set the Clicked state to on, invokes the OnClicked event
+            SetStateAndInvokeEvent(ClickedStateName, 1);
+
+            // Set the Clicked state to off
+            SetStateAndInvokeEvent(ClickedStateName, 0);
+        }
+
+        /// <summary>
+        /// Add the ToggleOn and ToggleOff state.
+        /// </summary>
+        public void AddToggleStates()
+        {
+            if (!IsStatePresent(ToggleOnStateName))
+            {
+                StateManager.AddNewState(ToggleOnStateName);
+            }
+
+            if (!IsStatePresent(ToggleOffStateName))
+            {
+                StateManager.AddNewState(ToggleOffStateName);
+            }
+        }
+
+        /// <summary>
+        /// Set the toggle based on the current values of the ToggleOn and ToggleOff states. 
+        /// </summary>
+        public void SetToggleStates()
+        {
+            if (IsStatePresent(ToggleOnStateName) && IsStatePresent(ToggleOffStateName))
+            {
+                bool setToggleOn = StateManager.GetState(ToggleOnStateName).Value > 0;
+
+                SetToggles(!setToggleOn);
+            }
+        }
+
+        /// <summary>
+        /// Force set the toggle states either on or off. 
+        /// </summary>
+        /// <param name="setToggleOn">If true, the toggle will be set to on. If false, the toggle will be set to off.</param>
+        public void ForceSetToggleStates(bool setToggleOn)
+        {
+            if (IsStatePresent(ToggleOnStateName) && IsStatePresent(ToggleOffStateName))
+            {
+                SetToggles(setToggleOn);
+            }
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        protected void SetToggles(bool setToggleOn)
+        {
+            if (setToggleOn)
+            {
+                SetStateAndInvokeEvent(ToggleOffStateName, 0);
+                SetStateAndInvokeEvent(ToggleOnStateName, 1);
+            }
+            else
+            {
+                SetStateAndInvokeEvent(ToggleOnStateName, 0);
+                SetStateAndInvokeEvent(ToggleOffStateName, 1);
+            }
+        }
+
         /// <summary>
         /// Used for setting the event configuration for a new state when the state is added via inspector.
         /// </summary>
         /// <param name="stateName">The name of the state</param>
-        public void SetEventConfigurationInstance(string stateName)
+        internal void SetEventConfigurationInstance(string stateName)
         {
             InteractionState state = States.Find((interactionState) => interactionState.Name == stateName);
             
             // Set the new Interaction Type and configuration
             state.SetEventConfiguration(stateName);
             state.SetInteractionType(stateName);
+        }
+
+        /// <summary>
+        /// Checks if a state is currently in the State list. This method is specifically used for checking the 
+        /// contents of the States list during edit mode as the State Manager contains runtime methods. 
+        /// </summary>
+        /// <param name="stateName">The name of the state</param>
+        /// <returns>True if the state is in the States list. False, if the state could not be found.</returns>
+        internal bool IsStatePresentEditMode(string stateName)
+        {
+            return States.Find((state) => state.Name == stateName) != null;
         }
 
         /// <summary>
@@ -291,7 +436,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         /// on the entire surface area of a collider.  While a Near Interaction Touchable component
         /// will be attached if the object is a button because touch input is only detected within the area of a plane. 
         /// </summary>
-        public void AddNearInteractionTouchable()
+        internal void AddNearInteractionTouchable()
         {
             if (gameObject.GetComponent<BaseNearInteractionTouchable>() == null)
             {
@@ -306,14 +451,38 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         }
 
         /// <summary>
-        /// Checks if a state is currently in the State list. This method is specifically used for checking the 
-        /// contents of the States list during edit mode as the State Manager contains runtime methods. 
+        /// Register the IMixedRealityPointerHandler for global input when the SelectFar state is
+        /// present on Start and the Global property is true.
         /// </summary>
-        /// <param name="stateName">The name of the state</param>
-        /// <returns>True if the state is in the States list. False, if the state could not be found.</returns>
-        public bool IsStatePresentEditMode(string stateName)
+        internal void RegisterSelectFarHandler(bool register)
         {
-            return States.Find((state) => state.Name == stateName) != null;
+            if (IsStatePresent(SelectFarStateName))
+            {
+                var selectFarEvents = GetStateEvents<SelectFarEvents>(SelectFarStateName);
+
+                // Check if far select has the Global property enabled
+                if (selectFarEvents.Global)
+                {
+                    RegisterHandler<IMixedRealityPointerHandler>(register);
+                }
+            }
         }
+
+        /// <summary>
+        /// Helper method for registering an IEventSystemHandler.
+        /// </summary>
+        internal void RegisterHandler<T>(bool register) where T : IEventSystemHandler
+        {
+            if (register)
+            {
+                CoreServices.InputSystem?.RegisterHandler<T>(this);
+            }
+            else
+            {
+                CoreServices.InputSystem?.UnregisterHandler<T>(this);
+            }
+        }
+
+        #endregion
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/BaseInteractiveElement.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/BaseInteractiveElement.cs
@@ -334,7 +334,12 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         #region Button Setting Utilities
 
         /// <summary>
-        /// Set the Clicked state and invoke the OnClicked event
+        /// Set the Clicked state which triggers the OnClicked event.  The click behavior in the
+        /// state management system is expressed by setting the Clicked state to on and then immediately setting
+        /// it to off. 
+        /// 
+        /// Note: Due to the fact that a click is triggered by setting the Clicked state to on and 
+        /// then immediately off, the cyan active state highlight in the inspector will not be visible.
         /// </summary>
         public void TriggerClickedState()
         {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ClickedEvents.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ClickedEvents.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The event configuration for the Clicked InteractionState.
+    /// </summary>
+    public class ClickedEvents : BaseInteractionEventConfiguration
+    {
+        /// <summary>
+        /// A Unity event that is fired when the Clicked state is active.
+        /// </summary>
+        public UnityEvent OnClicked = new UnityEvent();
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ClickedEvents.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ClickedEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea4bd53bef451064392bd287dab29017
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/SelectFarEvents.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/SelectFarEvents.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The event configuration for the SelectFar InteractionState.
+    /// </summary>
+    public class SelectFarEvents : BaseInteractionEventConfiguration
+    {
+        [SerializeField]
+        [Tooltip("Whether or not to register the IMixedRealityPointerHandler for global input. If Global is true, then" +
+        " events in the SelectFar state will be fired without requiring an object to be in focus. ")]
+        private bool global = false;
+
+        /// <summary>
+        /// Whether or not to register the IMixedRealityPointerHandler for global input. If Global is true, then
+        /// events in the SelectFar state will be fired without requiring an object to be in focus. 
+        /// </summary>
+        public bool Global
+        {
+            get => global;
+            set 
+            {
+                global = value;
+                OnGlobalChanged.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// A Unity event used to track whether or not the Global property has changed.
+        /// </summary>
+        [HideInInspector]
+        public UnityEvent OnGlobalChanged = new UnityEvent();
+
+        /// <summary>
+        /// A Unity event with MixedRealityPointerEventData. 
+        /// </summary>
+        public SelectFarInteractionEvent OnSelectDown = new SelectFarInteractionEvent();
+
+        /// <summary>
+        /// A Unity event with MixedRealityPointerEventData. 
+        /// </summary>
+        public SelectFarInteractionEvent OnSelectUp = new SelectFarInteractionEvent();
+
+        /// <summary>
+        /// A Unity event with MixedRealityPointerEventData. 
+        /// </summary>
+        public SelectFarInteractionEvent OnSelectHold = new SelectFarInteractionEvent();
+
+        /// <summary>
+        /// A Unity event with MixedRealityPointerEventData. 
+        /// </summary>
+        public SelectFarInteractionEvent OnSelectClicked = new SelectFarInteractionEvent();
+
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/SelectFarEvents.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/SelectFarEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d410f016522005e4b8f31916d380ced4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ToggleOffEvents.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ToggleOffEvents.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The event configuration for the ToggleOff InteractionState.
+    /// </summary>
+    public class ToggleOffEvents : BaseInteractionEventConfiguration
+    {
+        /// <summary>
+        /// A Unity event that is fired when the ToggleOff state is active.
+        /// </summary>
+        public UnityEvent OnToggleOff = new UnityEvent();
+    }
+}
+

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ToggleOffEvents.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ToggleOffEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df0d8365e7f1bbb4c9edc6d44a10000d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ToggleOnEvents.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ToggleOnEvents.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Configuration;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The event configuration for the ToggleOn InteractionState.
+    /// </summary>
+    public class ToggleOnEvents : BaseInteractionEventConfiguration
+    {
+        [SerializeField]
+        [Tooltip("Whether on not the toggle is selected when the application starts.")]
+        private bool isSelectedOnStart = false;
+
+        /// <summary>
+        /// Whether on not the toggle is selected when the application starts.
+        /// </summary>
+        public bool IsSelectedOnStart
+        {
+            get => isSelectedOnStart;
+            set => isSelectedOnStart = value;
+        }
+
+        /// <summary>
+        /// A Unity event that is fired when the ToggleOff state is active.
+        /// </summary>
+        public UnityEvent OnToggleOn = new UnityEvent();
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ToggleOnEvents.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/ToggleOnEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36fa7b1c9b5ff084b88f79504b2936ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceiverManager.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceiverManager.cs
@@ -58,16 +58,19 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         /// <param name="eventData">The event data for the state event (optional)</param>
         public void InvokeStateEvent(string stateName, BaseEventData eventData = null)
         {
-            BaseEventReceiver receiver = EventReceivers[stateName];
+            if (stateManager.InteractiveElement.IsStatePresent(stateName))
+            {
+                BaseEventReceiver receiver = EventReceivers[stateName];
 
-            // Only invoke state events if Interactive Element is Active
-            if (receiver != null && stateManager.InteractiveElement.Active)
-            {
-                receiver.OnUpdate(stateManager, eventData);
-            }
-            else if (receiver == null)
-            {
-                Debug.LogError($"The event receiver for the {stateName} state does not exist");
+                // Only invoke state events if Interactive Element is Active
+                if (receiver != null && stateManager.InteractiveElement.Active)
+                {
+                    receiver.OnUpdate(stateManager, eventData);
+                }
+                else if (receiver == null)
+                {
+                    Debug.LogError($"The event receiver for the {stateName} state does not exist");
+                }
             }
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ClickedReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ClickedReceiver.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The internal event receiver for the event defined in the Clicked Interaction Event Configuration.
+    /// </summary>
+    public class ClickedReceiver : BaseEventReceiver
+    {
+        public ClickedReceiver(BaseInteractionEventConfiguration eventConfiguration) : base(eventConfiguration) { }
+
+        private ClickedEvents ClickedEventConfig => EventConfiguration as ClickedEvents;
+
+        private UnityEvent onClicked => ClickedEventConfig.OnClicked;
+        /// <inheritdoc />
+        public override void OnUpdate(StateManager stateManager, BaseEventData eventData)
+        {
+            bool clicked = stateManager.GetState(StateName).Value > 0;
+
+            if (clicked)
+            {
+                onClicked.Invoke();
+            }
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ClickedReceiver.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ClickedReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5e3040d07c78d24da359ac0fd07cf10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SelectFarReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SelectFarReceiver.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The internal event receiver for the events defined in the SelectFar Interaction Event Configuration.
+    /// </summary>
+    public class SelectFarReceiver : BaseEventReceiver
+    {
+        public SelectFarReceiver(BaseInteractionEventConfiguration eventConfiguration) : base(eventConfiguration) { }
+
+        private SelectFarEvents SelectFarEventConfig => EventConfiguration as SelectFarEvents;
+
+        private SelectFarInteractionEvent onSelectDown => SelectFarEventConfig.OnSelectDown;
+
+        private SelectFarInteractionEvent onSelectUp => SelectFarEventConfig.OnSelectUp;
+
+        private SelectFarInteractionEvent onSelectHold => SelectFarEventConfig.OnSelectHold;
+
+        private SelectFarInteractionEvent onSelectClicked => SelectFarEventConfig.OnSelectClicked;
+
+        private bool hadFarSelect;
+
+        /// <inheritdoc />
+        public override void OnUpdate(StateManager stateManager, BaseEventData eventData)
+        {
+            bool hasFarSelect = stateManager.GetState(StateName).Value > 0;
+
+            if (hadFarSelect != hasFarSelect)
+            {
+                if (hasFarSelect)
+                {
+                    onSelectDown.Invoke(eventData as MixedRealityPointerEventData);
+                }
+                else
+                {
+                    onSelectClicked.Invoke(eventData as MixedRealityPointerEventData);
+                    onSelectUp.Invoke(eventData as MixedRealityPointerEventData);
+                }
+            }
+
+            if (hasFarSelect)
+            {
+                onSelectHold.Invoke(eventData as MixedRealityPointerEventData);
+            }
+
+            hadFarSelect = hasFarSelect;
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SelectFarReceiver.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SelectFarReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e20609b56bf4464195b43537776e9d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ToggleOffReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ToggleOffReceiver.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The internal event receiver for the event defined in the ToggleOff Interaction Event Configuration.
+    /// </summary>
+    public class ToggleOffReceiver : BaseEventReceiver
+    {
+        public ToggleOffReceiver(BaseInteractionEventConfiguration eventConfiguration) : base(eventConfiguration) { }
+
+        private ToggleOffEvents ToggleOffEventConfig => EventConfiguration as ToggleOffEvents;
+
+        private UnityEvent onToggleOff => ToggleOffEventConfig.OnToggleOff;
+
+        private bool wasToggledOff;
+
+        /// <inheritdoc />
+        public override void OnUpdate(StateManager stateManager, BaseEventData eventData)
+        {
+            bool isToggleOff = stateManager.GetState(StateName).Value > 0;
+
+            if (wasToggledOff != isToggleOff)
+            {
+                if (isToggleOff)
+                {
+                    onToggleOff.Invoke();
+                }
+            }
+
+            wasToggledOff = isToggleOff;
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ToggleOffReceiver.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ToggleOffReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75ed4fc2a7ad1524c931824e0479c2a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ToggleOnReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ToggleOnReceiver.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The internal event receiver for the event defined in the ToggleOn Interaction Event Configuration.
+    /// </summary>
+    public class ToggleOnReceiver : BaseEventReceiver
+    {
+        public ToggleOnReceiver(BaseInteractionEventConfiguration eventConfiguration) : base(eventConfiguration) { }
+
+        private ToggleOnEvents ToggleOnEventConfig => EventConfiguration as ToggleOnEvents;
+
+        private UnityEvent onToggleOn => ToggleOnEventConfig.OnToggleOn;
+
+        private bool wasToggledOn;
+
+        /// <inheritdoc />
+        public override void OnUpdate(StateManager stateManager, BaseEventData eventData)
+        {
+            bool isToggleOn = stateManager.GetState(StateName).Value > 0;
+
+            if (wasToggledOn != isToggleOn)
+            {
+                if (isToggleOn)
+                {
+                    onToggleOn.Invoke();
+                }
+            }
+
+            wasToggledOn = isToggleOn;
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ToggleOnReceiver.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/ToggleOnReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36133898ebbf4ce49bb8c79261c101ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/SelectFarInteractionEvent.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/SelectFarInteractionEvent.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine.Events;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// A Unity event with MixedRealityPointerEventData. This event is used in the event configuration for the 
+    /// SelectFar state.
+    /// </summary>
+    [System.Serializable]
+    public class SelectFarInteractionEvent : UnityEvent<MixedRealityPointerEventData> { }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/SelectFarInteractionEvent.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/SelectFarInteractionEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91e7ac13906ae464d84120ec37247c60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/CoreInteractionState.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/CoreInteractionState.cs
@@ -32,6 +32,26 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         /// Represents the Touch state. This is a near interaction state that also requires the attachment of a NearInteractionTouchable 
         /// component to register touch input. 
         /// </summary>
-        Touch
+        Touch,
+
+        /// <summary>
+        /// Represents the Select Far state. This is a far interaction state. 
+        /// </summary>
+        SelectFar,
+
+        /// <summary>
+        /// Represents the Clicked state. By default, this state is set through a far interaction selection.
+        /// </summary>
+        Clicked,
+
+        /// <summary>
+        /// Represents the Toggle On state. By default, this state is set through a far interaction selection.
+        /// </summary>
+        ToggleOn,
+
+        /// <summary>
+        /// Represents the Toggle Off state. By default, this state is set through a far interaction selection.
+        /// </summary>
+        ToggleOff
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/InteractionType.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/InteractionType.cs
@@ -10,27 +10,27 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
     public enum InteractionType
     {
         /// <summary>
-        /// Does not support any form of input interaction.
+        /// Pointer independent interaction support.
         /// </summary>
-        None = 0,
+        Other = 0,
 
         /// <summary>
         /// Near interaction support. Input is considered near interaction when an articulated hand has 
         /// direct contact with another game object, i.e. the position the articulated hand is 
         /// close to the position of the game object in world space.
         /// </summary>
-        Near = 1,
+        Near,
 
         /// <summary>
         /// Far interaction support. Input is considered far interaction when direct contact with 
         /// the game object is not required. For example, input via controller ray or gaze is considered
         /// far interaction input.
         /// </summary>
-        Far = 2,
+        Far,
         
         /// <summary>
         /// Encompasses both near and far interaction support. 
         /// </summary>
-        Both = 3
+        NearAndFar,
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/InteractionType.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/InteractionType.cs
@@ -10,9 +10,9 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
     public enum InteractionType
     {
         /// <summary>
-        /// Pointer independent interaction support.
+        /// Does not support any form of input interaction.
         /// </summary>
-        Other = 0,
+        None = 0,
 
         /// <summary>
         /// Near interaction support. Input is considered near interaction when an articulated hand has 
@@ -32,5 +32,10 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         /// Encompasses both near and far interaction support. 
         /// </summary>
         NearAndFar,
+
+        /// <summary>
+        /// Pointer independent interaction support.
+        /// </summary>
+        Other
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/InteractionState.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/InteractionState.cs
@@ -65,8 +65,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         }
 
         [SerializeField]
-        [Tooltip("The type of interaction (Near, Far, Both, None) this state is associated with.")]
-        private InteractionType interactionType = InteractionType.None;
+        [Tooltip("The type of interaction (Near, Far, Both, Other) this state is associated with.")]
+        private InteractionType interactionType = InteractionType.Other;
 
         /// <summary>
         /// The type of interaction (Near, Far, Both, None) this state is associated with.
@@ -129,45 +129,50 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         // Set the InteractionType for a state based on the state name 
         internal void SetInteractionType(string stateName)
         {
-            string defaultStateName = CoreInteractionState.Default.ToString();
             string touchStateName = CoreInteractionState.Touch.ToString();
+            string focusStateName = CoreInteractionState.Focus.ToString();
 
-            if (stateName == defaultStateName)
+            if (stateName.Contains(Far))
             {
-                // The Default State is a special case because it does not have an InteractionType
-                InteractionType = InteractionType.None;
+                InteractionType = InteractionType.Far;
             }
             // The Touch state is a special case because it does not contain "Near" in the state name but 
-            // its InteractionType is Near
+            // the InteractionType is Near
             else if (stateName.Contains(Near) || stateName == touchStateName)
             {
                 InteractionType = InteractionType.Near;
             }
-            else if (stateName.Contains(Far))
+            // Special case for Focus as that state supports near and far interaction without "Near" or "Far" in the name
+            else if (stateName == focusStateName)
             {
-                InteractionType = InteractionType.Far;
+                InteractionType = InteractionType.NearAndFar;
             }
-            else
+            else 
             {
-                InteractionType = InteractionType.Both;
+                InteractionType = InteractionType.Other;
             }  
         }
 
-        // Trim the name of a state if it contains "Near" or "Far"
+        // Trim the name of a state if it contains "Near" or "Far" if the current state contains "Focus" in the name
         internal string GetSubStateName()
         {
+            string focusStateName = CoreInteractionState.Focus.ToString();
+
             string subStateName = Name;
 
-            // If the state name contains Near, then remove "Near" and return the remaining sub-string
-            if (subStateName.Contains(Near))
+            if (subStateName.Contains(focusStateName))
             {
-                subStateName = stateName.Replace(Near, "");
+                // If the state name contains Near, then remove "Near" and return the remaining sub-string
+                if (subStateName.Contains(Near))
+                {
+                    subStateName = stateName.Replace(Near, "");
+                }
+                else if (stateName.Contains(Far))
+                {
+                    subStateName = stateName.Replace(Far, "");
+                }
             }
-            else if (stateName.Contains(Far))
-            {
-                subStateName = stateName.Replace(Far, "");
-            }
-            
+
             return subStateName;
         }
     }


### PR DESCRIPTION
## Overview

Added support for the following states:

#### SelectFar  
- Selection of an object via far interaction 

|SelectFar State Behavior| SelectFar State Global option behavior |
|---|---|
| ![SelectFarState](https://user-images.githubusercontent.com/53493796/101115405-2b23ce00-3598-11eb-8784-5cf643885e62.gif)| ![SelectFarGlobalProperty](https://user-images.githubusercontent.com/53493796/101222366-7abcd500-363e-11eb-9624-bb35c4a0c686.gif)|


#### ToggleOn and ToggleOff 
- The ToggleOn and ToggleOff states together create a toggle button.  These states are set by a far interaction click by default but can be set from any entry point using the `SetToggleStates()` method 

![ToggleStates](https://user-images.githubusercontent.com/53493796/101115615-7ccc5880-3598-11eb-9147-f106bea13db6.gif)


#### Clicked 
- This state is trigged with a far interaction click by default but can be triggered from any entry point using the `TriggerClickedState()` method.

The following figure illustrates the expected entry points for the clicked state moving forward.  The grey states in the figure are not in this PR. 

![image](https://user-images.githubusercontent.com/53493796/101196471-9e1f5a00-3615-11eb-8939-6ca99d76ddf5.png)


#### Other Updates

- Added tests for the new states
- Added new active state highlight in the inspector


## Changes
- Fixes: #8883 

## To do

- [x] Add clicked state diagram 


## Verification
1. Checkout the branch
1. Open new unity scene
1. Add MRTK to the scene
1. Add a cube to the scene
1. Attach the Interactive Element component
1. Select Add Core State button in the Interactive Element inspector
1. Add the SelectFar state
1. Press play and observe the state value changes in the inspector