### PR TITLE
Code style pass for null conditions

### DIFF
--- a/Assets/MRTK/Core/Attributes/MixedRealityServiceProfileAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/MixedRealityServiceProfileAttribute.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit
         public MixedRealityServiceProfileAttribute(Type[] requiredTypes, Type[] excludedTypes = null)
         {
             RequiredTypes = requiredTypes;
-            ExcludedTypes = excludedTypes != null ? excludedTypes : new Type[0];
+            ExcludedTypes = excludedTypes ?? (new Type[0]);
         }
 
         public Type[] RequiredTypes { get; private set; }

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -219,7 +219,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private static bool UsesCustomInteractionMapping(Type controllerType)
         {
             var attribute = MixedRealityControllerAttribute.Find(controllerType);
-            return attribute != null ? attribute.Flags.HasFlag(MixedRealityControllerConfigurationFlags.UseCustomInteractionMappings) : false;
+            return attribute != null && attribute.Flags.HasFlag(MixedRealityControllerConfigurationFlags.UseCustomInteractionMappings);
         }
 
         private static Handedness[] GetSupportedHandedness(Type controllerType)

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -214,8 +214,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             });
         }
 
-#endif // UNITY_EDITOR
-
         private static bool UsesCustomInteractionMapping(Type controllerType)
         {
             var attribute = MixedRealityControllerAttribute.Find(controllerType);
@@ -227,5 +225,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             var attribute = MixedRealityControllerAttribute.Find(controllerType);
             return attribute != null ? attribute.SupportedHandedness : Array.Empty<Handedness>();
         }
+#endif // UNITY_EDITOR
     }
 }

--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -639,7 +639,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     // case 5: only show the link
 
                     // case 5 -> can't create and/or store the local scriptable above - show link
