### PR TITLE
Various keyboard improvements & Chinese, Japanese, Korean input fix

### DIFF
--- a/Assets/MRTK/Examples/Demos/HandTracking/Scripts/SystemKeyboardExample.cs
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scripts/SystemKeyboardExample.cs
@@ -30,6 +30,8 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 #pragma warning disable 0414
         [SerializeField]
         private MixedRealityKeyboardPreview mixedRealityKeyboardPreview = null;
+        [SerializeField, Tooltip("Whether disable user's interaction with other UI elements while typing. Use this option to decrease the chance of keyboard getting accidentally closed.")]
+        private bool disableUIInteractionWhenTyping = false;
 #pragma warning restore 0414
 
         /// <summary>
@@ -57,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 #if WINDOWS_UWP
             // Windows mixed reality keyboard initialization goes here
             wmrKeyboard = gameObject.AddComponent<MixedRealityKeyboard>();
-
+            wmrKeyboard.DisableUIInteractionWhenTyping = disableUIInteractionWhenTyping;
             if (wmrKeyboard.OnShowKeyboard != null)
             {
                 wmrKeyboard.OnShowKeyboard.AddListener(() =>

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/KeyboardInputFieldBase.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/KeyboardInputFieldBase.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
 #if WINDOWS_UWP
 
-        protected virtual void Awake()
+        protected override void Awake()
         {
             if ((inputField = GetComponent<T>()) == null)
             {
@@ -56,7 +56,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         #region IDeselectHandler implementation
 
-        public void OnDeselect(BaseEventData eventData) => HideKeyboard();
+        public void OnDeselect(BaseEventData eventData)
+        {
+            if (!DisableUIInteractionWhenTyping)
+            {
+                HideKeyboard();
+            }
+        }
 
         #endregion
 

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKTMPInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKTMPInputField.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using UnityEngine.EventSystems;
+using TMPro;
+
+namespace Microsoft.MixedReality.Toolkit.Experimental.UI
+{
+    /// <summary>
+    /// A derived class of TMP's InputField to workaround with some issues of typing on HoloLens 2
+    /// No longer used in Unity 2019.3 and later versions.
+    /// </summary>
+    public class MRTKTMPInputField : TMP_InputField
+    {
+#if !UNITY_2019_3_OR_NEWER
+        public int SelectionPosition
+        {
+            get => caretSelectPositionInternal;
+            set
+            {
+                caretSelectPositionInternal = value;
+                selectionStringFocusPosition = value;
+                selectionStringAnchorPosition = value;
+            }
+        }
+        public override void OnUpdateSelected(BaseEventData eventData) { }
+#endif
+    }
+}

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKTMPInputField.cs.meta
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKTMPInputField.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 080160d1b3df57747bcd9840759f18d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Microsoft.MixedReality.Toolkit.Experimental.UI
+{
+    /// <summary>
+    /// A derived class of UGUI's InputField to workaround with some issues of typing on HoloLens 2
+    /// </summary>
+    public class MRTKUGUIInputField : InputField
+    {
+#if UNITY_2019_3_OR_NEWER
+        [SerializeField, Tooltip("Currently there is a Unity bug that needs a workaround. Please keep this setting to be true until an announcement of the version of Unity/UGUI that resolves the issue is made.")]
+        private bool enableUGUIWorkaround = false;
+#endif
+#if !UNITY_2019_3_OR_NEWER
+        public int SelectionPosition
+        {
+            get => caretSelectPositionInternal;
+            set => caretSelectPositionInternal = value;
+        }
+        public override void OnUpdateSelected(BaseEventData eventData) { }
+#else
+        protected override void LateUpdate()
+        {
+            if (enableUGUIWorkaround && isFocused && m_Keyboard != null && (Input.GetKeyDown(KeyCode.Backspace) || Input.GetKey(KeyCode.Backspace)))
+            {
+                m_Keyboard.text = m_Text;
+            }
+            base.LateUpdate();
+        }
+#endif
+    }
+}

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs
@@ -13,25 +13,33 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     public class MRTKUGUIInputField : InputField
     {
 #if UNITY_2019_3_OR_NEWER
-        [SerializeField, Tooltip("Currently there is a Unity bug that needs a workaround. Please keep this setting to be true until an announcement of the version of Unity/UGUI that resolves the issue is made.")]
-        private bool enableUGUIWorkaround = false;
-#endif
-#if !UNITY_2019_3_OR_NEWER
+        [SerializeField]
+        private bool disableUGUIWorkaround = false;
+
+        /// <summary>
+        /// Currently there is a Unity bug that needs a workaround. Please keep this setting to be false until an announcement of the version of Unity/UGUI that resolves the issue is made.
+        /// </summary>
+        public bool DisableUGUIWorkaround
+        {
+            get => disableUGUIWorkaround;
+            set => disableUGUIWorkaround = value;
+        }
+
+        protected override void LateUpdate()
+        {
+            if (!DisableUGUIWorkaround && isFocused && m_Keyboard != null && (UnityEngine.Input.GetKeyDown(KeyCode.Backspace)))
+            {
+                m_Keyboard.text = m_Text;
+            }
+            base.LateUpdate();
+        }
+#else
         public int SelectionPosition
         {
             get => caretSelectPositionInternal;
             set => caretSelectPositionInternal = value;
         }
         public override void OnUpdateSelected(BaseEventData eventData) { }
-#else
-        protected override void LateUpdate()
-        {
-            if (enableUGUIWorkaround && isFocused && m_Keyboard != null && (UnityEngine.Input.GetKeyDown(KeyCode.Backspace) || UnityEngine.Input.GetKey(KeyCode.Backspace)))
-            {
-                m_Keyboard.text = m_Text;
-            }
-            base.LateUpdate();
-        }
 #endif
     }
 }

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 #else
         protected override void LateUpdate()
         {
-            if (enableUGUIWorkaround && isFocused && m_Keyboard != null && (Input.GetKeyDown(KeyCode.Backspace) || Input.GetKey(KeyCode.Backspace)))
+            if (enableUGUIWorkaround && isFocused && m_Keyboard != null && (UnityEngine.Input.GetKeyDown(KeyCode.Backspace) || UnityEngine.Input.GetKey(KeyCode.Backspace)))
             {
                 m_Keyboard.text = m_Text;
             }

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs.meta
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84239935bdcf03749afaf60cbaaee80e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
@@ -398,7 +398,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private bool IsIMERequired(string language)
         {
-            return language.StartsWith("zh") || language.StartsWith("ja") || language.StartsWith("kr");
+            return language.StartsWith("zh") || language.StartsWith("ja") || language.StartsWith("ko");
         }
 #endif
         protected virtual void SyncCaret() { }

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
@@ -262,7 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
 
             onShowKeyboard?.Invoke();
-
+            MovePreviewCaretToEnd();
             if (stateUpdate == null)
             {
                 stateUpdate = StartCoroutine(UpdateState());

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
@@ -118,7 +118,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
 #if WINDOWS_UWP
         private InputPane inputPane = null;
-        
         private TouchScreenKeyboard keyboard = null;
 
         private Coroutine stateUpdate;

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
@@ -291,10 +291,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             if (keyboard != null)
             {
+                // Check the current language of the keyboard
                 string newKeyboardLanguage = Language.CurrentInputMethodLanguageTag;
                 if (newKeyboardLanguage != keyboardLanguage)
                 {
                     keyboard.text = Text;
+                    // For the languages requiring IME (Chinese, Japanese and Korean) move the caret to the end
+                    // As we do not support editing in the middle of a string
                     if (IsIMERequired(newKeyboardLanguage))
                     {
                         MovePreviewCaretToEnd();
@@ -307,11 +310,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 if (UnityEngine.Input.GetKey(KeyCode.Backspace) ||
                     UnityEngine.Input.GetKeyDown(KeyCode.Backspace))
                 {
+                    // Handle languages requiring IME
                     if (Text.Length > keyboard.text.Length && IsIMERequired(keyboardLanguage))
                     {
                         Text = keyboard.text;
                         CaretIndex = Mathf.Clamp(CaretIndex + characterDelta, 0, Text.Length);
-                        return;
                     }
                     else if (CaretIndex > 0)
                     {
@@ -320,7 +323,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         --CaretIndex;
                     }
                 }
-                if (IsIMERequired(keyboardLanguage))
+                // Handle other character changes for languages requiring IME
+                else if (IsIMERequired(keyboardLanguage))
                 {
                     Text = keyboard.text;
                     MovePreviewCaretToEnd();

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/Prefabs/MRKeyboardInputField_TMP.prefab
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/Prefabs/MRKeyboardInputField_TMP.prefab
@@ -216,10 +216,10 @@ GameObject:
   - component: {fileID: 2093565322073310842}
   - component: {fileID: 2093565322073310846}
   - component: {fileID: 2093565322073310847}
-  - component: {fileID: 2093565322073310844}
+  - component: {fileID: 5693768067435113710}
   - component: {fileID: 2093565322073310845}
   m_Layer: 5
-  m_Name: MRKeyboardInputField (TMP)
+  m_Name: MRKeyboardInputField_TMP
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -280,7 +280,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
---- !u!114 &2093565322073310844
+--- !u!114 &5693768067435113710
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -289,7 +289,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2093565322073310843}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Script: {fileID: 11500000, guid: 080160d1b3df57747bcd9840759f18d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -385,6 +385,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cac44176376ab544f9ca44f05c9b9091, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  disableUIInteractionWhenTyping: 0
   onShowKeyboard:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/Prefabs/MRKeyboardInputField_UGUI.prefab
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/Prefabs/MRKeyboardInputField_UGUI.prefab
@@ -88,10 +88,10 @@ GameObject:
   - component: {fileID: 6218909165142131981}
   - component: {fileID: 6218909165142131977}
   - component: {fileID: 6218909165142131976}
-  - component: {fileID: 6218909165142131979}
+  - component: {fileID: 8643514431004159166}
   - component: {fileID: 6218909165142131978}
   m_Layer: 5
-  m_Name: MRKeyboardInputField
+  m_Name: MRKeyboardInputField_UGUI
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -153,7 +153,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
---- !u!114 &6218909165142131979
+--- !u!114 &8643514431004159166
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -162,7 +162,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6218909165142131980}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 575553740, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 84239935bdcf03749afaf60cbaaee80e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -225,6 +225,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 22217b78c404b3d41816e937276869ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  disableUIInteractionWhenTyping: 0
   onShowKeyboard:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/TMP_KeyboardInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/TMP_KeyboardInputField.cs
@@ -3,19 +3,33 @@
 
 using UnityEngine;
 using UnityEngine.UI;
-using TMPro;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     /// <summary>
-    /// A component that can be added to TMP_InputField to make them work with Windows Mixed Reality's system keyboard
+    /// A component that can be added to InputField to make them work with Windows Mixed Reality's system keyboard.
+    /// No longer used in Unity 2019.3 and later versions.
     /// </summary>
-    [RequireComponent(typeof(TMP_InputField))]
+#if !UNITY_2019_3_OR_NEWER
+    [RequireComponent(typeof(MRTKTMPInputField))]
     [AddComponentMenu("Scripts/MRTK/Experimental/Keyboard/TMP_KeyboardInputField")]
-    public class TMP_KeyboardInputField : KeyboardInputFieldBase<TMP_InputField>
+#endif
+    public class TMP_KeyboardInputField :
+#if UNITY_2019_3_OR_NEWER
+        MonoBehaviour
+#else
+        KeyboardInputFieldBase<MRTKTMPInputField>
+#endif
     {
+#if !UNITY_2019_3_OR_NEWER
         public override string Text { get => inputField.text; protected set => inputField.text = value; }
-        protected override Graphic TextGraphic(TMP_InputField inputField) => inputField.textComponent;
-        protected override Graphic PlaceHolderGraphic(TMP_InputField inputField) => inputField.placeholder;
+        protected override Graphic TextGraphic(MRTKTMPInputField inputField) => inputField.textComponent;
+        protected override Graphic PlaceHolderGraphic(MRTKTMPInputField inputField) => inputField.placeholder;
+        protected override void SyncCaret()
+        {
+            inputField.caretPosition = CaretIndex;
+            inputField.SelectionPosition = CaretIndex;
+        }
+#endif
     }
 }

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/TMP_KeyboardInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/TMP_KeyboardInputField.cs
@@ -7,8 +7,9 @@ using UnityEngine.UI;
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     /// <summary>
-    /// A component that can be added to InputField to make them work with Windows Mixed Reality's system keyboard.
-    /// No longer used in Unity 2019.3 and later versions.
+    /// A component that can be added to InputField to make it work with Windows Mixed Reality's system keyboard.
+    /// Required when using Unity 2018.4.
+    /// No longer used in Unity 2019.3 and later versions (becomes an empty MonoBehaviour and is only around for compatibility) and you can safely remove it if you wish
     /// </summary>
 #if !UNITY_2019_3_OR_NEWER
     [RequireComponent(typeof(MRTKTMPInputField))]

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
@@ -31,10 +31,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 #else
         [SerializeField, Tooltip("Currently there is a Unity bug that needs a workaround. Please keep this setting to be false until an announcement of the version of Unity/UGUI that resolves the issue is made.")]
         private bool disableUGUIWorkaround = false;
+
+        private MRTKUGUIInputField inputField;
         
         private void OnValidate()
         {
-            GetComponent<MRTKUGUIInputField>().DisableUGUIWorkaround = disableUGUIWorkaround;
+            if (inputField == null)
+            {
+                inputField = GetComponent<MRTKUGUIInputField>();
+            }
+            inputField.DisableUGUIWorkaround = disableUGUIWorkaround;
         }
 #endif
     }

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
@@ -7,14 +7,29 @@ using UnityEngine.UI;
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     /// <summary>
-    /// A component that can be added to InputField to make them work with Windows Mixed Reality's system keyboard
+    /// A component that can be added to InputField to make them work with Windows Mixed Reality's system keyboard.
+    /// No longer used in Unity 2019.3 and later versions.
     /// </summary>
-    [RequireComponent(typeof(InputField))]
+#if !UNITY_2019_3_OR_NEWER
+    [RequireComponent(typeof(MRTKUGUIInputField))]
     [AddComponentMenu("Scripts/MRTK/Experimental/Keyboard/UI_KeyboardInputField")]
-    public class UI_KeyboardInputField : KeyboardInputFieldBase<InputField>
+#endif
+    public class UI_KeyboardInputField :
+#if UNITY_2019_3_OR_NEWER
+        MonoBehaviour
+#else
+        KeyboardInputFieldBase<MRTKUGUIInputField>
+#endif
     {
+#if !UNITY_2019_3_OR_NEWER
         public override string Text { get => inputField.text; protected set => inputField.text = value; }
-        protected override Graphic TextGraphic(InputField inputField) => inputField.textComponent;
-        protected override Graphic PlaceHolderGraphic(InputField inputField) => inputField.placeholder;
+        protected override Graphic TextGraphic(MRTKUGUIInputField inputField) => inputField.textComponent;
+        protected override Graphic PlaceHolderGraphic(MRTKUGUIInputField inputField) => inputField.placeholder;
+        protected override void SyncCaret()
+        {
+            inputField.caretPosition = CaretIndex;
+            inputField.SelectionPosition = CaretIndex;
+        }
+#endif
     }
 }

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
@@ -7,13 +7,11 @@ using UnityEngine.UI;
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     /// <summary>
-    /// A component that can be added to InputField to make them work with Windows Mixed Reality's system keyboard.
-    /// No longer used in Unity 2019.3 and later versions.
+    /// A component that can be added to InputField to make it work with Windows Mixed Reality's system keyboard.
+    /// Will no longer be necessary in Unity 2019.3 and later versions after a Unity/UGUI bug is fixed (see disableUGUIWorkaround).
     /// </summary>
-#if !UNITY_2019_3_OR_NEWER
     [RequireComponent(typeof(MRTKUGUIInputField))]
     [AddComponentMenu("Scripts/MRTK/Experimental/Keyboard/UI_KeyboardInputField")]
-#endif
     public class UI_KeyboardInputField :
 #if UNITY_2019_3_OR_NEWER
         MonoBehaviour
@@ -29,6 +27,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             inputField.caretPosition = CaretIndex;
             inputField.SelectionPosition = CaretIndex;
+        }
+#else
+        [SerializeField, Tooltip("Currently there is a Unity bug that needs a workaround. Please keep this setting to be false until an announcement of the version of Unity/UGUI that resolves the issue is made.")]
+        private bool disableUGUIWorkaround = false;
+        
+        private void OnValidate()
+        {
+            GetComponent<MRTKUGUIInputField>().DisableUGUIWorkaround = disableUGUIWorkaround;
         }
 #endif
     }

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Slate/SlateUGUI.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Slate/SlateUGUI.prefab
@@ -2915,7 +2915,7 @@ GameObject:
   - component: {fileID: 8242345886942139595}
   - component: {fileID: 4654131966140333715}
   - component: {fileID: 3755923931878965870}
-  - component: {fileID: 7316661051877317490}
+  - component: {fileID: 1238338373029837197}
   - component: {fileID: 5909963037666368398}
   m_Layer: 5
   m_Name: InputField
@@ -2980,7 +2980,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
---- !u!114 &7316661051877317490
+--- !u!114 &1238338373029837197
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2989,7 +2989,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 3773139067219331622}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 575553740, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 84239935bdcf03749afaf60cbaaee80e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -3052,6 +3052,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 22217b78c404b3d41816e937276869ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  disableUIInteractionWhenTyping: 0
   onShowKeyboard:
     m_PersistentCalls:
       m_Calls: []
@@ -6773,11 +6774,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 7779420039263858270, guid: 937ce507dd7ee334ba569554e24adbdd,
-        type: 3}
-      propertyPath: m_Name
-      value: SlateUGUI
-      objectReference: {fileID: 0}
     - target: {fileID: 1484589535602960653, guid: 937ce507dd7ee334ba569554e24adbdd,
         type: 3}
       propertyPath: m_textInfo.characterCount
@@ -6828,6 +6824,21 @@ PrefabInstance:
       propertyPath: m_textInfo.pageCount
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1763406999217791378, guid: 937ce507dd7ee334ba569554e24adbdd,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1807168023245165402, guid: 937ce507dd7ee334ba569554e24adbdd,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3348377780797107193, guid: 937ce507dd7ee334ba569554e24adbdd,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 40261cd01d861f241b945b4fb6609cff, type: 2}
     - target: {fileID: 5373150653584304409, guid: 937ce507dd7ee334ba569554e24adbdd,
         type: 3}
       propertyPath: m_Mesh
