### PR TITLE
Feature/back strafing steps

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/TeleportPointerInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/TeleportPointerInspector.cs
@@ -17,6 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
         private SerializedProperty rotationAmount;
         private SerializedProperty backStrafeActivationAngle;
         private SerializedProperty strafeAmount;
+        private SerializedProperty requiresBackStrafeHeight;
+        private SerializedProperty backStrafeHeight;
         private SerializedProperty upDirectionThreshold;
         private SerializedProperty lineColorHotSpot;
         private SerializedProperty validLayers;
@@ -40,11 +42,12 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
             rotationAmount = serializedObject.FindProperty("rotationAmount");
             backStrafeActivationAngle = serializedObject.FindProperty("backStrafeActivationAngle");
             strafeAmount = serializedObject.FindProperty("strafeAmount");
+            requiresBackStrafeHeight = serializedObject.FindProperty("requiresBackStrafeHeight");
+            backStrafeHeight = serializedObject.FindProperty("backStrafeHeight");
             upDirectionThreshold = serializedObject.FindProperty("upDirectionThreshold");
             lineColorHotSpot = serializedObject.FindProperty("LineColorHotSpot");
             validLayers = serializedObject.FindProperty("ValidLayers");
             invalidLayers = serializedObject.FindProperty("InvalidLayers");
-
             pointerAudioSource = serializedObject.FindProperty("pointerAudioSource");
             teleportRequestedClip = serializedObject.FindProperty("teleportRequestedClip");
             teleportCompletedClip = serializedObject.FindProperty("teleportCompletedClip");
@@ -68,6 +71,8 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
                 EditorGUILayout.PropertyField(rotationAmount);
                 EditorGUILayout.PropertyField(backStrafeActivationAngle);
                 EditorGUILayout.PropertyField(strafeAmount);
+                if(requiresBackStrafeHeight.boolValue)
+                    EditorGUILayout.PropertyField(backStrafeHeight);
                 EditorGUILayout.PropertyField(upDirectionThreshold);
                 EditorGUILayout.PropertyField(lineColorHotSpot);
                 EditorGUILayout.PropertyField(validLayers);


### PR DESCRIPTION
## Overview
In a game world or VR world its normal to have uneven planes and borders. Current teleport pointer does n't allow climbing steps when doing back strafe or its not block the movement if there is collider in the back. This pull request has one implementation to solve this issue, which checks whether there is flat plane exist so the user can back strafe or its just wont do the move if there is no plane or slope. Kindly check this pull and let me know if there is a better way to handle this.

## Changes
- Fixes: # back strafing on slopes and steps 

## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