-                    bool isStoredAsset = (scriptable.objectReferenceValue == null) ? false : AssetDatabase.Contains(scriptable.objectReferenceValue);
+                    bool isStoredAsset = scriptable.objectReferenceValue != null && AssetDatabase.Contains(scriptable.objectReferenceValue);
                     bool isEmptyInStagedPrefab = !isStoredAsset && ((Component)scriptable.serializedObject.targetObject).gameObject.scene.path == "";
                     if (scriptable.objectReferenceValue == null ||  isEmptyInStagedPrefab)
                     {

--- a/Assets/MRTK/Core/Inspectors/Utilities/Search/MixedRealitySearchUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/Search/MixedRealitySearchUtility.cs
@@ -129,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Search
             ProfileSearchResult result = new ProfileSearchResult();
             result.Profile = profile;
             BaseMixedRealityProfile baseProfile = (profile as BaseMixedRealityProfile);
-            result.IsCustomProfile = (baseProfile != null) ? baseProfile.IsCustomProfile : false;
+            result.IsCustomProfile = baseProfile != null && baseProfile.IsCustomProfile;
             searchResults.Add(result);
 
             // Go through the profile's serialized fields

--- a/Assets/MRTK/Core/Providers/Hands/HandJointService.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandJointService.cs
@@ -184,7 +184,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public bool IsHandTracked(Handedness handedness)
         {
-            return handedness == Handedness.Left ? leftHand != null : handedness == Handedness.Right ? rightHand != null : false;
+            return handedness == Handedness.Left ? leftHand != null : handedness == Handedness.Right && rightHand != null;
         }
 
         #endregion IMixedRealityHandJointService Implementation

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
@@ -62,21 +62,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public SimulatedMotionControllerData MotionControllerDataRight { get; } = new SimulatedMotionControllerData();
 
         /// <inheritdoc />
-        public bool IsSimulatingControllerLeft => (dataProvider != null ? dataProvider.IsSimulatingLeft : false);
+        public bool IsSimulatingControllerLeft => dataProvider != null && dataProvider.IsSimulatingLeft;
         /// <inheritdoc />
-        public bool IsSimulatingControllerRight => (dataProvider != null ? dataProvider.IsSimulatingRight : false);
+        public bool IsSimulatingControllerRight => dataProvider != null && dataProvider.IsSimulatingRight;
 
         /// <inheritdoc />
         public bool IsAlwaysVisibleControllerLeft
         {
-            get { return dataProvider != null ? dataProvider.IsAlwaysVisibleLeft : false; }
+            get { return dataProvider != null && dataProvider.IsAlwaysVisibleLeft; }
             set { if (dataProvider != null) { dataProvider.IsAlwaysVisibleLeft = value; } }
         }
 
         /// <inheritdoc />
         public bool IsAlwaysVisibleControllerRight
         {
-            get { return dataProvider != null ? dataProvider.IsAlwaysVisibleRight : false; }
+            get { return dataProvider != null && dataProvider.IsAlwaysVisibleRight; }
             set { if (dataProvider != null) { dataProvider.IsAlwaysVisibleRight = value; } }
         }
 

--- a/Assets/MRTK/Core/Services/BaseService.cs
+++ b/Assets/MRTK/Core/Services/BaseService.cs
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit
             get
             {
                 Debug.Assert(isInitialized.HasValue, $"{this.GetType()} has not set a value for IsInitialized, returning false.");
-                return isInitialized.HasValue ? isInitialized.Value : false;
+                return isInitialized ?? false;
             }
 
             set => isInitialized = value;
@@ -88,7 +88,7 @@ namespace Microsoft.MixedReality.Toolkit
             get
             {
                 Debug.Assert(isEnabled.HasValue, $"{this.GetType()} has not set a value for IsEnabled, returning false.");
-                return isEnabled.HasValue ? isEnabled.Value : false;
+                return isEnabled ?? false;
             }
 
             set => isEnabled = value;
@@ -105,7 +105,7 @@ namespace Microsoft.MixedReality.Toolkit
             get
             {
                 Debug.Assert(isMarkedDestroyed.HasValue, $"{this.GetType()} has not set a value for IsMarkedDestroyed, returning false.");
-                return isMarkedDestroyed.HasValue ? isMarkedDestroyed.Value : false;
+                return isMarkedDestroyed ?? false;
             }
 
             set => isMarkedDestroyed = value;

--- a/Assets/MRTK/Core/Utilities/Editor/AssemblyDefinition.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/AssemblyDefinition.cs
@@ -208,7 +208,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             FileInfo file = new FileInfo(fileName);
 
-            bool readOnly = (file.Exists) ? file.IsReadOnly : false;
+            bool readOnly = file.Exists && file.IsReadOnly;
             if (readOnly)
             {
                 file.IsReadOnly = false;

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -147,7 +147,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.AndroidMinSdkVersion, new ConfigGetter(() =>  PlayerSettings.Android.minSdkVersion >= MinAndroidSdk, BuildTarget.Android) },
 
             // iOS Settings
-            { Configurations.IOSMinOSVersion, new ConfigGetter(() => float.TryParse(PlayerSettings.iOS.targetOSVersionString, out float version) ? version >= iOSMinOsVersion : false, BuildTarget.iOS) },
+            { Configurations.IOSMinOSVersion, new ConfigGetter(() => float.TryParse(PlayerSettings.iOS.targetOSVersionString, out float version) && version >= iOSMinOsVersion, BuildTarget.iOS) },
             { Configurations.IOSArchitecture, new ConfigGetter(() => PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequirediOSArchitecture, BuildTarget.iOS) },
             { Configurations.IOSCameraUsageDescription, new ConfigGetter(() => !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription), BuildTarget.iOS) },
 

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetSelections/Scripts/TargetGroupIterator.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetSelections/Scripts/TargetGroupIterator.cs
@@ -284,8 +284,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         private void Fire_OnAllTargetsSelected()
         {
             // Make sure someone is listening to event
-            if (OnAllTargetsSelected != null)
-                OnAllTargetsSelected();
+            OnAllTargetsSelected?.Invoke();
         }
 
         /// <summary>
