### PR TITLE
Fix for errors occuring when no GazeProvider is selected.

### DIFF
--- a/Assets/MRTK/Core/Providers/BaseGenericInputSource.cs
+++ b/Assets/MRTK/Core/Providers/BaseGenericInputSource.cs
@@ -20,7 +20,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             SourceId = (CoreServices.InputSystem != null) ? CoreServices.InputSystem.GenerateNewSourceId() : 0;
             SourceName = name;
-            Pointers = pointers ?? new[] { CoreServices.InputSystem?.GazeProvider?.GazePointer };
+            if (pointers != null)
+            {
+                Pointers = pointers;
+            }
+            else if (CoreServices.InputSystem?.GazeProvider?.GazePointer is IMixedRealityPointer gazePointer)
+            {
+                Pointers = new[] { gazePointer };
+            }
+            else
+            {
+                Pointers = new IMixedRealityPointer[] { };
+            }
 
             SourceType = sourceType;
         }

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -834,7 +834,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     RegisterPointer(inputSource.Pointers[i]);
 
                     // Special Registration for Gaze
-                    if (inputSource.SourceId == CoreServices.InputSystem.GazeProvider.GazeInputSource.SourceId && gazeProviderPointingData == null)
+                    if (inputSource.SourceId == CoreServices.InputSystem.GazeProvider?.GazeInputSource.SourceId && gazeProviderPointingData == null)
                     {
                         gazeProviderPointingData = new PointerData(inputSource.Pointers[i]);
                     }


### PR DESCRIPTION
## Overview
When not selecting a GazeProviderType in the PointerProfile a couple of issues appear.
These changes are addressing the issues arising.

## Changes
- Fixes: BaseGenericInputSource will no longer create an array with a "null"-reference if no GazeProvider is set.
- Fixes: FocusProvider now checks if GazeProvider is present before accessing its inputSource
