### PR TITLE
Code style pass for pattern matching

### DIFF
--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputAction.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputAction.cs
@@ -78,12 +78,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) { return false; }
-            return obj is MixedRealityInputAction && Equals((MixedRealityInputAction)obj);
+            return obj is MixedRealityInputAction action && Equals(action);
         }
 
         int IEqualityComparer.GetHashCode(object obj)
         {
-            return obj is MixedRealityInputAction ? ((MixedRealityInputAction)obj).GetHashCode() : 0;
+            return obj is MixedRealityInputAction action ? action.GetHashCode() : 0;
         }
 
         public override int GetHashCode()

--- a/Assets/MRTK/Core/Definitions/Utilities/MixedRealityPose.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/MixedRealityPose.cs
@@ -125,13 +125,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) { return false; }
-            return obj is MixedRealityPose && Equals((MixedRealityPose)obj);
+            return obj is MixedRealityPose pose && Equals(pose);
         }
 
         /// <inheritdoc />
         int IEqualityComparer.GetHashCode(object obj)
         {
-            return obj is MixedRealityPose ? ((MixedRealityPose)obj).GetHashCode() : 0;
+            return obj is MixedRealityPose pose ? pose.GetHashCode() : 0;
         }
 
         public override int GetHashCode()

--- a/Assets/MRTK/Core/Definitions/Utilities/MixedRealityTransform.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/MixedRealityTransform.cs
@@ -135,13 +135,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) { return false; }
-            return obj is MixedRealityTransform && Equals((MixedRealityTransform)obj);
+            return obj is MixedRealityTransform transform && Equals(transform);
         }
 
         /// <inheritdoc />
         int IEqualityComparer.GetHashCode(object obj)
         {
-            return obj is MixedRealityTransform ? ((MixedRealityTransform)obj).GetHashCode() : 0;
+            return obj is MixedRealityTransform transform ? transform.GetHashCode() : 0;
         }
 
         public override int GetHashCode()

