### PR TITLE
Add support for HP Reverb G2 controllers and update WMRController with definition

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
     [MixedRealityController(
         SupportedControllerType.OculusTouch,
         new[] { Handedness.Left, Handedness.Right },
-        "StandardAssets/Textures/OculusControllersTouch")]
+        "Textures/OculusControllersTouch")]
     public class OculusXRSDKTouchController : GenericXRSDKController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/HPMotionController.cs
+++ b/Assets/MRTK/Providers/OpenVR/HPMotionController.cs
@@ -12,8 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.HPMotionController,
-        new[] { Handedness.Left, Handedness.Right },
-        "Textures/MotionController")]
+        new[] { Handedness.Left, Handedness.Right })]
     public class HPMotionController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenXR/Profiles/DefaultOpenXRControllerMappingProfile.asset
+++ b/Assets/MRTK/Providers/OpenXR/Profiles/DefaultOpenXRControllerMappingProfile.asset
@@ -2681,6 +2681,354 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.OpenXR.HPReverbG2Controller,
+        Microsoft.MixedReality.Toolkit.Providers.OpenXR
+    handedness: 1
+    interactions:
+    - id: 0
+      description: Spatial Pointer
+      axisType: 7
+      inputType: 3
+      inputAction:
+        id: 4
+        description: Pointer Pose
+        axisConstraint: 7
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 1
+      description: Spatial Grip
+      axisType: 7
+      inputType: 14
+      inputAction:
+        id: 3
+        description: Grip Pose
+        axisConstraint: 7
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 2
+      description: Grip Position
+      axisType: 3
+      inputType: 57
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 3
+      description: Grip Touch
+      axisType: 2
+      inputType: 58
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 4
+      description: Grip Press
+      axisType: 3
+      inputType: 60
+      inputAction:
+        id: 7
+        description: Grip Press
+        axisConstraint: 3
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 5
+      description: Trigger Position
+      axisType: 3
+      inputType: 10
+      inputAction:
+        id: 6
+        description: Trigger
+        axisConstraint: 3
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 6
+      description: Trigger Touch
+      axisType: 2
+      inputType: 11
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 7
+      description: Trigger Press (Select)
+      axisType: 2
+      inputType: 25
+      inputAction:
+        id: 1
+        description: Select
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 8
+      description: Button.X Press
+      axisType: 2
+      inputType: 51
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 9
+      description: Button.Y Press
+      axisType: 2
+      inputType: 54
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 10
+      description: Menu Press
+      axisType: 2
+      inputType: 27
+      inputAction:
+        id: 2
+        description: Menu
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 11
+      description: Thumbstick Position
+      axisType: 4
+      inputType: 17
+      inputAction:
+        id: 5
+        description: Teleport Direction
+        axisConstraint: 4
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 12
+      description: Thumbstick Press
+      axisType: 2
+      inputType: 18
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+  - controllerType:
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.OpenXR.HPReverbG2Controller,
+        Microsoft.MixedReality.Toolkit.Providers.OpenXR
+    handedness: 2
+    interactions:
+    - id: 0
+      description: Spatial Pointer
+      axisType: 7
+      inputType: 3
+      inputAction:
+        id: 4
+        description: Pointer Pose
+        axisConstraint: 7
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 1
+      description: Spatial Grip
+      axisType: 7
+      inputType: 14
+      inputAction:
+        id: 3
+        description: Grip Pose
+        axisConstraint: 7
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 2
+      description: Grip Position
+      axisType: 3
+      inputType: 57
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 3
+      description: Grip Touch
+      axisType: 2
+      inputType: 58
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 4
+      description: Grip Press
+      axisType: 3
+      inputType: 60
+      inputAction:
+        id: 7
+        description: Grip Press
+        axisConstraint: 3
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 5
+      description: Trigger Position
+      axisType: 3
+      inputType: 10
+      inputAction:
+        id: 6
+        description: Trigger
+        axisConstraint: 3
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 6
+      description: Trigger Touch
+      axisType: 2
+      inputType: 11
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 7
+      description: Trigger Press (Select)
+      axisType: 2
+      inputType: 25
+      inputAction:
+        id: 1
+        description: Select
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 8
+      description: Button.A Press
+      axisType: 2
+      inputType: 51
+      inputAction:
+        id: 1
+        description: Select
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 9
+      description: Button.B Press
+      axisType: 2
+      inputType: 54
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 10
+      description: Menu Press
+      axisType: 2
+      inputType: 27
+      inputAction:
+        id: 2
+        description: Menu
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 11
+      description: Thumbstick Position
+      axisType: 4
+      inputType: 17
+      inputAction:
+        id: 5
+        description: Teleport Direction
+        axisConstraint: 4
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 12
+      description: Thumbstick Press
+      axisType: 2
+      inputType: 18
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+  - controllerType:
       reference: Microsoft.MixedReality.Toolkit.XRSDK.OpenXR.MicrosoftArticulatedHand,
         Microsoft.MixedReality.Toolkit.Providers.OpenXR
     handedness: 1

