### PR TITLE
Update GGVPointer look rotation

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -309,6 +309,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #endregion  IMixedRealityInputHandler Implementation
 
+        #region MonoBehaviour Implementation
+
         protected override void OnEnable()
         {
             base.OnEnable();
@@ -333,6 +335,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
         }
+
+        #endregion MonoBehaviour Implementation
 
         #region InputSystemGlobalHandlerListener Implementation
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -226,6 +226,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // Now we're returning a rotation based on the vector from the camera position
                 // to the hand. This rotation is not affected by rotating your head.
                 Vector3 look = Position - CameraCache.Main.transform.position;
+
+                // If the input source is at the same position as the camera, assume it's the camera and return the InternalGazeProvider rotation.
+                // This prevents passing Vector3.zero into Quaternion.LookRotation, which isn't possible and causes a console log.
+                if (look == Vector3.zero)
+                {
+                    return Quaternion.LookRotation(gazeProvider.GazePointer.Rays[0].Direction);
+                }
+
                 return Quaternion.LookRotation(look);
             }
         }


### PR DESCRIPTION
## Overview

In the case where the hand hasn't moved, so no `OnInputChanged<MixedRealityPose>` event has been raised (which is the case in several of our tests), this method will fail and print out "Look rotation viewing vector is zero", because...it's hard to look in no direction. This updates the method to always look in a valid direction.

## Changes
- Fixes
    ![image](https://user-images.githubusercontent.com/3580640/103251241-d07a5980-492c-11eb-813b-d67a09805de5.png)
