### PR TITLE
Code style pass for compound assignment

### DIFF
--- a/Assets/MRTK/Core/Extensions/LayerExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/LayerExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit
             int combinedLayerMask = 0;
             for (int i = 0; i < layerMaskList.Length; i++)
             {
-                combinedLayerMask = combinedLayerMask | layerMaskList[i].value;
+                combinedLayerMask |= layerMaskList[i].value;
             }
             return combinedLayerMask;
         }

--- a/Assets/MRTK/Core/Inspectors/Utilities/Lines/DataProviders/SplineDataProviderInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/Lines/DataProviders/SplineDataProviderInspector.cs
@@ -234,7 +234,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             for (int i = 0; i < 3; i++)
             {
-                controlPoints.arraySize = controlPoints.arraySize + 1;
+                controlPoints.arraySize += 1;
                 var newControlPointProperty = controlPoints.GetArrayElementAtIndex(controlPoints.arraySize - 1);
                 newControlPointProperty.FindPropertyRelative("position").vector3Value = newControlPoints[i].Position;
                 newControlPointProperty.FindPropertyRelative("rotation").quaternionValue = Quaternion.identity;

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedControllerDataProvider.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedControllerDataProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 rotationDeltaEulerAngles.z += mouseDelta.screenDelta.z * rotationSensitivity;
                 rotationDeltaEulerAngles *= rotationScale;
 
-                ViewportRotation = ViewportRotation + rotationDeltaEulerAngles;
+                ViewportRotation += rotationDeltaEulerAngles;
             }
             else
             {

--- a/Assets/MRTK/Core/Utilities/Lines/DataProviders/BezierDataProvider.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/DataProviders/BezierDataProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     }
 
                     controlPoints.Point1 = point;
-                    controlPoints.Point2 = controlPoints.Point2 + localOffset;
+                    controlPoints.Point2 += localOffset;
                     break;
 
                 case 1:
@@ -93,7 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     }
 
                     controlPoints.Point4 = point;
-                    controlPoints.Point3 = controlPoints.Point3 + localOffset;
+                    controlPoints.Point3 += localOffset;
                     break;
 
                 default:

--- a/Assets/MRTK/Core/Utilities/Lines/DataProviders/BezierInertia.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/DataProviders/BezierInertia.cs
@@ -58,8 +58,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             p2Velocity = Vector3.Lerp(p2Velocity, p2Offset, Time.deltaTime * inertia);
             p2Velocity = Vector3.Lerp(p2Velocity, Vector3.zero, Time.deltaTime * dampen);
 
-            p1Position = p1Position + p1Velocity;
-            p2Position = p2Position + p2Velocity;
+            p1Position += p1Velocity;
+            p2Position += p2Velocity;
 
             p1Position = Vector3.Lerp(p1Position, p1WorldTarget, seekTargetStrength * Time.deltaTime);
             p2Position = Vector3.Lerp(p2Position, p2WorldTarget, seekTargetStrength * Time.deltaTime);

--- a/Assets/MRTK/Core/Utilities/Lines/DataProviders/SplineDataProvider.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/DataProviders/SplineDataProvider.cs
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     }
                     else if (changedControlPoint >= PointCount)
                     {
-                        changedControlPoint = changedControlPoint % (PointCount - 1);
+                        changedControlPoint %= (PointCount - 1);
                     }
 
                     if (prevControlPoint < 0)
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     }
                     else if (prevControlPoint >= PointCount)
                     {
-                        prevControlPoint = prevControlPoint % (PointCount - 1);
+                        prevControlPoint %= (PointCount - 1);
                     }
 
                     Vector3 midPoint = controlPoints[midPointIndex].Position;

--- a/Assets/MRTK/Core/Utilities/Physics/Distorters/DistorterBulge.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/Distorters/DistorterBulge.cs
@@ -81,7 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             {
                 float distortion = (1f - (bulgeFalloff.Evaluate(distanceToCenter / bulgeRadius))) * bulgeStrength;
                 Vector3 direction = (point - BulgeWorldCenter).normalized;
-                point = point + (direction * distortion * bulgeStrength);
+                point += (direction * distortion * bulgeStrength);
             }
 
             return point;

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/MoveObjByEyeGaze.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/MoveObjByEyeGaze.cs
@@ -668,7 +668,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
                     if (PlacementSurface == PlacementSurfaces.Horizontal)
                     {
-                        hitp.y = hitp.y + gameObject.transform.localScale.y / 2;
+                        hitp.y += gameObject.transform.localScale.y / 2;
                     }
 
                     Vector3 objp = gameObject.transform.position;