--- a/Assets/MRTK/Providers/OpenXR/Scripts/HPReverbG2Controller.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/HPReverbG2Controller.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.XRSDK.Input;
+using Unity.Profiling;
+using UnityEngine;
+using UnityEngine.XR;
+
+namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
+{
+    [MixedRealityController(
+        SupportedControllerType.HPMotionController,
+        new[] { Handedness.Left, Handedness.Right })]
+    public class HPReverbG2Controller : GenericXRSDKController
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public HPReverbG2Controller(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
+                : base(trackingState, controllerHandedness, inputSource, interactions)
+        {
+            controllerDefinition = new HPMotionControllerDefinition(inputSource, controllerHandedness);
+        }
+
+        /// <inheritdoc />
+        public override MixedRealityInteractionMapping[] DefaultLeftHandedInteractions => controllerDefinition.DefaultLeftHandedInteractions;
+
+        /// <inheritdoc />
+        public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => controllerDefinition.DefaultRightHandedInteractions;
+
+        private readonly HPMotionControllerDefinition controllerDefinition = null;
+
+        private Vector3 currentPointerPosition = Vector3.zero;
+        private Quaternion currentPointerRotation = Quaternion.identity;
+        private MixedRealityPose currentPointerPose = MixedRealityPose.ZeroIdentity;
+
+        private static readonly ProfilerMarker UpdatePoseDataPerfMarker = new ProfilerMarker("[MRTK] HPReverbG2Controller.UpdatePoseData");
+
+        /// <summary>
+        /// Update spatial pointer and spatial grip data.
+        /// </summary>
+        protected override void UpdatePoseData(MixedRealityInteractionMapping interactionMapping, InputDevice inputDevice)
+        {
+            using (UpdatePoseDataPerfMarker.Auto())
+            {
+                Debug.Assert(interactionMapping.AxisType == AxisType.SixDof);
+
+                // Update the interaction data source
+                switch (interactionMapping.InputType)
+                {
+                    case DeviceInputType.SpatialPointer:
+                        if (inputDevice.TryGetFeatureValue(CustomUsages.PointerPosition, out currentPointerPosition))
+                        {
+                            currentPointerPose.Position = MixedRealityPlayspace.TransformPoint(currentPointerPosition);
+                        }
+
+                        if (inputDevice.TryGetFeatureValue(CustomUsages.PointerRotation, out currentPointerRotation))
+                        {
+                            currentPointerPose.Rotation = MixedRealityPlayspace.Rotation * currentPointerRotation;
+                        }
+
+                        interactionMapping.PoseData = currentPointerPose;
+
+                        // If our value changed raise it.
+                        if (interactionMapping.Changed)
+                        {
+                            // Raise input system event if it's enabled
+                            CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.PoseData);
+                        }
+                        break;
+                    default:
+                        base.UpdatePoseData(interactionMapping, inputDevice);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/Assets/MRTK/Providers/OpenXR/Scripts/HPReverbG2Controller.cs.meta
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/HPReverbG2Controller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 287c21dda7da37a4c88a1f7a3dba1e64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftMotionController.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftMotionController.cs
@@ -23,24 +23,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// Constructor.
         /// </summary>
         public MicrosoftMotionController(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
-                : base(trackingState, controllerHandedness, inputSource, interactions) { }
+                : base(trackingState, controllerHandedness, inputSource, interactions)
+        {
+            controllerDefinition = new WindowsMixedRealityControllerDefinition(inputSource, controllerHandedness);
+        }
 
         /// <inheritdoc />
-        public override MixedRealityInteractionMapping[] DefaultInteractions => new[]
-        {
-            new MixedRealityInteractionMapping(0, "Spatial Pointer", AxisType.SixDof, DeviceInputType.SpatialPointer),
-            new MixedRealityInteractionMapping(1, "Spatial Grip", AxisType.SixDof, DeviceInputType.SpatialGrip),
-            new MixedRealityInteractionMapping(2, "Grip Press", AxisType.SingleAxis, DeviceInputType.GripPress),
-            new MixedRealityInteractionMapping(3, "Trigger Position", AxisType.SingleAxis, DeviceInputType.Trigger),
-            new MixedRealityInteractionMapping(4, "Trigger Touch", AxisType.Digital, DeviceInputType.TriggerTouch),
-            new MixedRealityInteractionMapping(5, "Trigger Press (Select)", AxisType.Digital, DeviceInputType.Select),
-            new MixedRealityInteractionMapping(6, "Touchpad Position", AxisType.DualAxis, DeviceInputType.Touchpad),
-            new MixedRealityInteractionMapping(7, "Touchpad Touch", AxisType.Digital, DeviceInputType.TouchpadTouch),
-            new MixedRealityInteractionMapping(8, "Touchpad Press", AxisType.Digital, DeviceInputType.TouchpadPress),
-            new MixedRealityInteractionMapping(9, "Menu Press", AxisType.Digital, DeviceInputType.Menu),
-            new MixedRealityInteractionMapping(10, "Thumbstick Position", AxisType.DualAxis, DeviceInputType.ThumbStick),
-            new MixedRealityInteractionMapping(11, "Thumbstick Press", AxisType.Digital, DeviceInputType.ThumbStickPress),
-        };
+        public override MixedRealityInteractionMapping[] DefaultInteractions => controllerDefinition?.DefaultInteractions;
+
+        private readonly WindowsMixedRealityControllerDefinition controllerDefinition = null;
 
         private Vector3 currentPointerPosition = Vector3.zero;
         private Quaternion currentPointerRotation = Quaternion.identity;

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftMotionController.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftMotionController.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
     [MixedRealityController(
         SupportedControllerType.WindowsMixedReality,
         new[] { Handedness.Left, Handedness.Right },
-        "StandardAssets/Textures/MotionController")]
+        "Textures/MotionController")]
     public class MicrosoftMotionController : GenericXRSDKController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -104,6 +104,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             {
                 case SupportedControllerType.WindowsMixedReality:
                     return typeof(MicrosoftMotionController);
+                case SupportedControllerType.HPMotionController:
+                    return typeof(HPReverbG2Controller);
                 case SupportedControllerType.ArticulatedHand:
                     return typeof(MicrosoftArticulatedHand);
                 default:
@@ -117,6 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             switch (supportedControllerType)
             {
                 case SupportedControllerType.WindowsMixedReality:
+                case SupportedControllerType.HPMotionController:
                     return InputSourceType.Controller;
                 case SupportedControllerType.ArticulatedHand:
                     return InputSourceType.Hand;
@@ -135,7 +138,14 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
             if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Controller))
             {
-                return SupportedControllerType.WindowsMixedReality;
+                if (inputDevice.manufacturer == "HP")
+                {
+                    return SupportedControllerType.HPMotionController;
+                }
+                else // Fall back to the base WMR controller
+                {
+                    return SupportedControllerType.WindowsMixedReality;
+                }
             }
 
             return base.GetCurrentControllerType(inputDevice);

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/HPMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/HPMotionController.cs
@@ -40,7 +40,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         }
 
         private readonly HPMotionControllerDefinition controllerDefinition;
+
+        /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultLeftHandedInteractions => controllerDefinition.DefaultLeftHandedInteractions;
+
+        /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => controllerDefinition.DefaultRightHandedInteractions;
 
         private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] HPController.UpdateController");

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR;
@@ -16,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
     [MixedRealityController(
         SupportedControllerType.WindowsMixedReality,
         new[] { Handedness.Left, Handedness.Right },
-        "StandardAssets/Textures/MotionController")]
+        "Textures/MotionController")]
     public class WindowsMixedRealityXRSDKMotionController : BaseWindowsMixedRealityXRSDKSource
     {
         /// <summary>

--- a/Assets/MRTK/Tools/RuntimeTools/Tools/InputFeatureUsageTool/ListInputFeatureUsages.cs
+++ b/Assets/MRTK/Tools/RuntimeTools/Tools/InputFeatureUsageTool/ListInputFeatureUsages.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Tools.Runtime
 
                 InputDevice inputDevice = inputDevices[i];
 
-                listInputDevicesTextMesh.text += $"{inputDevice.name}\n";
+                listInputDevicesTextMesh.text += $"{inputDevice.name} | {inputDevice.manufacturer} | {inputDevice.serialNumber}\n";
                 textMesh.text = $"{inputDevice.name}\n";
 
                 if (inputDevice.TryGetFeatureUsages(featureUsages))


### PR DESCRIPTION
## Overview

1. Adds OpenXR support for HP Reverb G2 controllers
1. Fixes some cases where the controller image wasn't loading properly
2. Refactor out the existing WMRController definition for the OpenXR class