### PR TITLE
Add CompressableButton component with PressedNear state

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/BaseInteractiveElementInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/BaseInteractiveElementInspector.cs
@@ -50,9 +50,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         // Const state names for case comparison 
         private const string SelectFarStateName = "SelectFar";
         private const string SpeechKeywordStateName = "SpeechKeyword";
+        private const string PressedNearStateName = "PressedNear";
 
         // The state selection menu is displayed when a user selects the "Add Core State" button
-        private StateSelectionMenu stateSelectionMenu; 
+        private StateSelectionMenu stateSelectionMenu;
+
+        private bool isCompressableButton;
         
         protected virtual void OnEnable()
         {
@@ -66,6 +69,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             previousActiveStatus = active.boolValue;
 
             stateSelectionMenu = ScriptableObject.CreateInstance<StateSelectionMenu>();
+
+            isCompressableButton = instance.GetType() == typeof(CompressableButton);
         }
 
         public override void OnInspectorGUI()
@@ -177,13 +182,17 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     }
 
                     // Do not draw a remove button for the default state
-                    if (stateName.stringValue != defaultStateName && !inPlayMode)
+                    if (!inPlayMode && stateName.stringValue != defaultStateName)
                     {
-                        // Draw a button with a '-' for state removal
-                        if (InspectorUIUtility.SmallButton(RemoveStateButtonLabel))
+                        // Do not draw a remove button for the Touch state or the PressedNear state if the current type is CompressableButton
+                        if (isCompressableButton && stateName.stringValue != touchStateName && stateName.stringValue != PressedNearStateName)
                         {
-                            states.DeleteArrayElementAtIndex(i);
-                            break;
+                            // Draw a button with a '-' for state removal
+                            if (InspectorUIUtility.SmallButton(RemoveStateButtonLabel))
+                            {
+                                states.DeleteArrayElementAtIndex(i);
+                                break;
+                            }
                         }
                     }
 

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/CompressableButtonInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/CompressableButtonInspector.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.UI;
-using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using System.Reflection;
+using Microsoft.MixedReality.Toolkit.UI.Interaction;
 using UnityEditor;
 using UnityEngine;
 

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/CompressableButtonInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/CompressableButtonInspector.cs
@@ -1,0 +1,448 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    [CustomEditor(typeof(CompressableButton))]
+    public class CompressableButtonInspector : BaseInteractiveElementInspector
+    {
+        // Struct used to store state of preview.
+        // This lets us display accurate info while button is being pressed.
+        // All vectors / distances are in local space.
+        private struct ButtonInfo
+        {
+            public Vector3 LocalCenter;
+            public Vector2 PlaneExtents;
+
+            // The rotation of the push space.
+            public Quaternion PushRotationLocal;
+
+            // The actual values that the button uses
+            public float StartPushDistance;
+            public float MaxPushDistance;
+            public float PressDistance;
+            public float ReleaseDistance;
+        }
+
+        const string EditingEnabledKey = "MRTK_CompressableButtonInspector_EditingEnabledKey";
+        const string VisiblePlanesKey = "MRTK_CompressableButtonInspector_VisiblePlanesKey";
+        private static bool EditingEnabled = false;
+        private static bool VisiblePlanes = true;
+
+        private const float labelMouseOverDistance = 0.025f;
+
+        private static GUIStyle labelStyle;
+
+        private CompressableButton button;
+        private Transform transform;
+        private NearInteractionTouchableSurface touchable;
+
+        private ButtonInfo currentInfo;
+
+        private SerializedProperty movingButtonVisuals;
+        private SerializedProperty distanceSpaceMode;
+        private SerializedProperty startPushDistance;
+        private SerializedProperty maxPushDistance;
+        private SerializedProperty pressDistance;
+        private SerializedProperty releaseDistanceDelta;
+
+        private static readonly Vector3[] startPlaneVertices = new Vector3[4];
+        private static readonly Vector3[] endPlaneVertices = new Vector3[4];
+        private static readonly Vector3[] pressPlaneVertices = new Vector3[4];
+        private static readonly Vector3[] pressStartPlaneVertices = new Vector3[4];
+        private static readonly Vector3[] releasePlaneVertices = new Vector3[4];
+
+        private static readonly GUIContent DistanceSpaceModeLabel = new GUIContent("Coordinate Space Mode");
+        private static readonly string[] excludeProperties = new string[] { "distanceSpaceMode", "movingButtonVisuals", "m_Script", "active", "states" };
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            button = (CompressableButton)target;
+            transform = button.transform;
+
+            if (labelStyle == null)
+            {
+                labelStyle = new GUIStyle();
+                labelStyle.normal.textColor = Color.white;
+            }
+
+            movingButtonVisuals = serializedObject.FindProperty("movingButtonVisuals");
+            distanceSpaceMode = serializedObject.FindProperty("distanceSpaceMode");
+            startPushDistance = serializedObject.FindProperty("startPushDistance");
+            maxPushDistance = serializedObject.FindProperty("maxPushDistance");
+            pressDistance = serializedObject.FindProperty("pressDistance");
+            releaseDistanceDelta = serializedObject.FindProperty("releaseDistanceDelta");
+
+            touchable = button.GetComponent<NearInteractionTouchableSurface>();
+        }
+
+        [DrawGizmo(GizmoType.Selected)]
+        private void OnSceneGUI()
+        {
+            if (touchable == null)
+            {
+                // The inspector code will prompt a developer to add a touchable.
+                return;
+            }
+
+            if (!VisiblePlanes)
+            {
+                return;
+            }
+
+            // If the button is being pressed, don't gather new info
+            // Just display the info we already gathered
+            // This lets people view button presses in real-time
+            if (button.IsTouching)
+            {
+                DrawButtonInfo(currentInfo, false);
+            }
+            else
+            {
+                currentInfo = GatherCurrentInfo();
+                DrawButtonInfo(currentInfo, EditingEnabled);
+            }
+        }
+
+        private ButtonInfo GatherCurrentInfo()
+        {
+            Vector3 pressDirLocal = (touchable != null) ? touchable.LocalPressDirection : Vector3.forward;
+            Vector3 upDirLocal = Vector3.up;
+
+            if (touchable is NearInteractionTouchable touchableConcrete)
+            {
+                upDirLocal = touchableConcrete.LocalUp;
+            }
+
+            return new ButtonInfo
+            {
+                LocalCenter = touchable.LocalCenter,
+                PlaneExtents = touchable.Bounds,
+                PushRotationLocal = Quaternion.LookRotation(pressDirLocal, upDirLocal),
+                StartPushDistance = startPushDistance.floatValue,
+                MaxPushDistance = maxPushDistance.floatValue,
+                PressDistance = pressDistance.floatValue,
+                ReleaseDistance = pressDistance.floatValue - releaseDistanceDelta.floatValue
+            };
+        }
+
+        private void DrawButtonInfo(ButtonInfo info, bool editingEnabled)
+        {
+            if (editingEnabled)
+            {
+                EditorGUI.BeginChangeCheck();
+            }
+
+            var targetBehaviour = (MonoBehaviour)target;
+            bool isOpaque = targetBehaviour.isActiveAndEnabled;
+            float alpha = (isOpaque) ? 1.0f : 0.5f;
+
+            // START PUSH
+            Handles.color = ApplyAlpha(Color.cyan, alpha);
+            float newStartPushDistance = DrawPlaneAndHandle(startPlaneVertices, info.PlaneExtents * 0.5f, info.StartPushDistance, info, "Start Push Distance", editingEnabled);
+            if (editingEnabled && newStartPushDistance != info.StartPushDistance)
+            {
+                EnforceDistanceOrdering(ref info);
+                info.StartPushDistance = ClampStartPushDistance(Mathf.Min(newStartPushDistance, info.ReleaseDistance));
+            }
+
+            // RELEASE DISTANCE
+            Handles.color = ApplyAlpha(Color.red, alpha);
+            float newReleaseDistance = DrawPlaneAndHandle(releasePlaneVertices, info.PlaneExtents * 0.3f, info.ReleaseDistance, info, "Release Distance", editingEnabled);
+            if (editingEnabled && newReleaseDistance != info.ReleaseDistance)
+            {
+                EnforceDistanceOrdering(ref info);
+                info.ReleaseDistance = Mathf.Clamp(newReleaseDistance, info.StartPushDistance, info.PressDistance);
+            }
+
+            // PRESS DISTANCE
+            Handles.color = ApplyAlpha(Color.yellow, alpha);
+            float newPressDistance = DrawPlaneAndHandle(pressPlaneVertices, info.PlaneExtents * 0.35f, info.PressDistance, info, "Press Distance", editingEnabled);
+            if (editingEnabled && newPressDistance != info.PressDistance)
+            {
+                EnforceDistanceOrdering(ref info);
+                info.PressDistance = Mathf.Clamp(newPressDistance, info.ReleaseDistance, info.MaxPushDistance);
+            }
+
+            // MAX PUSH
+            var purple = new Color(0.28f, 0.0f, 0.69f);
+            Handles.color = ApplyAlpha(purple, alpha);
+            float newMaxPushDistance = DrawPlaneAndHandle(endPlaneVertices, info.PlaneExtents * 0.5f, info.MaxPushDistance, info, "Max Push Distance", editingEnabled);
+            if (editingEnabled && newMaxPushDistance != info.MaxPushDistance)
+            {
+                EnforceDistanceOrdering(ref info);
+                info.MaxPushDistance = Mathf.Max(newMaxPushDistance, info.PressDistance);
+            }
+
+            if (editingEnabled && EditorGUI.EndChangeCheck())
+            {
+                Undo.RecordObject(target, string.Concat("Modify Button Planes of ", button.name));
+
+                startPushDistance.floatValue = info.StartPushDistance;
+                maxPushDistance.floatValue = info.MaxPushDistance;
+                pressDistance.floatValue = info.PressDistance;
+                releaseDistanceDelta.floatValue = info.PressDistance - info.ReleaseDistance;
+
+                serializedObject.ApplyModifiedProperties();
+            }
+
+            // Draw dotted lines showing path from beginning to end of button path
+            Handles.color = Color.Lerp(Color.cyan, Color.clear, 0.25f);
+            Handles.DrawDottedLine(startPlaneVertices[0], endPlaneVertices[0], 2.5f);
+            Handles.DrawDottedLine(startPlaneVertices[1], endPlaneVertices[1], 2.5f);
+            Handles.DrawDottedLine(startPlaneVertices[2], endPlaneVertices[2], 2.5f);
+            Handles.DrawDottedLine(startPlaneVertices[3], endPlaneVertices[3], 2.5f);
+        }
+
+        private void EnforceDistanceOrdering(ref ButtonInfo info)
+        {
+            info.StartPushDistance = ClampStartPushDistance(Mathf.Min(new[] { info.StartPushDistance, info.ReleaseDistance, info.PressDistance, info.MaxPushDistance }));
+            info.ReleaseDistance = Mathf.Min(new[] { info.ReleaseDistance, info.PressDistance, info.MaxPushDistance });
+            info.PressDistance = Mathf.Min(info.PressDistance, info.MaxPushDistance);
+        }
+
+        private float DrawPlaneAndHandle(Vector3[] vertices, Vector2 halfExtents, float distance, ButtonInfo info, string label, bool editingEnabled)
+        {
+            Vector3 centerWorld = button.GetWorldPositionAlongPushDirection(distance);
+            MakeQuadFromPoint(vertices, centerWorld, halfExtents, info);
+
+            if (VisiblePlanes)
+            {
+                Handles.DrawSolidRectangleWithOutline(vertices, Color.Lerp(Handles.color, Color.clear, 0.65f), Handles.color);
+            }
+
+            // Label
+            {
+                Vector3 mousePosition = SceneView.currentDrawingSceneView.camera.ScreenToViewportPoint(Event.current.mousePosition);
+                mousePosition.y = 1f - mousePosition.y;
+                mousePosition.z = 0;
+                Vector3 handleVisiblePos = SceneView.currentDrawingSceneView.camera.WorldToViewportPoint(vertices[1]);
+                handleVisiblePos.z = 0;
+
+                if (Vector3.Distance(mousePosition, handleVisiblePos) < labelMouseOverDistance)
+                {
+                    DrawLabel(vertices[1], transform.up - transform.right, label, labelStyle);
+                    HandleUtility.Repaint();
+                }
+            }
+
+            // Draw forward / backward arrows so people know they can drag
+            if (editingEnabled)
+            {
+                float handleSize = HandleUtility.GetHandleSize(vertices[1]) * 0.15f;
+
+                Vector3 dir = (touchable != null) ? touchable.LocalPressDirection : Vector3.forward;
+                Vector3 planeNormal = button.transform.TransformDirection(dir);
+                Handles.ArrowHandleCap(0, vertices[1], Quaternion.LookRotation(planeNormal), handleSize * 2, EventType.Repaint);
+                Handles.ArrowHandleCap(0, vertices[1], Quaternion.LookRotation(-planeNormal), handleSize * 2, EventType.Repaint);
+
+                Vector3 newPosition = Handles.FreeMoveHandle(vertices[1], Quaternion.identity, handleSize, Vector3.zero, Handles.SphereHandleCap);
+                if (!newPosition.Equals(vertices[1]))
+                {
+                    distance = button.GetDistanceAlongPushDirection(newPosition);
+                }
+            }
+
+            return distance;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            serializedObject.Update();
+
+            // Ensure there is a touchable.
+            if (touchable == null)
+            {
+                EditorGUILayout.HelpBox($"{target.GetType().Name} requires a {nameof(NearInteractionTouchableSurface)}-derived component on this game object to function.", MessageType.Warning);
+
+                bool isUnityUI = (button.GetComponent<RectTransform>() != null);
+                var typeToAdd = isUnityUI ? typeof(NearInteractionTouchableUnityUI) : typeof(NearInteractionTouchable);
+
+                if (GUILayout.Button($"Add {typeToAdd.Name} component"))
+                {
+                    Undo.RecordObject(target, string.Concat($"Add {typeToAdd.Name}"));
+                    var addedComponent = button.gameObject.AddComponent(typeToAdd);
+                    touchable = (NearInteractionTouchableSurface)addedComponent;
+                }
+                else
+                {
+                    // It won't work without it, return to avoid nullrefs.
+                    return;
+                }
+            }
+
+            // Ensure that the touchable has EventsToReceive set to Touch
+            if (touchable.EventsToReceive != TouchableEventType.Touch)
+            {
+                EditorGUILayout.HelpBox($"The {nameof(NearInteractionTouchableSurface)}-derived component on this game object currently has its EventsToReceive set to '{touchable.EventsToReceive}'.  It must be set to 'Touch' in order for PressableButton to function properly.", MessageType.Warning);
+
+                if (GUILayout.Button("Set EventsToReceive to 'Touch'"))
+                {
+                    Undo.RecordObject(touchable, string.Concat("Set EventsToReceive to Touch on ", touchable.name));
+                    touchable.EventsToReceive = TouchableEventType.Touch;
+                }
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.PropertyField(movingButtonVisuals);
+
+            // Ensure that there is a moving button visuals in the UnityUI case.  Even if it is not visible, it must be present to receive GraphicsRaycasts.
+            if (touchable is NearInteractionTouchableUnityUI)
+            {
+                if (movingButtonVisuals.objectReferenceValue == null)
+                {
+                    EditorGUILayout.HelpBox($"When used with a NearInteractionTouchableUnityUI, a MovingButtonVisuals is required, as it receives the GraphicsRaycast that allows pressing the button with near/hand interactions.  It does not need to be visible, but it must be able to receive GraphicsRaycasts.", MessageType.Warning);
+                }
+                else
+                {
+                    var movingVisualGameObject = (GameObject)movingButtonVisuals.objectReferenceValue;
+                    var movingGraphic = movingVisualGameObject.GetComponentInChildren<UnityEngine.UI.Graphic>();
+                    if (movingGraphic == null)
+                    {
+                        EditorGUILayout.HelpBox($"When used with a NearInteractionTouchableUnityUI, the MovingButtonVisuals must contain an Image, RawImage, or other Graphic element so that it can receive a GraphicsRaycast.", MessageType.Warning);
+                    }
+                }
+            }
+
+            EditorGUILayout.LabelField("Press Settings", EditorStyles.boldLabel);
+
+            EditorGUI.BeginChangeCheck();
+            var currentMode = distanceSpaceMode.intValue;
+            EditorGUILayout.PropertyField(distanceSpaceMode);
+            // EndChangeCheck returns true when something was selected in the dropdown, but
+            // doesn't necessarily mean that the value itself changed. Check for that too.
+            if (EditorGUI.EndChangeCheck() && currentMode != distanceSpaceMode.intValue)
+            {
+                // Changing the DistanceSpaceMode requires updating the plane distance values so they stay in the same relative ratio positions
+                Undo.RecordObject(target, string.Concat("Trigger Plane Distance Conversion of ", button.name));
+                button.DistanceSpaceMode = (CompressableButton.SpaceMode)distanceSpaceMode.enumValueIndex;
+                serializedObject.Update();
+            }
+
+            DrawPropertiesExcluding(serializedObject, excludeProperties);
+
+            startPushDistance.floatValue = ClampStartPushDistance(startPushDistance.floatValue);
+
+            // show button state in play mode
+            {
+                EditorGUI.BeginDisabledGroup(Application.isPlaying == false);
+
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("Button State", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField("Current Push Distance", button.CurrentPushDistance.ToString());
+                EditorGUILayout.Toggle("Touching", button.IsTouching);
+                EditorGUILayout.Toggle("Pressing", button.IsPressing);
+                EditorGUI.EndDisabledGroup();
+            }
+
+            // editor settings
+            {
+                EditorGUI.BeginDisabledGroup(Application.isPlaying == true);
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("Editor Settings", EditorStyles.boldLabel);
+                var prevVisiblePlanes = SessionState.GetBool(VisiblePlanesKey, true);
+                VisiblePlanes = EditorGUILayout.Toggle("Show Button Event Planes", prevVisiblePlanes);
+                if (VisiblePlanes != prevVisiblePlanes)
+                {
+                    SessionState.SetBool(VisiblePlanesKey, VisiblePlanes);
+                    EditorUtility.SetDirty(target);
+                }
+
+                // enable plane editing
+                {
+                    EditorGUI.BeginDisabledGroup(VisiblePlanes == false);
+                    var prevEditingEnabled = SessionState.GetBool(EditingEnabledKey, false);
+                    EditingEnabled = EditorGUILayout.Toggle("Make Planes Editable", EditingEnabled);
+                    if (EditingEnabled != prevEditingEnabled)
+                    {
+                        SessionState.SetBool(EditingEnabledKey, EditingEnabled);
+                        EditorUtility.SetDirty(target);
+                    }
+                    EditorGUI.EndDisabledGroup();
+                }
+
+                EditorGUI.EndDisabledGroup();
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        private bool IsMouseOverQuad(ButtonInfo info, Vector3 halfExtents, Vector3 centerLocal)
+        {
+            Vector3 mousePosition = Event.current.mousePosition;
+            mousePosition.y = SceneView.currentDrawingSceneView.camera.pixelHeight - mousePosition.y;
+            Ray mouseRay = SceneView.currentDrawingSceneView.camera.ScreenPointToRay(mousePosition);
+
+            // Transform to local object space.
+            mouseRay.direction = button.transform.InverseTransformDirection(mouseRay.direction);
+            mouseRay.origin = button.transform.InverseTransformPoint(mouseRay.origin);
+
+            // Transform to plane space, which transform the plane into the XY plane.
+            Quaternion quadRotationInverse = Quaternion.Inverse(info.PushRotationLocal);
+            mouseRay.direction = quadRotationInverse * mouseRay.direction;
+            mouseRay.origin = quadRotationInverse * (mouseRay.origin - centerLocal);
+
+            // Intersect ray with XY plane.
+            Plane xyPlane = new Plane(Vector3.forward, 0.0f);
+            if (xyPlane.Raycast(mouseRay, out float intersectionDistance))
+            {
+                Vector3 intersection = mouseRay.GetPoint(intersectionDistance);
+                return (Mathf.Abs(intersection.x) <= halfExtents.x && Mathf.Abs(intersection.y) <= halfExtents.y);
+            }
+
+            return false;
+        }
+
+        private void DrawLabel(Vector3 origin, Vector3 direction, string content, GUIStyle labelStyle)
+        {
+            Color colorOnEnter = Handles.color;
+
+            float handleSize = HandleUtility.GetHandleSize(origin);
+            Vector3 handlePos = origin + direction.normalized * handleSize * 2;
+            Handles.Label(handlePos + (Vector3.up * handleSize * 0.1f), content, labelStyle);
+            Handles.color = Color.Lerp(colorOnEnter, Color.clear, 0.25f);
+            Handles.DrawDottedLine(origin, handlePos, 5f);
+
+            Handles.color = colorOnEnter;
+        }
+
+        private void MakeQuadFromPoint(Vector3[] vertices, Vector3 centerWorld, Vector2 halfExtents, ButtonInfo info)
+        {
+            Vector3 touchCageOrigin = touchable.LocalCenter;
+            touchCageOrigin.z = 0.0f;
+            vertices[0] = transform.TransformVector(info.PushRotationLocal * (new Vector3(-halfExtents.x, -halfExtents.y, 0.0f) + touchCageOrigin)) + centerWorld;
+            vertices[1] = transform.TransformVector(info.PushRotationLocal * (new Vector3(-halfExtents.x, +halfExtents.y, 0.0f) + touchCageOrigin)) + centerWorld;
+            vertices[2] = transform.TransformVector(info.PushRotationLocal * (new Vector3(+halfExtents.x, +halfExtents.y, 0.0f) + touchCageOrigin)) + centerWorld;
+            vertices[3] = transform.TransformVector(info.PushRotationLocal * (new Vector3(+halfExtents.x, -halfExtents.y, 0.0f) + touchCageOrigin)) + centerWorld;
+        }
+
+        private float ClampStartPushDistance(float startDistance)
+        {
+            // If the touchable is UnityUI based, then the start distance must be positive.
+            if (touchable is NearInteractionTouchableUnityUI && startDistance < 0.0f)
+            {
+                return 0.0f;
+            }
+            else
+            {
+                return startDistance;
+            }
+        }
+
+        private static Color ApplyAlpha(Color color, float alpha)
+        {
+            return new Color(color.r, color.g, color.b, color.a * alpha);
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/CompressableButtonInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/CompressableButtonInspector.cs
@@ -8,6 +8,12 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
+    /// <summary>
+    /// Inspector for CompressableButton, includes the logic for the plane distance setting editor tool which allows for modification 
+    /// of the Start Push Distance, Max Push Distance, Press Distance and Release Distance.  
+    /// 
+    /// Note: This is the inspector for PressableButtonHoloLens2.
+    /// </summary>
     [CustomEditor(typeof(CompressableButton))]
     public class CompressableButtonInspector : BaseInteractiveElementInspector
     {

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/CompressableButtonInspector.cs.meta
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/InteractiveElement/CompressableButtonInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8460b214b88b4924ca4a99f312ebc57b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/InteractiveElement.meta
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/InteractiveElement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 788661cebeace6949a140ba9d3988cde
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/InteractiveElement/CompressableButtonCube.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/InteractiveElement/CompressableButtonCube.prefab
@@ -1,0 +1,236 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1705872005380488659
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1705872005380488663}
+  - component: {fileID: 1705872005380488662}
+  - component: {fileID: 1705872005380488657}
+  - component: {fileID: 1705872005380488656}
+  - component: {fileID: 1705872005380488660}
+  - component: {fileID: 1705872005380488682}
+  - component: {fileID: 1705872005380488661}
+  m_Layer: 0
+  m_Name: CompressableButtonCube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1705872005380488663
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1705872005380488659}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.6}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1705872005380488662
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1705872005380488659}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1705872005380488657
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1705872005380488659}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &1705872005380488656
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1705872005380488659}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1705872005380488660
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1705872005380488659}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 183e8dd8b58276c4a8f2b807059981b8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eventsToReceive: 0
+  debounceThreshold: 0.01
+  touchableCollider: {fileID: 1705872005380488656}
+--- !u!114 &1705872005380488682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1705872005380488659}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 98c748f3768ab714a8449b60fb9edc5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eventsToReceive: 0
+  debounceThreshold: 0.01
+  localForward: {x: -0, y: -0, z: -1}
+  localUp: {x: 0, y: 1, z: 0}
+  localCenter: {x: 0, y: 0, z: -0.5}
+  bounds: {x: 1, y: 1}
+  touchableCollider: {fileID: 1705872005380488656}
+--- !u!114 &1705872005380488661
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1705872005380488659}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c3830d4124a60a468b51201aba77fd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  states:
+  - stateName: Default
+    stateValue: 0
+    active: 0
+    interactionType: 4
+    eventConfiguration:
+      id: 0
+  - stateName: Focus
+    stateValue: 0
+    active: 0
+    interactionType: 3
+    eventConfiguration:
+      id: 1
+  - stateName: Touch
+    stateValue: 0
+    active: 0
+    interactionType: 1
+    eventConfiguration:
+      id: 2
+  - stateName: PressedNear
+    stateValue: 0
+    active: 0
+    interactionType: 1
+    eventConfiguration:
+      id: 3
+  movingButtonVisuals: {fileID: 1705872005380488659}
+  distanceSpaceMode: 0
+  startPushDistance: -0.09843373
+  maxPushDistance: 0.009303629
+  pressDistance: -0.036058128
+  releaseDistanceDelta: 0.03310579
+  returnSpeed: 25
+  releaseOnTouchEnd: 1
+  enforceFrontPush: 1
+  movingButtonIconText: {fileID: 0}
+  compressableButtonVisuals: {fileID: 0}
+  minCompressPercentage: 0.25
+  highlightPlate: {fileID: 0}
+  highlightPlateAnimationTime: 0.25
+  references:
+    version: 1
+    00000000:
+      type: {class: StateEvents, ns: Microsoft.MixedReality.Toolkit.UI.Interaction,
+        asm: Microsoft.MixedReality.Toolkit.SDK}
+      data:
+        stateName: Default
+        OnStateOn:
+          m_PersistentCalls:
+            m_Calls: []
+        OnStateOff:
+          m_PersistentCalls:
+            m_Calls: []
+    00000001:
+      type: {class: FocusEvents, ns: Microsoft.MixedReality.Toolkit.UI.Interaction,
+        asm: Microsoft.MixedReality.Toolkit.SDK}
+      data:
+        stateName: Focus
+        OnFocusOn:
+          m_PersistentCalls:
+            m_Calls: []
+        OnFocusOff:
+          m_PersistentCalls:
+            m_Calls: []
+    00000002:
+      type: {class: TouchEvents, ns: Microsoft.MixedReality.Toolkit.UI.Interaction,
+        asm: Microsoft.MixedReality.Toolkit.SDK}
+      data:
+        stateName: Touch
+        OnTouchStarted:
+          m_PersistentCalls:
+            m_Calls: []
+        OnTouchCompleted:
+          m_PersistentCalls:
+            m_Calls: []
+        OnTouchUpdated:
+          m_PersistentCalls:
+            m_Calls: []
+    00000003:
+      type: {class: PressedNearEvents, ns: Microsoft.MixedReality.Toolkit.UI.Interaction,
+        asm: Microsoft.MixedReality.Toolkit.SDK}
+      data:
+        stateName: PressedNear
+        OnButtonPressed:
+          m_PersistentCalls:
+            m_Calls: []
+        OnButtonPressReleased:
+          m_PersistentCalls:
+            m_Calls: []
+        OnButtonPressHold:
+          m_PersistentCalls:
+            m_Calls: []

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/InteractiveElement/CompressableButtonCube.prefab.meta
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/InteractiveElement/CompressableButtonCube.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cd2f1e5c2c0ca934ab7b77568de1b45a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/CompressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/CompressableButton.cs
@@ -127,12 +127,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         /// </summary>
         public bool EnforceFrontPush { get => enforceFrontPush; private set => enforceFrontPush = value; }
 