@@ -750,7 +750,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
                     // Discrete cursor-based target movement
                     if (PlacementSurface == PlacementSurfaces.Horizontal)
                     {
-                        destination.y = destination.y + gameObject.transform.localScale.y / 2;
+                        destination.y += gameObject.transform.localScale.y / 2;
                     }
 
                     Vector3 objp = gameObject.transform.position;

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLookAtRotateByEyeGaze.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLookAtRotateByEyeGaze.cs
@@ -75,11 +75,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
             if ((angle1y > 0) && (angle1z < 0))
             {
-                angle1y = angle1y - Mathf.PI;
+                angle1y -= Mathf.PI;
             }
             else if ((angle1y < 0) && (angle1z < 0))
             {
-                angle1y = angle1y + Mathf.PI;
+                angle1y += Mathf.PI;
             }
 
             float rotx, roty;

--- a/Assets/MRTK/SDK/Experimental/Elastic/Scripts/QuaternionElasticSystem.cs
+++ b/Assets/MRTK/SDK/Experimental/Elastic/Scripts/QuaternionElasticSystem.cs
@@ -89,7 +89,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Physics
             currentVelocity = Add(currentVelocity, Scale(accel, deltaTime));
 
             // x' = x + v' * deltaT
-            currentValue = currentValue * Scale(currentVelocity, deltaTime).normalized;
+            currentValue *= Scale(currentVelocity, deltaTime).normalized;
 
             // As the current value is a quaternion, we must renormalize the quaternion
             // before using it as a representation of a rotation.

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipBackgroundBlob.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipBackgroundBlob.cs
@@ -216,7 +216,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Vector3 currentDistortion = -velocity * blobDistortion;
             distortion = Vector3.Lerp(distortion, currentDistortion, 1f / blobDistortion * Time.deltaTime);
 
-            inertialContentBounds.center = inertialContentBounds.center + velocity;
+            inertialContentBounds.center += velocity;
             Vector3 size = inertialContentBounds.size + distortion;
             inertialContentBounds.size = size;
 

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -612,7 +612,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 return CalculateRayForSafeZone(origin, targetTransform, hand, handSafeZone, offsetBehavior);
             }
 
-            angleOffset = angleOffset % 360;
+            angleOffset %= 360;
             while (angleOffset < 0)
             {
                 angleOffset = (angleOffset + 360) % 360;

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/Orbital.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/Orbital.cs
@@ -98,8 +98,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
             Quaternion targetRot = SolverHandler.TransformTarget != null ? SolverHandler.TransformTarget.rotation : Quaternion.Euler(0, 1, 0);
             Quaternion yawOnlyRot = Quaternion.Euler(0, targetRot.eulerAngles.y, 0);
-            desiredPos = desiredPos + (SnapToTetherAngleSteps(targetRot) * LocalOffset);
-            desiredPos = desiredPos + (SnapToTetherAngleSteps(yawOnlyRot) * WorldOffset);
+            desiredPos += (SnapToTetherAngleSteps(targetRot) * LocalOffset);
+            desiredPos += (SnapToTetherAngleSteps(yawOnlyRot) * WorldOffset);
 
             Quaternion desiredRot = CalculateDesiredRotation(desiredPos);
 

--- a/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -618,7 +618,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
                     usedAnchor = CreateAnchor("UsedAnchor", limitBar.transform);
                     GameObject bar = CreateQuad("UsedBar", usedAnchor);
                     Material material = new Material(foregroundMaterial);
-                    material.renderQueue = material.renderQueue + 1;
+                    material.renderQueue += 1;
                     InitializeRenderer(bar, material, colorID, memoryUsedColor);
                     bar.transform.localScale = Vector3.one;
                     bar.transform.localPosition = new Vector3(0.5f, 0.0f, 0.0f);

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -2294,7 +2294,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
             // now adjust collider bounds and try grabbing the handle again
-            handleConfig.ColliderPadding = handleConfig.ColliderPadding + newColliderPadding;
+            handleConfig.ColliderPadding += newColliderPadding;
             yield return new WaitForFixedUpdate();
             Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
             Assert.IsNotNull(cornerVisual, "corner visual got destroyed when setting material");

--- a/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
@@ -220,7 +220,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             if (!thisAbsolute.EndsWith(Path.DirectorySeparatorChar.ToString()))
             {
-                thisAbsolute = thisAbsolute + Path.DirectorySeparatorChar;
+                thisAbsolute += Path.DirectorySeparatorChar;
             }
 
             return GetNormalizedPath(new Uri(thisAbsolute).MakeRelativeUri(new Uri(thatAbsolute)).OriginalString);


### PR DESCRIPTION
## Overview

1. Updates to prefer syntax like `foo += 1` instead of `foo = foo + 1`.
    1. https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0054-ide0074
