### PR TITLE
Oculus Documentation Data Provider Cleanup

### DIFF
--- a/Documentation/CrossPlatform/OculusQuestMRTK.md
+++ b/Documentation/CrossPlatform/OculusQuestMRTK.md
@@ -71,7 +71,7 @@ In that config file, you should see the HandTrackingSupport field set to "Contro
 
         ![OculusAddXRSDKDataProvider](../Images/CrossPlatform/OculusQuest/OculusAddDataXRSDKProvider.png)
 
-1. The Oculus XRSDK Data Provider includes an OVR Camera Rig Prefab which automatically configures the project with an OVR Camera Rig and OVR Hands to properly route input. Adding your own OVR Camera Rig to the scene will require you to manage your settings and input manually.
+1. The Oculus XRSDK Data Provider includes an OVR Camera Rig Prefab which automatically configures the project with an OVR Camera Rig and OVR Hands to properly route input. Manually adding an OVR Camera Rig to the scene will require manual configuration of settings and input.
 
 ## Build and deploy your project to Oculus Quest
 1. Plug in your Oculus Quest via a USB 3.0 -> USB C cable

--- a/Documentation/CrossPlatform/OculusQuestMRTK.md
+++ b/Documentation/CrossPlatform/OculusQuestMRTK.md
@@ -71,7 +71,7 @@ In that config file, you should see the HandTrackingSupport field set to "Contro
 
         ![OculusAddXRSDKDataProvider](../Images/CrossPlatform/OculusQuest/OculusAddDataXRSDKProvider.png)
 
-1. The Oculus XRSDK Data Provider includes a OVR Camera Rig Prefab which automatically configures the project to use Oculus's camera and correctly route input from Oculus devices. Adding your own OVR Camera Rig to the scene will require you to manage your settings and input manually.
+1. The Oculus XRSDK Data Provider includes a OVR Camera Rig Prefab which automatically configures the project with an OVR Camera Rig and OVR Hands to properly route input. Adding your own OVR Camera Rig to the scene will require you to manage your settings and input manually.
 
 ## Build and deploy your project to Oculus Quest
 1. Plug in your Oculus Quest via a USB 3.0 -> USB C cable

--- a/Documentation/CrossPlatform/OculusQuestMRTK.md
+++ b/Documentation/CrossPlatform/OculusQuestMRTK.md
@@ -71,7 +71,7 @@ In that config file, you should see the HandTrackingSupport field set to "Contro
 
         ![OculusAddXRSDKDataProvider](../Images/CrossPlatform/OculusQuest/OculusAddDataXRSDKProvider.png)
 
-    - You can verify that the Oculus Controllers are detected by 
+1. The Oculus XRSDK Data Provider includes a OVR Camera Rig Prefab which automatically configures the project to use Oculus's camera and correctly route input from Oculus devices. Adding your own OVR Camera Rig to the scene will require you to manage your settings and input manually.
 
 ## Build and deploy your project to Oculus Quest
 1. Plug in your Oculus Quest via a USB 3.0 -> USB C cable

--- a/Documentation/CrossPlatform/OculusQuestMRTK.md
+++ b/Documentation/CrossPlatform/OculusQuestMRTK.md
@@ -71,7 +71,7 @@ In that config file, you should see the HandTrackingSupport field set to "Contro
 
         ![OculusAddXRSDKDataProvider](../Images/CrossPlatform/OculusQuest/OculusAddDataXRSDKProvider.png)
 
-1. The Oculus XRSDK Data Provider includes a OVR Camera Rig Prefab which automatically configures the project with an OVR Camera Rig and OVR Hands to properly route input. Adding your own OVR Camera Rig to the scene will require you to manage your settings and input manually.
+1. The Oculus XRSDK Data Provider includes an OVR Camera Rig Prefab which automatically configures the project with an OVR Camera Rig and OVR Hands to properly route input. Adding your own OVR Camera Rig to the scene will require you to manage your settings and input manually.
 
 ## Build and deploy your project to Oculus Quest
 1. Plug in your Oculus Quest via a USB 3.0 -> USB C cable


### PR DESCRIPTION
## Overview
Removing a run on trailing line in the documentation.
Clarifying the functionality of the Oculus XRSDK Data provider and how it automatically sets up the OVR Camera Rig and OVR Hands for the user.

## Changes
- Fixes: #8991, #8993