-        //[Header("Events")]
-        //public UnityEvent TouchBegin = new UnityEvent();
-        //public UnityEvent TouchEnd = new UnityEvent();
-        //public UnityEvent ButtonPressed = new UnityEvent();
-        //public UnityEvent ButtonReleased = new UnityEvent();
-
         #region Private Members
 
         // The maximum distance before the button is reset to its initial position when retracting.
@@ -357,7 +351,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
         #endregion
         #endregion
 
-
         private void OnEnable()
         {
             currentPushDistance = startPushDistance;
@@ -456,7 +449,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.Interaction
                 UpdateHightlightPlateVisuals(0.0f);
                 highlightPlate.enabled = false;
             }
-
         }
 
         void OnDisable()

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/CompressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/CompressableButton.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.UI.Interaction;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections;
 using System.Collections.Generic;
@@ -10,7 +9,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Serialization;
 
-namespace Microsoft.MixedReality.Toolkit.UI
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
 {
     ///<summary>
     /// A button that can be pushed via direct touch.

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/CompressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/CompressableButton.cs
@@ -1,0 +1,809 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.UI.Interaction;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.Serialization;
+
+namespace Microsoft.MixedReality.Toolkit.UI
+{
+    ///<summary>
+    /// A button that can be pushed via direct touch.
+    ///</summary>
+    [RequireComponent(typeof(NearInteractionTouchable))]
+    public class CompressableButton : BaseInteractiveElement
+    {
+        const string InitialMarkerTransformName = "Initial Marker";
+
+        bool hasStarted = false;
+
+        /// <summary>
+        /// The object that is being pushed.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("The object that is being pushed.")]
+        protected GameObject movingButtonVisuals = null;
+
+        /// <summary>
+        /// Enum for defining space of plane distances.
+        /// </summary>
+        public enum SpaceMode
+        {
+            World,
+            Local
+        }
+
+        [SerializeField]
+        [Tooltip("Describes in which coordinate space the plane distances are stored and calculated")]
+        private SpaceMode distanceSpaceMode = SpaceMode.Local;
+
+        /// <summary>
+        /// Describes in which coordinate space the plane distances are stored and calculated
+        /// </summary>
+        public SpaceMode DistanceSpaceMode
+        {
+            get => distanceSpaceMode;
+            set
+            {
+                // Convert world to local distances and vice versa whenever we switch the mode
+                if (value != distanceSpaceMode)
+                {
+                    distanceSpaceMode = value;
+                    float scale = (distanceSpaceMode == SpaceMode.Local) ? WorldToLocalScale : LocalToWorldScale;
+
+                    startPushDistance *= scale;
+                    maxPushDistance *= scale;
+                    pressDistance *= scale;
+                    releaseDistanceDelta *= scale;
+                }
+            }
+        }
+
+        [SerializeField]
+        [Tooltip("The offset at which pushing starts. Offset is relative to the pivot of either the moving visuals if there's any or the button itself.  For UnityUI based CompressableButtons, this cannot be a negative value.")]
+        protected float startPushDistance = 0.0f;
+
+        /// <summary>
+        /// The offset at which pushing starts. Offset is relative to the pivot of either the moving visuals if there's any or the button itself.
+        /// </summary>
+        public float StartPushDistance { get => startPushDistance; set => startPushDistance = value; }
+
+        [SerializeField]
+        [Tooltip("Maximum push distance. Distance is relative to the pivot of either the moving visuals if there's any or the button itself.")]
+        private float maxPushDistance = 0.2f;
+
+        /// <summary>
+        /// Maximum push distance. Distance is relative to the pivot of either the moving visuals if there's any or the button itself.
+        /// </summary>
+        public float MaxPushDistance { get => maxPushDistance; set => maxPushDistance = value; }
+
+        [SerializeField]
+        [FormerlySerializedAs("minPressDepth")]
+        [Tooltip("Distance the button must be pushed until it is considered pressed. Distance is relative to the pivot of either the moving visuals if there's any or the button itself.")]
+        private float pressDistance = 0.02f;
+
+        /// <summary>
+        /// Distance the button must be pushed until it is considered pressed. Distance is relative to the pivot of either the moving visuals if there's any or the button itself.
+        /// </summary>
+        public float PressDistance { get => pressDistance; set => pressDistance = value; }
+
+        [SerializeField]
+        [FormerlySerializedAs("withdrawActivationAmount")]
+        [Tooltip("Withdraw amount needed to transition from Pressed to Released.")]
+        private float releaseDistanceDelta = 0.01f;
+
+        /// <summary>
+        ///  Withdraw amount needed to transition from Pressed to Released.
+        /// </summary>
+        public float ReleaseDistanceDelta { get => releaseDistanceDelta; set => releaseDistanceDelta = value; }
+
+        /// <summary>
+        ///  Speed for retracting the moving button visuals on release.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Speed for retracting the moving button visuals on release.")]
+        [FormerlySerializedAs("returnRate")]
+        private float returnSpeed = 25.0f;
+
+        [SerializeField]
+        [Tooltip("Button will send the release event on touch end after successful press even if release plane hasn't been passed.")]
+        private bool releaseOnTouchEnd = true;
+
+        /// <summary>
+        ///  Button will send the release event on touch end after successful press even if release plane hasn't been passed.
+        /// </summary>
+        public bool ReleaseOnTouchEnd { get => releaseOnTouchEnd; set => releaseOnTouchEnd = value; }
+
+        [SerializeField]
+        [Tooltip("Ensures that the button can only be pushed from the front. Touching the button from the back or side is prevented.")]
+        private bool enforceFrontPush = true;
+
+        /// <summary>
+        /// Ensures that the button can only be pushed from the front. Touching the button from the back or side is prevented.
+        /// </summary>
+        public bool EnforceFrontPush { get => enforceFrontPush; private set => enforceFrontPush = value; }
+
+        //[Header("Events")]
+        //public UnityEvent TouchBegin = new UnityEvent();
+        //public UnityEvent TouchEnd = new UnityEvent();
+        //public UnityEvent ButtonPressed = new UnityEvent();
+        //public UnityEvent ButtonReleased = new UnityEvent();
+
+        #region Private Members
+
+        // The maximum distance before the button is reset to its initial position when retracting.
+        private const float MaxRetractDistanceBeforeReset = 0.0001f;
+
+        private Dictionary<IMixedRealityController, Vector3> touchPoints = new Dictionary<IMixedRealityController, Vector3>();
+
+        private List<IMixedRealityInputSource> currentInputSources = new List<IMixedRealityInputSource>();
+
+        private float currentPushDistance = 0.0f;
+
+        /// <summary>
+        /// Current push distance relative to the start push plane. 
+        /// </summary>
+        public float CurrentPushDistance { get => currentPushDistance; protected set => currentPushDistance = value; }
+
+        private bool isTouching = false;
+
+        // The PressedNear state is not considered a CoreInteractionState because it is specific to the compressable button class
+        protected string PressedNearStateName = "PressedNear";
+
+        ///<summary>
+        /// Represents the state of whether or not a finger is currently touching this button.
+        ///</summary>
+        public bool IsTouching
+        {
+            get => isTouching;
+            private set
+            {
+                if (value != isTouching)
+                {
+                    isTouching = value;
+
+                    if (!isTouching)
+                    {
+                        // Abort press.
+                        if (!releaseOnTouchEnd)
+                        {
+                            IsPressing = false;
+                            SetStateAndInvokeEvent(PressedNearStateName, 0);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Represents the state of whether the button is currently being pressed.
+        /// </summary>
+        public bool IsPressing { get; private set; }
+
+        /// <summary>
+        /// Transform for local to world space in the world direction of a press
+        /// Multiply local scale positions by this value to convert to world space
+        /// </summary>
+        public float LocalToWorldScale => (WorldToLocalScale != 0) ? 1.0f / WorldToLocalScale : 0.0f;
+
+        /// <summary>
+        /// The press direction of the button as defined by a NearInteractionTouchableSurface.
+        /// </summary>
+        private Vector3 WorldSpacePressDirection
+        {
+            get
+            {
+                var nearInteractionTouchable = GetComponent<NearInteractionTouchableSurface>();
+                if (nearInteractionTouchable != null)
+                {
+                    return nearInteractionTouchable.transform.TransformDirection(nearInteractionTouchable.LocalPressDirection);
+                }
+
+                return transform.forward;
+            }
+        }
+
+        /// <summary>
+        /// The press direction of the button as defined by a NearInteractionTouchableSurface, in local space,
+        /// using Vector3.forward as an optional fallback when no NearInteractionTouchableSurface is defined.
+        /// </summary>
+        private Vector3 LocalSpacePressDirection
+        {
+            get
+            {
+                var nearInteractionTouchable = GetComponent<NearInteractionTouchableSurface>();
+                if (nearInteractionTouchable != null)
+                {
+                    return nearInteractionTouchable.LocalPressDirection;
+                }
+
+                return Vector3.forward;
+            }
+        }
+
+        private Transform PushSpaceSourceTransform
+        {
+            get => movingButtonVisuals != null ? movingButtonVisuals.transform : transform;
+        }
+
+        /// <summary>
+        /// Transform for world to local space in the world direction of press
+        /// Multiply world scale positions by this value to convert to local space
+        /// </summary>
+        private float WorldToLocalScale => transform.InverseTransformVector(WorldSpacePressDirection).magnitude;
+
+        /// <summary>
+        /// Initial offset from moving visuals to button
+        /// </summary>
+        private Vector3 movingVisualsInitialLocalPosition = Vector3.zero;
+
+        /// <summary>
+        /// The position from where the button starts to move.  Projected into world space based on the button's current world space position.
+        /// </summary>
+        private Vector3 InitialWorldPosition
+        {
+            get
+            {
+                if (Application.isPlaying && movingButtonVisuals) // we're using a cached position in play mode as the moving visuals will be moved during button interaction
+                {
+                    var parentTransform = PushSpaceSourceTransform.parent;
+                    var localPosition = (parentTransform == null) ? movingVisualsInitialLocalPosition : parentTransform.TransformVector(movingVisualsInitialLocalPosition);
+                    return PushSpaceSourceParentPosition + localPosition;
+                }
+                else
+                {
+                    return PushSpaceSourceTransform.position;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The position from where the button starts to move.  In local space, relative to button root.
+        /// </summary>
+        private Vector3 InitialLocalPosition
+        {
+            get
+            {
+                if (Application.isPlaying && movingButtonVisuals) // we're using a cached position in play mode as the moving visuals will be moved during button interaction
+                {
+                    return movingVisualsInitialLocalPosition;
+                }
+                else
+                {
+                    return PushSpaceSourceTransform.position;
+                }
+            }
+        }
+
+        #endregion
+
+        #region  Properties from PressableButtonHoloLens2
+        [Space()]
+        [SerializeField]
+        [Tooltip("The icon and text content moving inside the button.")]
+        private GameObject movingButtonIconText = null;
+
+        [SerializeField]
+        [Tooltip("The visuals which become compressed (scaled) along the z-axis when pressed.")]
+        private GameObject compressableButtonVisuals = null;
+
+        /// <summary>
+        /// The visuals which become compressed (scaled) along the z-axis when pressed.
+        /// </summary>
+        public GameObject CompressableButtonVisuals
+        {
+            get => compressableButtonVisuals;
+            set
+            {
+                compressableButtonVisuals = value;
+
+                if (compressableButtonVisuals != null)
+                {
+                    initialCompressableButtonVisualsLocalScale = compressableButtonVisuals.transform.localScale;
+                }
+
+            }
+        }
+
+        [SerializeField]
+        [Range(0.0f, 1.0f)]
+        [Tooltip("The minimum percentage of the original scale the compressableButtonVisuals can be compressed to.")]
+        private float minCompressPercentage = 0.25f;
+
+        /// <summary>
+        /// The minimum percentage of the original scale the compressableButtonVisuals can be compressed to.
+        /// </summary>
+        public float MinCompressPercentage { get => minCompressPercentage; set => minCompressPercentage = value; }
+
+        /// <summary>
+        /// Public property to set the moving content part(icon and text) of the button. 
+        /// This content part moves 1/2 distance of the front cage 
+        /// </summary>
+        public GameObject MovingButtonIconText
+        {
+            get
+            {
+                return movingButtonIconText;
+            }
+            set
+            {
+                if (movingButtonIconText != value)
+                {
+                    movingButtonIconText = value;
+                }
+            }
+        }
+
+        [SerializeField]
+        [Tooltip("The plate which represents the press-able surface of the button that highlights when focused.")]
+        private Renderer highlightPlate = null;
+
+        [SerializeField]
+        [Tooltip("The duration of time it takes to animate in/out the highlight plate.")]
+        private float highlightPlateAnimationTime = 0.25f;
+
+        #region Private Members
+
+        Vector3 initialCompressableButtonVisualsLocalScale = Vector3.one;
+        private int fluentLightIntensityID = 0;
+        private float targetFluentLightIntensity = 1.0f;
+        private MaterialPropertyBlock properties = null;
+        private Coroutine highlightPlateAnimationRoutine = null;
+
+        #endregion
+        #endregion
+
+
+        private void OnEnable()
+        {
+            currentPushDistance = startPushDistance;
+        }
+
+        private Vector3 PushSpaceSourceParentPosition => (PushSpaceSourceTransform.parent != null) ? PushSpaceSourceTransform.parent.position : Vector3.zero;
+
+
+        public override void Start()
+        {
+            base.Start();
+
+            hasStarted = true;
+
+            if (gameObject.layer == 2)
+            {
+                Debug.LogWarning("CompressableButton will not work if game object layer is set to 'Ignore Raycast'.");
+            }
+
+            movingVisualsInitialLocalPosition = PushSpaceSourceTransform.localPosition;
+
+            // Ensure everything is set to initial positions correctly.
+            UpdateMovingVisualsPosition();
+
+            AddRequiredStates();
+
+            if (IsStatePresent(TouchStateName))
+            {
+                var touchEvents = GetStateEvents<TouchEvents>("Touch");
+
+                touchEvents.OnTouchStarted.AddListener((touchEventData) =>
+                {
+                    if (touchPoints.ContainsKey(touchEventData.Controller))
+                    {
+                        return;
+                    }
+
+                    // Back-Press Detection:
+                    // Accept touch only if controller pushed from the front.
+                    if (enforceFrontPush && !HasPassedThroughStartPlane(touchEventData))
+                    {
+                        return;
+                    }
+
+                    touchPoints.Add(touchEventData.Controller, touchEventData.InputData);
+
+                    // Make sure only one instance of this input source exists and is at the "top of the stack."
+                    currentInputSources.Remove(touchEventData.InputSource);
+                    currentInputSources.Add(touchEventData.InputSource);
+
+                    IsTouching = true;
+
+                    touchEventData.Use();
+
+                });
+
+                touchEvents.OnTouchCompleted.AddListener((touchEventData) =>
+                {
+                    if (touchPoints.ContainsKey(touchEventData.Controller))
+                    {
+                        // When focus is lost, before removing controller, update the respective touch point to give a last chance for checking if pressed occurred 
+                        touchPoints[touchEventData.Controller] = touchEventData.InputData;
+                        UpdateTouch();
+
+                        touchPoints.Remove(touchEventData.Controller);
+                        currentInputSources.Remove(touchEventData.InputSource);
+
+                        IsTouching = (touchPoints.Count > 0);
+                        touchEventData.Use();
+                    }
+                });
+
+                touchEvents.OnTouchUpdated.AddListener((touchEventData) =>
+                {
+                    if (touchPoints.ContainsKey(touchEventData.Controller))
+                    {
+                        touchPoints[touchEventData.Controller] = touchEventData.InputData;
+                        touchEventData.Use();
+                    }
+                });
+            }
+
+            if (compressableButtonVisuals != null)
+            {
+                initialCompressableButtonVisualsLocalScale = compressableButtonVisuals.transform.localScale;
+            }
+
+            if (highlightPlate != null)
+            {
+                // Cache the initial highlight plate state.
+                fluentLightIntensityID = Shader.PropertyToID("_FluentLightIntensity");
+                properties = new MaterialPropertyBlock();
+                targetFluentLightIntensity = highlightPlate.sharedMaterial.GetFloat(fluentLightIntensityID);
+
+                // Hide the highlight plate initially.
+                UpdateHightlightPlateVisuals(0.0f);
+                highlightPlate.enabled = false;
+            }
+
+        }
+
+        void OnDisable()
+        {
+            // clear touch points in case we get disabled and can't receive the touch end event anymore
+            touchPoints.Clear();
+            currentInputSources.Clear();
+
+            if (hasStarted)
+            {
+                // make sure button doesn't stay in a pressed state in case we disable the button while pressing it
+                currentPushDistance = startPushDistance;
+                UpdateMovingVisualsPosition();
+            }
+        }
+
+        private void Update()
+        {
+            if (IsTouching)
+            {
+                UpdateTouch();
+            }
+            else if (currentPushDistance > startPushDistance)
+            {
+                RetractButton();
+            }
+
+            if (IsPressing)
+            {
+                // If the button is currently being pressed, invoke the OnButtonPressHold event
+                // contained in the PressedNear state
+                EventReceiverManager.InvokeStateEvent(PressedNearStateName);
+            }
+        }
+
+        private void UpdateTouch()
+        {
+            currentPushDistance = GetFarthestDistanceAlongPressDirection();
+
+            UpdateMovingVisualsPosition();
+
+            // Hand press is only allowed to happen while touching.
+            UpdatePressedState(currentPushDistance);
+        }
+
+        private void RetractButton()
+        {
+            float retractDistance = currentPushDistance - startPushDistance;
+            retractDistance -= retractDistance * returnSpeed * Time.deltaTime;
+
+            // Apply inverse scale of local z-axis. This constant should always have the same value in world units.
+            float localMaxRetractDistanceBeforeReset = MaxRetractDistanceBeforeReset * WorldSpacePressDirection.magnitude;
+            if (retractDistance < localMaxRetractDistanceBeforeReset)
+            {
+                currentPushDistance = startPushDistance;
+            }
+            else
+            {
+                currentPushDistance = startPushDistance + retractDistance;
+            }
+
+            UpdateMovingVisualsPosition();
+
+            if (releaseOnTouchEnd && IsPressing)
+            {
+                UpdatePressedState(currentPushDistance);
+            }
+        }
+
+        #region IMixedRealityTouchHandler implementation
+
+        private void PulseProximityLight()
+        {
+            // Pulse each proximity light on pointer cursors' interacting with this button.
+            if (currentInputSources.Count != 0)
+            {
+                foreach (var pointer in currentInputSources[currentInputSources.Count - 1].Pointers)
+                {
+                    if (!pointer.BaseCursor.TryGetMonoBehaviour(out MonoBehaviour baseCursor))
+                    {
+                        return;
+                    }
+
+                    GameObject cursorGameObject = baseCursor.gameObject;
+                    if (cursorGameObject == null)
+                    {
+                        return;
+                    }
+
+                    ProximityLight[] proximityLights = cursorGameObject.GetComponentsInChildren<ProximityLight>();
+
+                    if (proximityLights != null)
+                    {
+                        foreach (var proximityLight in proximityLights)
+                        {
+                            proximityLight.Pulse();
+                        }
+                    }
+                }
+            }
+        }
+
+        private bool HasPassedThroughStartPlane(HandTrackingInputEventData eventData)
+        {
+            foreach (var pointer in eventData.InputSource.Pointers)
+            {
+                // In the case that the input source has multiple poke pointers, this code
+                // will reason over the first such pointer that is actually interacting with
+                // an object. For input sources that have a single poke pointer, this is one
+                // and the same (i.e. this event will only fire for this object when the poke
+                // pointer is touching this object).
+                PokePointer poke = pointer as PokePointer;
+                if (poke && poke.CurrentTouchableObjectDown)
+                {
+                    // Extrapolate to get previous position.
+                    float previousDistance = GetDistanceAlongPushDirection(poke.PreviousPosition);
+                    return previousDistance <= StartPushDistance;
+                }
+            }
+
+            return false;
+        }
+
+        #endregion OnTouch
+
+        #region public transform utils
+
+        /// <summary>
+        /// Returns world space position along the push direction for the given local distance
+        /// </summary>
+        /// 
+        public Vector3 GetWorldPositionAlongPushDirection(float localDistance)
+        {
+            float distance = (distanceSpaceMode == SpaceMode.Local) ? localDistance * LocalToWorldScale : localDistance;
+            return InitialWorldPosition + WorldSpacePressDirection.normalized * distance;
+        }
+
+        /// <summary>
+        /// Returns local position along the push direction for the given local distance
+        /// </summary>
+        /// 
+        public Vector3 GetLocalPositionAlongPushDirection(float localDistance)
+        {
+            return InitialLocalPosition + LocalSpacePressDirection.normalized * localDistance;
+        }
+
+        /// <summary>
+        /// Returns the local distance along the push direction for the passed in world position
+        /// </summary>
+        public float GetDistanceAlongPushDirection(Vector3 positionWorldSpace)
+        {
+            Vector3 localPosition = positionWorldSpace - InitialWorldPosition;
+            float distance = Vector3.Dot(localPosition, WorldSpacePressDirection.normalized);
+            return (distanceSpaceMode == SpaceMode.Local) ? distance * WorldToLocalScale : distance;
+        }
+
+        #endregion
+
+        #region private Methods
+
+        protected virtual void UpdateMovingVisualsPosition()
+        {
+            if (movingButtonVisuals != null)
+            {
+                // Always move relative to startPushDistance
+                movingButtonVisuals.transform.localPosition = GetLocalPositionAlongPushDirection(currentPushDistance - startPushDistance);
+            }
+
+            if (compressableButtonVisuals != null)
+            {
+                // Compress the button visuals by the push amount.
+                Vector3 scale = compressableButtonVisuals.transform.localScale;
+                float pressPercentage;
+
+                // Prevent divide by zero when calculating pressPercentage.
+                if (MaxPushDistance <= float.Epsilon)
+                {
+                    pressPercentage = 0.0f;
+                }
+                else
+                {
+                    pressPercentage = Mathf.Max(minCompressPercentage, (1.0f - (CurrentPushDistance - startPushDistance) / MaxPushDistance));
+                }
+
+                scale.z = initialCompressableButtonVisualsLocalScale.z * pressPercentage;
+                compressableButtonVisuals.transform.localScale = scale;
+            }
+
+            if (movingButtonIconText != null)
+            {
+                // Always move relative to startPushDistance
+                movingButtonIconText.transform.localPosition = GetLocalPositionAlongPushDirection((CurrentPushDistance - startPushDistance) / 2.0f);
+            }
+
+        }
+
+        // This function projects the current touch positions onto the 1D press direction of the button.
+        // It will output the farthest pushed distance from the button's initial position.
+        private float GetFarthestDistanceAlongPressDirection()
+        {
+            float farthestDistance = startPushDistance;
+
+            foreach (var touchEntry in touchPoints)
+            {
+                float testDistance = GetDistanceAlongPushDirection(touchEntry.Value);
+                farthestDistance = Mathf.Max(testDistance, farthestDistance);
+            }
+
+            return Mathf.Clamp(farthestDistance, startPushDistance, maxPushDistance);
+        }
+
+        private void UpdatePressedState(float pushDistance)
+        {
+            // If we aren't in a press and can't start a simple one.
+            if (!IsPressing)
+            {
+                // Compare to our previous push depth. Use previous push distance to handle back-presses.
+                if (pushDistance >= pressDistance)
+                {
+                    SetStateAndInvokeEvent(PressedNearStateName, 1);
+                    IsPressing = true;
+                    TriggerClickedState();
+                    PulseProximityLight();
+                }
+            }
+            // If we're in a press, check if the press is released now.
+            else
+            {
+                float releaseDistance = pressDistance - releaseDistanceDelta;
+                if (pushDistance <= releaseDistance)
+                {
+                    SetStateAndInvokeEvent(PressedNearStateName, 0);
+                    IsPressing = false;
+                }
+            }
+        }
+
+        #endregion
+
+        // Add the required states for CompressableButton during edit mode
+        internal void AddRequiredStatesEditMode()
+        {
+            if (!IsStatePresentEditMode(TouchStateName))
+            {
+                States.Add(new InteractionState(TouchStateName));
+            }
+
+            if (!IsStatePresentEditMode(PressedNearStateName))
+            {
+                States.Add(new InteractionState(PressedNearStateName));
+            }
+
+            if (!IsStatePresentEditMode(FocusStateName))
+            {
+                States.Add(new InteractionState(FocusStateName));
+            }
+        }
+
+        // Add the required states for CompressableButton during runtime
+        private void AddRequiredStates()
+        {
+            if (!IsStatePresent(TouchStateName))
+            {
+                AddNewState(TouchStateName);
+            }
+
+            if (!IsStatePresent(PressedNearStateName))
+            {
+                AddNewState(PressedNearStateName);
+            }
+
+            if (!IsStatePresent(FocusStateName))
+            {
+                AddNewState(FocusStateName);
+            }
+        }
+
+        public override void OnValidate()
+        {
+            base.OnValidate();
+            AddRequiredStatesEditMode();
+        }
+
+        /// <summary>
+        /// Animates in the highlight plate.
+        /// </summary>
+        public void AnimateInHighlightPlate()
+        {
+            if (highlightPlate != null)
+            {
+                if (highlightPlateAnimationRoutine != null)
+                {
+                    StopCoroutine(highlightPlateAnimationRoutine);
+                }
+
+                highlightPlateAnimationRoutine = StartCoroutine(AnimateHighlightPlate(true, highlightPlateAnimationTime));
+            }
+        }
+
+        /// <summary>
+        /// Animates out the highlight plate and disables it when animated out.
+        /// </summary>
+        public void AnimateOutHighlightPlate()
+        {
+            if (highlightPlate != null)
+            {
+                if (highlightPlateAnimationRoutine != null)
+                {
+                    StopCoroutine(highlightPlateAnimationRoutine);
+                }
+
+                highlightPlateAnimationRoutine = StartCoroutine(AnimateHighlightPlate(false, highlightPlateAnimationTime));
+            }
+        }
+
+        private IEnumerator AnimateHighlightPlate(bool fadeIn, float time)
+        {
+            highlightPlate.enabled = true;
+
+            // Calculate how much time is left in the blend based on current intensity.
+            var normalizedIntensity = (targetFluentLightIntensity != 0.0f) ? properties.GetFloat(fluentLightIntensityID) / targetFluentLightIntensity : 1.0f;
+            var blendTime = fadeIn ? (1.0f - normalizedIntensity) * time : normalizedIntensity * time;
+
+            while (blendTime > 0.0f)
+            {
+                float t = 1.0f - (blendTime / time);
+                UpdateHightlightPlateVisuals(fadeIn ? t : 1.0f - t);
+                blendTime -= Time.deltaTime;
+
+                yield return null;
+            }
+
+            UpdateHightlightPlateVisuals(fadeIn ? targetFluentLightIntensity : 0.0f);
+
+            // When completely faded out, hide the highlight plate.
+            if (!fadeIn)
+            {
+                highlightPlate.enabled = false;
+            }
+        }
+
+        private void UpdateHightlightPlateVisuals(float lightIntensity)
+        {
+            highlightPlate.GetPropertyBlock(properties);
+            properties.SetFloat(fluentLightIntensityID, lightIntensity);
+            highlightPlate.SetPropertyBlock(properties);
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/CompressableButton.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/CompressableButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c3830d4124a60a468b51201aba77fd7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/PressedNearEvents.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/PressedNearEvents.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine.Events;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The event configuration for the PressedNear InteractionState. This state is specific to the 
+    /// CompressableButton class.
+    /// </summary>
+    public class PressedNearEvents : BaseInteractionEventConfiguration
+    {
+        /// <summary>
+        /// Fired when a button is pressed via near interaction. 
+        /// </summary>
+        public UnityEvent OnButtonPressed = new UnityEvent();
+
+        /// <summary>
+        /// Fired when a button press is released via near interaction. 
+        /// </summary>
+        public UnityEvent OnButtonPressReleased = new UnityEvent();
+
+        /// <summary>
+        /// Fired when a button is currently being pressed. 
+        /// </summary>
+        public UnityEvent OnButtonPressHold = new UnityEvent();
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/PressedNearEvents.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventConfigurations/PressedNearEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 651ca6cd9f17cdc46907054a070b4beb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/PressedNearReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/PressedNearReceiver.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Interaction
+{
+    /// <summary>
+    /// The internal event receiver for the events defined in the PressedNear Interaction Event Configuration.
+    /// The PressedNear state is specific to the CompressableButton class. 
+    /// </summary>
+    public class PressedNearReceiver : BaseEventReceiver
+    {
+        /// <inheritdoc />
+        public PressedNearReceiver(BaseInteractionEventConfiguration eventConfiguration) : base(eventConfiguration) { }
+
+        private PressedNearEvents pressedNearEventConfig => EventConfiguration as PressedNearEvents;
+
+        private UnityEvent onButtonPressed => pressedNearEventConfig.OnButtonPressed;
+
+        private UnityEvent onButtonPressReleased => pressedNearEventConfig.OnButtonPressReleased;
+
+        private UnityEvent onButtonPressHold => pressedNearEventConfig.OnButtonPressHold;
+
+        private bool wasButtonPressedNear;
+
+        /// <inheritdoc />
+        public override void OnUpdate(StateManager stateManager, BaseEventData eventData)
+        {
+            bool isButtonPressedNear = stateManager.GetState(StateName).Value > 0;
+
+            if (isButtonPressedNear != wasButtonPressedNear)
+            {
+                if (isButtonPressedNear)
+                {
+                    onButtonPressed.Invoke();
+                }
+                else
+                {
+                    onButtonPressReleased.Invoke();
+                }
+            }
+
+            if (isButtonPressedNear)
+            {
+                onButtonPressHold.Invoke();
+            }
+
+            wasButtonPressedNear = isButtonPressedNear;
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/PressedNearReceiver.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/InteractiveElement/Events/EventReceivers/PressedNearReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 306b20febbdcd5d43b939158be03eef1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

`CompressableButton` is a component that contains the same exact logic and properties as `PressableButtonHoloLens2`.

The difference between `CompressableButton` and `PressableHoloLens2` is that CompressableButton inherits from `BaseInteractiveElement`.  The inheritance from `BaseInteractiveElement` adds far interaction support to CompressableButton, which eliminates the need for the `PhysicalPressEventRouter` component. 

The purpose of the `PhysicalPressEventRouter` was to trigger a clicked event in the `Interactable` component when a button was pressed via near interaction.  Now a near interaction press and a far interaction pointer down selection trigger the same clicked state. 

For MRTK 2.6, the current PressableButtonHoloLens2 prefabs will NOT be modified to avoid breaking changes for customers.  However, all MRTK buttons will eventually migrate to use CompressableButton while PressableButton + PressableButtonHoloLens2 will be removed in versions beyond 2.6.

| Compressable Button Inspector| PressableButtonHoloLens2 Inspector|
|---|---|
|![image](https://user-images.githubusercontent.com/53493796/102396322-27794980-3f91-11eb-8af2-8209f9db7ac3.png)| ![image](https://user-images.githubusercontent.com/53493796/102387743-9badf000-3f85-11eb-9f36-316a21315b2a.png)| 


### Pressed Near State Setting
![CompressableButtonCube](https://user-images.githubusercontent.com/53493796/102387373-2510f280-3f85-11eb-81e7-598bad769713.gif)


## Changes
- Fixes: #4258 
- Fixes: #8883 - adds a class specifically for a button
- Fixes: #6095


## Verification
1. Checkout the branch
1. Open new unity scene
1. Add MRTK to the scene
1. Add a cube to the scene
1. Attach the Compressable Button component