### PR TITLE
Apply playspace transform to eye gaze data

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -185,14 +185,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
                         if (eyes.Gaze.HasValue)
                         {
-#if true // Send data in world space
                             Vector3 origin = MixedRealityPlayspace.TransformPoint(eyes.Gaze.Value.Origin.ToUnityVector3());
                             Vector3 direction = MixedRealityPlayspace.TransformDirection(eyes.Gaze.Value.Direction.ToUnityVector3());
 
                             Ray newGaze = new Ray(origin, direction);
-#else // Send data relative to playspace
-                            Ray newGaze = new Ray(eyes.Gaze.Value.Origin.ToUnityVector3(), eyes.Gaze.Value.Direction.ToUnityVector3());
-#endif // Send data in proper space
 
                             if (SmoothEyeTracking)
                             {

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -185,7 +185,14 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
                         if (eyes.Gaze.HasValue)
                         {
+#if true // Send data in world space
+                            Vector3 origin = MixedRealityPlayspace.TransformPoint(eyes.Gaze.Value.Origin.ToUnityVector3());
+                            Vector3 direction = MixedRealityPlayspace.TransformDirection(eyes.Gaze.Value.Direction.ToUnityVector3());
+
+                            Ray newGaze = new Ray(origin, direction);
+#else // Send data relative to playspace
                             Ray newGaze = new Ray(eyes.Gaze.Value.Origin.ToUnityVector3(), eyes.Gaze.Value.Direction.ToUnityVector3());
+#endif // Send data in proper space
 
                             if (SmoothEyeTracking)
                             {

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -609,7 +609,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public void UpdateEyeGaze(IMixedRealityEyeGazeDataProvider provider, Ray eyeRay, DateTime timestamp)
         {
+#if false // Receive data relative to playspace, transform to world space
+            Ray worldEyeRay = new Ray(
+                MixedRealityPlayspace.TransformPoint(eyeRay.origin),
+                MixedRealityPlayspace.TransformDirection(eyeRay.direction));
+            LatestEyeGaze = worldEyeRay;
+#else // Receive data in world space
             LatestEyeGaze = eyeRay;
+#endif // Transform incoming data if necessary
+
             latestEyeTrackingUpdate = DateTime.UtcNow;
             Timestamp = timestamp;
         }
@@ -620,9 +628,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IsEyeCalibrationValid = userIsEyeCalibrated;
         }
 
-        #endregion IMixedRealityEyeGazeProvider Implementation
+#endregion IMixedRealityEyeGazeProvider Implementation
 
-        #region IMixedRealityGazeProviderHeadOverride Implementation
+#region IMixedRealityGazeProviderHeadOverride Implementation
 
         /// <inheritdoc />
         public bool UseHeadGazeOverride { get; set; }
@@ -634,6 +642,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             overrideHeadForward = forward;
         }
 
-        #endregion IMixedRealityGazeProviderHeadOverride Implementation
+#endregion IMixedRealityGazeProviderHeadOverride Implementation
     }
 }

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -609,14 +609,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public void UpdateEyeGaze(IMixedRealityEyeGazeDataProvider provider, Ray eyeRay, DateTime timestamp)
         {
-#if false // Receive data relative to playspace, transform to world space
-            Ray worldEyeRay = new Ray(
-                MixedRealityPlayspace.TransformPoint(eyeRay.origin),
-                MixedRealityPlayspace.TransformDirection(eyeRay.direction));
-            LatestEyeGaze = worldEyeRay;
-#else // Receive data in world space
             LatestEyeGaze = eyeRay;
-#endif // Transform incoming data if necessary
 
             latestEyeTrackingUpdate = DateTime.UtcNow;
             Timestamp = timestamp;

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -621,9 +621,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IsEyeCalibrationValid = userIsEyeCalibrated;
         }
 
-#endregion IMixedRealityEyeGazeProvider Implementation
+        #endregion IMixedRealityEyeGazeProvider Implementation
 
-#region IMixedRealityGazeProviderHeadOverride Implementation
+        #region IMixedRealityGazeProviderHeadOverride Implementation
 
         /// <inheritdoc />
         public bool UseHeadGazeOverride { get; set; }
@@ -635,6 +635,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             overrideHeadForward = forward;
         }
 
-#endregion IMixedRealityGazeProviderHeadOverride Implementation
+        #endregion IMixedRealityGazeProviderHeadOverride Implementation
     }
 }


### PR DESCRIPTION
## Overview
Playspace transform was being ignored by EyeGazeDataProvider, but GazeProvider assumed incoming data was in world space.

## Changes
- Fixes: #9049  .

> 
> This fix has the EyeGazeDataProvider transform the platform data, which is relative to the MRTKPlayspace, into world space before passing it to the consuming GazeProvider. Arguments could be made that the EyeGazeDataProvider should pass the data as is, and let the GazeProvider transform it to whatever space it wants. 
> 
> That approach, however, assumes that all platform data providers will have raw data in the same space, or else that another data provider which might have the data in world space, would have to transform it to playspace, then have the GazeProvider transform it back to world space.
>
> So I have taken the approach which I have, because world space is something we can all agree on.

## Verification
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
