### PR TITLE
Clean up more test logs

### DIFF
--- a/Assets/MRTK/Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
@@ -473,7 +473,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core
             {
                 Scene scene = SceneManager.GetSceneAt(i);
                 SceneManager.SetActiveScene(scene);
-                MixedRealityToolkit newInstance = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+                _ = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
             }
 
             MixedRealityToolkit[] instances = GameObject.FindObjectsOfType<MixedRealityToolkit>();

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
             Assert.IsNotNull(bbox);
 
-            GameObject.Destroy(bbox.gameObject);
+            Object.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
         }
@@ -121,8 +121,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Debug.Assert(b.center == bc.center, $"bounds center should be {bc.center} but they are {b.center}");
             Debug.Assert(b.size == bc.size, $"bounds size should be {bc.size} but they are {b.size}");
 
-            GameObject.Destroy(bbox.gameObject);
-            GameObject.Destroy(newObject);
+            Object.Destroy(bbox.gameObject);
+            Object.Destroy(newObject);
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
         }
@@ -188,8 +188,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 Debug.Assert(bc.size == expectedSize, $"boundsOverride's size was corrupted.");
             }
 
-            GameObject.Destroy(bbox.gameObject);
-            GameObject.Destroy(newObject);
+            Object.Destroy(bbox.gameObject);
+            Object.Destroy(newObject);
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
         }
@@ -217,8 +217,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(new Vector3(0, 0, 1.5f), bounds.center);
             Assert.AreEqual(new Vector3(.5f, .5f, .5f), bounds.size);
 
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-
             // Defining the edge and corner handlers that will be used
             Debug.Log(bbox.transform.Find("rigRoot/midpoint_0").GetChild(0));
             var originalCornerHandlerScale = bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale;
@@ -232,7 +230,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Move the hand to a handler on the corner 
             TestHand rightHand = new TestHand(Handedness.Right);
             yield return rightHand.Show(new Vector3(0, 0, 0.5f));
-            var delta = new Vector3(0.1f, 0.1f, 0f);
             yield return rightHand.MoveTo(cornerHandlerPosition, numSteps);
 
             // Wait for the scaling/unscaling animation to finish
@@ -251,7 +248,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestUtilities.AssertAboutEqual(bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale.normalized, originalEdgeHandlerScale.normalized, "The edge handler scale has changed");
             Assert.AreApproximatelyEqual(bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale.x / originalEdgeHandlerScale.x, bbox.MediumScale, 0.1f, "The edge handler did not grow when a pointer was near it");
 
-            GameObject.Destroy(bbox.gameObject);
+            Object.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
         }
@@ -270,8 +267,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(new Vector3(0, 0, 1.5f), bounds.center);
             Assert.AreEqual(new Vector3(.5f, .5f, .5f), bounds.size);
 
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-
             // front right corner is corner 3
             var frontRightCornerPos = bbox.ScaleCorners[3].transform.position;
 
@@ -286,10 +281,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center");
             TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .567f, "endBounds incorrect size");
 
-            GameObject.Destroy(bbox.gameObject);
+            Object.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
-
         }
 
         /// <summary>
@@ -336,7 +330,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Assert scale at min
             Assert.AreEqual(Vector3.one * scaleHandler.ScaleMinimum, bbox.transform.localScale);
 
-            GameObject.Destroy(bbox.gameObject);
+            Object.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
 
@@ -427,7 +421,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center", 0.02f);
             TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .561f, "endBounds incorrect size", 0.02f);
 
-            GameObject.Destroy(bbox.gameObject);
+            Object.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
 
@@ -482,7 +476,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center", 0.02f);
             TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .561f, "endBounds incorrect size", 0.02f);
 
-            GameObject.Destroy(bbox.gameObject);
+            Object.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
 
@@ -534,7 +528,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 cc0_rotated = c0.transform.position - bboxBottomCenter;
             Assert.AreApproximatelyEqual(Vector3.Angle(cc0, cc0_rotated), 30, $"rotated angle is not correct. expected {rotateAmount} but got {Vector3.Angle(cc0, cc0_rotated)}");
 
-            GameObject.Destroy(bbox.gameObject);
+            Object.Destroy(bbox.gameObject);
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
@@ -697,7 +697,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             moveConstraint.UseLocalSpaceForConstraint = true;
             moveConstraint.ConstraintOnMovement = AxisFlags.XAxis | AxisFlags.YAxis;
 
