### PR TITLE
Use unused param in SpatialAwarenessPlanarObject

### DIFF
--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/SpatialAwarenessPlanarObject.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/SpatialAwarenessPlanarObject.cs
@@ -29,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 
             newMesh.Id = planeId;
             newMesh.GameObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            newMesh.GameObject.name = name;
             newMesh.GameObject.layer = layer;
             newMesh.GameObject.transform.localScale = size;
 


### PR DESCRIPTION
## Overview

The `name` parameter in `CreateSpatialObject` was previously unused.
This change aligns with the mesh observer, which uses the name to name the GameObject

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/d0884451fcc2516f769f416863893b0387a1facc/Assets/MRTK/Core/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs#L51