### PR TITLE
Add OpenXR to link.xml

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitPreserveSettings.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitPreserveSettings.cs
@@ -41,6 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             "  <!-- Data providers --> \n" +
             "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.LeapMotion\" preserve=\"all\"/> \n" +
             "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.OpenVR\" preserve=\"all\"/> \n" +
+            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.OpenXR\" preserve=\"all\"/> \n" +
             "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.UnityAR\" preserve=\"all\"/> \n" +
             "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared\" preserve=\"all\"/> \n" +
             "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality\" preserve=\"all\"/> \n" +


### PR DESCRIPTION
## Overview

This is currently a manual step for 2.5.3, since I completely missed adding it. Will add the step to the 2.5.3 docs.

We should probably try to find a better way to do this, instead of blanket-preserving the entire assemblies, as pointed out at https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5273#issuecomment-513974004.