### PR TITLE
Fix boundary visualization for 2.5.2

### DIFF
--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -316,17 +316,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                 {
                     showFloor = value;
 
-                    if (value && (currentFloorObject == null))
-                    {
-                        GetFloorVisualization();
-                    }
-
-                    if (currentFloorObject != null)
-                    {
-                        currentFloorObject.SetActive(value);
-                    }
-
-                    RaiseBoundaryVisualizationChanged();
+                    PropertyAction(value, currentFloorObject, () => GetFloorVisualization());
                 }
             }
         }
@@ -367,17 +357,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                 {
                     showPlayArea = value;
 
-                    if (value && (currentPlayAreaObject == null))
-                    {
-                        GetPlayAreaVisualization();
-                    }
-
-                    if (currentPlayAreaObject != null)
-                    {
-                        currentPlayAreaObject.SetActive(value);
-                    }
-
-                    RaiseBoundaryVisualizationChanged();
+                    PropertyAction(value, currentPlayAreaObject, () => GetPlayAreaVisualization());
                 }
             }
         }
@@ -419,17 +399,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                 {
                     showTrackedArea = value;
 
-                    if (value && (currentTrackedAreaObject == null))
-                    {
-                        GetTrackedAreaVisualization();
-                    }
-
-                    if (currentTrackedAreaObject != null)
-                    {
-                        currentTrackedAreaObject.SetActive(value);
-                    }
-
-                    RaiseBoundaryVisualizationChanged();
+                    PropertyAction(value, currentTrackedAreaObject, () => GetTrackedAreaVisualization());
                 }
             }
         }
@@ -471,17 +441,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                 {
                     showBoundaryWalls = value;
 
-                    if (value && (currentBoundaryWallObject == null))
-                    {
-                        GetBoundaryWallVisualization();
-                    }
-
-                    if (currentBoundaryWallObject != null)
-                    {
-                        currentBoundaryWallObject.SetActive(value);
-                    }
-
-                    RaiseBoundaryVisualizationChanged();
+                    PropertyAction(value, currentBoundaryWallObject, () => GetBoundaryWallVisualization());
                 }
             }
         }
@@ -523,17 +483,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                 {
                     showCeiling = value;
 
-                    if (value && (currentCeilingObject == null))
-                    {
-                        GetBoundaryCeilingVisualization();
-                    }
-
-                    if (currentCeilingObject != null)
-                    {
-                        currentCeilingObject.SetActive(value);
-                    }
-
-                    RaiseBoundaryVisualizationChanged();
+                    PropertyAction(value, currentCeilingObject, () => GetBoundaryCeilingVisualization());
                 }
             }
         }
@@ -561,6 +511,21 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                     currentFloorObject.layer = ceilingPhysicsLayer;
                 }
             }
+        }
+
+        private void PropertyAction(bool value, GameObject boundaryObject, System.Action getVisualizationMethod)
+        {
+            if (value && (boundaryObject == null))
+            {
+                getVisualizationMethod();
+            }
+
+            if (boundaryObject != null)
+            {
+                boundaryObject.SetActive(value);
+            }
+
+            RaiseBoundaryVisualizationChanged();
         }
 
         /// <inheritdoc/>

--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -76,6 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
 
             isInitialized = true;
 
+            RefreshVisualization();
             RaiseBoundaryVisualizationChanged();
         }
 
@@ -517,7 +518,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             }
         }
 
-        private void PropertyAction(bool value, GameObject boundaryObject, System.Action getVisualizationMethod)
+        private void PropertyAction(bool value, GameObject boundaryObject, System.Action getVisualizationMethod, bool raiseEvent = true)
         {
             // If not done initializing, no need to raise the changed event or check the visualization.
             // These will both happen at the end of the initialization flow.
@@ -536,7 +537,23 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                 boundaryObject.SetActive(value);
             }
 
-            RaiseBoundaryVisualizationChanged();
+            if (raiseEvent)
+            {
+                RaiseBoundaryVisualizationChanged();
+            }
+        }
+
+        /// <summary>
+        /// Refreshes the current boundary visualizations without raising changed events.
+        /// Used during the initialization flow.
+        /// </summary>
+        private void RefreshVisualization()
+        {
+            PropertyAction(ShowFloor, currentFloorObject, () => GetFloorVisualization(), false);
+            PropertyAction(ShowPlayArea, currentPlayAreaObject, () => GetPlayAreaVisualization(), false);
+            PropertyAction(ShowTrackedArea, currentTrackedAreaObject, () => GetTrackedAreaVisualization(), false);
+            PropertyAction(ShowBoundaryWalls, currentBoundaryWallObject, () => GetBoundaryWallVisualization(), false);
+            PropertyAction(ShowBoundaryCeiling, currentCeilingObject, () => GetBoundaryCeilingVisualization(), false);
         }
 
         /// <inheritdoc/>

--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -58,6 +58,8 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// <inheritdoc/>
         public override string Name { get; protected set; } = "Mixed Reality Boundary System";
 
+        private bool isInitialized = false;
+
         /// <inheritdoc/>
         public override void Initialize()
         {
@@ -71,6 +73,8 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
 
             SetTrackingSpace();
             CalculateBoundaryBounds();
+
+            isInitialized = true;
 
             RaiseBoundaryVisualizationChanged();
         }
@@ -515,6 +519,13 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
 
         private void PropertyAction(bool value, GameObject boundaryObject, System.Action getVisualizationMethod)
         {
+            // If not done initializing, no need to raise the changed event or check the visualization.
+            // These will both happen at the end of the initialization flow.
+            if (!isInitialized)
+            {
+                return;
+            }
+
             if (value && (boundaryObject == null))
             {
                 getVisualizationMethod();


### PR DESCRIPTION
## Overview

In testing #9060, I realized that the boundary floor never shows up. In debugging, I realized we had a PR for 2.5.0 that moved the profile read before the bounds calculation, which means the visualization is never triggered. This is a regression from 2.4, so we're choosing to take this change in 2.5.2.

This change

1. Refactors out some common code from the property setters, so we only have to make changes to the flow in one place (and allows us to refresh the visualization without raising events)
2. Gates the event behind initialization, so we don't send a stream of them during profile read
3. Refreshes the visualization near the end of initialization