@@ -294,8 +293,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         private void Fire_OnTargetSelected()
         {
             // Make sure someone is listening to event
-            if (OnTargetSelected != null)
-                OnTargetSelected();
+            OnTargetSelected?.Invoke();
         }
 
         #region IMixedRealityPointerHandler

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLookAtShowHoverFeedback.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLookAtShowHoverFeedback.cs
@@ -358,7 +358,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Targeting
 
             ShowFeedback(normalizedInterest);
 
-            highlightOn = (!highlightOn) ? true : highlightOn;
+            highlightOn = true;
         }
 
         #endregion

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/Targeting/DwellSelection.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/Targeting/DwellSelection.cs
@@ -98,10 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
             useDwell = false;
         }
 
-        private bool UseDwell
-        {
-            get { return (useDwell.HasValue ? useDwell.Value : false); }
-        }
+        private bool UseDwell => useDwell ?? false;
 
         protected override void OnEyeFocusStart()
         {

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboard.cs
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboard.cs
@@ -797,10 +797,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             if (SubmitOnEnter)
             {
                 // Send text entered event and close the keyboard
-                if (OnTextSubmitted != null)
-                {
-                    OnTextSubmitted(this, EventArgs.Empty);
-                }
+                OnTextSubmitted?.Invoke(this, EventArgs.Empty);
 
                 Close();
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -510,8 +510,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         private void OnDrawGizmos()
         {
-            bool NearObjectCheck = queryBufferNearObjectRadius != null ? IsNearObject : false;
-            bool IsInteractionEnabledCheck = queryBufferInteractionRadius != null ? IsInteractionEnabled : false;
+            bool NearObjectCheck = queryBufferNearObjectRadius != null && IsNearObject;
+            bool IsInteractionEnabledCheck = queryBufferInteractionRadius != null && IsInteractionEnabled;
 
             TryGetNearGraspAxis(out Vector3 sectorForwardAxis);
             TryGetNearGraspPoint(out Vector3 point);

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
@@ -189,7 +189,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         protected internal int GameObjectLayer { get; protected set; }
 
-        protected internal bool IsColliderPresent => gameObject != null ? gameObject.GetComponent<Collider>() != null : false;
+        protected internal bool IsColliderPresent => gameObject != null && gameObject.GetComponent<Collider>() != null;
 
         /// <summary>
         /// The default value for SurfaceNormalOffset if UseDefaultSurfaceNormalOffset is true.  This value ensures an object

--- a/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -564,7 +564,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
                         AsyncOperation sceneOp = SceneManager.LoadSceneAsync(sceneIndex, LoadSceneMode.Additive);
                         // Set this to true unless we have an activation token
-                        sceneOp.allowSceneActivation = (activationToken != null) ? activationToken.AllowSceneActivation : true;
+                        sceneOp.allowSceneActivation = activationToken == null || activationToken.AllowSceneActivation;
                         loadSceneOps.Add(sceneOp);
                     }
 
@@ -580,7 +580,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
                         completedAllSceneOps = true;
                         bool readyToProceed = false;
-                        bool allowSceneActivation = (activationToken != null) ? activationToken.AllowSceneActivation : true;
+                        bool allowSceneActivation = activationToken == null || activationToken.AllowSceneActivation;
 
                         // Go through all the load scene ops and see if we're ready to be activated
                         float sceneOpProgress = 0;


### PR DESCRIPTION
## Overview

1. Update to use the null coalescing expression `??` when Unity objects aren't involved
    1. https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0029-ide0030
1. Simplify conditional checks when explicit `true` and `false` are used
    1. For example, `if (foo != null ? foo.IsValid : false)` can just be `if (foo != null && foo.IsValid)`
    1. https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0075
1. Use conditional delegate calls instead of explicit null checks
    1. https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide1005