-            var constraint = manipHandler.EnsureComponent<MaintainApparentSizeConstraint>();
+            manipHandler.EnsureComponent<MaintainApparentSizeConstraint>();
 
             Vector3 topLeft = testObject.transform.TransformPoint(new Vector3(-0.5f, 0.5f, -0.5f));
             Vector3 bottomRight = testObject.transform.TransformPoint(new Vector3(0.5f, -0.5f, -0.5f));
@@ -742,7 +742,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             testObject.transform.localScale = new Vector3(0.2f, 0.2f, 0.001f);
             testObject.transform.position = new Vector3(0f, 0f, 1f);
             TestUtilities.PlaceRelativeToPlayspace(testObject.transform);
-            Vector3 initialObjectPosition = testObject.transform.position;
             var manipHandler = testObject.AddComponent<ObjectManipulator>();
             manipHandler.HostTransform = testObject.transform;
             manipHandler.SmoothingFar = false;
@@ -750,7 +749,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             manipHandler.ManipulationType = ManipulationHandFlags.OneHanded;
             manipHandler.OneHandRotationModeNear = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
-            var constraint = manipHandler.EnsureComponent<FixedRotationToUserConstraint>();
+            manipHandler.EnsureComponent<FixedRotationToUserConstraint>();
 
             // add near interaction grabbable to be able to grab the cube with the simulated articulated hand
             testObject.AddComponent<NearInteractionGrabbable>();

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
@@ -125,6 +125,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return null;
 
+            // NearInteractionTouchable only works with BoxColliders
+            Object.Destroy(interactable.GetComponent<Collider>());
+            interactable.gameObject.AddComponent<BoxCollider>();
+
             // Add a touchable and configure for touch events
             NearInteractionTouchable touchable = interactable.gameObject.AddComponent<NearInteractionTouchable>();
             touchable.EventsToReceive = TouchableEventType.Touch;
@@ -270,7 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             AssembleInteractableButton(
                 out Interactable interactable,
-                out Transform translateTargetObject);
+                out _);
 
             // Test Button type
             interactable.NumOfDimensions = 1;
@@ -364,7 +368,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(wasClicked, "Interactable was not clicked.");
             Assert.True(interactable.IsVisited, "Interactable was not visited.");
 
-            GameObject.Destroy(interactable.gameObject);
+            Object.Destroy(interactable.gameObject);
         }
 
         /// <summary>
@@ -376,7 +380,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestButtonUtilities.InstantiateDefaultButton(
                 TestButtonUtilities.DefaultButtonType.DefaultPushButton,
                 out Interactable interactable,
-                out Transform translateTargetObject);
+                out _);
 
             interactable.gameObject.AddComponent<NearInteractionTouchableVolume>();
 
@@ -905,12 +909,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Pose noRollPose = restorePose;
             noRollPose.rotation.eulerAngles = new Vector3(noRollPose.rotation.eulerAngles.x, noRollPose.rotation.eulerAngles.y, 0.0f);
             TestUtilities.ArbitraryPlayspacePose = noRollPose;
-            TestUtilities.PlayspaceToArbitraryPose();
 
+            TestUtilities.PlayspaceToArbitraryPose();
             TestButtonUtilities.InstantiateDefaultButton(
                 TestButtonUtilities.DefaultButtonType.DefaultHL2Button,
                 out Interactable interactable,
-                out Transform interactableTransform);
+                out _);
 
             interactable.transform.position = TestUtilities.PositionRelativeToPlayspace(new Vector3(0.0f, 0.1f, 0.4f));
             Assert.True(interactable.IsEnabled);
@@ -1023,7 +1027,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 Assert.True(wasClicked, "Interactable was not clicked.");
             }
 
-            GameObject.Destroy(result);
+            Object.Destroy(result);
         }
 
         #region Test Helpers
@@ -1053,7 +1057,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             childObject.transform.localPosition = new Vector3(0f, 1.5f, 0f);
             childObject.transform.localRotation = Quaternion.identity;
             // Only use a collider on the main object
-            GameObject.Destroy(childObject.GetComponent<Collider>());
+            Object.Destroy(childObject.GetComponent<Collider>());
 
             translateTargetObject = childObject.transform;
 

