### PR TITLE
Fix MSBuild in Unity 2019 for docs

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/MSBuildMRTKTemplates/SDKProjectTemplate.csproj.template
+++ b/Assets/MRTK/Tools/MSBuild/MSBuildMRTKTemplates/SDKProjectTemplate.csproj.template
@@ -150,7 +150,7 @@
   </Target>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y $(TargetDir)$(TargetName).dll $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y $(TargetDir)$(TargetName).pdb $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\" />
+    <Exec Command="xcopy /y $(TargetDir)$(TargetName).dll $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y $(TargetDir)$(TargetName).pdb $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y $(TargetDir)$(TargetName).xml $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\" />
   </Target>
 
 </Project>

--- a/Assets/MRTK/Tools/MSBuild/Scripts/CSProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/CSProjectInfo.cs
@@ -243,13 +243,15 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             switch (sourceFile.AssetLocation)
             {
                 case AssetLocation.BuiltInPackage:
-                    relativeSourcePath = sourceFile.File.FullName;
                     return;
                 case AssetLocation.Project:
                     relativeSourcePath = $"..\\..\\{Utilities.GetAssetsRelativePathFrom(sourceFile.File.FullName)}";
                     break;
                 case AssetLocation.Package:
                     relativeSourcePath = $"..\\{Utilities.GetPackagesRelativePathFrom(sourceFile.File.FullName)}";
+                    break;
+                case AssetLocation.BuiltInPackageWithSource:
+                    relativeSourcePath = Path.GetFullPath(sourceFile.File.FullName);
                     break;
                 default: throw new InvalidDataException("Unknown asset location.");
             }

--- a/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
@@ -30,9 +30,14 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         Package,
 
         /// <summary>
-        /// Inside the Packages folder shipped with the Unity version.
+        /// Inside the Packages folder shipped with the Unity version (without source).
         /// </summary>
-        BuiltInPackage
+        BuiltInPackage,
+
+        /// <summary>
+        /// Inside the Packages folder shipped with the Unity version (with source).
+        /// </summary>
+        BuiltInPackageWithSource
     }
 
     /// <summary>
@@ -145,6 +150,12 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             {
                 return AssetLocation.Project;
             }
+#if UNITY_2019_3_OR_NEWER
+            else if (UnityProjectInfo.SpecialPluginNameMappingUnity2019.Keys.Any(s => absolutePath.ToLower().Contains(s.ToLower())))
+            {
+                return AssetLocation.BuiltInPackageWithSource;
+            }
+#endif
             else if (absolutePath.Contains(packagesPath) || absolutePath.Contains(PackagesCopyPath))
             {
                 return AssetLocation.Package;

--- a/NuGet/BuildSource.proj
+++ b/NuGet/BuildSource.proj
@@ -5,37 +5,37 @@
   </ItemGroup>
 
   <Target Name="BuildStandaloneEditor">
-    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=InEditor;Platform=WindowsStandalone32;BuildProjectReferences=false">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=InEditor;Platform=WindowsStandalone32;BuildProjectReferences=false;GenerateDocumentationFile=true">
       <Output TaskParameter="TargetOutputs" ItemName="BuildStandaloneEditorOutputs" /><!--AssembliesBuiltByChildProjects-->
     </MSBuild>
   </Target>
 
   <Target Name="BuildWSAEditor">
-    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=InEditor;Platform=WSA;BuildProjectReferences=false">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=InEditor;Platform=WSA;BuildProjectReferences=false;GenerateDocumentationFile=true">
       <Output TaskParameter="TargetOutputs" ItemName="BuildWSAEditorOutputs" /><!--AssembliesBuiltByChildProjects-->
     </MSBuild>
   </Target>
 
   <Target Name="BuildStandalonePlayer">
-    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WindowsStandalone32;BuildProjectReferences=false">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WindowsStandalone32;BuildProjectReferences=false;GenerateDocumentationFile=true">
       <Output TaskParameter="TargetOutputs" ItemName="BuildStandalonePlayerOutputs" />
     </MSBuild>
   </Target>
 
   <Target Name="BuildAndroidPlayer">
-    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=Android;BuildProjectReferences=false">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=Android;BuildProjectReferences=false;GenerateDocumentationFile=true">
       <Output TaskParameter="TargetOutputs" ItemName="BuildAndroidPlayerOutputs" />
     </MSBuild>
   </Target>
   
   <Target Name="BuildIOSPlayer">
-    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=IOS;BuildProjectReferences=false">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=IOS;BuildProjectReferences=false;GenerateDocumentationFile=true">
       <Output TaskParameter="TargetOutputs" ItemName="BuildIOSPlayerOutputs" />
     </MSBuild>
   </Target>
 
   <Target Name="BuildWSAPlayer">
-    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WSA;BuildProjectReferences=false;MSBuildExtensionsPathOverride=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WSA;BuildProjectReferences=false;MSBuildExtensionsPathOverride=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild;GenerateDocumentationFile=true">
       <Output TaskParameter="TargetOutputs" ItemName="BuildWSAPlayerOutputs" />
     </MSBuild>
   </Target>


### PR DESCRIPTION
## Overview
Fix issues preventing MSBuild from working in Unity 2019. Some of the changes are specific to the doc generation task.