### PR TITLE
Clean up speech recognizer logs in test runner batch mode

### DIFF
--- a/Assets/MRTK/Providers/Windows/WindowsDictationInputProvider.cs
+++ b/Assets/MRTK/Providers/Windows/WindowsDictationInputProvider.cs
@@ -284,7 +284,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             }
             catch (System.Exception ex)
             {
-                Debug.LogWarning($"Failed to start dictation recognizer. Are microphone permissions granted? Exception: {ex}");
+                // Don't log if the application is currently running in batch mode (for example, when running tests). This failure is expected in this case.
+                if (!Application.isBatchMode)
+                {
+                    Debug.LogWarning($"Failed to start dictation recognizer. Are microphone permissions granted? Exception: {ex}");
+                }
                 Disable();
                 dictationRecognizer = null;
             }

--- a/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
+++ b/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
@@ -169,7 +169,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"Failed to start keyword recognizer. Are microphone permissions granted? Exception: {ex}");
+                // Don't log if the application is currently running in batch mode (for example, when running tests). This failure is expected in this case.
+                if (!Application.isBatchMode)
+                {
+                    Debug.LogWarning($"Failed to start keyword recognizer. Are microphone permissions granted? Exception: {ex}");
+                }
                 keywordRecognizer = null;
                 return;
             }


### PR DESCRIPTION
## Overview

To prevent our play mode test logs from being 18300 lines long, mostly [filled with speech exceptions](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=15958&view=logs&j=c1841906-0df4-5516-e3c5-68840a78c082&t=74fd8acb-620e-53b4-2aaa-89fc9e6ab02f&l=18300), this PR blocks our log from printing when running via batch mode. Speech not being supported in batch mode is expected.