### PR TITLE
Move caret index to end when open keyboard

### DIFF
--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
@@ -225,6 +225,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
             onShowKeyboard?.Invoke();
 
+            // if initial Text is not empty, cart index will be placed at the end when open keyboard (Maybe it's common in most case)
+            MovePreviewCaretToEnd()
+
             if (stateUpdate == null)
             {
                 stateUpdate = StartCoroutine(UpdateState());


### PR DESCRIPTION
## Overview
It just a minor change in "MixedRealityKeyboardBase.cs"
In most cases, the caret index needs to be at the end of the string.
So when open the keyboard with non-empty text, it should put caret index to the end.

## Changes
- Add: "MixedRealityKeyboardBase.cs" -> "ShowKeyboard" -> Add "MovePreviewCaretToEnd()" at the end

