### PR TITLE
Fix Follow recenter behavior

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
@@ -335,7 +335,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         protected override void OnEnable()
         {
             base.OnEnable();
-            Recenter();
             RecalculateBoundsExtents();
         }
 

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
@@ -326,8 +326,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         private Vector3 ReferencePosition => SolverHandler.TransformTarget != null ? SolverHandler.TransformTarget.position : Vector3.zero;
         private Quaternion ReferenceRotation => SolverHandler.TransformTarget != null ? SolverHandler.TransformTarget.rotation : Quaternion.identity;
-        private Vector3 PreviousReferencePosition = Vector3.zero;
-        private Quaternion PreviousReferenceRotation = Quaternion.identity;
         private Quaternion PreviousGoalRotation = Quaternion.identity;
         private bool recenterNextUpdate = true;
         private Vector3 boundsExtents = Vector3.one;
@@ -376,9 +374,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             if (recenterNextUpdate)
             {
                 PreviousGoalRotation = goalRotation;
-                PreviousReferencePosition = goalPosition;
-                PreviousReferenceRotation = goalRotation;
-                SnapTo(goalPosition, goalRotation);
+                SnapTo(goalPosition, goalRotation, WorkingScale);
                 recenterNextUpdate = false;
             }
             else
@@ -391,8 +387,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
                 GoalRotation = goalRotation;
                 PreviousGoalRotation = goalRotation;
-                PreviousReferencePosition = refPosition;
-                PreviousReferenceRotation = refRotation;
                 UpdateWorkingPositionToGoal();
                 UpdateWorkingRotationToGoal();
             }

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
@@ -5,14 +5,14 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
+namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 {
     /// <summary>
     /// Follow solver positions an element in front of the of the tracked target (relative to its local forward axis).
     /// The element can be loosely constrained (a.k.a. tag-along) so that it doesn't follow until the tracked target moves
     /// beyond user defined bounds.
     /// </summary>
-    [AddComponentMenu("Scripts/MRTK/Experimental/Solver/Follow")]
+    [AddComponentMenu("Scripts/MRTK/SDK/Follow")]
     public class Follow : Solver
     {
         [SerializeField]

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
@@ -41,7 +41,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             set => faceTrackedObjectWhileClamped = value;
         }
 
-        [Experimental]
         [SerializeField]
         [Tooltip("Face a user defined transform rather than using the solver orientation type.")]
         private bool faceUserDefinedTargetTransform = false;

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
@@ -1,16 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
+namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
 {
     /// <summary>
     /// Follow solver positions an element in front of the of the tracked target (relative to its local forward axis).
     /// The element can be loosely constrained (a.k.a. tag-along) so that it doesn't follow until the tracked target moves
     /// beyond user defined bounds.
-    /// </summary> 
-    [AddComponentMenu("Scripts/MRTK/SDK/Follow")]
+    /// </summary>
+    [AddComponentMenu("Scripts/MRTK/Experimental/Solver/Follow")]
     public class Follow : Solver
     {
         [SerializeField]
@@ -39,6 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             set => faceTrackedObjectWhileClamped = value;
         }
 
+        [Experimental]
         [SerializeField]
         [Tooltip("Face a user defined transform rather than using the solver orientation type.")]
         private bool faceUserDefinedTargetTransform = false;
@@ -365,7 +368,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
             // Distance clamp to determine goal position to place the element
             Vector3 goalPosition = currentPosition;
-            if (!ignoreDistanceClamp)
+            if (!ignoreDistanceClamp && !recenterNextUpdate)
             {
                 wasClamped |= DistanceClamp(currentPosition, refPosition, goalDirection, ref goalPosition);
             }
@@ -374,22 +377,29 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             Quaternion goalRotation = Quaternion.identity;
             ComputeOrientation(goalPosition, wasClamped, ref goalRotation);
 
-            // Avoid drift by not updating the goal position when not clamped
-            if (wasClamped)
+            if (recenterNextUpdate)
             {
-                GoalPosition = goalPosition;
+                PreviousGoalRotation = goalRotation;
+                PreviousReferencePosition = goalPosition;
+                PreviousReferenceRotation = goalRotation;
+                SnapTo(goalPosition, goalRotation);
+                recenterNextUpdate = false;
             }
+            else
+            {
+                // Avoid drift by not updating the goal position when not clamped
+                if (wasClamped)
+                {
+                    GoalPosition = goalPosition;
+                }
 
-            GoalRotation = goalRotation;
-
-            PreviousGoalRotation = goalRotation;
-
-            PreviousReferencePosition = refPosition;
-            PreviousReferenceRotation = refRotation;
-            recenterNextUpdate = false;
-
-            UpdateWorkingPositionToGoal();
-            UpdateWorkingRotationToGoal();
+                GoalRotation = goalRotation;
+                PreviousGoalRotation = goalRotation;
+                PreviousReferencePosition = refPosition;
+                PreviousReferenceRotation = refRotation;
+                UpdateWorkingPositionToGoal();
+                UpdateWorkingRotationToGoal();
+            }
         }
 
         /// <summary>
@@ -437,7 +447,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         /// <summary>
-        /// This method ensures that the refForward vector remains within the bounds set by the 
+        /// This method ensures that the refForward vector remains within the bounds set by the
         /// leashing parameters. To do this, it determines the angles between toTarget and the reference
         /// local xz and yz planes. If these angles fall within the leashing bounds, then we don't have
         /// to modify refForward. Otherwise, we apply a correction rotation to bring it within bounds.
@@ -555,7 +565,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         /// <summary>
-        /// This method ensures that the distance from clampedPosition to the tracked target remains within 
+        /// This method ensures that the distance from clampedPosition to the tracked target remains within
         /// the bounds set by the leashing parameters. To do this, it clamps the current distance to these
         /// bounds and then uses this clamped distance with refForward to calculate the new position. If
         /// IgnoreReferencePitchAndRoll is true and we have a PitchOffset, we only apply these calculations


### PR DESCRIPTION
## Overview
Fixes the re-centering logic in the Follow Solver for both Recenter() method.

## Changes
- Fixes: recenterNextUpdate wasn't being considered in several calculations. Now when this flag is set, the follow solver will instantaneously move the object in front of the user at the default distance.

Fixes: #8152