--- a/Assets/MRTK/Tests/PlayModeTests/NearInteractionGrabbableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/NearInteractionGrabbableTests.cs
@@ -11,7 +11,6 @@
 // play mode tests in this check.
 
 using Microsoft.MixedReality.Toolkit.Input;
-using NUnit.Framework;
 using System.Collections;
 using System.Text.RegularExpressions;
 using UnityEngine;

--- a/Assets/MRTK/Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PressableButtonTests.cs
@@ -16,7 +16,6 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -635,9 +634,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             GameObject emptyParent = new GameObject();
             emptyParent.transform.position = testButton.transform.position;
             // This should not cause any NaN errors, as per resolution to #7874
-            emptyParent.transform.localScale = Vector3.zero; 
+            emptyParent.transform.localScale = Vector3.zero;
             // Parent our button to the empty object.
-            testButton.transform.parent = emptyParent.transform;
+            testButton.transform.SetParent(emptyParent.transform, false);
             yield return null;
 
             // Scale up the parent. Should not throw NaN exceptions.

--- a/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
@@ -10,12 +10,9 @@
 // issue will likely persist for 2018, this issue is worked around by wrapping all
 // play mode tests in this check.
 
-using Microsoft.MixedReality.Toolkit.Editor;
-using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -169,7 +166,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Generate default theme properties for InteractableRotationTheme. 
             // Set Relative Rotation property (index=0) to true so theme values are applied in addition instead of absolutely set
-            // Set Local Rotation property (index=1) to false so euler angles are world space
+            // Set Local Rotation property (index=1) to false so Euler angles are world space
             var defaultThemeProperties = (new InteractableRotationTheme()).GetDefaultThemeDefinition().CustomProperties;
             defaultThemeProperties[0].Value.Bool = true;
             defaultThemeProperties[1].Value.Bool = false;
@@ -476,7 +473,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Action<GameObject, InteractableThemeBase> resetTest,
             params Action<InteractableThemeBase>[] stateTests)
             where T : InteractableThemeBase
-            where C : UnityEngine.Component
+            where C : Component
         {
             yield return TestTheme<T, C>(new GameObject("TestObject"), stateValues, new List<ThemeProperty>() { }, resetTest, stateTests);
         }
@@ -487,7 +484,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Action<GameObject, InteractableThemeBase> resetTest,
             params Action<InteractableThemeBase>[] stateTests)
             where T : InteractableThemeBase
-            where C : UnityEngine.Component
+            where C : Component
         {
             yield return TestTheme<T, C>(new GameObject("TestObject"), stateValues, customProperties, resetTest, stateTests);
         }
@@ -498,7 +495,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Action<GameObject, InteractableThemeBase> resetTest,
             params Action<InteractableThemeBase>[] stateTests)
             where T : InteractableThemeBase
-            where C : UnityEngine.Component
+            where C : Component
         {
             yield return TestTheme<T, C>(host, stateValues, new List<ThemeProperty>() { }, resetTest, stateTests);
         }
@@ -510,7 +507,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Action<GameObject, InteractableThemeBase> resetTest,
             params Action<InteractableThemeBase>[] stateTests)
             where T : InteractableThemeBase
-            where C : UnityEngine.Component
+            where C : Component
         {
             foreach (List<ThemePropertyValue> values in stateValues)
             {
@@ -536,9 +533,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             ThemeDefinition themeDefinition,
             Action<GameObject, InteractableThemeBase> resetTest,
             params Action<InteractableThemeBase>[] stateTests)
-            where C : UnityEngine.Component
+            where C : Component
         {
-            host.AddComponent<C>();
+            host.EnsureComponent<C>();
 
             var theme = InteractableThemeBase.CreateAndInitTheme(themeDefinition, host);
 


### PR DESCRIPTION
## Overview

Follow-up to #9080 and #9081. Removes the following logs:

1. `Can't add component 'MeshRenderer' to Cube because such a component is already added to the game object!`
    1. We were trying to add a mesh renderer when we didn't need to. Uses `EnsureComponent` now
1. `Parent of RectTransform is being set with parent property. Consider using the SetParent method instead, with the worldPositionStays argument set to false. This will retain local orientation and scale rather than world orientation and scale, which can prevent common UI scaling issues.`
1. `BoxCollider is null, cannot set bounds of NearInteractionTouchable plane`

and some other assorted clean-up of unused local variables and method call simplification.