@@ -6933,6 +6944,11 @@ PrefabInstance:
       propertyPath: assetVersion
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7779420039263858270, guid: 937ce507dd7ee334ba569554e24adbdd,
+        type: 3}
+      propertyPath: m_Name
+      value: SlateUGUI
+      objectReference: {fileID: 0}
     - target: {fileID: 7779420039263858271, guid: 937ce507dd7ee334ba569554e24adbdd,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7012,21 +7028,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Center.z
       value: 0.07609945
-      objectReference: {fileID: 0}
-    - target: {fileID: 1763406999217791378, guid: 937ce507dd7ee334ba569554e24adbdd,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3348377780797107193, guid: 937ce507dd7ee334ba569554e24adbdd,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 40261cd01d861f241b945b4fb6609cff, type: 2}
-    - target: {fileID: 1807168023245165402, guid: 937ce507dd7ee334ba569554e24adbdd,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 937ce507dd7ee334ba569554e24adbdd, type: 3}

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
@@ -50,6 +50,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool ManualInitializationRequired { get; private set; } = false;
 
+        /// <summary>
+        /// Whether the input module should pause processing temporarily
+        /// </summary>
+        public bool ProcessPaused { get; set; } = false;
+
         public IEnumerable<IMixedRealityPointer> ActiveMixedRealityPointers
         {
             get
@@ -131,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             using (ProcessPerfMarker.Auto())
             {
                 // Do not process when we are waiting for initialization
-                if (ManualInitializationRequired)
+                if (ManualInitializationRequired || ProcessPaused)
                 {
                     return;
                 }


### PR DESCRIPTION
## Overview
This PR addresses a few keyboard related bugs across Unity 208.4/2019.4, Unity UI input field, TMP input field and the MixedRealityKeyboard class. Some of the bugs being addressed have been filed as issues (see the Changes section), but for this PR all combinations of Unity versions and keyboard invocation methods have been tested and in each combination the state of keyboard is improved to the point where further improvement are constrained by external issues (e.g. Unity side bug). Please see #9056 for the aimed state of native keyboard after merging this PR.

This PR also adds a `DisableUIInteractionWhenTyping` property to MixedRealityKeyboardBase so that the user will be distracted less often due to inadvertent interactions with other UI elements. Note this property is not available to users of Unity UI/TMP input field under Unity 2019 as in that case those packages directly control the open/close behavior of the keyboard.

## Changes
- Fixes: #8917, #8959, #8984, #9010, #9054
Special thanks to @traianlavric for purposing a fix for #9054

## Verification
- Open the HandInteractionExamples scene and test the keyboard by clicking the open keyboard button on the left and by clicking on the Unity UI input field on the right (note due to #8983 you need to deploy to HL2 in release mode)
- Open the MixedRealityKeyboardExample scene and test the input fields for both Unity UI and TMP.