### PR TITLE
Add SpeechKeyword state to Interactive Element

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/SpeechKeywordEvents.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/SpeechKeywordEvents.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The event configuration for the SpeechKeyword InteractionState.
+    /// </summary>
+    public class SpeechKeywordEvents : BaseInteractionEventConfiguration
+    {
+        [SerializeField]
+        [Tooltip("Whether or not to register the IMixedRealitySpeechHandler for global input. If Global is true, then" +
+        " events in the SpeechKeyword state will be fired without requiring an object to be in focus. ")]
+        private bool global = false;
+
+        /// <summary>
+        /// Whether or not to register the IMixedRealitySpeechHandler for global input. If Global is true, then
+        /// events in the SpeechKeyword state will be fired without requiring an object to be in focus. 
+        /// </summary>
+        public bool Global
+        {
+            get => global;
+            set
+            {
+                global = value;
+                OnGlobalChanged.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// A Unity event used to track whether or not the Global property has changed.
+        /// </summary>
+        [HideInInspector]
+        public UnityEvent OnGlobalChanged = new UnityEvent();
+
+        [SerializeField]
+        [Tooltip("A Unity event with SpeechEventData. This event will be fired when any of the keywords registered" +
+            "in the Speech input Configuration Profile are recognized.")]
+        private SpeechInteractionEvent onAnySpeechKeywordRecognized = new SpeechInteractionEvent();
+
+        /// <summary>
+        /// A Unity event with SpeechEventData. This event will be fired when any of the keywords registered
+        /// in the Speech input Configuration Profile are recognized.
+        /// </summary>
+        public SpeechInteractionEvent OnAnySpeechKeywordRecognized
+        {
+            get => onAnySpeechKeywordRecognized;
+            private set => onAnySpeechKeywordRecognized = value;
+        }
+
+        [SerializeField]
+        [Tooltip("List of keywords and Unity Events for the Speech input handler to listen for.")]
+        private List<KeywordEvent> keywords = new List<KeywordEvent>();
+
+        /// <summary>
+        /// List of keywords and Unity Events for the Speech input handler to listen for.
+        /// </summary>
+        public List<KeywordEvent> Keywords
+        {
+            get => keywords;
+            set => keywords = value;
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/SpeechKeywordEvents.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/SpeechKeywordEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58693799beddc3243acdb49b0e2f6108
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SpeechKeywordReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SpeechKeywordReceiver.cs
@@ -42,11 +42,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
                     // Get the keyword that was recognized
                     string speechEventKeyword = speechData.Command.Keyword;
 
-                    // Capitalize the first letter of the state in case the keyword is in lower case
-                    string speechEventKeywordUpperCase = CapitalizeFirstLetter(speechEventKeyword);
-
                     // Find the corresponding event for the speech keyword that was recognized
-                    KeywordEvent keywordResponseEvent = keywordsAndResponses.Find((keyEvent) => keyEvent.Keyword == speechEventKeyword || keyEvent.Keyword == speechEventKeywordUpperCase);
+                    KeywordEvent keywordResponseEvent = keywordsAndResponses.Find((keyEvent) => String.Equals(keyEvent.Keyword, speechEventKeyword, StringComparison.OrdinalIgnoreCase));
 
                     if (keywordResponseEvent != null)
                     {
@@ -58,14 +55,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
                 // Set the state to off after the events have been fired
                 stateManager.SetStateOff(StateName);
             }
-        }
-
-        // Capitalize the first letter of a keyword string
-        private string CapitalizeFirstLetter(string keyword)
-        {
-            char[] keywordChars = keyword.ToCharArray();
-
-            return Char.ToUpper(keywordChars[0]) + keyword.Substring(1);
         }
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SpeechKeywordReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SpeechKeywordReceiver.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+using Microsoft.MixedReality.Toolkit.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The internal event receiver for the events defined in the SpeechKeyword Interaction Event Configuration.
+    /// </summary>
+    public class SpeechKeywordReceiver : BaseEventReceiver
+    {
+        public SpeechKeywordReceiver(BaseInteractionEventConfiguration eventConfiguration) : base(eventConfiguration) { }
+
+        private SpeechKeywordEvents SpeechKeywordEventConfig => EventConfiguration as SpeechKeywordEvents;
+
+        private SpeechInteractionEvent onSpeechKeywordRecognized => SpeechKeywordEventConfig.OnAnySpeechKeywordRecognized;
+        
+        private List<KeywordEvent> keywordsAndResponses => SpeechKeywordEventConfig.Keywords;
+
+        /// <inheritdoc />
+        public override void OnUpdate(StateManager stateManager, BaseEventData eventData)
+        {
+            bool keywordRecognized = stateManager.GetState(StateName).Value > 0;
+
+            if (keywordRecognized)
+            {
+                SpeechEventData speechData = eventData as SpeechEventData;
+
+                onSpeechKeywordRecognized.Invoke(speechData);
+
+                bool speechKeywordRecognized = speechData.Command.Keyword != null;
+
+                if (speechKeywordRecognized)
+                {
+                    // Get the keyword that was recognized
+                    string speechEventKeyword = speechData.Command.Keyword;
+
+                    // Capitalize the first letter of the state in case the keyword is in lower case
+                    string speechEventKeywordUpperCase = CapitalizeFirstLetter(speechEventKeyword);
+
+                    // Find the corresponding event for the speech keyword that was recognized
+                    KeywordEvent keywordResponseEvent = keywordsAndResponses.Find((keyEvent) => keyEvent.Keyword == speechEventKeyword || keyEvent.Keyword == speechEventKeywordUpperCase);
+
+                    if (keywordResponseEvent != null)
+                    {
+                        // Fire the OnKeywordRecognized event that is associated with the recognized keyword
+                        keywordResponseEvent.OnKeywordRecognized.Invoke();
+                    }
+                }
+
+                // Set the state to off after the events have been fired
+                stateManager.SetStateOff(StateName);
+            }
+        }
+
+        // Capitalize the first letter of a keyword string
+        private string CapitalizeFirstLetter(string keyword)
+        {
+            char[] keywordChars = keyword.ToCharArray();
+
+            return Char.ToUpper(keywordChars[0]) + keyword.Substring(1);
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SpeechKeywordReceiver.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/SpeechKeywordReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7ecd332859282b44b4c05c8c434b8f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/KeywordEvent.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/KeywordEvent.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+using System;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// A container for a keyword and its associated Unity event. This container is utilized
+    /// in SpeechKeywordEvents. 
+    /// </summary>
+    [Serializable]
+    public class KeywordEvent
+    {
+        [SerializeField]
+        [Tooltip("The Keyword for the Speech Handler to listen for if speech is enabled.  If this keyword is recognized, the OnKeywordRecognized" +
+            "event will fire.  This keyword must also be registered in the Speech Input configuration profile. ")]
+        private string keyword;
+
+        /// <summary>
+        /// The Keyword for the Speech Handler to listen for if speech is enabled.  If this keyword is recognized, the OnKeywordRecognized
+        /// event will fire.  This keyword must also be registered in the Speech Input configuration profile. 
+        /// </summary>
+        public string Keyword
+        {
+            get => keyword;
+            set => keyword = value;
+        }
+
+        /// <summary>
+        /// Unity Event fired when a specific keyword is recognized. 
+        /// </summary>
+        public UnityEvent OnKeywordRecognized = new UnityEvent();
+
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/KeywordEvent.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/KeywordEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c1748a7a7aa3af479a581c7bec32548
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/SpeechInteractionEvent.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/SpeechInteractionEvent.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine.Events;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// A Unity event with SpeechEventData. This event is used in the event configuration for the 
+    /// SpeechKeyword state.
+    /// </summary>
+    [System.Serializable]
+    public class SpeechInteractionEvent : UnityEvent<SpeechEventData> { }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/SpeechInteractionEvent.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/UnityEventDefinitions/SpeechInteractionEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cbbf34836d85edf49926bf4c10812ba3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/CoreInteractionState.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/Definitions/CoreInteractionState.cs
@@ -40,6 +40,11 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         SelectFar,
 
         /// <summary>
+        /// Represents the Speech Keyword state.  This state is set when a speech keyword is recognized.
+        /// </summary>
+        SpeechKeyword,
+
+        /// <summary>
         /// Represents the Clicked state. By default, this state is set through a far interaction selection.
         /// </summary>
         Clicked,

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/StateManager.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/States/StateManager.cs
@@ -83,6 +83,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         private string defaultStateName = CoreInteractionState.Default.ToString();
         private string touchStateName = CoreInteractionState.Touch.ToString();
         private string selectFarStateName = CoreInteractionState.SelectFar.ToString();
+        private string speechKeywordStateName = CoreInteractionState.SpeechKeyword.ToString();
 
         /// <summary>
         /// Gets a state by using the state name.
@@ -379,7 +380,13 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
             if (state.Name == selectFarStateName)
             {
                 // Add listeners that monitor whether or not the SelectFar state's Global property has been changed
-                AddSelectFarListeners();
+                AddGlobalPropertyChangedListeners(selectFarStateName);
+            }
+
+            if (state.Name == speechKeywordStateName)
+            {
+                // Add listeners that monitor whether or not the SpeechKeyword state's Global property has been changed
+                AddGlobalPropertyChangedListeners(speechKeywordStateName);
             }
         }
 
@@ -407,20 +414,33 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
             });
         }
 
-        // Add listeners to the Global Changed event contained in the SelectFarEvents event configuration. 
-        internal void AddSelectFarListeners()
+        // Add listeners to the Global Changed event contained in the SelectFarEvents or the SpeechKeywordEvents event configuration 
+        internal void AddGlobalPropertyChangedListeners(string stateName)
         {
-            InteractionState selectFarState = GetState(selectFarStateName);
+            InteractionState state = GetState(stateName);
 
-            if (selectFarState != null)
+            if (state != null)
             {
-                SelectFarEvents events = InteractiveElement.GetStateEvents<SelectFarEvents>(selectFarStateName);
-
-                // If the select far state is added during runtime, then add listeners to keep track of the Global property
-                events.OnGlobalChanged.AddListener(() =>
+                if (state.Name == selectFarStateName)
                 {
-                    InteractiveElement.RegisterHandler<IMixedRealityPointerHandler>(events.Global);
-                });
+                    var eventConfiguration = InteractiveElement.GetStateEvents<SelectFarEvents>(selectFarStateName);
+
+                    // If the select far state is added during runtime, then add listeners to keep track of the Global property
+                    eventConfiguration.OnGlobalChanged.AddListener(() =>
+                    {
+                        InteractiveElement.RegisterHandler<IMixedRealityPointerHandler>(eventConfiguration.Global);
+                    });
+                }
+                else if (state.Name == speechKeywordStateName)
+                {
+                    var eventConfiguration = InteractiveElement.GetStateEvents<SpeechKeywordEvents>(speechKeywordStateName);
+
+                    // If the speech keyword state is added during runtime, then add listeners to keep track of the Global property
+                    eventConfiguration.OnGlobalChanged.AddListener(() =>
+                    {
+                        InteractiveElement.RegisterHandler<IMixedRealitySpeechHandler>(eventConfiguration.Global);
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
## Overview
Added support for the SpeechKeyword state in Interactive Element.  This state has a custom inspector.

In MRTK, a keyword has to be registered in the Speech Profile first.  If a user tries to add a keyword in this state, directions will appear on how to add a keyword in the Speech profile first.

![image](https://user-images.githubusercontent.com/53493796/102284191-98b0f200-3ee8-11eb-8341-3f8bbe05aa1f.png)

If the keyword is registered in the Speech profile then an event for that keyword will be displayed.

![SpeechKeywordState](https://user-images.githubusercontent.com/53493796/102284263-baaa7480-3ee8-11eb-91d3-abdc4e09a625.gif)

## Verification
1. Checkout the branch
1. Open new unity scene
1. Add MRTK to the scene
1. Add a cube to the scene
1. Attach the Interactive Element component
1. Select Add Core State button in the Interactive Element inspector
1. Add the SpeechKeyword state 