--- a/Assets/MRTK/Core/Extensions/GameObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/GameObjectExtensions.cs
@@ -184,8 +184,7 @@ namespace Microsoft.MixedReality.Toolkit
 
                 foreach (var attribute in attributes)
                 {
-                    var requireComponentAttribute = attribute as RequireComponent;
-                    if (requireComponentAttribute != null)
+                    if (attribute is RequireComponent requireComponentAttribute)
                     {
                         if (requireComponentAttribute.m_Type0 == genericType ||
                             requireComponentAttribute.m_Type1 == genericType ||

--- a/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
@@ -105,8 +105,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             if (dataProviderType != null)
             {
-                MixedRealityDataProviderAttribute providerAttribute = MixedRealityDataProviderAttribute.Find(dataProviderType) as MixedRealityDataProviderAttribute;
-                if (providerAttribute != null)
+                if (MixedRealityDataProviderAttribute.Find(dataProviderType) is MixedRealityDataProviderAttribute providerAttribute)
                 {
                     providerProperties.componentName.stringValue = !string.IsNullOrWhiteSpace(providerAttribute.Name) ? providerAttribute.Name : dataProviderType.Name;
                     providerProperties.providerProfile.objectReferenceValue = providerAttribute.DefaultProfile;

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -181,9 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             if (componentType != null)
             {
-                MixedRealityExtensionServiceAttribute attr = MixedRealityExtensionServiceAttribute.Find(componentType) as MixedRealityExtensionServiceAttribute;
-
-                if (attr != null)
+                if (MixedRealityExtensionServiceAttribute.Find(componentType) is MixedRealityExtensionServiceAttribute attr)
                 {
                     componentName.stringValue = !string.IsNullOrWhiteSpace(attr.Name) ? attr.Name : componentType.Name;
                     configurationProfile.objectReferenceValue = attr.DefaultProfile;

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/ExperimentalDrawer.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/ExperimentalDrawer.cs
@@ -17,9 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <param name="position">Rectangle to display the GUI in</param>
         public override void OnGUI(Rect position)
         {
-            var experimental = attribute as ExperimentalAttribute;
-
-            if (experimental != null)
+            if (attribute is ExperimentalAttribute experimental)
             {
                 var defaultValue = EditorStyles.helpBox.richText;
                 EditorStyles.helpBox.richText = true;
@@ -34,9 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <returns>The height required by OnGUI.</returns>
         public override float GetHeight()
         {
-            var experimental = attribute as ExperimentalAttribute;
-
-            if (experimental != null)
+            if (attribute is ExperimentalAttribute experimental)
             {
                 return EditorStyles.helpBox.CalcHeight(new GUIContent(experimental.Text), EditorGUIUtility.currentViewWidth);
             }

--- a/Assets/MRTK/Core/Inspectors/ServiceInspectors/SceneSystemInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/ServiceInspectors/SceneSystemInspector.cs
@@ -32,10 +32,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             // Get the scene system itself
             IMixedRealitySceneSystem sceneSystem = target as IMixedRealitySceneSystem;
-            // Get the scene system's editor interface
-            IMixedRealitySceneSystemEditor sceneSystemEditor = target as IMixedRealitySceneSystemEditor;
 
-            if (sceneSystemEditor == null)
+            // Get the scene system's editor interface
+            if (!(target is IMixedRealitySceneSystemEditor sceneSystemEditor))
             {
                 EditorGUILayout.HelpBox("This scene service implementation does not implement IMixedRealitySceneSystemEditor. Inspector will not be rendered.", MessageType.Info);
                 return;

--- a/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
@@ -246,9 +246,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 for (int i = 0; i < inputSource?.Pointers?.Length; i++)
                 {
                     if (inputSource.Pointers[i] == null) continue;
-                    if (inputSource.Pointers[i] is IMixedRealityNearPointer)
+                    if (inputSource.Pointers[i] is IMixedRealityNearPointer nearPointer)
                     {
-                        var nearPointer = (IMixedRealityNearPointer)inputSource.Pointers[i];
                         anyPointersLockedWithHand |= nearPointer.IsNearObject;
                     }
                     anyPointersLockedWithHand |= inputSource.Pointers[i].IsFocusLocked;

--- a/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
@@ -245,15 +245,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 bool anyPointersLockedWithHand = false;
                 for (int i = 0; i < inputSource?.Pointers?.Length; i++)
                 {
-                    if (inputSource.Pointers[i] == null) continue;
-                    if (inputSource.Pointers[i] is IMixedRealityNearPointer nearPointer)
+                    IMixedRealityPointer mixedRealityPointer = inputSource.Pointers[i];
+                    if (mixedRealityPointer.IsNull()) continue;
+                    if (mixedRealityPointer is IMixedRealityNearPointer nearPointer)
                     {
                         anyPointersLockedWithHand |= nearPointer.IsNearObject;
                     }
-                    anyPointersLockedWithHand |= inputSource.Pointers[i].IsFocusLocked;
+                    anyPointersLockedWithHand |= mixedRealityPointer.IsFocusLocked;
 
                     // If official teleport mode and we have a teleport pointer registered, we get the input action to trigger it.
-                    if (teleportPointer == null && inputSource.Pointers[i] is IMixedRealityTeleportPointer pointer)
+                    if (teleportPointer == null && mixedRealityPointer is IMixedRealityTeleportPointer pointer)
                     {
                         teleportPointer = pointer;
                     }

--- a/Assets/MRTK/Core/Providers/Hands/HandJointService.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandJointService.cs
@@ -64,8 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             foreach (var detectedController in Service.DetectedControllers)
             {
-                var hand = detectedController as IMixedRealityHand;
-                if (hand != null)
+                if (detectedController is IMixedRealityHand hand)
                 {
                     if (detectedController.ControllerHandedness == Handedness.Left)
                     {

--- a/Assets/MRTK/Core/Providers/Hands/HandJointUtils.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandJointUtils.cs
@@ -51,8 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             foreach (var detectedController in CoreServices.InputSystem.DetectedControllers)
             {
-                var hand = detectedController as T;
-                if (hand != null)
+                if (detectedController is T hand)
                 {
                     if (detectedController.ControllerHandedness.IsMatch(handedness))
                     {

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedMotionControllerDataProvider.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedMotionControllerDataProvider.cs
@@ -72,8 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         internal override void SimulateInput(ref long lastMotionControllerTrackedTimestamp, SimulatedControllerState state, bool isSimulating, bool isAlwaysVisible, MouseDelta mouseDelta, bool useMouseRotation)
         {
-            var motionControllerState = state as SimulatedMotionControllerState;
-            if (motionControllerState == null)
+            if (!(state is SimulatedMotionControllerState motionControllerState))
             {
                 return;
             }

--- a/Assets/MRTK/Core/Services/BaseDataProviderAccessCoreSystem.cs
+++ b/Assets/MRTK/Core/Services/BaseDataProviderAccessCoreSystem.cs
@@ -105,9 +105,9 @@ namespace Microsoft.MixedReality.Toolkit
 
             foreach (var provider in dataProviders)
             {
-                if (provider is T)
+                if (provider is T providerT)
                 {
-                    selected.Add((T)provider);
+                    selected.Add(providerT);
                 }
             }
 
@@ -133,11 +133,11 @@ namespace Microsoft.MixedReality.Toolkit
         {
             foreach (var provider in dataProviders)
             {
-                if (provider is T)
+                if (provider is T providerT)
                 {
                     if (name == null || provider.Name == name)
                     {
-                        return (T)provider;
+                        return providerT;
                     }
                 }
             }

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -1268,9 +1268,9 @@ namespace Microsoft.MixedReality.Toolkit
             for (int i = 0; i < length; i++)
             {
                 IMixedRealityService service = systems[i];
-                if (service is T && (isNullServiceName || service.Name == serviceName))
+                if (service is T serviceT && (isNullServiceName || service.Name == serviceName))
                 {
-                    services.Add((T)service);
+                    services.Add(serviceT);
                 }
             }
 

--- a/Assets/MRTK/Core/Utilities/Async/AwaiterExtensions.cs
+++ b/Assets/MRTK/Core/Utilities/Async/AwaiterExtensions.cs
@@ -292,8 +292,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     // We could just yield return nested IEnumerator's here but we choose to do
                     // our own handling here so that we can catch exceptions in nested coroutines
                     // instead of just top level coroutine
-                    var item = topWorker.Current as IEnumerator;
-                    if (item != null)
+                    if (topWorker.Current is IEnumerator item)
                     {
                         processStack.Push(item);
                     }

--- a/Assets/MRTK/Core/Utilities/CoreServices.cs
+++ b/Assets/MRTK/Core/Utilities/CoreServices.cs
@@ -128,8 +128,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </remarks>
         public static T GetDataProvider<T>(IMixedRealityService service) where T : IMixedRealityDataProvider
         {
-            var dataProviderAccess = service as IMixedRealityDataProviderAccess;
-            if (dataProviderAccess != null)
+            if (service is IMixedRealityDataProviderAccess dataProviderAccess)
             {
                 return dataProviderAccess.GetDataProvider<T>();
             }

--- a/Assets/MRTK/Examples/Demos/Input/Scenes/DisablePointers/DisablePointersExample.cs
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/DisablePointers/DisablePointersExample.cs
@@ -28,8 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         public void ResetExample()
         {
             var pointerControl = GetComponent<PointerBehaviorControls>();
-            IMixedRealityCapabilityCheck capabilityChecker = CoreServices.InputSystem as IMixedRealityCapabilityCheck;
-            if (capabilityChecker != null)
+            if (CoreServices.InputSystem is IMixedRealityCapabilityCheck capabilityChecker)
             {
                 if (capabilityChecker.CheckCapability(MixedRealityCapability.ArticulatedHand))
                 {

--- a/Assets/MRTK/Examples/Demos/Utilities/Scripts/MixedRealityCapabilityDemo.cs
+++ b/Assets/MRTK/Examples/Demos/Utilities/Scripts/MixedRealityCapabilityDemo.cs
@@ -43,8 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 
         private void Start()
         {
-            IMixedRealityCapabilityCheck capabilityChecker = CoreServices.InputSystem as IMixedRealityCapabilityCheck;
-            if (capabilityChecker != null)
+            if (CoreServices.InputSystem is IMixedRealityCapabilityCheck capabilityChecker)
             {
                 bool isSupported = capabilityChecker.CheckCapability(MixedRealityCapability.ArticulatedHand);
                 articulatedHandResult.text = isSupported ? "Yes" : "No";

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -437,9 +437,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
                 if (controller != null)
                 {
-                    var mrtkController = controller as WindowsMixedRealityController;
-
-                    if (mrtkController != null)
+                    if (controller is WindowsMixedRealityController mrtkController)
                     {
                         mrtkController.EnsureControllerModel(interactionSourceState.source);
                     }

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
@@ -16,9 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void Start()
         {
-            var capabilityChecker = CoreServices.InputSystem as IMixedRealityCapabilityCheck;
-
-            if (capabilityChecker != null && capabilityChecker.CheckCapability(MixedRealityCapability.ArticulatedHand))
+            if (CoreServices.InputSystem is IMixedRealityCapabilityCheck capabilityChecker && capabilityChecker.CheckCapability(MixedRealityCapability.ArticulatedHand))
             {
                 EnableTouch();
             }

--- a/Assets/MRTK/SDK/Experimental/PulseShader/Scripts/HandPulseLogic.cs
+++ b/Assets/MRTK/SDK/Experimental/PulseShader/Scripts/HandPulseLogic.cs
@@ -80,9 +80,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.SurfacePulse
                 if (c.ControllerHandedness.IsMatch(Handedness.Both))
                 {
                     MixedRealityPose palmPose;
-                    var jointedHand = c as IMixedRealityHand;
 
-                    if ((jointedHand != null) && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
+                    if (c is IMixedRealityHand jointedHand && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
                     {
                         if (Vector3.Dot(palmPose.Up, CameraCache.Main.transform.forward) > 0.0f)
                         {

--- a/Assets/MRTK/SDK/Features/Input/Handlers/TeleportHotSpot.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/TeleportHotSpot.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         {
             base.OnBeforeFocusChange(eventData);
 
-            if (!(eventData.Pointer is IMixedRealityTeleportPointer teleportPointer))
+            if (!(eventData.Pointer is IMixedRealityTeleportPointer teleportPointer) || teleportPointer.IsNull())
             {
                 return;
             }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/TeleportHotSpot.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/TeleportHotSpot.cs
@@ -20,12 +20,10 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         {
             base.OnBeforeFocusChange(eventData);
 
-            if (!(eventData.Pointer is TeleportPointer)) { return; }
-
-            IMixedRealityTeleportPointer teleportPointer = eventData.Pointer as IMixedRealityTeleportPointer;
-
-            if (teleportPointer == null)
+            if (!(eventData.Pointer is IMixedRealityTeleportPointer teleportPointer))
+            {
                 return;
+            }
 
             if (eventData.NewFocusedObject == gameObject)
             {

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1063,9 +1063,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             for (int i = 0; i < InteractableEvents.Count; i++)
             {
-                if (InteractableEvents[i] != null && InteractableEvents[i].Receiver is T)
+                if (InteractableEvents[i] != null && InteractableEvents[i].Receiver is T receiverT)
                 {
-                    return (T)InteractableEvents[i].Receiver;
+                    return receiverT;
                 }
             }
 
@@ -1081,9 +1081,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
             List<T> result = new List<T>();
             for (int i = 0; i < InteractableEvents.Count; i++)
             {
-                if (InteractableEvents[i] != null && InteractableEvents[i].Receiver is T)
+                if (InteractableEvents[i] != null && InteractableEvents[i].Receiver is T receiverT)
                 {
-                    result.Add((T)InteractableEvents[i].Receiver);
+                    result.Add(receiverT);
                 }
             }
             return result;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
@@ -373,8 +373,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         protected virtual void OnClickRemove()
         {
             // Set the app bar and bounding box to inactive
-            var boundsProvider = Target as IBoundsTargetProvider;
-            if (boundsProvider != null)
+            if (Target is IBoundsTargetProvider boundsProvider)
             {
                 boundsProvider.Target.SetActive(false);
             }
@@ -461,8 +460,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void UpdateTargetObject()
         {
-            var boundsProvider = Target as IBoundsTargetProvider;
-            if (boundsProvider == null || boundsProvider.Target == null)
+            if (!(Target is IBoundsTargetProvider boundsProvider) || boundsProvider.Target == null)
             {
                 if (DisplayType == AppBarDisplayTypeEnum.Manipulation)
                 {
@@ -497,9 +495,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void FollowTargetObject(bool smooth)
         {
-            var boundsProvider = Target as IBoundsTargetProvider;
-            if (boundsProvider == null)
+            if (!(Target is IBoundsTargetProvider boundsProvider))
+            {
                 return;
+            }
 
             // Calculate the best follow position
             Vector3 finalPosition = Vector3.zero;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
@@ -373,7 +373,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         protected virtual void OnClickRemove()
         {
             // Set the app bar and bounding box to inactive
-            if (Target is IBoundsTargetProvider boundsProvider)
+            if (Target is IBoundsTargetProvider boundsProvider && !boundsProvider.IsNull())
             {
                 boundsProvider.Target.SetActive(false);
             }
@@ -460,7 +460,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void UpdateTargetObject()
         {
-            if (!(Target is IBoundsTargetProvider boundsProvider) || boundsProvider.Target == null)
+            if (!(Target is IBoundsTargetProvider boundsProvider) || boundsProvider.IsNull() || boundsProvider.Target == null)
             {
                 if (DisplayType == AppBarDisplayTypeEnum.Manipulation)
                 {
@@ -495,7 +495,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void FollowTargetObject(bool smooth)
         {
-            if (!(Target is IBoundsTargetProvider boundsProvider))
+            if (!(Target is IBoundsTargetProvider boundsProvider) || boundsProvider.IsNull())
             {
                 return;
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
@@ -183,8 +183,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (Pointer != null)
             {
-                var hand = Pointer.Controller as IMixedRealityHand;
-                if (hand != null)
+                if (Pointer.Controller is IMixedRealityHand hand)
                 {
                     if (hand.TryGetJoint(joint, out MixedRealityPose handJoint))
                     {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -754,8 +754,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool TryGetHandPositionFromController(IMixedRealityController controller, TrackedHandJoint joint, out Vector3 position)
         {
-            var hand = controller as IMixedRealityHand;
-            if (hand != null)
+            if (controller is IMixedRealityHand hand)
             {
                 if (hand.TryGetJoint(joint, out MixedRealityPose pose))
                 {

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/ControllerFinder.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/ControllerFinder.cs
@@ -57,16 +57,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         public void OnSourceDetected(SourceStateEventData eventData)
         {
-            if (eventData.Controller?.ControllerHandedness == handedness)
+            // Check the handedness and don't track hands
+            if (eventData.Controller?.ControllerHandedness == handedness && !(eventData.Controller is IMixedRealityHand))
             {
-                if (eventData.Controller is IMixedRealityHand)
-                {
-
-                }
-                else
-                {
-                    AddControllerTransform(eventData.Controller);
-                }
+                AddControllerTransform(eventData.Controller);
             }
         }
 

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -653,9 +653,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         private static MixedRealityPose? GetPalmPose(IMixedRealityController hand)
         {
             MixedRealityPose palmPose;
-            var jointedHand = hand as IMixedRealityHand;
 
-            if ((jointedHand != null) && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
+            if (hand is IMixedRealityHand jointedHand && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
             {
                 return palmPose;
             }

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -392,8 +392,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             while (!SolverHandler.UpdateSolvers && useGazeActivation)
             {
                 MixedRealityPose palmPose;
-                var jointedHand = GetController(SolverHandler.CurrentTrackedHandedness) as IMixedRealityHand;
-                if (jointedHand != null)
+                if (GetController(SolverHandler.CurrentTrackedHandedness) is IMixedRealityHand jointedHand)
                 {
                     if (jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
                     {

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -898,8 +898,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             List<T> typePointers = new List<T>();
             foreach (var pointer in pointers.Values)
             {
-                T typePointer = pointer.Pointer as T;
-                if (typePointer != null)
+                if (pointer.Pointer is T typePointer)
                 {
                     typePointers.Add(typePointer);
                 }

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -896,9 +896,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public IEnumerable<T> GetPointers<T>() where T : class, IMixedRealityPointer
         {
             List<T> typePointers = new List<T>();
-            foreach (var pointer in pointers.Values)
+            foreach (PointerData pointer in pointers.Values)
             {
-                if (pointer.Pointer is T typePointer)
+                if (pointer.Pointer is T typePointer && !typePointer.IsNull())
                 {
                     typePointers.Add(typePointer);
                 }
@@ -1166,7 +1166,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 foreach (var pointerData in pointers.Values)
                 {
-                    if (pointerData.Pointer is IMixedRealityNearPointer nearPointer)
+                    if (pointerData.Pointer is IMixedRealityNearPointer nearPointer && !nearPointer.IsNull())
                     {
                         if (nearPointer.IsInteractionEnabled || nearPointer.IsNearObject)
                         {

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -1185,9 +1185,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     foreach (var component in currentObject.GetComponents<Component>())
                     {
-                        if (component is IMixedRealityPointerHandler)
+                        if (component is IMixedRealityPointerHandler handler)
                         {
-                            ancestorPointerHandler = (IMixedRealityPointerHandler)component;
+                            ancestorPointerHandler = handler;
                             break;
                         }
                     }

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -1305,14 +1305,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var inputData = ExecuteEvents.ValidateEventData<InputEventData>(eventData);
                 Debug.Assert(inputData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                var inputHandler = handler as IMixedRealityInputHandler;
-                if (inputHandler != null)
+                if (handler is IMixedRealityInputHandler inputHandler)
                 {
                     inputHandler.OnInputDown(inputData);
                 }
 
-                var actionHandler = handler as IMixedRealityInputActionHandler;
-                if (actionHandler != null)
+                if (handler is IMixedRealityInputActionHandler actionHandler)
                 {
                     actionHandler.OnActionStarted(inputData);
                 }
@@ -1359,14 +1357,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var inputData = ExecuteEvents.ValidateEventData<InputEventData>(eventData);
                 Debug.Assert(inputData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                var inputHandler = handler as IMixedRealityInputHandler;
-                if (inputHandler != null)
+                if (handler is IMixedRealityInputHandler inputHandler)
                 {
                     inputHandler.OnInputUp(inputData);
                 }
 
-                var actionHandler = handler as IMixedRealityInputActionHandler;
-                if (actionHandler != null)
+                if (handler is IMixedRealityInputActionHandler actionHandler)
                 {
                     actionHandler.OnActionEnded(inputData);
                 }
@@ -1549,14 +1545,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var inputData = ExecuteEvents.ValidateEventData<InputEventData>(eventData);
                 Debug.Assert(inputData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                var gestureHandler = handler as IMixedRealityGestureHandler;
-                if (gestureHandler != null)
+                if (handler is IMixedRealityGestureHandler gestureHandler)
                 {
                     gestureHandler.OnGestureStarted(inputData);
                 }
 
-                var actionHandler = handler as IMixedRealityInputActionHandler;
-                if (actionHandler != null)
+                if (handler is IMixedRealityInputActionHandler actionHandler)
                 {
                     actionHandler.OnActionStarted(inputData);
                 }
@@ -1686,14 +1680,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var inputData = ExecuteEvents.ValidateEventData<InputEventData>(eventData);
                 Debug.Assert(inputData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                var gestureHandler = handler as IMixedRealityGestureHandler;
-                if (gestureHandler != null)
+                if (handler is IMixedRealityGestureHandler gestureHandler)
                 {
                     gestureHandler.OnGestureCompleted(inputData);
                 }
 
-                var actionHandler = handler as IMixedRealityInputActionHandler;
-                if (actionHandler != null)
+                if (handler is IMixedRealityInputActionHandler actionHandler)
                 {
                     actionHandler.OnActionEnded(inputData);
                 }
@@ -1829,14 +1821,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var speechData = ExecuteEvents.ValidateEventData<SpeechEventData>(eventData);
                 Debug.Assert(speechData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                var speechHandler = handler as IMixedRealitySpeechHandler;
-                if (speechHandler != null)
+                if (handler is IMixedRealitySpeechHandler speechHandler)
                 {
                     speechHandler.OnSpeechKeywordRecognized(speechData);
                 }
 
-                var actionHandler = handler as IMixedRealityInputActionHandler;
-                if (actionHandler != null)
+                if (handler is IMixedRealityInputActionHandler actionHandler)
                 {
                     actionHandler.OnActionStarted(speechData);
                     actionHandler.OnActionEnded(speechData);

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -1305,12 +1305,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var inputData = ExecuteEvents.ValidateEventData<InputEventData>(eventData);
                 Debug.Assert(inputData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                if (handler is IMixedRealityInputHandler inputHandler)
+                if (handler is IMixedRealityInputHandler inputHandler && !inputHandler.IsNull())
                 {
                     inputHandler.OnInputDown(inputData);
                 }
 
-                if (handler is IMixedRealityInputActionHandler actionHandler)
+                if (handler is IMixedRealityInputActionHandler actionHandler && !actionHandler.IsNull())
                 {
                     actionHandler.OnActionStarted(inputData);
                 }
@@ -1357,12 +1357,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var inputData = ExecuteEvents.ValidateEventData<InputEventData>(eventData);
                 Debug.Assert(inputData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                if (handler is IMixedRealityInputHandler inputHandler)
+                if (handler is IMixedRealityInputHandler inputHandler && !inputHandler.IsNull())
                 {
                     inputHandler.OnInputUp(inputData);
                 }
 
-                if (handler is IMixedRealityInputActionHandler actionHandler)
+                if (handler is IMixedRealityInputActionHandler actionHandler && !actionHandler.IsNull())
                 {
                     actionHandler.OnActionEnded(inputData);
                 }
@@ -1545,12 +1545,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var inputData = ExecuteEvents.ValidateEventData<InputEventData>(eventData);
                 Debug.Assert(inputData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                if (handler is IMixedRealityGestureHandler gestureHandler)
+                if (handler is IMixedRealityGestureHandler gestureHandler && !gestureHandler.IsNull())
                 {
                     gestureHandler.OnGestureStarted(inputData);
                 }
 
-                if (handler is IMixedRealityInputActionHandler actionHandler)
+                if (handler is IMixedRealityInputActionHandler actionHandler && !actionHandler.IsNull())
                 {
                     actionHandler.OnActionStarted(inputData);
                 }
@@ -1680,12 +1680,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var inputData = ExecuteEvents.ValidateEventData<InputEventData>(eventData);
                 Debug.Assert(inputData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                if (handler is IMixedRealityGestureHandler gestureHandler)
+                if (handler is IMixedRealityGestureHandler gestureHandler && !gestureHandler.IsNull())
                 {
                     gestureHandler.OnGestureCompleted(inputData);
                 }
 
-                if (handler is IMixedRealityInputActionHandler actionHandler)
+                if (handler is IMixedRealityInputActionHandler actionHandler && !actionHandler.IsNull())
                 {
                     actionHandler.OnActionEnded(inputData);
                 }
@@ -1821,12 +1821,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var speechData = ExecuteEvents.ValidateEventData<SpeechEventData>(eventData);
                 Debug.Assert(speechData.MixedRealityInputAction != MixedRealityInputAction.None);
 
-                if (handler is IMixedRealitySpeechHandler speechHandler)
+                if (handler is IMixedRealitySpeechHandler speechHandler && !speechHandler.IsNull())
                 {
                     speechHandler.OnSpeechKeywordRecognized(speechData);
                 }
 
-                if (handler is IMixedRealityInputActionHandler actionHandler)
+                if (handler is IMixedRealityInputActionHandler actionHandler && !actionHandler.IsNull())
                 {
                     actionHandler.OnActionStarted(speechData);
                     actionHandler.OnActionEnded(speechData);

--- a/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -49,11 +49,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         {
             foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
             {
-                IMixedRealityCapabilityCheck capabilityChecker = observer as IMixedRealityCapabilityCheck;
-
                 // If one of the running data providers supports the requested capability, 
                 // the application has the needed support to leverage the desired functionality.
-                if ((capabilityChecker != null) &&
+                if (observer is IMixedRealityCapabilityCheck capabilityChecker &&
                     capabilityChecker.CheckCapability(capability))
                 {
                     return true;

--- a/Assets/MRTK/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/Assets/MRTK/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -281,7 +281,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                 isProcessingTeleportRequest = true;
 
                 targetRotation = Vector3.zero;
-                if (eventData.Pointer is IMixedRealityTeleportPointer teleportPointer)
+                if (eventData.Pointer is IMixedRealityTeleportPointer teleportPointer && !teleportPointer.IsNull())
                 {
                     targetRotation.y = teleportPointer.PointerOrientation;
                 }

--- a/Assets/MRTK/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/Assets/MRTK/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -281,8 +281,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                 isProcessingTeleportRequest = true;
 
                 targetRotation = Vector3.zero;
-                var teleportPointer = eventData.Pointer as IMixedRealityTeleportPointer;
-                if (teleportPointer != null)
+                if (eventData.Pointer is IMixedRealityTeleportPointer teleportPointer)
                 {
                     targetRotation.y = teleportPointer.PointerOrientation;
                 }

--- a/Assets/MRTK/Tests/EditModeTests/Core/Utilities/ProjectPreferencesTest.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Utilities/ProjectPreferencesTest.cs
@@ -15,10 +15,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core.Utilities.Editor
         private const string BaseKey = "ProjectPreferencesTest_";
         private static readonly Dictionary<string, object> TestData = new Dictionary<string, object>
         {
-            { BaseKey + typeof(bool).Name, (object)true },
-            { BaseKey + typeof(float).Name, (object)2.3f },
-            { BaseKey + typeof(int).Name, (object)5 },
-            { BaseKey + typeof(string).Name, (object)"TEST"},
+            { BaseKey + typeof(bool).Name, true },
+            { BaseKey + typeof(float).Name, 2.3f },
+            { BaseKey + typeof(int).Name, 5 },
+            { BaseKey + typeof(string).Name, "TEST"},
         };
 
         /// <summary>
@@ -31,29 +31,25 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core.Utilities.Editor
             {
                 foreach (var test in TestData)
                 {
-                    if (test.Value is float)
+                    if (test.Value is float floatValue)
                     {
-                        var value = (float)test.Value;
-                        ProjectPreferences.Set(test.Key, value);
-                        Assert.AreEqual(value, ProjectPreferences.Get(test.Key, 0f));
+                        ProjectPreferences.Set(test.Key, floatValue);
+                        Assert.AreEqual(floatValue, ProjectPreferences.Get(test.Key, 0f));
                     }
-                    else if (test.Value is bool)
+                    else if (test.Value is bool boolValue)
                     {
-                        var value = (bool)test.Value;
-                        ProjectPreferences.Set(test.Key, value);
-                        Assert.AreEqual(value, ProjectPreferences.Get(test.Key, false));
+                        ProjectPreferences.Set(test.Key, boolValue);
+                        Assert.AreEqual(boolValue, ProjectPreferences.Get(test.Key, false));
                     }
-                    else if (test.Value is int)
+                    else if (test.Value is int intValue)
                     {
-                        var value = (int)test.Value;
-                        ProjectPreferences.Set(test.Key, value);
-                        Assert.AreEqual(value, ProjectPreferences.Get(test.Key, 0));
+                        ProjectPreferences.Set(test.Key, intValue);
+                        Assert.AreEqual(intValue, ProjectPreferences.Get(test.Key, 0));
                     }
-                    else if (test.Value is string)
+                    else if (test.Value is string stringValue)
                     {
-                        var value = (string)test.Value;
-                        ProjectPreferences.Set(test.Key, value);
-                        Assert.AreEqual(value, ProjectPreferences.Get(test.Key, string.Empty));
+                        ProjectPreferences.Set(test.Key, stringValue);
+                        Assert.AreEqual(stringValue, ProjectPreferences.Get(test.Key, string.Empty));
                     }
                 }
             }
@@ -76,25 +72,21 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core.Utilities.Editor
             {
                 foreach (var test in TestData)
                 {
-                    if (test.Value is float)
+                    if (test.Value is float floatValue)
                     {
-                        var value = (float)test.Value;
-                        Assert.AreEqual(value, ProjectPreferences.Get(test.Key, value));
+                        Assert.AreEqual(floatValue, ProjectPreferences.Get(test.Key, floatValue));
                     }
-                    else if (test.Value is bool)
+                    else if (test.Value is bool boolValue)
                     {
-                        var value = (bool)test.Value;
-                        Assert.AreEqual(value, ProjectPreferences.Get(test.Key, value));
+                        Assert.AreEqual(boolValue, ProjectPreferences.Get(test.Key, boolValue));
                     }
-                    else if (test.Value is int)
+                    else if (test.Value is int intValue)
                     {
-                        var value = (int)test.Value;
-                        Assert.AreEqual(value, ProjectPreferences.Get(test.Key, value));
+                        Assert.AreEqual(intValue, ProjectPreferences.Get(test.Key, intValue));
                     }
-                    else if (test.Value is string)
+                    else if (test.Value is string stringValue)
                     {
-                        var value = (string)test.Value;
-                        Assert.AreEqual(value, ProjectPreferences.Get(test.Key, value));
+                        Assert.AreEqual(stringValue, ProjectPreferences.Get(test.Key, stringValue));
                     }
                 }
             }

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -370,8 +370,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
                         foreach (Object asset in assets)
                         {
-                            MonoScript monoScript = asset as MonoScript;
-                            if (!(monoScript is null) && AssetDatabase.TryGetGUIDAndLocalFileIdentifier(monoScript, out string guid, out long fileId))
+                            if (asset is MonoScript monoScript && AssetDatabase.TryGetGUIDAndLocalFileIdentifier(monoScript, out string guid, out long fileId))
                             {
                                 Type type = monoScript.GetClass();
 

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -370,7 +370,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
                         foreach (Object asset in assets)
                         {
-                            if (asset is MonoScript monoScript && AssetDatabase.TryGetGUIDAndLocalFileIdentifier(monoScript, out string guid, out long fileId))
+                            if (asset is MonoScript monoScript && monoScript != null && AssetDatabase.TryGetGUIDAndLocalFileIdentifier(monoScript, out string guid, out long fileId))
                             {
                                 Type type = monoScript.GetClass();
 


### PR DESCRIPTION
## Overview

1. Updates to prefer `if (foo is Bar fooBar)` over `Bar fooBar = foo as Bar` with a null check following
    1. [This doc page](https://docs.microsoft.com/en-us/dotnet/csharp/how-to/safely-cast-using-pattern-matching-is-and-as-operators) claims "Use the pattern matching syntax whenever possible." 
    1. https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0019 