### PR TITLE
Fixed hand ray not showing up on Oculus

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -182,6 +182,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             }
         }
 
+        /// <inheritdoc/>
+        public override bool IsInPointingPose => handDefinition.IsInPointingPose;
+
         protected bool IsPinching { set; get; }
 
         // Pinch was also used as grab, we want to allow hand-curl grab not just pinch.


### PR DESCRIPTION
## Overview
Fixed regression with Oculus Hand pointer not displaying properly after moving towards using the Articulated Hand Definition for detecting Teleport Gestures
