### PR TITLE
Performance improvements for ScrollingObjectCollection

### DIFF
--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -1,150 +1,157 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.MixedReality.Toolkit.Boundary;
-using Microsoft.MixedReality.Toolkit.Diagnostics;
-using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.SpatialAwareness;
-using Microsoft.MixedReality.Toolkit.Teleport;
-using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.MixedReality.Toolkit.Boundary;
+using Microsoft.MixedReality.Toolkit.CameraSystem;
+using Microsoft.MixedReality.Toolkit.Diagnostics;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Rendering;
+using Microsoft.MixedReality.Toolkit.SceneSystem;
+using Microsoft.MixedReality.Toolkit.SpatialAwareness;
+using Microsoft.MixedReality.Toolkit.Teleport;
+using Microsoft.MixedReality.Toolkit.Utilities;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using Microsoft.MixedReality.Toolkit.SceneSystem;
-using Microsoft.MixedReality.Toolkit.CameraSystem;
-using Microsoft.MixedReality.Toolkit.Rendering;
-
 #if UNITY_EDITOR
 using Microsoft.MixedReality.Toolkit.Input.Editor;
 using UnityEditor;
+
 #endif
 
 namespace Microsoft.MixedReality.Toolkit
 {
     /// <summary>
-    /// This class is responsible for coordinating the operation of the Mixed Reality Toolkit. It is the only Singleton in the entire project.
-    /// It provides a service registry for all active services that are used within a project as well as providing the active configuration profile for the project.
-    /// The Profile can be swapped out at any time to meet the needs of your project.
+    ///     This class is responsible for coordinating the operation of the Mixed Reality Toolkit. It is the only Singleton in
+    ///     the entire project.
+    ///     It provides a service registry for all active services that are used within a project as well as providing the
+    ///     active configuration profile for the project.
+    ///     The Profile can be swapped out at any time to meet the needs of your project.
     /// </summary>
     [DisallowMultipleComponent]
     [AddComponentMenu("Scripts/MRTK/Core/MixedRealityToolkit")]
     public class MixedRealityToolkit : MonoBehaviour, IMixedRealityServiceRegistrar
     {
-        private static bool isInitializing = false;
-        private static bool isApplicationQuitting = false;
-        private static bool internalShutdown = false;
-        private const string NoMRTKProfileErrorMessage = "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit";
+        private static bool isInitializing;
+        private static bool isApplicationQuitting;
+        private static bool internalShutdown;
+
+        private const string NoMRTKProfileErrorMessage =
+            "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit";
 
         /// <summary>
-        /// Whether an active profile switching is currently in progress
+        ///     Whether an active profile switching is currently in progress
         /// </summary>
         public bool IsProfileSwitching { get; private set; }
 
         #region Mixed Reality Toolkit Profile configuration
 
         /// <summary>
-        /// Checks if there is a valid instance of the MixedRealityToolkit, then checks if there is there a valid Active Profile.
+        ///     Checks if there is a valid instance of the MixedRealityToolkit, then checks if there is there a valid Active
+        ///     Profile.
         /// </summary>
         public bool HasActiveProfile
         {
             get
             {
-                if (!IsInitialized)
-                {
-                    return false;
-                }
+                if (!IsInitialized) return false;
 
                 return ActiveProfile != null;
             }
         }
 
         /// <summary>
-        /// Returns true if this is the active instance.
+        ///     Returns true if this is the active instance.
         /// </summary>
-        public bool IsActiveInstance
-        {
-            get
-            {
-                return activeInstance == this;
-            }
-        }
+        public bool IsActiveInstance => activeInstance == this;
 
         private bool HasProfileAndIsInitialized => activeProfile != null && IsInitialized;
 
         /// <summary>
-        /// The active profile of the Mixed Reality Toolkit which controls which services are active and their initial configuration.
-        /// *Note configuration is used on project initialization or replacement, changes to properties while it is running has no effect.
+        ///     The active profile of the Mixed Reality Toolkit which controls which services are active and their initial
+        ///     configuration.
+        ///     *Note configuration is used on project initialization or replacement, changes to properties while it is running has
+        ///     no effect.
         /// </summary>
         [SerializeField]
         [Tooltip("The current active configuration for the Mixed Reality project")]
-        private MixedRealityToolkitConfigurationProfile activeProfile = null;
+        private MixedRealityToolkitConfigurationProfile activeProfile;
 
         /// <summary>
-        /// The public property of the Active Profile, ensuring events are raised on the change of the configuration
+        ///     The public property of the Active Profile, ensuring events are raised on the change of the configuration
         /// </summary>
         /// <remarks>
-        /// If changing the Active profile prior to the initialization (i.e. Awake()) of <see cref="MixedRealityToolkit"/> is desired, 
-        /// call the static funtion <see cref="SetProfileBeforeInitialization(MixedRealityToolkitConfigurationProfile)"/> instead.
-        /// When setting the ActiveProfile during runtime, the destroy of the currently running services will happen after the last LateUpdate()
-        /// of all services, and the instantiation and initialization of the services associated with the new profile will happen before the
-        /// first Update() of all services.
-        /// A noticable application hesitation may occur during this process. Also any script with higher priority than this can enter its Update
-        /// before the new profile is properly setup.
-        /// You are strongly recommended to see 
-        /// <see href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">here</see> 
-        /// for more information on profile switching.
+        ///     If changing the Active profile prior to the initialization (i.e. Awake()) of <see cref="MixedRealityToolkit" /> is
+        ///     desired,
+        ///     call the static funtion <see cref="SetProfileBeforeInitialization(MixedRealityToolkitConfigurationProfile)" />
+        ///     instead.
+        ///     When setting the ActiveProfile during runtime, the destroy of the currently running services will happen after the
+        ///     last LateUpdate()
+        ///     of all services, and the instantiation and initialization of the services associated with the new profile will
+        ///     happen before the
+        ///     first Update() of all services.
+        ///     A noticable application hesitation may occur during this process. Also any script with higher priority than this
+        ///     can enter its Update
+        ///     before the new profile is properly setup.
+        ///     You are strongly recommended to see
+        ///     <see
+        ///         href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">
+        ///         here
+        ///     </see>
+        ///     for more information on profile switching.
         /// </remarks>
         public MixedRealityToolkitConfigurationProfile ActiveProfile
         {
-            get
-            {
-                return activeProfile;
-            }
+            get => activeProfile;
             set
             {
                 // Behavior during a valid runtime profile switch
                 if (Application.isPlaying && activeProfile != null && value != null)
-                {
                     newProfile = value;
-                }
                 // Behavior in other scenarios (e.g. when profile switch is being requested by editor code)
                 else
-                {
                     ResetConfiguration(value);
-                }
-
             }
         }
 
         /// <summary>
-        /// Set the active profile prior to the initialization (i.e. Awake()) of <see cref="MixedRealityToolkit"/>
+        ///     Set the active profile prior to the initialization (i.e. Awake()) of <see cref="MixedRealityToolkit" />
         /// </summary>
         /// <remarks>
-        /// If changing the Active profile after <see cref="MixedRealityToolkit"/> has been initialized, modify <see cref="ActiveProfile"/> of the active instance directly.
-        /// This function requires the caller script to be executed earlier than the <see cref="MixedRealityToolkit"/> script, which can be achieved by setting 
-        /// <see href="https://docs.unity3d.com/Manual/class-MonoManager.html">Script Execution Order settings</see>.
-        /// You are strongly recommended to see 
-        /// <see href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">here</see> 
-        /// for more information on profile switching.
+        ///     If changing the Active profile after <see cref="MixedRealityToolkit" /> has been initialized, modify
+        ///     <see cref="ActiveProfile" /> of the active instance directly.
+        ///     This function requires the caller script to be executed earlier than the <see cref="MixedRealityToolkit" /> script,
+        ///     which can be achieved by setting
+        ///     <see href="https://docs.unity3d.com/Manual/class-MonoManager.html">Script Execution Order settings</see>.
+        ///     You are strongly recommended to see
+        ///     <see
+        ///         href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">
+        ///         here
+        ///     </see>
+        ///     for more information on profile switching.
         /// </remarks>
         public static void SetProfileBeforeInitialization(MixedRealityToolkitConfigurationProfile profile)
         {
-            MixedRealityToolkit toolkit = FindObjectOfType<MixedRealityToolkit>();
+            var toolkit = FindObjectOfType<MixedRealityToolkit>();
             toolkit.activeProfile = profile;
         }
 
         /// <summary>
-        /// When a configuration Profile is replaced with a new configuration, force all services to reset and read the new values
+        ///     When a configuration Profile is replaced with a new configuration, force all services to reset and read the new
+        ///     values
         /// </summary>
         /// <remarks>
-        /// This function should only be used by editor code in most cases.
-        /// Do not call this function if resetting profile at runtime.
-        /// Instead see 
-        /// <see href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">here</see> 
-        /// for more information on profile switching at runtime.
+        ///     This function should only be used by editor code in most cases.
+        ///     Do not call this function if resetting profile at runtime.
+        ///     Instead see
+        ///     <see
+        ///         href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">
+        ///         here
+        ///     </see>
+        ///     for more information on profile switching at runtime.
         /// </remarks>
         public void ResetConfiguration(MixedRealityToolkitConfigurationProfile profile)
         {
@@ -156,32 +163,23 @@ namespace Microsoft.MixedReality.Toolkit
         {
             InitializeServiceLocator();
 
-            if (profile != null && Application.IsPlaying(profile))
-            {
-                EnableAllServices();
-            }
+            if (profile != null && Application.IsPlaying(profile)) EnableAllServices();
         }
 
         private void RemoveCurrentProfile(MixedRealityToolkitConfigurationProfile profile)
         {
-            if (activeProfile != null)
+            if (activeProfile)
             {
                 // Services are only enabled when playing.
-                if (Application.IsPlaying(activeProfile))
-                {
-                    DisableAllServices();
-                }
+                if (Application.IsPlaying(activeProfile)) DisableAllServices();
                 DestroyAllServices();
             }
 
             activeProfile = profile;
 
-            if (profile != null)
+            if (profile)
             {
-                if (Application.IsPlaying(profile))
-                {
-                    DisableAllServices();
-                }
+                if (Application.IsPlaying(profile)) DisableAllServices();
                 DestroyAllServices();
             }
         }
@@ -192,24 +190,29 @@ namespace Microsoft.MixedReality.Toolkit
 
         #region Mixed Reality runtime service registry
 
-        private static readonly Dictionary<Type, IMixedRealityService> activeSystems = new Dictionary<Type, IMixedRealityService>();
+        private static readonly Dictionary<Type, IMixedRealityService> activeSystems =
+            new Dictionary<Type, IMixedRealityService>();
 
         /// <summary>
-        /// Current active systems registered with the MixedRealityToolkit.
+        ///     Current active systems registered with the MixedRealityToolkit.
         /// </summary>
         /// <remarks>
-        /// Systems can only be registered once by <see cref="System.Type"/>
+        ///     Systems can only be registered once by <see cref="System.Type" />
         /// </remarks>
         [Obsolete("Use CoreService, MixedRealityServiceRegistry, or GetService<T> instead")]
-        public IReadOnlyDictionary<Type, IMixedRealityService> ActiveSystems => new Dictionary<Type, IMixedRealityService>(activeSystems) as IReadOnlyDictionary<Type, IMixedRealityService>;
+        public IReadOnlyDictionary<Type, IMixedRealityService> ActiveSystems =>
+            new Dictionary<Type, IMixedRealityService>(activeSystems);
 
-        private static readonly List<Tuple<Type, IMixedRealityService>> registeredMixedRealityServices = new List<Tuple<Type, IMixedRealityService>>();
+        private static readonly List<Tuple<Type, IMixedRealityService>> registeredMixedRealityServices =
+            new List<Tuple<Type, IMixedRealityService>>();
 
         /// <summary>
-        /// Local service registry for the Mixed Reality Toolkit, to allow runtime use of the <see cref="Microsoft.MixedReality.Toolkit.IMixedRealityService"/>.
+        ///     Local service registry for the Mixed Reality Toolkit, to allow runtime use of the
+        ///     <see cref="Microsoft.MixedReality.Toolkit.IMixedRealityService" />.
         /// </summary>
         [Obsolete("Use GetDataProvider<T> of MixedRealityService registering the desired IMixedRealityDataProvider")]
-        public IReadOnlyList<Tuple<Type, IMixedRealityService>> RegisteredMixedRealityServices => new List<Tuple<Type, IMixedRealityService>>(registeredMixedRealityServices) as IReadOnlyList<Tuple<Type, IMixedRealityService>>;
+        public IReadOnlyList<Tuple<Type, IMixedRealityService>> RegisteredMixedRealityServices =>
+            new List<Tuple<Type, IMixedRealityService>>(registeredMixedRealityServices);
 
         #endregion Mixed Reality runtime service registry
 
@@ -218,13 +221,13 @@ namespace Microsoft.MixedReality.Toolkit
         /// <inheritdoc />
         public bool RegisterService<T>(T serviceInstance) where T : IMixedRealityService
         {
-            return RegisterServiceInternal<T>(serviceInstance);
+            return RegisterServiceInternal(serviceInstance);
         }
 
         /// <inheritdoc />
         public bool RegisterService<T>(
             Type concreteType,
-            SupportedPlatforms supportedPlatforms = (SupportedPlatforms)(-1),
+            SupportedPlatforms supportedPlatforms = (SupportedPlatforms) (-1),
             params object[] args) where T : IMixedRealityService
         {
             return RegisterServiceInternal<T>(
@@ -235,30 +238,30 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Internal method that creates an instance of the specified concrete type and registers the service.
+        ///     Internal method that creates an instance of the specified concrete type and registers the service.
         /// </summary>
         private bool RegisterServiceInternal<T>(
             bool retryWithRegistrar,
             Type concreteType,
-            SupportedPlatforms supportedPlatforms = (SupportedPlatforms)(-1),
+            SupportedPlatforms supportedPlatforms = (SupportedPlatforms) (-1),
             params object[] args) where T : IMixedRealityService
         {
             DebugUtilities.LogVerboseFormat("Attempting to register service of type: {0}", concreteType);
 
-            if (isApplicationQuitting)
-            {
-                return false;
-            }
+            if (isApplicationQuitting) return false;
 
             if (!PlatformUtility.IsPlatformSupported(supportedPlatforms))
             {
-                DebugUtilities.LogVerboseFormat("Service of type: {0} does not support the current platform given supported platforms {1}", concreteType, supportedPlatforms);
+                DebugUtilities.LogVerboseFormat(
+                    "Service of type: {0} does not support the current platform given supported platforms {1}",
+                    concreteType, supportedPlatforms);
                 return false;
             }
 
             if (concreteType == null)
             {
-                Debug.LogError($"Unable to register {typeof(T).Name} service because the value of concreteType is null.\n" +
+                Debug.LogError(
+                    $"Unable to register {typeof(T).Name} service because the value of concreteType is null.\n" +
                     "This may be caused by code being stripped during linking. The link.xml file in the MixedRealityToolkit.Generated folder is used to control code preservation.\n" +
                     "More information can be found at https://docs.unity3d.com/Manual/ManagedCodeStripping.html.");
                 return false;
@@ -266,7 +269,8 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (!typeof(IMixedRealityService).IsAssignableFrom(concreteType))
             {
-                Debug.LogError($"Unable to register the {concreteType.Name} service. It does not implement {typeof(IMixedRealityService)}.");
+                Debug.LogError(
+                    $"Unable to register the {concreteType.Name} service. It does not implement {typeof(IMixedRealityService)}.");
                 return false;
             }
 
@@ -274,19 +278,17 @@ namespace Microsoft.MixedReality.Toolkit
 
             try
             {
-                serviceInstance = (T)Activator.CreateInstance(concreteType, args);
+                serviceInstance = (T) Activator.CreateInstance(concreteType, args);
             }
             catch (Exception e)
             {
-                if (retryWithRegistrar && (e is MissingMethodException))
+                if (retryWithRegistrar && e is MissingMethodException)
                 {
-                    Debug.LogWarning($"Failed to find an appropriate constructor for the {concreteType.Name} service. Adding the Registrar instance and re-attempting registration.");
-                    List<object> updatedArgs = new List<object>();
-                    updatedArgs.Add(this);
+                    Debug.LogWarning(
+                        $"Failed to find an appropriate constructor for the {concreteType.Name} service. Adding the Registrar instance and re-attempting registration.");
+                    var updatedArgs = new List<object> {this};
                     if (args != null)
-                    {
                         updatedArgs.AddRange(args);
-                    }
                     return RegisterServiceInternal<T>(
                         false, // Do NOT retry, we have already added the configured IMIxedRealityServiceRegistrar
                         concreteType,
@@ -299,24 +301,21 @@ namespace Microsoft.MixedReality.Toolkit
                 // Failures to create the concrete type generally surface as nested exceptions - just logging
                 // the top level exception itself may not be helpful. If there is a nested exception (for example,
                 // null reference in the constructor of the object itself), it's helpful to also surface those here.
-                if (e.InnerException != null)
-                {
-                    Debug.LogError("Underlying exception information: " + e.InnerException);
-                }
+                if (e.InnerException != null) Debug.LogError("Underlying exception information: " + e.InnerException);
                 return false;
             }
 
-            return RegisterServiceInternal<T>(serviceInstance);
+            return RegisterServiceInternal(serviceInstance);
         }
 
         /// <inheritdoc />
         public bool UnregisterService<T>(string name = null) where T : IMixedRealityService
         {
-            T serviceInstance = GetServiceByName<T>(name);
+            var serviceInstance = GetServiceByName<T>(name);
 
-            if (serviceInstance == null) { return false; }
+            if (serviceInstance == null) return false;
 
-            return UnregisterService<T>(serviceInstance);
+            return UnregisterService(serviceInstance);
         }
 
         /// <inheritdoc />
@@ -324,11 +323,13 @@ namespace Microsoft.MixedReality.Toolkit
         {
             DebugUtilities.LogVerboseFormat("Unregistering service of type: {0}", typeof(T));
 
-            Type interfaceType = typeof(T);
+            var interfaceType = typeof(T);
 
             if (IsInitialized)
             {
-                DebugUtilities.LogVerboseFormat("Unregistered service of type {0} was an initialized service, disabling and destroying it", typeof(T));
+                DebugUtilities.LogVerboseFormat(
+                    "Unregistered service of type {0} was an initialized service, disabling and destroying it",
+                    typeof(T));
                 serviceInstance.Disable();
                 serviceInstance.Destroy();
             }
@@ -342,34 +343,33 @@ namespace Microsoft.MixedReality.Toolkit
                 return true;
             }
 
-            return MixedRealityServiceRegistry.RemoveService<T>(serviceInstance, this);
+            return MixedRealityServiceRegistry.RemoveService(serviceInstance, this);
         }
 
         /// <inheritdoc />
         public bool IsServiceRegistered<T>(string name = null) where T : IMixedRealityService
         {
-            Type interfaceType = typeof(T);
+            var interfaceType = typeof(T);
             if (typeof(IMixedRealityDataProvider).IsAssignableFrom(interfaceType))
             {
-                Debug.LogWarning($"Unable to check a service of type {typeof(IMixedRealityDataProvider).Name}. Inquire with the MixedRealityService that registered the DataProvider type in question");
+                Debug.LogWarning(
+                    $"Unable to check a service of type {nameof(IMixedRealityDataProvider)}. Inquire with the MixedRealityService that registered the DataProvider type in question");
                 return false;
             }
 
-            T service;
-            MixedRealityServiceRegistry.TryGetService<T>(out service, name);
+            MixedRealityServiceRegistry.TryGetService<T>(out var service, name);
             return service != null;
         }
 
         /// <inheritdoc />
         public T GetService<T>(string name = null, bool showLogs = true) where T : IMixedRealityService
         {
-            Type interfaceType = typeof(T);
-            T serviceInstance = GetServiceByName<T>(name);
+            var interfaceType = typeof(T);
+            var serviceInstance = GetServiceByName<T>(name);
 
-            if ((serviceInstance == null) && showLogs)
-            {
-                Debug.LogError($"Unable to find {(string.IsNullOrWhiteSpace(name) ? interfaceType.Name : name)} service.");
-            }
+            if (serviceInstance == null && showLogs)
+                Debug.LogError(
+                    $"Unable to find {(string.IsNullOrWhiteSpace(name) ? interfaceType.Name : name)} service.");
 
             return serviceInstance;
         }
@@ -383,25 +383,22 @@ namespace Microsoft.MixedReality.Toolkit
         #endregion IMixedRealityServiceRegistrar implementation
 
         /// <summary>
-        /// Once all services are registered and properties updated, the Mixed Reality Toolkit will initialize all active services.
-        /// This ensures all services can reference each other once started.
+        ///     Once all services are registered and properties updated, the Mixed Reality Toolkit will initialize all active
+        ///     services.
+        ///     This ensures all services can reference each other once started.
         /// </summary>
         private void InitializeServiceLocator()
         {
             isInitializing = true;
 
             // If the Mixed Reality Toolkit is not configured, stop.
-            if (ActiveProfile == null)
+            if (!ActiveProfile)
             {
                 if (!Application.isPlaying)
-                {
                     // Log as warning if in edit mode. Likely user is making changes etc.
                     Debug.LogWarning(NoMRTKProfileErrorMessage);
-                }
                 else
-                {
                     Debug.LogError(NoMRTKProfileErrorMessage);
-                }
 
                 return;
             }
@@ -409,18 +406,14 @@ namespace Microsoft.MixedReality.Toolkit
             // If verbose logging is to be enabled, this should be done as early in service
             // initialization as possible to allow for other services to use verbose logging
             // as they initialize.
-            DebugUtilities.LogLevel = activeProfile.EnableVerboseLogging ? DebugUtilities.LoggingLevel.Verbose : DebugUtilities.LoggingLevel.Information;
+            DebugUtilities.LogLevel = activeProfile.EnableVerboseLogging
+                ? DebugUtilities.LoggingLevel.Verbose
+                : DebugUtilities.LoggingLevel.Information;
 
 #if UNITY_EDITOR
-            if (activeSystems.Count > 0)
-            {
-                activeSystems.Clear();
-            }
+            if (activeSystems.Count > 0) activeSystems.Clear();
 
-            if (registeredMixedRealityServices.Count > 0)
-            {
-                registeredMixedRealityServices.Clear();
-            }
+            if (registeredMixedRealityServices.Count > 0) registeredMixedRealityServices.Clear();
 
             EnsureEditorSetup();
 #endif
@@ -440,23 +433,25 @@ namespace Microsoft.MixedReality.Toolkit
                 InputMappingAxisUtility.CheckUnityInputManagerMappings(ControllerMappingLibrary.UnityInputManagerAxes);
 #endif
 
-                object[] args = { ActiveProfile.InputSystemProfile };
-                if (!RegisterService<IMixedRealityInputSystem>(ActiveProfile.InputSystemType, args: args) || CoreServices.InputSystem == null)
-                {
-                    Debug.LogError("Failed to start the Input System!");
-                }
+                object[] args = {ActiveProfile.InputSystemProfile};
+                if (!RegisterService<IMixedRealityInputSystem>(ActiveProfile.InputSystemType, args: args) ||
+                    CoreServices.InputSystem == null) Debug.LogError("Failed to start the Input System!");
 
-                args = new object[] { ActiveProfile.InputSystemProfile };
-                if (!RegisterService<IMixedRealityFocusProvider>(ActiveProfile.InputSystemProfile.FocusProviderType, args: args))
+                args = new object[] {ActiveProfile.InputSystemProfile};
+                if (!RegisterService<IMixedRealityFocusProvider>(ActiveProfile.InputSystemProfile.FocusProviderType,
+                    args: args))
                 {
-                    Debug.LogError("Failed to register the focus provider! The input system will not function without it.");
+                    Debug.LogError(
+                        "Failed to register the focus provider! The input system will not function without it.");
                     return;
                 }
 
-                args = new object[] { ActiveProfile.InputSystemProfile };
-                if (!RegisterService<IMixedRealityRaycastProvider>(ActiveProfile.InputSystemProfile.RaycastProviderType, args: args))
+                args = new object[] {ActiveProfile.InputSystemProfile};
+                if (!RegisterService<IMixedRealityRaycastProvider>(ActiveProfile.InputSystemProfile.RaycastProviderType,
+                    args: args))
                 {
-                    Debug.LogError("Failed to register the raycast provider! The input system will not function without it.");
+                    Debug.LogError(
+                        "Failed to register the raycast provider! The input system will not function without it.");
                     return;
                 }
 
@@ -473,11 +468,9 @@ namespace Microsoft.MixedReality.Toolkit
             if (ActiveProfile.IsBoundarySystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the boundary system");
-                object[] args = { ActiveProfile.BoundaryVisualizationProfile, ActiveProfile.TargetExperienceScale };
-                if (!RegisterService<IMixedRealityBoundarySystem>(ActiveProfile.BoundarySystemSystemType, args: args) || CoreServices.BoundarySystem == null)
-                {
-                    Debug.LogError("Failed to start the Boundary System!");
-                }
+                object[] args = {ActiveProfile.BoundaryVisualizationProfile, ActiveProfile.TargetExperienceScale};
+                if (!RegisterService<IMixedRealityBoundarySystem>(ActiveProfile.BoundarySystemSystemType, args: args) ||
+                    CoreServices.BoundarySystem == null) Debug.LogError("Failed to start the Boundary System!");
                 DebugUtilities.LogVerbose("End registration of the boundary system");
             }
 
@@ -485,11 +478,9 @@ namespace Microsoft.MixedReality.Toolkit
             if (ActiveProfile.IsCameraSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the camera system");
-                object[] args = { ActiveProfile.CameraProfile };
-                if (!RegisterService<IMixedRealityCameraSystem>(ActiveProfile.CameraSystemType, args: args) || CoreServices.CameraSystem == null)
-                {
-                    Debug.LogError("Failed to start the Camera System!");
-                }
+                object[] args = {ActiveProfile.CameraProfile};
+                if (!RegisterService<IMixedRealityCameraSystem>(ActiveProfile.CameraSystemType, args: args) ||
+                    CoreServices.CameraSystem == null) Debug.LogError("Failed to start the Camera System!");
                 DebugUtilities.LogVerbose("End registration of the camera system");
             }
 
@@ -497,11 +488,11 @@ namespace Microsoft.MixedReality.Toolkit
             if (ActiveProfile.IsSpatialAwarenessSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the spatial awareness system");
-                object[] args = { ActiveProfile.SpatialAwarenessSystemProfile };
-                if (!RegisterService<IMixedRealitySpatialAwarenessSystem>(ActiveProfile.SpatialAwarenessSystemSystemType, args: args) && CoreServices.SpatialAwarenessSystem != null)
-                {
+                object[] args = {ActiveProfile.SpatialAwarenessSystemProfile};
+                if (!RegisterService<IMixedRealitySpatialAwarenessSystem>(
+                        ActiveProfile.SpatialAwarenessSystemSystemType, args: args) &&
+                    CoreServices.SpatialAwarenessSystem != null)
                     Debug.LogError("Failed to start the Spatial Awareness System!");
-                }
                 DebugUtilities.LogVerbose("End registration of the spatial awareness system");
             }
 
@@ -509,48 +500,42 @@ namespace Microsoft.MixedReality.Toolkit
             if (ActiveProfile.IsTeleportSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the teleport system");
-                if (!RegisterService<IMixedRealityTeleportSystem>(ActiveProfile.TeleportSystemSystemType) || CoreServices.TeleportSystem == null)
-                {
-                    Debug.LogError("Failed to start the Teleport System!");
-                }
+                if (!RegisterService<IMixedRealityTeleportSystem>(ActiveProfile.TeleportSystemSystemType) ||
+                    CoreServices.TeleportSystem == null) Debug.LogError("Failed to start the Teleport System!");
                 DebugUtilities.LogVerbose("End registration of the teleport system");
             }
 
             if (ActiveProfile.IsDiagnosticsSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the diagnostic system");
-                object[] args = { ActiveProfile.DiagnosticsSystemProfile };
-                if (!RegisterService<IMixedRealityDiagnosticsSystem>(ActiveProfile.DiagnosticsSystemSystemType, args: args) || CoreServices.DiagnosticsSystem == null)
-                {
-                    Debug.LogError("Failed to start the Diagnostics System!");
-                }
+                object[] args = {ActiveProfile.DiagnosticsSystemProfile};
+                if (!RegisterService<IMixedRealityDiagnosticsSystem>(ActiveProfile.DiagnosticsSystemSystemType,
+                        args: args) ||
+                    CoreServices.DiagnosticsSystem == null) Debug.LogError("Failed to start the Diagnostics System!");
                 DebugUtilities.LogVerbose("End registration of the diagnostic system");
             }
 
             if (ActiveProfile.IsSceneSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the scene system");
-                object[] args = { ActiveProfile.SceneSystemProfile };
-                if (!RegisterService<IMixedRealitySceneSystem>(ActiveProfile.SceneSystemSystemType, args: args) || CoreServices.SceneSystem == null)
-                {
-                    Debug.LogError("Failed to start the Scene System!");
-                }
+                object[] args = {ActiveProfile.SceneSystemProfile};
+                if (!RegisterService<IMixedRealitySceneSystem>(ActiveProfile.SceneSystemSystemType, args: args) ||
+                    CoreServices.SceneSystem == null) Debug.LogError("Failed to start the Scene System!");
                 DebugUtilities.LogVerbose("End registration of the scene system");
             }
 
-            if (ActiveProfile.RegisteredServiceProvidersProfile != null)
-            {
-                for (int i = 0; i < ActiveProfile.RegisteredServiceProvidersProfile.Configurations?.Length; i++)
+            if (ActiveProfile.RegisteredServiceProvidersProfile)
+                for (var i = 0; i < ActiveProfile.RegisteredServiceProvidersProfile.Configurations?.Length; i++)
                 {
                     var configuration = ActiveProfile.RegisteredServiceProvidersProfile.Configurations[i];
 
-                    if (typeof(IMixedRealityExtensionService).IsAssignableFrom(configuration.ComponentType.Type))
-                    {
-                        object[] args = { configuration.ComponentName, configuration.Priority, configuration.Profile };
-                        RegisterService<IMixedRealityExtensionService>(configuration.ComponentType, configuration.RuntimePlatform, args);
-                    }
+                    if (!typeof(IMixedRealityExtensionService).IsAssignableFrom(configuration.ComponentType.Type))
+                        continue;
+
+                    object[] args = {configuration.ComponentName, configuration.Priority, configuration.Profile};
+                    RegisterService<IMixedRealityExtensionService>(configuration.ComponentType,
+                        configuration.RuntimePlatform, args);
                 }
-            }
 
             #endregion Service Registration
 
@@ -572,13 +557,14 @@ namespace Microsoft.MixedReality.Toolkit
         {
             // There's lots of documented cases that if the camera doesn't start at 0,0,0, things break with the WMR SDK specifically.
             // We'll enforce that here, then tracking can update it to the appropriate position later.
-            CameraCache.Main.transform.position = Vector3.zero;
-            CameraCache.Main.transform.rotation = Quaternion.identity;
+            var cameraTransform = CameraCache.Main.transform;
+            cameraTransform.position = Vector3.zero;
+            cameraTransform.rotation = Quaternion.identity;
 
             // This will create the playspace
             _ = MixedRealityPlayspace.Transform;
 
-            bool addedComponents = false;
+            var addedComponents = false;
             if (!Application.isPlaying)
             {
                 var eventSystems = FindObjectsOfType<EventSystem>();
@@ -593,18 +579,13 @@ namespace Microsoft.MixedReality.Toolkit
                     bool raiseWarning;
 
                     if (eventSystems.Length == 1)
-                    {
                         raiseWarning = eventSystems[0].gameObject != CameraCache.Main.gameObject;
-                    }
                     else
-                    {
                         raiseWarning = true;
-                    }
 
                     if (raiseWarning)
-                    {
-                        Debug.LogWarning("Found an existing event system in your scene. The Mixed Reality Toolkit requires only one, and must be found on the main camera.");
-                    }
+                        Debug.LogWarning(
+                            "Found an existing event system in your scene. The Mixed Reality Toolkit requires only one, and must be found on the main camera.");
                 }
             }
 
@@ -618,20 +599,17 @@ namespace Microsoft.MixedReality.Toolkit
         #region MonoBehaviour Implementation
 
         private static MixedRealityToolkit activeInstance;
-        private static bool newInstanceBeingInitialized = false;
+        private static bool newInstanceBeingInitialized;
 
 #if UNITY_EDITOR
         /// <summary>
-        /// Returns the Singleton instance of the classes type.
+        ///     Returns the Singleton instance of the classes type.
         /// </summary>
         public static MixedRealityToolkit Instance
         {
             get
             {
-                if (activeInstance != null)
-                {
-                    return activeInstance;
-                }
+                if (activeInstance) return activeInstance;
 
                 // It's possible for MRTK to exist in the scene but for activeInstance to be
                 // null when a custom editor component accesses Instance before the MRTK
@@ -639,14 +617,14 @@ namespace Microsoft.MixedReality.Toolkit
                 //
                 // To avoid returning null in this case, make sure to search the scene for MRTK.
                 // We do this only when in editor to avoid any performance cost at runtime.
-                List<MixedRealityToolkit> mrtks = new List<MixedRealityToolkit>(FindObjectsOfType<MixedRealityToolkit>());
+                var mrtks = new List<MixedRealityToolkit>(FindObjectsOfType<MixedRealityToolkit>());
                 // Sort the list by instance ID so we get deterministic results when selecting our next active instance
-                mrtks.Sort(delegate (MixedRealityToolkit i1, MixedRealityToolkit i2) { return i1.GetInstanceID().CompareTo(i2.GetInstanceID()); });
-
-                for (int i = 0; i < mrtks.Count; i++)
+                mrtks.Sort(delegate(MixedRealityToolkit i1, MixedRealityToolkit i2)
                 {
-                    RegisterInstance(mrtks[i]);
-                }
+                    return i1.GetInstanceID().CompareTo(i2.GetInstanceID());
+                });
+
+                for (var i = 0; i < mrtks.Count; i++) RegisterInstance(mrtks[i]);
                 return activeInstance;
             }
         }
@@ -659,25 +637,19 @@ namespace Microsoft.MixedReality.Toolkit
 
         private void InitializeInstance()
         {
-            if (newInstanceBeingInitialized)
-            {
-                return;
-            }
+            if (newInstanceBeingInitialized) return;
 
             newInstanceBeingInitialized = true;
 
             gameObject.SetActive(true);
 
-            if (HasActiveProfile)
-            {
-                InitializeServiceLocator();
-            }
+            if (HasActiveProfile) InitializeServiceLocator();
 
             newInstanceBeingInitialized = false;
         }
 
         /// <summary>
-        /// Expose an assertion whether the MixedRealityToolkit class is initialized.
+        ///     Expose an assertion whether the MixedRealityToolkit class is initialized.
         /// </summary>
         public static void AssertIsInitialized()
         {
@@ -685,12 +657,12 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Returns whether the instance has been initialized or not.
+        ///     Returns whether the instance has been initialized or not.
         /// </summary>
         public static bool IsInitialized => activeInstance != null;
 
         /// <summary>
-        /// Static function to determine if the MixedRealityToolkit class has been initialized or not.
+        ///     Static function to determine if the MixedRealityToolkit class has been initialized or not.
         /// </summary>
         public static bool ConfirmInitialized()
         {
@@ -706,10 +678,7 @@ namespace Microsoft.MixedReality.Toolkit
 
         private void OnEnable()
         {
-            if (IsActiveInstance)
-            {
-                EnableAllServices();
-            }
+            if (IsActiveInstance) EnableAllServices();
         }
 
         private void Update()
@@ -718,12 +687,13 @@ namespace Microsoft.MixedReality.Toolkit
             {
                 // Before any Update() of a service is performed check to see if we need to switch profile
                 // If so we instantiate and initialize the services associated with the new profile.
-                if (newProfile != null && IsProfileSwitching)
+                if (newProfile && IsProfileSwitching)
                 {
                     InitializeNewProfile(newProfile);
                     newProfile = null;
                     IsProfileSwitching = false;
                 }
+
                 UpdateAllServices();
             }
         }
@@ -735,7 +705,7 @@ namespace Microsoft.MixedReality.Toolkit
                 LateUpdateAllServices();
                 // After LateUpdate()s of all services are finished check to see if we need to switch profile
                 // If so we destroy currently running services.
-                if (newProfile != null)
+                if (newProfile)
                 {
                     IsProfileSwitching = true;
                     RemoveCurrentProfile(newProfile);
@@ -745,10 +715,7 @@ namespace Microsoft.MixedReality.Toolkit
 
         private void OnDisable()
         {
-            if (IsActiveInstance)
-            {
-                DisableAllServices();
-            }
+            if (IsActiveInstance) DisableAllServices();
         }
 
         private void OnDestroy()
@@ -762,19 +729,17 @@ namespace Microsoft.MixedReality.Toolkit
 
         private const string activeInstanceGameObjectName = "MixedRealityToolkit";
         private const string inactiveInstanceGameObjectName = "MixedRealityToolkit (Inactive)";
-        private static List<MixedRealityToolkit> toolkitInstances = new List<MixedRealityToolkit>();
+        private static readonly List<MixedRealityToolkit> toolkitInstances = new List<MixedRealityToolkit>();
 
         public static void SetActiveInstance(MixedRealityToolkit toolkitInstance)
         {
-            if (MixedRealityToolkit.isApplicationQuitting)
-            {   // Don't register instances while application is quitting
+            if (isApplicationQuitting)
+                // Don't register instances while application is quitting
                 return;
-            }
 
             if (toolkitInstance == activeInstance)
-            {   // Don't do anything
+                // Don't do anything
                 return;
-            }
 
             // Disable the old instance
             SetInstanceInactive(activeInstance);
@@ -785,58 +750,53 @@ namespace Microsoft.MixedReality.Toolkit
 
         private static void RegisterInstance(MixedRealityToolkit toolkitInstance, bool setAsActiveInstance = false)
         {
-            if (MixedRealityToolkit.isApplicationQuitting || toolkitInstance == null)
-            {   // Don't register instances while application is quitting
+            if (isApplicationQuitting || toolkitInstance == null)
+                // Don't register instances while application is quitting
                 return;
-            }
 
             internalShutdown = false;
 
             if (!toolkitInstances.Contains(toolkitInstance))
-            {   // If we're already registered, no need to proceed
+            {
+                // If we're already registered, no need to proceed
                 // Add to list
                 toolkitInstances.Add(toolkitInstance);
                 // Sort the list by instance ID so we get deterministic results when selecting our next active instance
-                toolkitInstances.Sort(delegate (MixedRealityToolkit i1, MixedRealityToolkit i2) { return i1.GetInstanceID().CompareTo(i2.GetInstanceID()); });
+                toolkitInstances.Sort(delegate(MixedRealityToolkit i1, MixedRealityToolkit i2)
+                {
+                    return i1.GetInstanceID().CompareTo(i2.GetInstanceID());
+                });
             }
 
-            if (activeInstance == null)
+            if (!activeInstance)
             {
                 // If we don't have an active instance, either set this instance
                 // to be the active instance if requested, or get the first valid remaining instance
                 // in the list.
                 if (setAsActiveInstance)
-                {
                     activeInstance = toolkitInstance;
-                }
                 else
-                {
-                    for (int i = 0; i < toolkitInstances.Count; i++)
+                    for (var i = 0; i < toolkitInstances.Count; i++)
                     {
-                        if (toolkitInstances[i] != null)
-                        {
-                            activeInstance = toolkitInstances[i];
-                            break;
-                        }
+                        if (!toolkitInstances[i])
+                            continue;
+
+                        activeInstance = toolkitInstances[i];
+                        break;
                     }
-                }
 
                 activeInstance.DestroyAllServices();
                 activeInstance.InitializeInstance();
             }
 
             // Update instance's Name so it's clear who is the active instance
-            for (int i = toolkitInstances.Count - 1; i >= 0; i--)
-            {
-                if (toolkitInstances[i] == null)
-                {
+            for (var i = toolkitInstances.Count - 1; i >= 0; i--)
+                if (!toolkitInstances[i])
                     toolkitInstances.RemoveAt(i);
-                }
                 else
-                {
-                    toolkitInstances[i].name = toolkitInstances[i].IsActiveInstance ? activeInstanceGameObjectName : inactiveInstanceGameObjectName;
-                }
-            }
+                    toolkitInstances[i].name = toolkitInstances[i].IsActiveInstance
+                        ? activeInstanceGameObjectName
+                        : inactiveInstanceGameObjectName;
         }
 
         private static void UnregisterInstance(MixedRealityToolkit toolkitInstance)
@@ -846,26 +806,28 @@ namespace Microsoft.MixedReality.Toolkit
 
             toolkitInstances.Remove(toolkitInstance);
             // Sort the list by instance ID so we get deterministic results when selecting our next active instance
-            toolkitInstances.Sort(delegate (MixedRealityToolkit i1, MixedRealityToolkit i2) { return i1.GetInstanceID().CompareTo(i2.GetInstanceID()); });
+            toolkitInstances.Sort(delegate(MixedRealityToolkit i1, MixedRealityToolkit i2)
+            {
+                return i1.GetInstanceID().CompareTo(i2.GetInstanceID());
+            });
 
-            if (MixedRealityToolkit.activeInstance == toolkitInstance)
-            {   // If this is the active instance, we need to break it down
+            if (activeInstance == toolkitInstance)
+            {
+                // If this is the active instance, we need to break it down
                 toolkitInstance.DestroyAllServices();
                 CoreServices.ResetCacheReferences();
 
                 // If this was the active instance, unregister the active instance
-                MixedRealityToolkit.activeInstance = null;
-                if (MixedRealityToolkit.isApplicationQuitting)
-                {   // Don't search for additional instances if we're quitting
+                activeInstance = null;
+                if (isApplicationQuitting)
+                    // Don't search for additional instances if we're quitting
                     return;
-                }
 
-                for (int i = 0; i < toolkitInstances.Count; i++)
+                for (var i = 0; i < toolkitInstances.Count; i++)
                 {
                     if (toolkitInstances[i] == null)
-                    {   // This may have been a mass-deletion - be wary of soon-to-be-unregistered instances
+                        // This may have been a mass-deletion - be wary of soon-to-be-unregistered instances
                         continue;
-                    }
                     // Select the first available instance and register it immediately
                     RegisterInstance(toolkitInstances[i]);
                     break;
@@ -875,25 +837,22 @@ namespace Microsoft.MixedReality.Toolkit
 
         public static void SetInstanceInactive(MixedRealityToolkit toolkitInstance)
         {
-            if (toolkitInstance == null)
-            {   // Don't do anything.
+            if (!toolkitInstance)
+                // Don't do anything.
                 return;
-            }
 
             if (toolkitInstance == activeInstance)
-            {   // If this was the active instance, un-register the active instance
+            {
+                // If this was the active instance, un-register the active instance
                 // Break down all services
-                if (Application.isPlaying)
-                {
-                    toolkitInstance.DisableAllServices();
-                }
+                if (Application.isPlaying) toolkitInstance.DisableAllServices();
 
                 toolkitInstance.DestroyAllServices();
 
                 CoreServices.ResetCacheReferences();
 
                 // If this was the active instance, unregister the active instance
-                MixedRealityToolkit.activeInstance = null;
+                activeInstance = null;
             }
         }
 
@@ -902,6 +861,7 @@ namespace Microsoft.MixedReality.Toolkit
         #region Service Container Management
 
         #region Registration
+
         // NOTE: This method intentionally does not add to the registry. This is actually mostly a helper function for RegisterServiceInternal<T>.
         private bool RegisterServiceInternal(Type interfaceType, IMixedRealityService serviceInstance)
         {
@@ -913,16 +873,14 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (typeof(IMixedRealityDataProvider).IsAssignableFrom(interfaceType))
             {
-                Debug.LogWarning($"Unable to register a service of type {typeof(IMixedRealityDataProvider).Name}. Register this DataProvider with the MixedRealityService that depends on it.");
+                Debug.LogWarning(
+                    $"Unable to register a service of type {nameof(IMixedRealityDataProvider)}. Register this DataProvider with the MixedRealityService that depends on it.");
                 return false;
             }
 
-            if (!CanGetService(interfaceType))
-            {
-                return false;
-            }
+            if (!CanGetService(interfaceType)) return false;
 
-            IMixedRealityService preExistingService = GetServiceByNameInternal(interfaceType, serviceInstance.Name);
+            var preExistingService = GetServiceByNameInternal(interfaceType, serviceInstance.Name);
 
             if (preExistingService != null)
             {
@@ -936,29 +894,22 @@ namespace Microsoft.MixedReality.Toolkit
                 activeSystems.Add(interfaceType, serviceInstance);
             }
 
-            if (!isInitializing)
-            {
-                serviceInstance.Initialize();
-            }
+            if (!isInitializing) serviceInstance.Initialize();
             return true;
         }
 
         /// <summary>
-        /// Internal service registration.
+        ///     Internal service registration.
         /// </summary>
-        /// <param name="interfaceType">The interface type for the system to be registered.</param>
         /// <param name="serviceInstance">Instance of the service.</param>
         /// <returns>True if registration is successful, false otherwise.</returns>
         private bool RegisterServiceInternal<T>(T serviceInstance) where T : IMixedRealityService
         {
-            Type interfaceType = typeof(T);
-            if (RegisterServiceInternal(interfaceType, serviceInstance))
-            {
-                MixedRealityServiceRegistry.AddService<T>(serviceInstance, this);
-                return true;
-            }
-
-            return false;
+            var interfaceType = typeof(T);
+            if (!RegisterServiceInternal(interfaceType, serviceInstance))
+                return false;
+            MixedRealityServiceRegistry.AddService(serviceInstance, this);
+            return true;
         }
 
         #endregion Registration
@@ -966,7 +917,7 @@ namespace Microsoft.MixedReality.Toolkit
         #region Multiple Service Management
 
         /// <summary>
-        /// Enable all services in the Mixed Reality Toolkit active service registry for a given type
+        ///     Enable all services in the Mixed Reality Toolkit active service registry for a given type
         /// </summary>
         /// <param name="interfaceType">The interface type for the system to be enabled.  E.G. InputSystem, BoundarySystem</param>
         public void EnableAllServicesByType(Type interfaceType)
@@ -975,7 +926,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Enable all services in the Mixed Reality Toolkit active service registry for a given type and name
+        ///     Enable all services in the Mixed Reality Toolkit active service registry for a given type and name
         /// </summary>
         /// <param name="interfaceType">The interface type for the system to be enabled.  E.G. InputSystem, BoundarySystem</param>
         /// <param name="serviceName">Name of the specific service</param>
@@ -987,15 +938,12 @@ namespace Microsoft.MixedReality.Toolkit
                 return;
             }
 
-            IReadOnlyList<IMixedRealityService> services = GetAllServicesByNameInternal<IMixedRealityService>(interfaceType, serviceName);
-            for (int i = 0; i < services.Count; i++)
-            {
-                services[i].Enable();
-            }
+            var services = GetAllServicesByNameInternal<IMixedRealityService>(interfaceType, serviceName);
+            for (var i = 0; i < services.Count; i++) services[i].Enable();
         }
 
         /// <summary>
-        /// Disable all services in the Mixed Reality Toolkit active service registry for a given type
+        ///     Disable all services in the Mixed Reality Toolkit active service registry for a given type
         /// </summary>
         /// <param name="interfaceType">The interface type for the system to be removed.  E.G. InputSystem, BoundarySystem</param>
         public void DisableAllServicesByType(Type interfaceType)
@@ -1004,7 +952,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Disable all services in the Mixed Reality Toolkit active service registry for a given type and name
+        ///     Disable all services in the Mixed Reality Toolkit active service registry for a given type and name
         /// </summary>
         /// <param name="interfaceType">The interface type for the system to be disabled.  E.G. InputSystem, BoundarySystem</param>
         /// <param name="serviceName">Name of the specific service</param>
@@ -1016,11 +964,8 @@ namespace Microsoft.MixedReality.Toolkit
                 return;
             }
 
-            IReadOnlyList<IMixedRealityService> services = GetAllServicesByNameInternal<IMixedRealityService>(interfaceType, serviceName);
-            for (int i = 0; i < services.Count; i++)
-            {
-                services[i].Disable();
-            }
+            var services = GetAllServicesByNameInternal<IMixedRealityService>(interfaceType, serviceName);
+            for (var i = 0; i < services.Count; i++) services[i].Disable();
         }
 
         private void InitializeAllServices()
@@ -1044,7 +989,8 @@ namespace Microsoft.MixedReality.Toolkit
             ExecuteOnAllServicesInOrder(service => service.Enable());
         }
 
-        private static readonly ProfilerMarker UpdateAllServicesPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.UpdateAllServices");
+        private static readonly ProfilerMarker UpdateAllServicesPerfMarker =
+            new ProfilerMarker("[MRTK] MixedRealityToolkit.UpdateAllServices");
 
         private void UpdateAllServices()
         {
@@ -1055,17 +1001,18 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-        private static readonly ProfilerMarker LateUpdateAllServicesPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.LateUpdateAllServices");
+        private static readonly ProfilerMarker LateUpdateAllServicesPerfMarker =
+            new ProfilerMarker("[MRTK] MixedRealityToolkit.LateUpdateAllServices");
 
         private void LateUpdateAllServices()
         {
             using (LateUpdateAllServicesPerfMarker.Auto())
             {
                 // If the Mixed Reality Toolkit is not configured, stop.
-                if (activeProfile == null) { return; }
+                if (!activeProfile) return;
 
                 // If the Mixed Reality Toolkit is not initialized, stop.
-                if (!IsInitialized) { return; }
+                if (!IsInitialized) return;
 
                 // Update all systems
                 ExecuteOnAllServicesInOrder(service => service.LateUpdate());
@@ -1090,36 +1037,22 @@ namespace Microsoft.MixedReality.Toolkit
 
             foreach (var service in orderedActiveSystems)
             {
-                Type type = service.Key;
+                var type = service.Key;
 
                 if (typeof(IMixedRealityBoundarySystem).IsAssignableFrom(type))
-                {
                     UnregisterService<IMixedRealityBoundarySystem>();
-                }
                 else if (typeof(IMixedRealityCameraSystem).IsAssignableFrom(type))
-                {
                     UnregisterService<IMixedRealityCameraSystem>();
-                }
                 else if (typeof(IMixedRealityDiagnosticsSystem).IsAssignableFrom(type))
-                {
                     UnregisterService<IMixedRealityDiagnosticsSystem>();
-                }
                 else if (typeof(IMixedRealityFocusProvider).IsAssignableFrom(type))
-                {
                     UnregisterService<IMixedRealityFocusProvider>();
-                }
                 else if (typeof(IMixedRealityInputSystem).IsAssignableFrom(type))
-                {
                     UnregisterService<IMixedRealityInputSystem>();
-                }
                 else if (typeof(IMixedRealitySpatialAwarenessSystem).IsAssignableFrom(type))
-                {
                     UnregisterService<IMixedRealitySpatialAwarenessSystem>();
-                }
                 else if (typeof(IMixedRealityTeleportSystem).IsAssignableFrom(type))
-                {
                     UnregisterService<IMixedRealityTeleportSystem>();
-                }
             }
 
             activeSystems.Clear();
@@ -1127,46 +1060,36 @@ namespace Microsoft.MixedReality.Toolkit
             MixedRealityServiceRegistry.ClearAllServices();
         }
 
-        private static readonly ProfilerMarker ExecuteOnAllServicesInOrderPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesInOrder");
+        private static readonly ProfilerMarker ExecuteOnAllServicesInOrderPerfMarker =
+            new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesInOrder");
 
         private bool ExecuteOnAllServicesInOrder(Action<IMixedRealityService> execute)
         {
             using (ExecuteOnAllServicesInOrderPerfMarker.Auto())
             {
-                if (!HasProfileAndIsInitialized)
-                {
-                    return false;
-                }
+                if (!HasProfileAndIsInitialized) return false;
 
                 var services = MixedRealityServiceRegistry.GetAllServices();
-                int length = services.Count;
-                for (int i = 0; i < length; i++)
-                {
-                    execute(services[i]);
-                }
+                var length = services.Count;
+                for (var i = 0; i < length; i++) execute(services[i]);
 
                 return true;
             }
         }
 
-        private static readonly ProfilerMarker ExecuteOnAllServicesReverseOrderPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesReverseOrder");
+        private static readonly ProfilerMarker ExecuteOnAllServicesReverseOrderPerfMarker =
+            new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesReverseOrder");
 
         private bool ExecuteOnAllServicesReverseOrder(Action<IMixedRealityService> execute)
         {
             using (ExecuteOnAllServicesReverseOrderPerfMarker.Auto())
             {
-                if (!HasProfileAndIsInitialized)
-                {
-                    return false;
-                }
+                if (!HasProfileAndIsInitialized) return false;
 
                 var services = MixedRealityServiceRegistry.GetAllServices();
-                int length = services.Count;
+                var length = services.Count;
 
-                for (int i = length - 1; i >= 0; i--)
-                {
-                    execute(services[i]);
-                }
+                for (var i = length - 1; i >= 0; i--) execute(services[i]);
 
                 return true;
             }
@@ -1177,11 +1100,12 @@ namespace Microsoft.MixedReality.Toolkit
         #region Service Utilities
 
         /// <summary>
-        /// Generic function used to interrogate the Mixed Reality Toolkit active system registry for the existence of a core system.
+        ///     Generic function used to interrogate the Mixed Reality Toolkit active system registry for the existence of a core
+        ///     system.
         /// </summary>
         /// <typeparam name="T">The interface type for the system to be retrieved.  E.G. InputSystem, BoundarySystem.</typeparam>
         /// <remarks>
-        /// Note: type should be the Interface of the system to be retrieved and not the concrete class itself.
+        ///     Note: type should be the Interface of the system to be retrieved and not the concrete class itself.
         /// </remarks>
         /// <returns>True, there is a system registered with the selected interface, False, no system found for that interface</returns>
         [Obsolete("Use IsServiceRegistered instead")]
@@ -1189,17 +1113,13 @@ namespace Microsoft.MixedReality.Toolkit
         {
             if (!IsCoreSystem(typeof(T))) return false;
 
-            T service;
-            MixedRealityServiceRegistry.TryGetService<T>(out service);
+            MixedRealityServiceRegistry.TryGetService<T>(out var service);
 
-            if (service == null)
-            {
-                IMixedRealityService activeSerivce;
-                activeSystems.TryGetValue(typeof(T), out activeSerivce);
-                return activeSerivce != null;
-            }
+            if (service != null)
+                return true;
 
-            return service != null;
+            activeSystems.TryGetValue(typeof(T), out var activeService);
+            return activeService != null;
         }
 
         private static bool IsCoreSystem(Type type)
@@ -1225,98 +1145,83 @@ namespace Microsoft.MixedReality.Toolkit
         {
             if (typeof(IMixedRealityDataProvider).IsAssignableFrom(interfaceType))
             {
-                Debug.LogWarning($"Unable to get a service of type {typeof(IMixedRealityDataProvider).Name}.");
+                Debug.LogWarning($"Unable to get a service of type {nameof(IMixedRealityDataProvider)}.");
                 return null;
             }
 
-            if (!CanGetService(interfaceType)) { return null; }
+            if (!CanGetService(interfaceType)) return null;
 
-            IMixedRealityService service;
-            MixedRealityServiceRegistry.TryGetService(interfaceType, out service, out _, serviceName);
-            if (service != null)
-            {
-                return service;
-            }
-
-            return null;
+            MixedRealityServiceRegistry.TryGetService(interfaceType, out var service, out _, serviceName);
+            return service;
         }
 
         /// <summary>
-        /// Retrieve the first service from the registry that meets the selected type and name
+        ///     Retrieve the first service from the registry that meets the selected type and name
         /// </summary>
-        /// <param name="interfaceType">Interface type of the service being requested</param>
         /// <param name="serviceName">Name of the specific service</param>
-        /// <param name="serviceInstance">return parameter of the function</param>
         private T GetServiceByName<T>(string serviceName) where T : IMixedRealityService
         {
-            return (T)GetServiceByNameInternal(typeof(T), serviceName);
+            return (T) GetServiceByNameInternal(typeof(T), serviceName);
         }
 
         /// <summary>
-        /// Gets all services by type and name.
+        ///     Gets all services by type and name.
         /// </summary>
-        /// <param name="serviceName">The name of the service to search for. If the string is empty than any matching <see cref="interfaceType"/> will be added to the <see cref="services"/> list.</param>
-        private IReadOnlyList<T> GetAllServicesByNameInternal<T>(Type interfaceType, string serviceName) where T : IMixedRealityService
+        /// <param name="serviceName">
+        ///     The name of the service to search for. If the string is empty than any matching
+        ///     <see cref="interfaceType" /> will be added to the <see cref="services" /> list.
+        /// </param>
+        private IReadOnlyList<T> GetAllServicesByNameInternal<T>(Type interfaceType, string serviceName)
+            where T : IMixedRealityService
         {
-            List<T> services = new List<T>();
+            var services = new List<T>();
 
-            if (!CanGetService(interfaceType)) { return new List<T>() as IReadOnlyList<T>; }
+            if (!CanGetService(interfaceType)) return new List<T>();
 
-            bool isNullServiceName = string.IsNullOrEmpty(serviceName);
+            var isNullServiceName = string.IsNullOrEmpty(serviceName);
             var systems = MixedRealityServiceRegistry.GetAllServices();
-            int length = systems.Count;
-            for (int i = 0; i < length; i++)
+            var length = systems.Count;
+            for (var i = 0; i < length; i++)
             {
-                IMixedRealityService service = systems[i];
-                if (service is T serviceT && (isNullServiceName || service.Name == serviceName))
-                {
-                    services.Add(serviceT);
-                }
+                var service = systems[i];
+                if (service is T serviceT && (isNullServiceName || service.Name == serviceName)) services.Add(serviceT);
             }
 
             return services;
         }
 
         /// <summary>
-        /// Check if the interface type and name matches the registered interface type and service instance found.
+        ///     Check if the interface type and name matches the registered interface type and service instance found.
         /// </summary>
         /// <param name="interfaceType">The interface type of the service to check.</param>
         /// <param name="serviceName">The name of the service to check.</param>
         /// <param name="registeredInterfaceType">The registered interface type.</param>
         /// <param name="serviceInstance">The instance of the registered service.</param>
         /// <returns>True, if the registered service contains the interface type and name.</returns>
-        private static bool CheckServiceMatch(Type interfaceType, string serviceName, Type registeredInterfaceType, IMixedRealityService serviceInstance)
+        private static bool CheckServiceMatch(Type interfaceType, string serviceName, Type registeredInterfaceType,
+            IMixedRealityService serviceInstance)
         {
-            bool isValid = string.IsNullOrEmpty(serviceName) || serviceInstance.Name == serviceName;
+            var isValid = string.IsNullOrEmpty(serviceName) || serviceInstance.Name == serviceName;
 
-            if ((registeredInterfaceType.Name == interfaceType.Name || serviceInstance.GetType().Name == interfaceType.Name) && isValid)
-            {
-                return true;
-            }
+            if ((registeredInterfaceType.Name == interfaceType.Name ||
+                 serviceInstance.GetType().Name == interfaceType.Name) && isValid) return true;
 
             var interfaces = serviceInstance.GetType().GetInterfaces();
 
-            for (int i = 0; i < interfaces.Length; i++)
-            {
+            for (var i = 0; i < interfaces.Length; i++)
                 if (interfaces[i].Name == interfaceType.Name && isValid)
-                {
                     return true;
-                }
-            }
 
             return false;
         }
 
         /// <summary>
-        /// Checks if the system is ready to get a service.
+        ///     Checks if the system is ready to get a service.
         /// </summary>
         /// <param name="interfaceType">The interface type of the service being checked.</param>
         private static bool CanGetService(Type interfaceType)
         {
-            if (isApplicationQuitting && !internalShutdown)
-            {
-                return false;
-            }
+            if (isApplicationQuitting && !internalShutdown) return false;
 
             if (!IsInitialized)
             {
@@ -1326,13 +1231,13 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (interfaceType == null)
             {
-                Debug.LogError($"Interface type is null.");
+                Debug.LogError("Interface type is null.");
                 return false;
             }
 
             if (!typeof(IMixedRealityService).IsAssignableFrom(interfaceType))
             {
-                Debug.LogError($"{interfaceType.Name} does not implement {typeof(IMixedRealityService).Name}.");
+                Debug.LogError($"{interfaceType.Name} does not implement {nameof(IMixedRealityService)}.");
                 return false;
             }
 
@@ -1346,129 +1251,110 @@ namespace Microsoft.MixedReality.Toolkit
         #region Core System Accessors
 
         /// <summary>
-        /// The current Input System registered with the Mixed Reality Toolkit.
+        ///     The current Input System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.InputSystem instead")]
         public static IMixedRealityInputSystem InputSystem
         {
             get
             {
-                if (isApplicationQuitting)
-                {
-                    return null;
-                }
+                if (isApplicationQuitting) return null;
 
                 return CoreServices.InputSystem;
             }
         }
 
         /// <summary>
-        /// The current Boundary System registered with the Mixed Reality Toolkit.
+        ///     The current Boundary System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.BoundarySystem instead")]
         public static IMixedRealityBoundarySystem BoundarySystem
         {
             get
             {
-                if (isApplicationQuitting)
-                {
-                    return null;
-                }
+                if (isApplicationQuitting) return null;
 
                 return CoreServices.BoundarySystem;
             }
         }
 
         /// <summary>
-        /// The current Camera System registered with the Mixed Reality Toolkit.
+        ///     The current Camera System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.CameraSystem instead")]
         public static IMixedRealityCameraSystem CameraSystem
         {
             get
             {
-                if (isApplicationQuitting)
-                {
-                    return null;
-                }
+                if (isApplicationQuitting) return null;
 
                 return CoreServices.CameraSystem;
             }
         }
 
         /// <summary>
-        /// The current Spatial Awareness System registered with the Mixed Reality Toolkit.
+        ///     The current Spatial Awareness System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.SpatialAwarenessSystem instead")]
         public static IMixedRealitySpatialAwarenessSystem SpatialAwarenessSystem
         {
             get
             {
-                if (isApplicationQuitting)
-                {
-                    return null;
-                }
+                if (isApplicationQuitting) return null;
 
                 return CoreServices.SpatialAwarenessSystem;
             }
         }
 
         /// <summary>
-        /// Returns true if the MixedRealityToolkit exists and has an active profile that has Teleport system enabled.
+        ///     Returns true if the MixedRealityToolkit exists and has an active profile that has Teleport system enabled.
         /// </summary>
-        public static bool IsTeleportSystemEnabled => IsInitialized && Instance.HasActiveProfile && Instance.ActiveProfile.IsTeleportSystemEnabled;
+        public static bool IsTeleportSystemEnabled => IsInitialized && Instance.HasActiveProfile &&
+                                                      Instance.ActiveProfile.IsTeleportSystemEnabled;
 
         /// <summary>
-        /// The current Teleport System registered with the Mixed Reality Toolkit.
+        ///     The current Teleport System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.TeleportSystem instead")]
         public static IMixedRealityTeleportSystem TeleportSystem
         {
             get
             {
-                if (isApplicationQuitting)
-                {
-                    return null;
-                }
+                if (isApplicationQuitting) return null;
 
                 return CoreServices.TeleportSystem;
             }
         }
 
         /// <summary>
-        /// The current Diagnostics System registered with the Mixed Reality Toolkit.
+        ///     The current Diagnostics System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.DiagnosticsSystem instead")]
         public static IMixedRealityDiagnosticsSystem DiagnosticsSystem
         {
             get
             {
-                if (isApplicationQuitting)
-                {
-                    return null;
-                }
+                if (isApplicationQuitting) return null;
 
                 return CoreServices.DiagnosticsSystem;
             }
         }
 
         /// <summary>
-        /// Returns true if the MixedRealityToolkit exists and has an active profile that has Scene system enabled.
+        ///     Returns true if the MixedRealityToolkit exists and has an active profile that has Scene system enabled.
         /// </summary>
-        public static bool IsSceneSystemEnabled => IsInitialized && Instance.HasActiveProfile && Instance.ActiveProfile.IsSceneSystemEnabled;
+        public static bool IsSceneSystemEnabled =>
+            IsInitialized && Instance.HasActiveProfile && Instance.ActiveProfile.IsSceneSystemEnabled;
 
         /// <summary>
-        /// The current Scene System registered with the Mixed Reality Toolkit.
+        ///     The current Scene System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.SceneSystem instead")]
         public static IMixedRealitySceneSystem SceneSystem
         {
             get
             {
-                if (isApplicationQuitting)
-                {
-                    return null;
-                }
+                if (isApplicationQuitting) return null;
 
                 return CoreServices.SceneSystem;
             }
@@ -1477,22 +1363,20 @@ namespace Microsoft.MixedReality.Toolkit
         #endregion Core System Accessors
 
         #region Application Event Listeners
+
         /// <summary>
-        /// Registers once on startup and sets isApplicationQuitting to true when quit event is detected.
+        ///     Registers once on startup and sets isApplicationQuitting to true when quit event is detected.
         /// </summary>
         [RuntimeInitializeOnLoadMethod]
         private static void RegisterRuntimePlayModeListener()
         {
-            Application.quitting += () =>
-            {
-                isApplicationQuitting = true;
-            };
+            Application.quitting += () => { isApplicationQuitting = true; };
         }
 
 #if UNITY_EDITOR
         /// <summary>
-        /// Static class whose constructor is called once on startup. Listens for editor events.
-        /// Removes the need for individual instances to listen for events.
+        ///     Static class whose constructor is called once on startup. Listens for editor events.
+        ///     Removes the need for individual instances to listen for events.
         /// </summary>
         [InitializeOnLoad]
         private static class EditorEventListener
@@ -1513,13 +1397,14 @@ namespace Microsoft.MixedReality.Toolkit
                             isApplicationQuitting = false;
 
                             if (activeInstance != null && activeInstance.activeProfile == null)
-                            {
                                 // If we have an active instance, and its profile is null,
                                 // Alert the user that we don't have an active profile
                                 // Keep track though whether user has instructed to ignore this warning
                                 if (SessionState.GetBool(WarnUser_EmptyActiveProfile, true))
                                 {
-                                    if (EditorUtility.DisplayDialog("Warning!", "Mixed Reality Toolkit cannot initialize because no Active Profile has been assigned.", "OK", "Ignore"))
+                                    if (EditorUtility.DisplayDialog("Warning!",
+                                        "Mixed Reality Toolkit cannot initialize because no Active Profile has been assigned.",
+                                        "OK", "Ignore"))
                                     {
                                         // Stop play mode as changes done in play mode will be lost
                                         EditorApplication.isPlaying = false;
@@ -1531,9 +1416,7 @@ namespace Microsoft.MixedReality.Toolkit
                                         SessionState.SetBool(WarnUser_EmptyActiveProfile, false);
                                     }
                                 }
-                            }
-                            break;
-                        default:
+
                             break;
                     }
                 };
@@ -1544,40 +1427,37 @@ namespace Microsoft.MixedReality.Toolkit
                     if (!Application.isPlaying)
                     {
                         // Clean the toolkit instances hierarchy in case instances were deleted.
-                        for (int i = toolkitInstances.Count - 1; i >= 0; i--)
-                        {
+                        for (var i = toolkitInstances.Count - 1; i >= 0; i--)
                             if (toolkitInstances[i] == null)
-                            {
                                 // If it has been destroyed, remove it
                                 toolkitInstances.RemoveAt(i);
-                            }
-                        }
 
                         // If the active instance is null, it may not have been set, or it may have been deleted.
                         if (activeInstance == null)
                         {
                             // Do a search for a new active instance
-                            MixedRealityToolkit instanceCheck = Instance;
+                            var instanceCheck = Instance;
                         }
                     }
 
-                    for (int i = toolkitInstances.Count - 1; i >= 0; i--)
-                    {
+                    for (var i = toolkitInstances.Count - 1; i >= 0; i--)
                         // Make sure MRTK is not parented under anything
-                        Debug.Assert(toolkitInstances[i].transform.parent == null, "MixedRealityToolkit instances should not be parented under any other GameObject.");
-                    }
+                        Debug.Assert(toolkitInstances[i].transform.parent == null,
+                            "MixedRealityToolkit instances should not be parented under any other GameObject.");
                 };
             }
         }
 
         private void OnValidate()
         {
-            EditorApplication.delayCall += DelayOnValidate; // This is a workaround for a known unity issue when calling refresh assetdatabase from inside a on validate scope.
+            EditorApplication.delayCall +=
+                DelayOnValidate; // This is a workaround for a known unity issue when calling refresh assetdatabase from inside a on validate scope.
         }
 
         /// <summary>
-        /// Used to register newly created instances in edit mode.
-        /// Initially handled by using ExecuteAlways, but this attribute causes the instance to be destroyed as we enter play mode, which is disruptive to services.
+        ///     Used to register newly created instances in edit mode.
+        ///     Initially handled by using ExecuteAlways, but this attribute causes the instance to be destroyed as we enter play
+        ///     mode, which is disruptive to services.
         /// </summary>
         private void DelayOnValidate()
         {
@@ -1588,9 +1468,7 @@ namespace Microsoft.MixedReality.Toolkit
             if (EditorApplication.isPlayingOrWillChangePlaymode ||
                 EditorApplication.isCompiling ||
                 BuildPipeline.isBuildingPlayer)
-            {
                 return;
-            }
 
             RegisterInstance(this);
         }

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -1,107 +1,95 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.MixedReality.Toolkit.Boundary;
-using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Diagnostics;
 using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Rendering;
-using Microsoft.MixedReality.Toolkit.SceneSystem;
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Teleport;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using Microsoft.MixedReality.Toolkit.SceneSystem;
+using Microsoft.MixedReality.Toolkit.CameraSystem;
+using Microsoft.MixedReality.Toolkit.Rendering;
+
 #if UNITY_EDITOR
 using Microsoft.MixedReality.Toolkit.Input.Editor;
 using UnityEditor;
-
 #endif
 
 namespace Microsoft.MixedReality.Toolkit
 {
     /// <summary>
-    ///     This class is responsible for coordinating the operation of the Mixed Reality Toolkit. It is the only Singleton in
-    ///     the entire project.
-    ///     It provides a service registry for all active services that are used within a project as well as providing the
-    ///     active configuration profile for the project.
-    ///     The Profile can be swapped out at any time to meet the needs of your project.
+    /// This class is responsible for coordinating the operation of the Mixed Reality Toolkit. It is the only Singleton in the entire project.
+    /// It provides a service registry for all active services that are used within a project as well as providing the active configuration profile for the project.
+    /// The Profile can be swapped out at any time to meet the needs of your project.
     /// </summary>
     [DisallowMultipleComponent]
     [AddComponentMenu("Scripts/MRTK/Core/MixedRealityToolkit")]
     public class MixedRealityToolkit : MonoBehaviour, IMixedRealityServiceRegistrar
     {
-        private static bool isInitializing;
-        private static bool isApplicationQuitting;
-        private static bool internalShutdown;
-
-        private const string NoMRTKProfileErrorMessage =
-            "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit";
+        private static bool isInitializing = false;
+        private static bool isApplicationQuitting = false;
+        private static bool internalShutdown = false;
+        private const string NoMRTKProfileErrorMessage = "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit";
 
         /// <summary>
-        ///     Whether an active profile switching is currently in progress
+        /// Whether an active profile switching is currently in progress
         /// </summary>
         public bool IsProfileSwitching { get; private set; }
 
         #region Mixed Reality Toolkit Profile configuration
 
         /// <summary>
-        ///     Checks if there is a valid instance of the MixedRealityToolkit, then checks if there is there a valid Active
-        ///     Profile.
+        /// Checks if there is a valid instance of the MixedRealityToolkit, then checks if there is there a valid Active Profile.
         /// </summary>
         public bool HasActiveProfile
         {
             get
             {
-                if (!IsInitialized) return false;
+                if (!IsInitialized)
+                {
+                    return false;
+                }
 
-                return ActiveProfile != null;
+                return ActiveProfile;
             }
         }
 
         /// <summary>
-        ///     Returns true if this is the active instance.
+        /// Returns true if this is the active instance.
         /// </summary>
         public bool IsActiveInstance => activeInstance == this;
 
         private bool HasProfileAndIsInitialized => activeProfile != null && IsInitialized;
 
         /// <summary>
-        ///     The active profile of the Mixed Reality Toolkit which controls which services are active and their initial
-        ///     configuration.
-        ///     *Note configuration is used on project initialization or replacement, changes to properties while it is running has
-        ///     no effect.
+        /// The active profile of the Mixed Reality Toolkit which controls which services are active and their initial configuration.
+        /// *Note configuration is used on project initialization or replacement, changes to properties while it is running has no effect.
         /// </summary>
         [SerializeField]
         [Tooltip("The current active configuration for the Mixed Reality project")]
-        private MixedRealityToolkitConfigurationProfile activeProfile;
+        private MixedRealityToolkitConfigurationProfile activeProfile = null;
 
         /// <summary>
-        ///     The public property of the Active Profile, ensuring events are raised on the change of the configuration
+        /// The public property of the Active Profile, ensuring events are raised on the change of the configuration
         /// </summary>
         /// <remarks>
-        ///     If changing the Active profile prior to the initialization (i.e. Awake()) of <see cref="MixedRealityToolkit" /> is
-        ///     desired,
-        ///     call the static funtion <see cref="SetProfileBeforeInitialization(MixedRealityToolkitConfigurationProfile)" />
-        ///     instead.
-        ///     When setting the ActiveProfile during runtime, the destroy of the currently running services will happen after the
-        ///     last LateUpdate()
-        ///     of all services, and the instantiation and initialization of the services associated with the new profile will
-        ///     happen before the
-        ///     first Update() of all services.
-        ///     A noticable application hesitation may occur during this process. Also any script with higher priority than this
-        ///     can enter its Update
-        ///     before the new profile is properly setup.
-        ///     You are strongly recommended to see
-        ///     <see
-        ///         href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">
-        ///         here
-        ///     </see>
-        ///     for more information on profile switching.
+        /// If changing the Active profile prior to the initialization (i.e. Awake()) of <see cref="MixedRealityToolkit"/> is desired, 
+        /// call the static funtion <see cref="SetProfileBeforeInitialization(MixedRealityToolkitConfigurationProfile)"/> instead.
+        /// When setting the ActiveProfile during runtime, the destroy of the currently running services will happen after the last LateUpdate()
+        /// of all services, and the instantiation and initialization of the services associated with the new profile will happen before the
+        /// first Update() of all services.
+        /// A noticable application hesitation may occur during this process. Also any script with higher priority than this can enter its Update
+        /// before the new profile is properly setup.
+        /// You are strongly recommended to see 
+        /// <see href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">here</see> 
+        /// for more information on profile switching.
         /// </remarks>
         public MixedRealityToolkitConfigurationProfile ActiveProfile
         {
@@ -109,49 +97,45 @@ namespace Microsoft.MixedReality.Toolkit
             set
             {
                 // Behavior during a valid runtime profile switch
-                if (Application.isPlaying && activeProfile != null && value != null)
+                if (Application.isPlaying && activeProfile && value)
+                {
                     newProfile = value;
+                }
                 // Behavior in other scenarios (e.g. when profile switch is being requested by editor code)
                 else
+                {
                     ResetConfiguration(value);
+                }
+
             }
         }
 
         /// <summary>
-        ///     Set the active profile prior to the initialization (i.e. Awake()) of <see cref="MixedRealityToolkit" />
+        /// Set the active profile prior to the initialization (i.e. Awake()) of <see cref="MixedRealityToolkit"/>
         /// </summary>
         /// <remarks>
-        ///     If changing the Active profile after <see cref="MixedRealityToolkit" /> has been initialized, modify
-        ///     <see cref="ActiveProfile" /> of the active instance directly.
-        ///     This function requires the caller script to be executed earlier than the <see cref="MixedRealityToolkit" /> script,
-        ///     which can be achieved by setting
-        ///     <see href="https://docs.unity3d.com/Manual/class-MonoManager.html">Script Execution Order settings</see>.
-        ///     You are strongly recommended to see
-        ///     <see
-        ///         href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">
-        ///         here
-        ///     </see>
-        ///     for more information on profile switching.
+        /// If changing the Active profile after <see cref="MixedRealityToolkit"/> has been initialized, modify <see cref="ActiveProfile"/> of the active instance directly.
+        /// This function requires the caller script to be executed earlier than the <see cref="MixedRealityToolkit"/> script, which can be achieved by setting 
+        /// <see href="https://docs.unity3d.com/Manual/class-MonoManager.html">Script Execution Order settings</see>.
+        /// You are strongly recommended to see 
+        /// <see href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">here</see> 
+        /// for more information on profile switching.
         /// </remarks>
         public static void SetProfileBeforeInitialization(MixedRealityToolkitConfigurationProfile profile)
         {
-            var toolkit = FindObjectOfType<MixedRealityToolkit>();
+            MixedRealityToolkit toolkit = FindObjectOfType<MixedRealityToolkit>();
             toolkit.activeProfile = profile;
         }
 
         /// <summary>
-        ///     When a configuration Profile is replaced with a new configuration, force all services to reset and read the new
-        ///     values
+        /// When a configuration Profile is replaced with a new configuration, force all services to reset and read the new values
         /// </summary>
         /// <remarks>
-        ///     This function should only be used by editor code in most cases.
-        ///     Do not call this function if resetting profile at runtime.
-        ///     Instead see
-        ///     <see
-        ///         href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">
-        ///         here
-        ///     </see>
-        ///     for more information on profile switching at runtime.
+        /// This function should only be used by editor code in most cases.
+        /// Do not call this function if resetting profile at runtime.
+        /// Instead see 
+        /// <see href="https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html#changing-profiles-at-runtime">here</see> 
+        /// for more information on profile switching at runtime.
         /// </remarks>
         public void ResetConfiguration(MixedRealityToolkitConfigurationProfile profile)
         {
@@ -163,7 +147,10 @@ namespace Microsoft.MixedReality.Toolkit
         {
             InitializeServiceLocator();
 
-            if (profile != null && Application.IsPlaying(profile)) EnableAllServices();
+            if (profile && Application.IsPlaying(profile))
+            {
+                EnableAllServices();
+            }
         }
 
         private void RemoveCurrentProfile(MixedRealityToolkitConfigurationProfile profile)
@@ -171,7 +158,10 @@ namespace Microsoft.MixedReality.Toolkit
             if (activeProfile)
             {
                 // Services are only enabled when playing.
-                if (Application.IsPlaying(activeProfile)) DisableAllServices();
+                if (Application.IsPlaying(activeProfile))
+                {
+                    DisableAllServices();
+                }
                 DestroyAllServices();
             }
 
@@ -179,7 +169,10 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (profile)
             {
-                if (Application.IsPlaying(profile)) DisableAllServices();
+                if (Application.IsPlaying(profile))
+                {
+                    DisableAllServices();
+                }
                 DestroyAllServices();
             }
         }
@@ -190,29 +183,24 @@ namespace Microsoft.MixedReality.Toolkit
 
         #region Mixed Reality runtime service registry
 
-        private static readonly Dictionary<Type, IMixedRealityService> activeSystems =
-            new Dictionary<Type, IMixedRealityService>();
+        private static readonly Dictionary<Type, IMixedRealityService> activeSystems = new Dictionary<Type, IMixedRealityService>();
 
         /// <summary>
-        ///     Current active systems registered with the MixedRealityToolkit.
+        /// Current active systems registered with the MixedRealityToolkit.
         /// </summary>
         /// <remarks>
-        ///     Systems can only be registered once by <see cref="System.Type" />
+        /// Systems can only be registered once by <see cref="System.Type"/>
         /// </remarks>
         [Obsolete("Use CoreService, MixedRealityServiceRegistry, or GetService<T> instead")]
-        public IReadOnlyDictionary<Type, IMixedRealityService> ActiveSystems =>
-            new Dictionary<Type, IMixedRealityService>(activeSystems);
+        public IReadOnlyDictionary<Type, IMixedRealityService> ActiveSystems => new Dictionary<Type, IMixedRealityService>(activeSystems) as IReadOnlyDictionary<Type, IMixedRealityService>;
 
-        private static readonly List<Tuple<Type, IMixedRealityService>> registeredMixedRealityServices =
-            new List<Tuple<Type, IMixedRealityService>>();
+        private static readonly List<Tuple<Type, IMixedRealityService>> registeredMixedRealityServices = new List<Tuple<Type, IMixedRealityService>>();
 
         /// <summary>
-        ///     Local service registry for the Mixed Reality Toolkit, to allow runtime use of the
-        ///     <see cref="Microsoft.MixedReality.Toolkit.IMixedRealityService" />.
+        /// Local service registry for the Mixed Reality Toolkit, to allow runtime use of the <see cref="Microsoft.MixedReality.Toolkit.IMixedRealityService"/>.
         /// </summary>
         [Obsolete("Use GetDataProvider<T> of MixedRealityService registering the desired IMixedRealityDataProvider")]
-        public IReadOnlyList<Tuple<Type, IMixedRealityService>> RegisteredMixedRealityServices =>
-            new List<Tuple<Type, IMixedRealityService>>(registeredMixedRealityServices);
+        public IReadOnlyList<Tuple<Type, IMixedRealityService>> RegisteredMixedRealityServices => new List<Tuple<Type, IMixedRealityService>>(registeredMixedRealityServices) as IReadOnlyList<Tuple<Type, IMixedRealityService>>;
 
         #endregion Mixed Reality runtime service registry
 
@@ -221,13 +209,13 @@ namespace Microsoft.MixedReality.Toolkit
         /// <inheritdoc />
         public bool RegisterService<T>(T serviceInstance) where T : IMixedRealityService
         {
-            return RegisterServiceInternal(serviceInstance);
+            return RegisterServiceInternal<T>(serviceInstance);
         }
 
         /// <inheritdoc />
         public bool RegisterService<T>(
             Type concreteType,
-            SupportedPlatforms supportedPlatforms = (SupportedPlatforms) (-1),
+            SupportedPlatforms supportedPlatforms = (SupportedPlatforms)(-1),
             params object[] args) where T : IMixedRealityService
         {
             return RegisterServiceInternal<T>(
@@ -238,30 +226,30 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        ///     Internal method that creates an instance of the specified concrete type and registers the service.
+        /// Internal method that creates an instance of the specified concrete type and registers the service.
         /// </summary>
         private bool RegisterServiceInternal<T>(
             bool retryWithRegistrar,
             Type concreteType,
-            SupportedPlatforms supportedPlatforms = (SupportedPlatforms) (-1),
+            SupportedPlatforms supportedPlatforms = (SupportedPlatforms)(-1),
             params object[] args) where T : IMixedRealityService
         {
             DebugUtilities.LogVerboseFormat("Attempting to register service of type: {0}", concreteType);
 
-            if (isApplicationQuitting) return false;
+            if (isApplicationQuitting)
+            {
+                return false;
+            }
 
             if (!PlatformUtility.IsPlatformSupported(supportedPlatforms))
             {
-                DebugUtilities.LogVerboseFormat(
-                    "Service of type: {0} does not support the current platform given supported platforms {1}",
-                    concreteType, supportedPlatforms);
+                DebugUtilities.LogVerboseFormat("Service of type: {0} does not support the current platform given supported platforms {1}", concreteType, supportedPlatforms);
                 return false;
             }
 
             if (concreteType == null)
             {
-                Debug.LogError(
-                    $"Unable to register {typeof(T).Name} service because the value of concreteType is null.\n" +
+                Debug.LogError($"Unable to register {typeof(T).Name} service because the value of concreteType is null.\n" +
                     "This may be caused by code being stripped during linking. The link.xml file in the MixedRealityToolkit.Generated folder is used to control code preservation.\n" +
                     "More information can be found at https://docs.unity3d.com/Manual/ManagedCodeStripping.html.");
                 return false;
@@ -269,8 +257,7 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (!typeof(IMixedRealityService).IsAssignableFrom(concreteType))
             {
-                Debug.LogError(
-                    $"Unable to register the {concreteType.Name} service. It does not implement {typeof(IMixedRealityService)}.");
+                Debug.LogError($"Unable to register the {concreteType.Name} service. It does not implement {typeof(IMixedRealityService)}.");
                 return false;
             }
 
@@ -278,17 +265,19 @@ namespace Microsoft.MixedReality.Toolkit
 
             try
             {
-                serviceInstance = (T) Activator.CreateInstance(concreteType, args);
+                serviceInstance = (T)Activator.CreateInstance(concreteType, args);
             }
             catch (Exception e)
             {
-                if (retryWithRegistrar && e is MissingMethodException)
+                if (retryWithRegistrar && (e is MissingMethodException))
                 {
-                    Debug.LogWarning(
-                        $"Failed to find an appropriate constructor for the {concreteType.Name} service. Adding the Registrar instance and re-attempting registration.");
-                    var updatedArgs = new List<object> {this};
+                    Debug.LogWarning($"Failed to find an appropriate constructor for the {concreteType.Name} service. Adding the Registrar instance and re-attempting registration.");
+                    List<object> updatedArgs = new List<object>();
+                    updatedArgs.Add(this);
                     if (args != null)
+                    {
                         updatedArgs.AddRange(args);
+                    }
                     return RegisterServiceInternal<T>(
                         false, // Do NOT retry, we have already added the configured IMIxedRealityServiceRegistrar
                         concreteType,
@@ -301,21 +290,24 @@ namespace Microsoft.MixedReality.Toolkit
                 // Failures to create the concrete type generally surface as nested exceptions - just logging
                 // the top level exception itself may not be helpful. If there is a nested exception (for example,
                 // null reference in the constructor of the object itself), it's helpful to also surface those here.
-                if (e.InnerException != null) Debug.LogError("Underlying exception information: " + e.InnerException);
+                if (e.InnerException != null)
+                {
+                    Debug.LogError("Underlying exception information: " + e.InnerException);
+                }
                 return false;
             }
 
-            return RegisterServiceInternal(serviceInstance);
+            return RegisterServiceInternal<T>(serviceInstance);
         }
 
         /// <inheritdoc />
         public bool UnregisterService<T>(string name = null) where T : IMixedRealityService
         {
-            var serviceInstance = GetServiceByName<T>(name);
+            T serviceInstance = GetServiceByName<T>(name);
 
-            if (serviceInstance == null) return false;
+            if (serviceInstance == null) { return false; }
 
-            return UnregisterService(serviceInstance);
+            return UnregisterService<T>(serviceInstance);
         }
 
         /// <inheritdoc />
@@ -323,13 +315,11 @@ namespace Microsoft.MixedReality.Toolkit
         {
             DebugUtilities.LogVerboseFormat("Unregistering service of type: {0}", typeof(T));
 
-            var interfaceType = typeof(T);
+            Type interfaceType = typeof(T);
 
             if (IsInitialized)
             {
-                DebugUtilities.LogVerboseFormat(
-                    "Unregistered service of type {0} was an initialized service, disabling and destroying it",
-                    typeof(T));
+                DebugUtilities.LogVerboseFormat("Unregistered service of type {0} was an initialized service, disabling and destroying it", typeof(T));
                 serviceInstance.Disable();
                 serviceInstance.Destroy();
             }
@@ -343,33 +333,34 @@ namespace Microsoft.MixedReality.Toolkit
                 return true;
             }
 
-            return MixedRealityServiceRegistry.RemoveService(serviceInstance, this);
+            return MixedRealityServiceRegistry.RemoveService<T>(serviceInstance, this);
         }
 
         /// <inheritdoc />
         public bool IsServiceRegistered<T>(string name = null) where T : IMixedRealityService
         {
-            var interfaceType = typeof(T);
+            Type interfaceType = typeof(T);
             if (typeof(IMixedRealityDataProvider).IsAssignableFrom(interfaceType))
             {
-                Debug.LogWarning(
-                    $"Unable to check a service of type {nameof(IMixedRealityDataProvider)}. Inquire with the MixedRealityService that registered the DataProvider type in question");
+                Debug.LogWarning($"Unable to check a service of type {nameof(IMixedRealityDataProvider)}. Inquire with the MixedRealityService that registered the DataProvider type in question");
                 return false;
             }
 
-            MixedRealityServiceRegistry.TryGetService<T>(out var service, name);
+            T service;
+            MixedRealityServiceRegistry.TryGetService<T>(out service, name);
             return service != null;
         }
 
         /// <inheritdoc />
         public T GetService<T>(string name = null, bool showLogs = true) where T : IMixedRealityService
         {
-            var interfaceType = typeof(T);
-            var serviceInstance = GetServiceByName<T>(name);
+            Type interfaceType = typeof(T);
+            T serviceInstance = GetServiceByName<T>(name);
 
-            if (serviceInstance == null && showLogs)
-                Debug.LogError(
-                    $"Unable to find {(string.IsNullOrWhiteSpace(name) ? interfaceType.Name : name)} service.");
+            if ((serviceInstance == null) && showLogs)
+            {
+                Debug.LogError($"Unable to find {(string.IsNullOrWhiteSpace(name) ? interfaceType.Name : name)} service.");
+            }
 
             return serviceInstance;
         }
@@ -383,9 +374,8 @@ namespace Microsoft.MixedReality.Toolkit
         #endregion IMixedRealityServiceRegistrar implementation
 
         /// <summary>
-        ///     Once all services are registered and properties updated, the Mixed Reality Toolkit will initialize all active
-        ///     services.
-        ///     This ensures all services can reference each other once started.
+        /// Once all services are registered and properties updated, the Mixed Reality Toolkit will initialize all active services.
+        /// This ensures all services can reference each other once started.
         /// </summary>
         private void InitializeServiceLocator()
         {
@@ -395,10 +385,14 @@ namespace Microsoft.MixedReality.Toolkit
             if (!ActiveProfile)
             {
                 if (!Application.isPlaying)
+                {
                     // Log as warning if in edit mode. Likely user is making changes etc.
                     Debug.LogWarning(NoMRTKProfileErrorMessage);
+                }
                 else
+                {
                     Debug.LogError(NoMRTKProfileErrorMessage);
+                }
 
                 return;
             }
@@ -406,14 +400,18 @@ namespace Microsoft.MixedReality.Toolkit
             // If verbose logging is to be enabled, this should be done as early in service
             // initialization as possible to allow for other services to use verbose logging
             // as they initialize.
-            DebugUtilities.LogLevel = activeProfile.EnableVerboseLogging
-                ? DebugUtilities.LoggingLevel.Verbose
-                : DebugUtilities.LoggingLevel.Information;
+            DebugUtilities.LogLevel = activeProfile.EnableVerboseLogging ? DebugUtilities.LoggingLevel.Verbose : DebugUtilities.LoggingLevel.Information;
 
 #if UNITY_EDITOR
-            if (activeSystems.Count > 0) activeSystems.Clear();
+            if (activeSystems.Count > 0)
+            {
+                activeSystems.Clear();
+            }
 
-            if (registeredMixedRealityServices.Count > 0) registeredMixedRealityServices.Clear();
+            if (registeredMixedRealityServices.Count > 0)
+            {
+                registeredMixedRealityServices.Clear();
+            }
 
             EnsureEditorSetup();
 #endif
@@ -433,25 +431,23 @@ namespace Microsoft.MixedReality.Toolkit
                 InputMappingAxisUtility.CheckUnityInputManagerMappings(ControllerMappingLibrary.UnityInputManagerAxes);
 #endif
 
-                object[] args = {ActiveProfile.InputSystemProfile};
-                if (!RegisterService<IMixedRealityInputSystem>(ActiveProfile.InputSystemType, args: args) ||
-                    CoreServices.InputSystem == null) Debug.LogError("Failed to start the Input System!");
-
-                args = new object[] {ActiveProfile.InputSystemProfile};
-                if (!RegisterService<IMixedRealityFocusProvider>(ActiveProfile.InputSystemProfile.FocusProviderType,
-                    args: args))
+                object[] args = { ActiveProfile.InputSystemProfile };
+                if (!RegisterService<IMixedRealityInputSystem>(ActiveProfile.InputSystemType, args: args) || CoreServices.InputSystem == null)
                 {
-                    Debug.LogError(
-                        "Failed to register the focus provider! The input system will not function without it.");
+                    Debug.LogError("Failed to start the Input System!");
+                }
+
+                args = new object[] { ActiveProfile.InputSystemProfile };
+                if (!RegisterService<IMixedRealityFocusProvider>(ActiveProfile.InputSystemProfile.FocusProviderType, args: args))
+                {
+                    Debug.LogError("Failed to register the focus provider! The input system will not function without it.");
                     return;
                 }
 
-                args = new object[] {ActiveProfile.InputSystemProfile};
-                if (!RegisterService<IMixedRealityRaycastProvider>(ActiveProfile.InputSystemProfile.RaycastProviderType,
-                    args: args))
+                args = new object[] { ActiveProfile.InputSystemProfile };
+                if (!RegisterService<IMixedRealityRaycastProvider>(ActiveProfile.InputSystemProfile.RaycastProviderType, args: args))
                 {
-                    Debug.LogError(
-                        "Failed to register the raycast provider! The input system will not function without it.");
+                    Debug.LogError("Failed to register the raycast provider! The input system will not function without it.");
                     return;
                 }
 
@@ -468,9 +464,11 @@ namespace Microsoft.MixedReality.Toolkit
             if (ActiveProfile.IsBoundarySystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the boundary system");
-                object[] args = {ActiveProfile.BoundaryVisualizationProfile, ActiveProfile.TargetExperienceScale};
-                if (!RegisterService<IMixedRealityBoundarySystem>(ActiveProfile.BoundarySystemSystemType, args: args) ||
-                    CoreServices.BoundarySystem == null) Debug.LogError("Failed to start the Boundary System!");
+                object[] args = { ActiveProfile.BoundaryVisualizationProfile, ActiveProfile.TargetExperienceScale };
+                if (!RegisterService<IMixedRealityBoundarySystem>(ActiveProfile.BoundarySystemSystemType, args: args) || CoreServices.BoundarySystem == null)
+                {
+                    Debug.LogError("Failed to start the Boundary System!");
+                }
                 DebugUtilities.LogVerbose("End registration of the boundary system");
             }
 
@@ -478,9 +476,11 @@ namespace Microsoft.MixedReality.Toolkit
             if (ActiveProfile.IsCameraSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the camera system");
-                object[] args = {ActiveProfile.CameraProfile};
-                if (!RegisterService<IMixedRealityCameraSystem>(ActiveProfile.CameraSystemType, args: args) ||
-                    CoreServices.CameraSystem == null) Debug.LogError("Failed to start the Camera System!");
+                object[] args = { ActiveProfile.CameraProfile };
+                if (!RegisterService<IMixedRealityCameraSystem>(ActiveProfile.CameraSystemType, args: args) || CoreServices.CameraSystem == null)
+                {
+                    Debug.LogError("Failed to start the Camera System!");
+                }
                 DebugUtilities.LogVerbose("End registration of the camera system");
             }
 
@@ -488,11 +488,11 @@ namespace Microsoft.MixedReality.Toolkit
             if (ActiveProfile.IsSpatialAwarenessSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the spatial awareness system");
-                object[] args = {ActiveProfile.SpatialAwarenessSystemProfile};
-                if (!RegisterService<IMixedRealitySpatialAwarenessSystem>(
-                        ActiveProfile.SpatialAwarenessSystemSystemType, args: args) &&
-                    CoreServices.SpatialAwarenessSystem != null)
+                object[] args = { ActiveProfile.SpatialAwarenessSystemProfile };
+                if (!RegisterService<IMixedRealitySpatialAwarenessSystem>(ActiveProfile.SpatialAwarenessSystemSystemType, args: args) && CoreServices.SpatialAwarenessSystem != null)
+                {
                     Debug.LogError("Failed to start the Spatial Awareness System!");
+                }
                 DebugUtilities.LogVerbose("End registration of the spatial awareness system");
             }
 
@@ -500,42 +500,48 @@ namespace Microsoft.MixedReality.Toolkit
             if (ActiveProfile.IsTeleportSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the teleport system");
-                if (!RegisterService<IMixedRealityTeleportSystem>(ActiveProfile.TeleportSystemSystemType) ||
-                    CoreServices.TeleportSystem == null) Debug.LogError("Failed to start the Teleport System!");
+                if (!RegisterService<IMixedRealityTeleportSystem>(ActiveProfile.TeleportSystemSystemType) || CoreServices.TeleportSystem == null)
+                {
+                    Debug.LogError("Failed to start the Teleport System!");
+                }
                 DebugUtilities.LogVerbose("End registration of the teleport system");
             }
 
             if (ActiveProfile.IsDiagnosticsSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the diagnostic system");
-                object[] args = {ActiveProfile.DiagnosticsSystemProfile};
-                if (!RegisterService<IMixedRealityDiagnosticsSystem>(ActiveProfile.DiagnosticsSystemSystemType,
-                        args: args) ||
-                    CoreServices.DiagnosticsSystem == null) Debug.LogError("Failed to start the Diagnostics System!");
+                object[] args = { ActiveProfile.DiagnosticsSystemProfile };
+                if (!RegisterService<IMixedRealityDiagnosticsSystem>(ActiveProfile.DiagnosticsSystemSystemType, args: args) || CoreServices.DiagnosticsSystem == null)
+                {
+                    Debug.LogError("Failed to start the Diagnostics System!");
+                }
                 DebugUtilities.LogVerbose("End registration of the diagnostic system");
             }
 
             if (ActiveProfile.IsSceneSystemEnabled)
             {
                 DebugUtilities.LogVerbose("Begin registration of the scene system");
-                object[] args = {ActiveProfile.SceneSystemProfile};
-                if (!RegisterService<IMixedRealitySceneSystem>(ActiveProfile.SceneSystemSystemType, args: args) ||
-                    CoreServices.SceneSystem == null) Debug.LogError("Failed to start the Scene System!");
+                object[] args = { ActiveProfile.SceneSystemProfile };
+                if (!RegisterService<IMixedRealitySceneSystem>(ActiveProfile.SceneSystemSystemType, args: args) || CoreServices.SceneSystem == null)
+                {
+                    Debug.LogError("Failed to start the Scene System!");
+                }
                 DebugUtilities.LogVerbose("End registration of the scene system");
             }
 
-            if (ActiveProfile.RegisteredServiceProvidersProfile)
-                for (var i = 0; i < ActiveProfile.RegisteredServiceProvidersProfile.Configurations?.Length; i++)
+            if (ActiveProfile.RegisteredServiceProvidersProfile != null)
+            {
+                for (int i = 0; i < ActiveProfile.RegisteredServiceProvidersProfile.Configurations?.Length; i++)
                 {
                     var configuration = ActiveProfile.RegisteredServiceProvidersProfile.Configurations[i];
 
-                    if (!typeof(IMixedRealityExtensionService).IsAssignableFrom(configuration.ComponentType.Type))
-                        continue;
-
-                    object[] args = {configuration.ComponentName, configuration.Priority, configuration.Profile};
-                    RegisterService<IMixedRealityExtensionService>(configuration.ComponentType,
-                        configuration.RuntimePlatform, args);
+                    if (typeof(IMixedRealityExtensionService).IsAssignableFrom(configuration.ComponentType.Type))
+                    {
+                        object[] args = { configuration.ComponentName, configuration.Priority, configuration.Profile };
+                        RegisterService<IMixedRealityExtensionService>(configuration.ComponentType, configuration.RuntimePlatform, args);
+                    }
                 }
+            }
 
             #endregion Service Registration
 
@@ -557,14 +563,13 @@ namespace Microsoft.MixedReality.Toolkit
         {
             // There's lots of documented cases that if the camera doesn't start at 0,0,0, things break with the WMR SDK specifically.
             // We'll enforce that here, then tracking can update it to the appropriate position later.
-            var cameraTransform = CameraCache.Main.transform;
-            cameraTransform.position = Vector3.zero;
-            cameraTransform.rotation = Quaternion.identity;
+            CameraCache.Main.transform.position = Vector3.zero;
+            CameraCache.Main.transform.rotation = Quaternion.identity;
 
             // This will create the playspace
             _ = MixedRealityPlayspace.Transform;
 
-            var addedComponents = false;
+            bool addedComponents = false;
             if (!Application.isPlaying)
             {
                 var eventSystems = FindObjectsOfType<EventSystem>();
@@ -579,13 +584,18 @@ namespace Microsoft.MixedReality.Toolkit
                     bool raiseWarning;
 
                     if (eventSystems.Length == 1)
+                    {
                         raiseWarning = eventSystems[0].gameObject != CameraCache.Main.gameObject;
+                    }
                     else
+                    {
                         raiseWarning = true;
+                    }
 
                     if (raiseWarning)
-                        Debug.LogWarning(
-                            "Found an existing event system in your scene. The Mixed Reality Toolkit requires only one, and must be found on the main camera.");
+                    {
+                        Debug.LogWarning("Found an existing event system in your scene. The Mixed Reality Toolkit requires only one, and must be found on the main camera.");
+                    }
                 }
             }
 
@@ -599,17 +609,20 @@ namespace Microsoft.MixedReality.Toolkit
         #region MonoBehaviour Implementation
 
         private static MixedRealityToolkit activeInstance;
-        private static bool newInstanceBeingInitialized;
+        private static bool newInstanceBeingInitialized = false;
 
 #if UNITY_EDITOR
         /// <summary>
-        ///     Returns the Singleton instance of the classes type.
+        /// Returns the Singleton instance of the classes type.
         /// </summary>
         public static MixedRealityToolkit Instance
         {
             get
             {
-                if (activeInstance) return activeInstance;
+                if (activeInstance)
+                {
+                    return activeInstance;
+                }
 
                 // It's possible for MRTK to exist in the scene but for activeInstance to be
                 // null when a custom editor component accesses Instance before the MRTK
@@ -617,14 +630,14 @@ namespace Microsoft.MixedReality.Toolkit
                 //
                 // To avoid returning null in this case, make sure to search the scene for MRTK.
                 // We do this only when in editor to avoid any performance cost at runtime.
-                var mrtks = new List<MixedRealityToolkit>(FindObjectsOfType<MixedRealityToolkit>());
+                List<MixedRealityToolkit> mrtks = new List<MixedRealityToolkit>(FindObjectsOfType<MixedRealityToolkit>());
                 // Sort the list by instance ID so we get deterministic results when selecting our next active instance
-                mrtks.Sort(delegate(MixedRealityToolkit i1, MixedRealityToolkit i2)
-                {
-                    return i1.GetInstanceID().CompareTo(i2.GetInstanceID());
-                });
+                mrtks.Sort(delegate (MixedRealityToolkit i1, MixedRealityToolkit i2) { return i1.GetInstanceID().CompareTo(i2.GetInstanceID()); });
 
-                for (var i = 0; i < mrtks.Count; i++) RegisterInstance(mrtks[i]);
+                for (int i = 0; i < mrtks.Count; i++)
+                {
+                    RegisterInstance(mrtks[i]);
+                }
                 return activeInstance;
             }
         }
@@ -637,19 +650,25 @@ namespace Microsoft.MixedReality.Toolkit
 
         private void InitializeInstance()
         {
-            if (newInstanceBeingInitialized) return;
+            if (newInstanceBeingInitialized)
+            {
+                return;
+            }
 
             newInstanceBeingInitialized = true;
 
             gameObject.SetActive(true);
 
-            if (HasActiveProfile) InitializeServiceLocator();
+            if (HasActiveProfile)
+            {
+                InitializeServiceLocator();
+            }
 
             newInstanceBeingInitialized = false;
         }
 
         /// <summary>
-        ///     Expose an assertion whether the MixedRealityToolkit class is initialized.
+        /// Expose an assertion whether the MixedRealityToolkit class is initialized.
         /// </summary>
         public static void AssertIsInitialized()
         {
@@ -657,12 +676,12 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        ///     Returns whether the instance has been initialized or not.
+        /// Returns whether the instance has been initialized or not.
         /// </summary>
         public static bool IsInitialized => activeInstance != null;
 
         /// <summary>
-        ///     Static function to determine if the MixedRealityToolkit class has been initialized or not.
+        /// Static function to determine if the MixedRealityToolkit class has been initialized or not.
         /// </summary>
         public static bool ConfirmInitialized()
         {
@@ -678,7 +697,10 @@ namespace Microsoft.MixedReality.Toolkit
 
         private void OnEnable()
         {
-            if (IsActiveInstance) EnableAllServices();
+            if (IsActiveInstance)
+            {
+                EnableAllServices();
+            }
         }
 
         private void Update()
@@ -693,7 +715,6 @@ namespace Microsoft.MixedReality.Toolkit
                     newProfile = null;
                     IsProfileSwitching = false;
                 }
-
                 UpdateAllServices();
             }
         }
@@ -715,7 +736,10 @@ namespace Microsoft.MixedReality.Toolkit
 
         private void OnDisable()
         {
-            if (IsActiveInstance) DisableAllServices();
+            if (IsActiveInstance)
+            {
+                DisableAllServices();
+            }
         }
 
         private void OnDestroy()
@@ -734,12 +758,14 @@ namespace Microsoft.MixedReality.Toolkit
         public static void SetActiveInstance(MixedRealityToolkit toolkitInstance)
         {
             if (isApplicationQuitting)
-                // Don't register instances while application is quitting
+            {   // Don't register instances while application is quitting
                 return;
+            }
 
             if (toolkitInstance == activeInstance)
-                // Don't do anything
+            {   // Don't do anything
                 return;
+            }
 
             // Disable the old instance
             SetInstanceInactive(activeInstance);
@@ -750,22 +776,19 @@ namespace Microsoft.MixedReality.Toolkit
 
         private static void RegisterInstance(MixedRealityToolkit toolkitInstance, bool setAsActiveInstance = false)
         {
-            if (isApplicationQuitting || toolkitInstance == null)
-                // Don't register instances while application is quitting
+            if (MixedRealityToolkit.isApplicationQuitting || toolkitInstance == null)
+            {   // Don't register instances while application is quitting
                 return;
+            }
 
             internalShutdown = false;
 
             if (!toolkitInstances.Contains(toolkitInstance))
-            {
-                // If we're already registered, no need to proceed
+            {   // If we're already registered, no need to proceed
                 // Add to list
                 toolkitInstances.Add(toolkitInstance);
                 // Sort the list by instance ID so we get deterministic results when selecting our next active instance
-                toolkitInstances.Sort(delegate(MixedRealityToolkit i1, MixedRealityToolkit i2)
-                {
-                    return i1.GetInstanceID().CompareTo(i2.GetInstanceID());
-                });
+                toolkitInstances.Sort(delegate (MixedRealityToolkit i1, MixedRealityToolkit i2) { return i1.GetInstanceID().CompareTo(i2.GetInstanceID()); });
             }
 
             if (!activeInstance)
@@ -774,29 +797,37 @@ namespace Microsoft.MixedReality.Toolkit
                 // to be the active instance if requested, or get the first valid remaining instance
                 // in the list.
                 if (setAsActiveInstance)
+                {
                     activeInstance = toolkitInstance;
+                }
                 else
-                    for (var i = 0; i < toolkitInstances.Count; i++)
+                {
+                    for (int i = 0; i < toolkitInstances.Count; i++)
                     {
-                        if (!toolkitInstances[i])
-                            continue;
-
-                        activeInstance = toolkitInstances[i];
-                        break;
+                        if (toolkitInstances[i])
+                        {
+                            activeInstance = toolkitInstances[i];
+                            break;
+                        }
                     }
+                }
 
                 activeInstance.DestroyAllServices();
                 activeInstance.InitializeInstance();
             }
 
             // Update instance's Name so it's clear who is the active instance
-            for (var i = toolkitInstances.Count - 1; i >= 0; i--)
+            for (int i = toolkitInstances.Count - 1; i >= 0; i--)
+            {
                 if (!toolkitInstances[i])
+                {
                     toolkitInstances.RemoveAt(i);
+                }
                 else
-                    toolkitInstances[i].name = toolkitInstances[i].IsActiveInstance
-                        ? activeInstanceGameObjectName
-                        : inactiveInstanceGameObjectName;
+                {
+                    toolkitInstances[i].name = toolkitInstances[i].IsActiveInstance ? activeInstanceGameObjectName : inactiveInstanceGameObjectName;
+                }
+            }
         }
 
         private static void UnregisterInstance(MixedRealityToolkit toolkitInstance)
@@ -806,28 +837,26 @@ namespace Microsoft.MixedReality.Toolkit
 
             toolkitInstances.Remove(toolkitInstance);
             // Sort the list by instance ID so we get deterministic results when selecting our next active instance
-            toolkitInstances.Sort(delegate(MixedRealityToolkit i1, MixedRealityToolkit i2)
-            {
-                return i1.GetInstanceID().CompareTo(i2.GetInstanceID());
-            });
+            toolkitInstances.Sort(delegate (MixedRealityToolkit i1, MixedRealityToolkit i2) { return i1.GetInstanceID().CompareTo(i2.GetInstanceID()); });
 
             if (activeInstance == toolkitInstance)
-            {
-                // If this is the active instance, we need to break it down
+            {   // If this is the active instance, we need to break it down
                 toolkitInstance.DestroyAllServices();
                 CoreServices.ResetCacheReferences();
 
                 // If this was the active instance, unregister the active instance
                 activeInstance = null;
                 if (isApplicationQuitting)
-                    // Don't search for additional instances if we're quitting
+                {   // Don't search for additional instances if we're quitting
                     return;
+                }
 
-                for (var i = 0; i < toolkitInstances.Count; i++)
+                for (int i = 0; i < toolkitInstances.Count; i++)
                 {
                     if (toolkitInstances[i] == null)
-                        // This may have been a mass-deletion - be wary of soon-to-be-unregistered instances
+                    {   // This may have been a mass-deletion - be wary of soon-to-be-unregistered instances
                         continue;
+                    }
                     // Select the first available instance and register it immediately
                     RegisterInstance(toolkitInstances[i]);
                     break;
@@ -838,14 +867,17 @@ namespace Microsoft.MixedReality.Toolkit
         public static void SetInstanceInactive(MixedRealityToolkit toolkitInstance)
         {
             if (!toolkitInstance)
-                // Don't do anything.
+            {   // Don't do anything.
                 return;
+            }
 
             if (toolkitInstance == activeInstance)
-            {
-                // If this was the active instance, un-register the active instance
+            {   // If this was the active instance, un-register the active instance
                 // Break down all services
-                if (Application.isPlaying) toolkitInstance.DisableAllServices();
+                if (Application.isPlaying)
+                {
+                    toolkitInstance.DisableAllServices();
+                }
 
                 toolkitInstance.DestroyAllServices();
 
@@ -861,7 +893,6 @@ namespace Microsoft.MixedReality.Toolkit
         #region Service Container Management
 
         #region Registration
-
         // NOTE: This method intentionally does not add to the registry. This is actually mostly a helper function for RegisterServiceInternal<T>.
         private bool RegisterServiceInternal(Type interfaceType, IMixedRealityService serviceInstance)
         {
@@ -873,14 +904,16 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (typeof(IMixedRealityDataProvider).IsAssignableFrom(interfaceType))
             {
-                Debug.LogWarning(
-                    $"Unable to register a service of type {nameof(IMixedRealityDataProvider)}. Register this DataProvider with the MixedRealityService that depends on it.");
+                Debug.LogWarning($"Unable to register a service of type {typeof(IMixedRealityDataProvider).Name}. Register this DataProvider with the MixedRealityService that depends on it.");
                 return false;
             }
 
-            if (!CanGetService(interfaceType)) return false;
+            if (!CanGetService(interfaceType))
+            {
+                return false;
+            }
 
-            var preExistingService = GetServiceByNameInternal(interfaceType, serviceInstance.Name);
+            IMixedRealityService preExistingService = GetServiceByNameInternal(interfaceType, serviceInstance.Name);
 
             if (preExistingService != null)
             {
@@ -894,22 +927,29 @@ namespace Microsoft.MixedReality.Toolkit
                 activeSystems.Add(interfaceType, serviceInstance);
             }
 
-            if (!isInitializing) serviceInstance.Initialize();
+            if (!isInitializing)
+            {
+                serviceInstance.Initialize();
+            }
             return true;
         }
 
         /// <summary>
-        ///     Internal service registration.
+        /// Internal service registration.
         /// </summary>
+        /// <param name="interfaceType">The interface type for the system to be registered.</param>
         /// <param name="serviceInstance">Instance of the service.</param>
         /// <returns>True if registration is successful, false otherwise.</returns>
         private bool RegisterServiceInternal<T>(T serviceInstance) where T : IMixedRealityService
         {
-            var interfaceType = typeof(T);
-            if (!RegisterServiceInternal(interfaceType, serviceInstance))
-                return false;
-            MixedRealityServiceRegistry.AddService(serviceInstance, this);
-            return true;
+            Type interfaceType = typeof(T);
+            if (RegisterServiceInternal(interfaceType, serviceInstance))
+            {
+                MixedRealityServiceRegistry.AddService<T>(serviceInstance, this);
+                return true;
+            }
+
+            return false;
         }
 
         #endregion Registration
@@ -917,7 +957,7 @@ namespace Microsoft.MixedReality.Toolkit
         #region Multiple Service Management
 
         /// <summary>
-        ///     Enable all services in the Mixed Reality Toolkit active service registry for a given type
+        /// Enable all services in the Mixed Reality Toolkit active service registry for a given type
         /// </summary>
         /// <param name="interfaceType">The interface type for the system to be enabled.  E.G. InputSystem, BoundarySystem</param>
         public void EnableAllServicesByType(Type interfaceType)
@@ -926,7 +966,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        ///     Enable all services in the Mixed Reality Toolkit active service registry for a given type and name
+        /// Enable all services in the Mixed Reality Toolkit active service registry for a given type and name
         /// </summary>
         /// <param name="interfaceType">The interface type for the system to be enabled.  E.G. InputSystem, BoundarySystem</param>
         /// <param name="serviceName">Name of the specific service</param>
@@ -938,12 +978,15 @@ namespace Microsoft.MixedReality.Toolkit
                 return;
             }
 
-            var services = GetAllServicesByNameInternal<IMixedRealityService>(interfaceType, serviceName);
-            for (var i = 0; i < services.Count; i++) services[i].Enable();
+            IReadOnlyList<IMixedRealityService> services = GetAllServicesByNameInternal<IMixedRealityService>(interfaceType, serviceName);
+            for (int i = 0; i < services.Count; i++)
+            {
+                services[i].Enable();
+            }
         }
 
         /// <summary>
-        ///     Disable all services in the Mixed Reality Toolkit active service registry for a given type
+        /// Disable all services in the Mixed Reality Toolkit active service registry for a given type
         /// </summary>
         /// <param name="interfaceType">The interface type for the system to be removed.  E.G. InputSystem, BoundarySystem</param>
         public void DisableAllServicesByType(Type interfaceType)
@@ -952,7 +995,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        ///     Disable all services in the Mixed Reality Toolkit active service registry for a given type and name
+        /// Disable all services in the Mixed Reality Toolkit active service registry for a given type and name
         /// </summary>
         /// <param name="interfaceType">The interface type for the system to be disabled.  E.G. InputSystem, BoundarySystem</param>
         /// <param name="serviceName">Name of the specific service</param>
@@ -964,8 +1007,11 @@ namespace Microsoft.MixedReality.Toolkit
                 return;
             }
 
-            var services = GetAllServicesByNameInternal<IMixedRealityService>(interfaceType, serviceName);
-            for (var i = 0; i < services.Count; i++) services[i].Disable();
+            IReadOnlyList<IMixedRealityService> services = GetAllServicesByNameInternal<IMixedRealityService>(interfaceType, serviceName);
+            for (int i = 0; i < services.Count; i++)
+            {
+                services[i].Disable();
+            }
         }
 
         private void InitializeAllServices()
@@ -989,8 +1035,7 @@ namespace Microsoft.MixedReality.Toolkit
             ExecuteOnAllServicesInOrder(service => service.Enable());
         }
 
-        private static readonly ProfilerMarker UpdateAllServicesPerfMarker =
-            new ProfilerMarker("[MRTK] MixedRealityToolkit.UpdateAllServices");
+        private static readonly ProfilerMarker UpdateAllServicesPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.UpdateAllServices");
 
         private void UpdateAllServices()
         {
@@ -1001,18 +1046,17 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-        private static readonly ProfilerMarker LateUpdateAllServicesPerfMarker =
-            new ProfilerMarker("[MRTK] MixedRealityToolkit.LateUpdateAllServices");
+        private static readonly ProfilerMarker LateUpdateAllServicesPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.LateUpdateAllServices");
 
         private void LateUpdateAllServices()
         {
             using (LateUpdateAllServicesPerfMarker.Auto())
             {
                 // If the Mixed Reality Toolkit is not configured, stop.
-                if (!activeProfile) return;
+                if (!activeProfile) { return; }
 
                 // If the Mixed Reality Toolkit is not initialized, stop.
-                if (!IsInitialized) return;
+                if (!IsInitialized) { return; }
 
                 // Update all systems
                 ExecuteOnAllServicesInOrder(service => service.LateUpdate());
@@ -1037,22 +1081,36 @@ namespace Microsoft.MixedReality.Toolkit
 
             foreach (var service in orderedActiveSystems)
             {
-                var type = service.Key;
+                Type type = service.Key;
 
                 if (typeof(IMixedRealityBoundarySystem).IsAssignableFrom(type))
+                {
                     UnregisterService<IMixedRealityBoundarySystem>();
+                }
                 else if (typeof(IMixedRealityCameraSystem).IsAssignableFrom(type))
+                {
                     UnregisterService<IMixedRealityCameraSystem>();
+                }
                 else if (typeof(IMixedRealityDiagnosticsSystem).IsAssignableFrom(type))
+                {
                     UnregisterService<IMixedRealityDiagnosticsSystem>();
+                }
                 else if (typeof(IMixedRealityFocusProvider).IsAssignableFrom(type))
+                {
                     UnregisterService<IMixedRealityFocusProvider>();
+                }
                 else if (typeof(IMixedRealityInputSystem).IsAssignableFrom(type))
+                {
                     UnregisterService<IMixedRealityInputSystem>();
+                }
                 else if (typeof(IMixedRealitySpatialAwarenessSystem).IsAssignableFrom(type))
+                {
                     UnregisterService<IMixedRealitySpatialAwarenessSystem>();
+                }
                 else if (typeof(IMixedRealityTeleportSystem).IsAssignableFrom(type))
+                {
                     UnregisterService<IMixedRealityTeleportSystem>();
+                }
             }
 
             activeSystems.Clear();
@@ -1060,36 +1118,46 @@ namespace Microsoft.MixedReality.Toolkit
             MixedRealityServiceRegistry.ClearAllServices();
         }
 
-        private static readonly ProfilerMarker ExecuteOnAllServicesInOrderPerfMarker =
-            new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesInOrder");
+        private static readonly ProfilerMarker ExecuteOnAllServicesInOrderPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesInOrder");
 
         private bool ExecuteOnAllServicesInOrder(Action<IMixedRealityService> execute)
         {
             using (ExecuteOnAllServicesInOrderPerfMarker.Auto())
             {
-                if (!HasProfileAndIsInitialized) return false;
+                if (!HasProfileAndIsInitialized)
+                {
+                    return false;
+                }
 
                 var services = MixedRealityServiceRegistry.GetAllServices();
-                var length = services.Count;
-                for (var i = 0; i < length; i++) execute(services[i]);
+                int length = services.Count;
+                for (int i = 0; i < length; i++)
+                {
+                    execute(services[i]);
+                }
 
                 return true;
             }
         }
 
-        private static readonly ProfilerMarker ExecuteOnAllServicesReverseOrderPerfMarker =
-            new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesReverseOrder");
+        private static readonly ProfilerMarker ExecuteOnAllServicesReverseOrderPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesReverseOrder");
 
         private bool ExecuteOnAllServicesReverseOrder(Action<IMixedRealityService> execute)
         {
             using (ExecuteOnAllServicesReverseOrderPerfMarker.Auto())
             {
-                if (!HasProfileAndIsInitialized) return false;
+                if (!HasProfileAndIsInitialized)
+                {
+                    return false;
+                }
 
                 var services = MixedRealityServiceRegistry.GetAllServices();
-                var length = services.Count;
+                int length = services.Count;
 
-                for (var i = length - 1; i >= 0; i--) execute(services[i]);
+                for (int i = length - 1; i >= 0; i--)
+                {
+                    execute(services[i]);
+                }
 
                 return true;
             }
@@ -1100,12 +1168,11 @@ namespace Microsoft.MixedReality.Toolkit
         #region Service Utilities
 
         /// <summary>
-        ///     Generic function used to interrogate the Mixed Reality Toolkit active system registry for the existence of a core
-        ///     system.
+        /// Generic function used to interrogate the Mixed Reality Toolkit active system registry for the existence of a core system.
         /// </summary>
         /// <typeparam name="T">The interface type for the system to be retrieved.  E.G. InputSystem, BoundarySystem.</typeparam>
         /// <remarks>
-        ///     Note: type should be the Interface of the system to be retrieved and not the concrete class itself.
+        /// Note: type should be the Interface of the system to be retrieved and not the concrete class itself.
         /// </remarks>
         /// <returns>True, there is a system registered with the selected interface, False, no system found for that interface</returns>
         [Obsolete("Use IsServiceRegistered instead")]
@@ -1113,13 +1180,17 @@ namespace Microsoft.MixedReality.Toolkit
         {
             if (!IsCoreSystem(typeof(T))) return false;
 
-            MixedRealityServiceRegistry.TryGetService<T>(out var service);
+            T service;
+            MixedRealityServiceRegistry.TryGetService<T>(out service);
 
-            if (service != null)
-                return true;
+            if (service == null)
+            {
+                IMixedRealityService activeSerivce;
+                activeSystems.TryGetValue(typeof(T), out activeSerivce);
+                return activeSerivce != null;
+            }
 
-            activeSystems.TryGetValue(typeof(T), out var activeService);
-            return activeService != null;
+            return service != null;
         }
 
         private static bool IsCoreSystem(Type type)
@@ -1145,83 +1216,98 @@ namespace Microsoft.MixedReality.Toolkit
         {
             if (typeof(IMixedRealityDataProvider).IsAssignableFrom(interfaceType))
             {
-                Debug.LogWarning($"Unable to get a service of type {nameof(IMixedRealityDataProvider)}.");
+                Debug.LogWarning($"Unable to get a service of type {typeof(IMixedRealityDataProvider).Name}.");
                 return null;
             }
 
-            if (!CanGetService(interfaceType)) return null;
+            if (!CanGetService(interfaceType)) { return null; }
 
-            MixedRealityServiceRegistry.TryGetService(interfaceType, out var service, out _, serviceName);
-            return service;
+            IMixedRealityService service;
+            MixedRealityServiceRegistry.TryGetService(interfaceType, out service, out _, serviceName);
+            if (service != null)
+            {
+                return service;
+            }
+
+            return null;
         }
 
         /// <summary>
-        ///     Retrieve the first service from the registry that meets the selected type and name
+        /// Retrieve the first service from the registry that meets the selected type and name
         /// </summary>
         /// <param name="serviceName">Name of the specific service</param>
+        /// <param name="serviceInstance">return parameter of the function</param>
         private T GetServiceByName<T>(string serviceName) where T : IMixedRealityService
         {
-            return (T) GetServiceByNameInternal(typeof(T), serviceName);
+            return (T)GetServiceByNameInternal(typeof(T), serviceName);
         }
 
         /// <summary>
-        ///     Gets all services by type and name.
+        /// Gets all services by type and name.
         /// </summary>
-        /// <param name="serviceName">
-        ///     The name of the service to search for. If the string is empty than any matching
-        ///     <see cref="interfaceType" /> will be added to the <see cref="services" /> list.
-        /// </param>
-        private IReadOnlyList<T> GetAllServicesByNameInternal<T>(Type interfaceType, string serviceName)
-            where T : IMixedRealityService
+        /// <param name="interfaceType">Interface type of the service being requested</param>
+        /// <param name="serviceName">The name of the service to search for. If the string is empty than any matching <see cref="interfaceType"/> will be added to the <see cref="services"/> list.</param>
+        private IReadOnlyList<T> GetAllServicesByNameInternal<T>(Type interfaceType, string serviceName) where T : IMixedRealityService
         {
-            var services = new List<T>();
+            List<T> services = new List<T>();
 
-            if (!CanGetService(interfaceType)) return new List<T>();
+            if (!CanGetService(interfaceType)) { return new List<T>(); }
 
-            var isNullServiceName = string.IsNullOrEmpty(serviceName);
+            bool isNullServiceName = string.IsNullOrEmpty(serviceName);
             var systems = MixedRealityServiceRegistry.GetAllServices();
-            var length = systems.Count;
-            for (var i = 0; i < length; i++)
+            int length = systems.Count;
+            for (int i = 0; i < length; i++)
             {
-                var service = systems[i];
-                if (service is T serviceT && (isNullServiceName || service.Name == serviceName)) services.Add(serviceT);
+                IMixedRealityService service = systems[i];
+                if (service is T serviceT && (isNullServiceName || service.Name == serviceName))
+                {
+                    services.Add(serviceT);
+                }
             }
 
             return services;
         }
 
         /// <summary>
-        ///     Check if the interface type and name matches the registered interface type and service instance found.
+        /// Check if the interface type and name matches the registered interface type and service instance found.
         /// </summary>
         /// <param name="interfaceType">The interface type of the service to check.</param>
         /// <param name="serviceName">The name of the service to check.</param>
         /// <param name="registeredInterfaceType">The registered interface type.</param>
         /// <param name="serviceInstance">The instance of the registered service.</param>
         /// <returns>True, if the registered service contains the interface type and name.</returns>
-        private static bool CheckServiceMatch(Type interfaceType, string serviceName, Type registeredInterfaceType,
-            IMixedRealityService serviceInstance)
+        private static bool CheckServiceMatch(Type interfaceType, string serviceName, Type registeredInterfaceType, IMixedRealityService serviceInstance)
         {
-            var isValid = string.IsNullOrEmpty(serviceName) || serviceInstance.Name == serviceName;
+            bool isValid = string.IsNullOrEmpty(serviceName) || serviceInstance.Name == serviceName;
 
-            if ((registeredInterfaceType.Name == interfaceType.Name ||
-                 serviceInstance.GetType().Name == interfaceType.Name) && isValid) return true;
+            if ((registeredInterfaceType.Name == interfaceType.Name || serviceInstance.GetType().Name == interfaceType.Name) && isValid)
+            {
+                return true;
+            }
 
             var interfaces = serviceInstance.GetType().GetInterfaces();
 
-            for (var i = 0; i < interfaces.Length; i++)
+            for (int i = 0; i < interfaces.Length; i++)
+            {
                 if (interfaces[i].Name == interfaceType.Name && isValid)
+                {
                     return true;
+                }
+            }
 
             return false;
         }
 
         /// <summary>
-        ///     Checks if the system is ready to get a service.
+        /// Checks if the system is ready to get a service.
         /// </summary>
         /// <param name="interfaceType">The interface type of the service being checked.</param>
         private static bool CanGetService(Type interfaceType)
         {
-            if (isApplicationQuitting && !internalShutdown) return false;
+            if (isApplicationQuitting && !internalShutdown)
+            {
+                return false;
+            }
 
             if (!IsInitialized)
             {
@@ -1231,7 +1317,7 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (interfaceType == null)
             {
-                Debug.LogError("Interface type is null.");
+                Debug.LogError($"Interface type is null.");
                 return false;
             }
 
@@ -1251,110 +1337,129 @@ namespace Microsoft.MixedReality.Toolkit
         #region Core System Accessors
 
         /// <summary>
-        ///     The current Input System registered with the Mixed Reality Toolkit.
+        /// The current Input System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.InputSystem instead")]
         public static IMixedRealityInputSystem InputSystem
         {
             get
             {
-                if (isApplicationQuitting) return null;
+                if (isApplicationQuitting)
+                {
+                    return null;
+                }
 
                 return CoreServices.InputSystem;
             }
         }
 
         /// <summary>
-        ///     The current Boundary System registered with the Mixed Reality Toolkit.
+        /// The current Boundary System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.BoundarySystem instead")]
         public static IMixedRealityBoundarySystem BoundarySystem
         {
             get
             {
-                if (isApplicationQuitting) return null;
+                if (isApplicationQuitting)
+                {
+                    return null;
+                }
 
                 return CoreServices.BoundarySystem;
             }
         }
 
         /// <summary>
-        ///     The current Camera System registered with the Mixed Reality Toolkit.
+        /// The current Camera System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.CameraSystem instead")]
         public static IMixedRealityCameraSystem CameraSystem
         {
             get
             {
-                if (isApplicationQuitting) return null;
+                if (isApplicationQuitting)
+                {
+                    return null;
+                }
 
                 return CoreServices.CameraSystem;
             }
         }
 
         /// <summary>
-        ///     The current Spatial Awareness System registered with the Mixed Reality Toolkit.
+        /// The current Spatial Awareness System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.SpatialAwarenessSystem instead")]
         public static IMixedRealitySpatialAwarenessSystem SpatialAwarenessSystem
         {
             get
             {
-                if (isApplicationQuitting) return null;
+                if (isApplicationQuitting)
+                {
+                    return null;
+                }
 
                 return CoreServices.SpatialAwarenessSystem;
             }
         }
 
         /// <summary>
-        ///     Returns true if the MixedRealityToolkit exists and has an active profile that has Teleport system enabled.
+        /// Returns true if the MixedRealityToolkit exists and has an active profile that has Teleport system enabled.
         /// </summary>
-        public static bool IsTeleportSystemEnabled => IsInitialized && Instance.HasActiveProfile &&
-                                                      Instance.ActiveProfile.IsTeleportSystemEnabled;
+        public static bool IsTeleportSystemEnabled => IsInitialized && Instance.HasActiveProfile && Instance.ActiveProfile.IsTeleportSystemEnabled;
 
         /// <summary>
-        ///     The current Teleport System registered with the Mixed Reality Toolkit.
+        /// The current Teleport System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.TeleportSystem instead")]
         public static IMixedRealityTeleportSystem TeleportSystem
         {
             get
             {
-                if (isApplicationQuitting) return null;
+                if (isApplicationQuitting)
+                {
+                    return null;
+                }
 
                 return CoreServices.TeleportSystem;
             }
         }
 
         /// <summary>
-        ///     The current Diagnostics System registered with the Mixed Reality Toolkit.
+        /// The current Diagnostics System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.DiagnosticsSystem instead")]
         public static IMixedRealityDiagnosticsSystem DiagnosticsSystem
         {
             get
             {
-                if (isApplicationQuitting) return null;
+                if (isApplicationQuitting)
+                {
+                    return null;
+                }
 
                 return CoreServices.DiagnosticsSystem;
             }
         }
 
         /// <summary>
-        ///     Returns true if the MixedRealityToolkit exists and has an active profile that has Scene system enabled.
+        /// Returns true if the MixedRealityToolkit exists and has an active profile that has Scene system enabled.
         /// </summary>
-        public static bool IsSceneSystemEnabled =>
-            IsInitialized && Instance.HasActiveProfile && Instance.ActiveProfile.IsSceneSystemEnabled;
+        public static bool IsSceneSystemEnabled => IsInitialized && Instance.HasActiveProfile && Instance.ActiveProfile.IsSceneSystemEnabled;
 
         /// <summary>
-        ///     The current Scene System registered with the Mixed Reality Toolkit.
+        /// The current Scene System registered with the Mixed Reality Toolkit.
         /// </summary>
         [Obsolete("Utilize CoreServices.SceneSystem instead")]
         public static IMixedRealitySceneSystem SceneSystem
         {
             get
             {
-                if (isApplicationQuitting) return null;
+                if (isApplicationQuitting)
+                {
+                    return null;
+                }
 
                 return CoreServices.SceneSystem;
             }
@@ -1363,20 +1468,22 @@ namespace Microsoft.MixedReality.Toolkit
         #endregion Core System Accessors
 
         #region Application Event Listeners
-
         /// <summary>
-        ///     Registers once on startup and sets isApplicationQuitting to true when quit event is detected.
+        /// Registers once on startup and sets isApplicationQuitting to true when quit event is detected.
         /// </summary>
         [RuntimeInitializeOnLoadMethod]
         private static void RegisterRuntimePlayModeListener()
         {
-            Application.quitting += () => { isApplicationQuitting = true; };
+            Application.quitting += () =>
+            {
+                isApplicationQuitting = true;
+            };
         }
 
 #if UNITY_EDITOR
         /// <summary>
-        ///     Static class whose constructor is called once on startup. Listens for editor events.
-        ///     Removes the need for individual instances to listen for events.
+        /// Static class whose constructor is called once on startup. Listens for editor events.
+        /// Removes the need for individual instances to listen for events.
         /// </summary>
         [InitializeOnLoad]
         private static class EditorEventListener
@@ -1397,14 +1504,13 @@ namespace Microsoft.MixedReality.Toolkit
                             isApplicationQuitting = false;
 
                             if (activeInstance != null && activeInstance.activeProfile == null)
+                            {
                                 // If we have an active instance, and its profile is null,
                                 // Alert the user that we don't have an active profile
                                 // Keep track though whether user has instructed to ignore this warning
                                 if (SessionState.GetBool(WarnUser_EmptyActiveProfile, true))
                                 {
-                                    if (EditorUtility.DisplayDialog("Warning!",
-                                        "Mixed Reality Toolkit cannot initialize because no Active Profile has been assigned.",
-                                        "OK", "Ignore"))
+                                    if (EditorUtility.DisplayDialog("Warning!", "Mixed Reality Toolkit cannot initialize because no Active Profile has been assigned.", "OK", "Ignore"))
                                     {
                                         // Stop play mode as changes done in play mode will be lost
                                         EditorApplication.isPlaying = false;
@@ -1416,7 +1522,9 @@ namespace Microsoft.MixedReality.Toolkit
                                         SessionState.SetBool(WarnUser_EmptyActiveProfile, false);
                                     }
                                 }
-
+                            }
+                            break;
+                        default:
                             break;
                     }
                 };
@@ -1427,37 +1535,40 @@ namespace Microsoft.MixedReality.Toolkit
                     if (!Application.isPlaying)
                     {
                         // Clean the toolkit instances hierarchy in case instances were deleted.
-                        for (var i = toolkitInstances.Count - 1; i >= 0; i--)
+                        for (int i = toolkitInstances.Count - 1; i >= 0; i--)
+                        {
                             if (toolkitInstances[i] == null)
+                            {
                                 // If it has been destroyed, remove it
                                 toolkitInstances.RemoveAt(i);
+                            }
+                        }
 
                         // If the active instance is null, it may not have been set, or it may have been deleted.
                         if (activeInstance == null)
                         {
                             // Do a search for a new active instance
-                            var instanceCheck = Instance;
+                            MixedRealityToolkit instanceCheck = Instance;
                         }
                     }
 
-                    for (var i = toolkitInstances.Count - 1; i >= 0; i--)
+                    for (int i = toolkitInstances.Count - 1; i >= 0; i--)
+                    {
                         // Make sure MRTK is not parented under anything
-                        Debug.Assert(toolkitInstances[i].transform.parent == null,
-                            "MixedRealityToolkit instances should not be parented under any other GameObject.");
+                        Debug.Assert(toolkitInstances[i].transform.parent == null, "MixedRealityToolkit instances should not be parented under any other GameObject.");
+                    }
                 };
             }
         }
 
         private void OnValidate()
         {
-            EditorApplication.delayCall +=
-                DelayOnValidate; // This is a workaround for a known unity issue when calling refresh assetdatabase from inside a on validate scope.
+            EditorApplication.delayCall += DelayOnValidate; // This is a workaround for a known unity issue when calling refresh assetdatabase from inside a on validate scope.
         }
 
         /// <summary>
-        ///     Used to register newly created instances in edit mode.
-        ///     Initially handled by using ExecuteAlways, but this attribute causes the instance to be destroyed as we enter play
-        ///     mode, which is disruptive to services.
+        /// Used to register newly created instances in edit mode.
+        /// Initially handled by using ExecuteAlways, but this attribute causes the instance to be destroyed as we enter play mode, which is disruptive to services.
         /// </summary>
         private void DelayOnValidate()
         {
@@ -1468,7 +1579,9 @@ namespace Microsoft.MixedReality.Toolkit
             if (EditorApplication.isPlayingOrWillChangePlaymode ||
                 EditorApplication.isCompiling ||
                 BuildPipeline.isBuildingPlayer)
+            {
                 return;
+            }
 
             RegisterInstance(this);
         }

--- a/Assets/MRTK/Core/Utilities/CoreServices.cs
+++ b/Assets/MRTK/Core/Utilities/CoreServices.cs
@@ -43,70 +43,70 @@ namespace Microsoft.MixedReality.Toolkit
             new Dictionary<Type, WeakReference<IMixedRealityService>>();
 
         /// <summary>
-        ///     Cached reference to the active instance of the boundary system.
-        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
+        /// Cached reference to the active instance of the boundary system.
+        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
         public static IMixedRealityBoundarySystem BoundarySystem =>
             boundarySystem ?? (boundarySystem = GetService<IMixedRealityBoundarySystem>());
 
         /// <summary>
-        ///     Cached reference to the active instance of the camera system.
-        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
+        /// Cached reference to the active instance of the camera system.
+        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
         public static IMixedRealityCameraSystem CameraSystem =>
             cameraSystem ?? (cameraSystem = GetService<IMixedRealityCameraSystem>());
 
         /// <summary>
-        ///     Cached reference to the active instance of the diagnostics system.
-        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
+        /// Cached reference to the active instance of the diagnostics system.
+        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
         public static IMixedRealityDiagnosticsSystem DiagnosticsSystem =>
             diagnosticsSystem ?? (diagnosticsSystem = GetService<IMixedRealityDiagnosticsSystem>());
 
         /// <summary>
-        ///     Cached reference to the active instance of the focus provider.
-        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
+        /// Cached reference to the active instance of the focus provider.
+        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
         public static IMixedRealityFocusProvider FocusProvider =>
             focusProvider ?? (focusProvider = GetService<IMixedRealityFocusProvider>());
 
         /// <summary>
-        ///     Cached reference to the active instance of the input system.
-        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
+        /// Cached reference to the active instance of the input system.
+        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
         public static IMixedRealityInputSystem InputSystem =>
             inputSystem ?? (inputSystem = GetService<IMixedRealityInputSystem>());
 
         /// <summary>
-        ///     Cached reference to the active instance of the raycast provider.
-        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
+        /// Cached reference to the active instance of the raycast provider.
+        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
         public static IMixedRealityRaycastProvider RaycastProvider =>
             raycastProvider ?? (raycastProvider = GetService<IMixedRealityRaycastProvider>());
 
         /// <summary>
-        ///     Cached reference to the active instance of the scene system.
-        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
+        /// Cached reference to the active instance of the scene system.
+        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
         public static IMixedRealitySceneSystem SceneSystem =>
             sceneSystem ?? (sceneSystem = GetService<IMixedRealitySceneSystem>());
 
         /// <summary>
-        ///     Cached reference to the active instance of the spatial awareness system.
-        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
+        /// Cached reference to the active instance of the spatial awareness system.
+        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
         public static IMixedRealitySpatialAwarenessSystem SpatialAwarenessSystem =>
             spatialAwarenessSystem ?? (spatialAwarenessSystem = GetService<IMixedRealitySpatialAwarenessSystem>());
 
         /// <summary>
-        ///     Cached reference to the active instance of the teleport system.
-        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
+        /// Cached reference to the active instance of the teleport system.
+        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
         public static IMixedRealityTeleportSystem TeleportSystem =>
             teleportSystem ?? (teleportSystem = GetService<IMixedRealityTeleportSystem>());
 
         /// <summary>
-        ///     Resets all cached system references to null
+        /// Resets all cached system references to null
         /// </summary>
         public static void ResetCacheReferences()
         {

--- a/Assets/MRTK/Core/Utilities/CoreServices.cs
+++ b/Assets/MRTK/Core/Utilities/CoreServices.cs
@@ -20,64 +20,116 @@ namespace Microsoft.MixedReality.Toolkit
     /// </summary>
     public static class CoreServices
     {
-        /// <summary>
-        /// Cached reference to the active instance of the boundary system.
-        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences() 
-        /// </summary>
-        public static IMixedRealityBoundarySystem BoundarySystem => GetService<IMixedRealityBoundarySystem>();
+        private static IMixedRealityBoundarySystem boundarySystem;
+
+        private static IMixedRealityCameraSystem cameraSystem;
+
+        private static IMixedRealityDiagnosticsSystem diagnosticsSystem;
+
+        private static IMixedRealityFocusProvider focusProvider;
+
+        private static IMixedRealityInputSystem inputSystem;
+
+        private static IMixedRealityRaycastProvider raycastProvider;
+
+        private static IMixedRealitySceneSystem sceneSystem;
+
+        private static IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem;
+
+        private static IMixedRealityTeleportSystem teleportSystem;
+
+        // We do not want to keep a service around so use WeakReference
+        private static readonly Dictionary<Type, WeakReference<IMixedRealityService>> ServiceCache =
+            new Dictionary<Type, WeakReference<IMixedRealityService>>();
 
         /// <summary>
-        /// Cached reference to the active instance of the camera system.
-        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences() 
+        ///     Cached reference to the active instance of the boundary system.
+        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
-        public static IMixedRealityCameraSystem CameraSystem => GetService<IMixedRealityCameraSystem>();
+        public static IMixedRealityBoundarySystem BoundarySystem =>
+            boundarySystem ?? (boundarySystem = GetService<IMixedRealityBoundarySystem>());
 
         /// <summary>
-        /// Cached reference to the active instance of the diagnostics system.
-        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences() 
+        ///     Cached reference to the active instance of the camera system.
+        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
-        public static IMixedRealityDiagnosticsSystem DiagnosticsSystem => GetService<IMixedRealityDiagnosticsSystem>();
+        public static IMixedRealityCameraSystem CameraSystem =>
+            cameraSystem ?? (cameraSystem = GetService<IMixedRealityCameraSystem>());
 
         /// <summary>
-        /// Cached reference to the active instance of the focus provider.
-        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences() 
+        ///     Cached reference to the active instance of the diagnostics system.
+        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
-        public static IMixedRealityFocusProvider FocusProvider => GetService<IMixedRealityFocusProvider>();
+        public static IMixedRealityDiagnosticsSystem DiagnosticsSystem =>
+            diagnosticsSystem ?? (diagnosticsSystem = GetService<IMixedRealityDiagnosticsSystem>());
 
         /// <summary>
-        /// Cached reference to the active instance of the input system.
-        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences() 
+        ///     Cached reference to the active instance of the focus provider.
+        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
-        public static IMixedRealityInputSystem InputSystem => GetService<IMixedRealityInputSystem>();
+        public static IMixedRealityFocusProvider FocusProvider =>
+            focusProvider ?? (focusProvider = GetService<IMixedRealityFocusProvider>());
 
         /// <summary>
-        /// Cached reference to the active instance of the raycast provider.
-        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences() 
+        ///     Cached reference to the active instance of the input system.
+        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
-        public static IMixedRealityRaycastProvider RaycastProvider => GetService<IMixedRealityRaycastProvider>();
+        public static IMixedRealityInputSystem InputSystem =>
+            inputSystem ?? (inputSystem = GetService<IMixedRealityInputSystem>());
 
         /// <summary>
-        /// Cached reference to the active instance of the scene system.
-        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences() 
+        ///     Cached reference to the active instance of the raycast provider.
+        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
-        public static IMixedRealitySceneSystem SceneSystem => GetService<IMixedRealitySceneSystem>();
+        public static IMixedRealityRaycastProvider RaycastProvider =>
+            raycastProvider ?? (raycastProvider = GetService<IMixedRealityRaycastProvider>());
 
         /// <summary>
-        /// Cached reference to the active instance of the spatial awareness system.
-        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences() 
+        ///     Cached reference to the active instance of the scene system.
+        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
-        public static IMixedRealitySpatialAwarenessSystem SpatialAwarenessSystem => GetService<IMixedRealitySpatialAwarenessSystem>();
+        public static IMixedRealitySceneSystem SceneSystem =>
+            sceneSystem ?? (sceneSystem = GetService<IMixedRealitySceneSystem>());
 
         /// <summary>
-        /// Cached reference to the active instance of the teleport system.
-        /// If system is destroyed, reference will be invalid. Please use ResetCacheReferences() 
+        ///     Cached reference to the active instance of the spatial awareness system.
+        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
-        public static IMixedRealityTeleportSystem TeleportSystem => GetService<IMixedRealityTeleportSystem>();
+        public static IMixedRealitySpatialAwarenessSystem SpatialAwarenessSystem =>
+            spatialAwarenessSystem ?? (spatialAwarenessSystem = GetService<IMixedRealitySpatialAwarenessSystem>());
 
         /// <summary>
-        /// Resets all cached system references to null
+        ///     Cached reference to the active instance of the teleport system.
+        ///     If system is destroyed, reference will be invalid. Please use ResetCacheReferences()
         /// </summary>
-        public static void ResetCacheReferences() => serviceCache.Clear();
+        public static IMixedRealityTeleportSystem TeleportSystem =>
+            teleportSystem ?? (teleportSystem = GetService<IMixedRealityTeleportSystem>());
+
+        /// <summary>
+        ///     Resets all cached system references to null
+        /// </summary>
+        public static void ResetCacheReferences()
+        {
+            ServiceCache.Clear();
+            boundarySystem?.Dispose();
+            boundarySystem = null;
+            cameraSystem?.Dispose();
+            cameraSystem = null;
+            diagnosticsSystem?.Dispose();
+            diagnosticsSystem = null;
+            focusProvider?.Dispose();
+            focusProvider = null;
+            inputSystem?.Dispose();
+            inputSystem = null;
+            raycastProvider?.Dispose();
+            raycastProvider = null;
+            sceneSystem?.Dispose();
+            sceneSystem = null;
+            teleportSystem?.Dispose();
+            teleportSystem = null;
+            spatialAwarenessSystem?.Dispose();
+            spatialAwarenessSystem = null;
+        }
 
         /// <summary>
         /// Clears the cache of the reference with key of given type if present and applicable
@@ -88,9 +140,9 @@ namespace Microsoft.MixedReality.Toolkit
         {
             if (typeof(IMixedRealityService).IsAssignableFrom(serviceType))
             {
-                if (serviceCache.ContainsKey(serviceType))
+                if (ServiceCache.ContainsKey(serviceType))
                 {
-                    serviceCache.Remove(serviceType);
+                    ServiceCache.Remove(serviceType);
                     return true;
                 }
             }
@@ -133,38 +185,33 @@ namespace Microsoft.MixedReality.Toolkit
                 return dataProviderAccess.GetDataProvider<T>();
             }
 
-            return default(T);
+            return default;
         }
-
-        // We do not want to keep a service around so use WeakReference
-        private static readonly Dictionary<Type, WeakReference<IMixedRealityService>> serviceCache = new Dictionary<Type, WeakReference<IMixedRealityService>>();
 
         private static T GetService<T>() where T : IMixedRealityService
         {
             Type serviceType = typeof(T);
 
             // See if we already have a WeakReference entry for this service type
-            if (serviceCache.TryGetValue(serviceType, out WeakReference<IMixedRealityService> weakService))
+            if (ServiceCache.TryGetValue(serviceType, out var weakService))
             {
-                IMixedRealityService svc;
                 // If our reference object is still alive, return it
-                if (weakService.TryGetTarget(out svc))
+                if (weakService.TryGetTarget(out var svc))
                 {
                     return (T)svc;
                 }
 
                 // Our reference object has been collected by the GC. Try to get the latest service if available
-                serviceCache.Remove(serviceType);
+                ServiceCache.Remove(serviceType);
             }
 
             // This is the first request for the given service type. See if it is available and if so, add entry
-            T service;
-            if (!MixedRealityServiceRegistry.TryGetService(out service))
+            if (!MixedRealityServiceRegistry.TryGetService(out T service))
             {
-                return default(T);
+                return default;
             }
 
-            serviceCache.Add(serviceType, new WeakReference<IMixedRealityService>(service, false));
+            ServiceCache.Add(serviceType, new WeakReference<IMixedRealityService>(service, false));
             return service;
         }
     }

--- a/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
@@ -7,53 +7,108 @@ using UnityEngine;
 using Object = UnityEngine.Object;
 #if UNITY_EDITOR
 using UnityEditor;
+
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.Rendering
 {
     /// <summary>
-    /// The MaterialInstance behavior aides in tracking instance material lifetime and automatically destroys instanced materials for the user. 
-    /// This utility component can be used as a replacement to <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see> or 
-    /// <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>. When invoking Unity's Renderer.material(s), Unity 
-    /// automatically instantiates new materials. It is the caller's responsibility to destroy the materials when a material is no longer needed or the game object is 
-    /// destroyed. The MaterialInstance behavior helps avoid material leaks and keeps material allocation paths consistent during edit and run time.
+    ///     The MaterialInstance behavior aides in tracking instance material lifetime and automatically destroys instanced
+    ///     materials for the user.
+    ///     This utility component can be used as a replacement to
+    ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see> or
+    ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>. When
+    ///     invoking Unity's Renderer.material(s), Unity
+    ///     automatically instantiates new materials. It is the caller's responsibility to destroy the materials when a
+    ///     material is no longer needed or the game object is
+    ///     destroyed. The MaterialInstance behavior helps avoid material leaks and keeps material allocation paths consistent
+    ///     during edit and run time.
     /// </summary>
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Rendering/MaterialInstance.html")]
-    [ExecuteAlways, RequireComponent(typeof(Renderer))]
+    [ExecuteAlways]
+    [RequireComponent(typeof(Renderer))]
     [AddComponentMenu("Scripts/MRTK/Core/MaterialInstance")]
     public class MaterialInstance : MonoBehaviour
     {
+        private const string InstancePostfix = " (Instance)";
+
+        [SerializeField]
+        [HideInInspector]
+        private Material[] defaultMaterials;
+
+        private readonly HashSet<Object> _materialOwners = new HashSet<Object>();
+
+        private Renderer _cachedRenderer;
+
+        private Material[] _cachedSharedMaterials;
+        private bool _initialized;
+
+        private Material[] _instanceMaterials;
+        private bool _materialsInstanced;
+
         /// <summary>
-        /// Returns the first instantiated Material assigned to the renderer, similar to <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see>. 
-        /// If any owner is specified the instanced material(s) will not be released until all owners are released. When a material
-        /// is no longer needed ReleaseMaterial should be called with the matching owner.
+        ///     Returns the first instantiated Material assigned to the renderer, similar to
+        ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see>.
+        /// </summary>
+        public Material Material => AcquireMaterial();
+
+        /// <summary>
+        ///     Returns all the instantiated materials of this object, similar to
+        ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>.
+        /// </summary>
+        public Material[] Materials => AcquireMaterials();
+
+        private Renderer CachedRenderer
+        {
+            get
+            {
+                if (_cachedRenderer)
+                    return _cachedRenderer;
+
+                _cachedRenderer = GetComponent<Renderer>();
+                _cachedSharedMaterials = _cachedRenderer.sharedMaterials;
+
+                return _cachedRenderer;
+            }
+        }
+
+        private Material[] CachedSharedMaterials
+        {
+            get => _cachedSharedMaterials;
+            set
+            {
+                _cachedSharedMaterials = value;
+                _cachedRenderer.sharedMaterials = value;
+            }
+        }
+        
+        /// <summary>
+        ///     Returns the first instantiated Material assigned to the renderer, similar to
+        ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see>.
+        ///     If any owner is specified the instanced material(s) will not be released until all owners are released. When a
+        ///     material
+        ///     is no longer needed ReleaseMaterial should be called with the matching owner.
         /// </summary>
         /// <param name="owner">An optional owner to track instance ownership.</param>
+        /// <param name="instance">Should this acquisition attempt to instance materials?</param>
         /// <returns>The first instantiated Material.</returns>
         public Material AcquireMaterial(Object owner = null, bool instance = true)
         {
             if (owner != null)
-            {
-                materialOwners.Add(owner);
-            }
+                _materialOwners.Add(owner);
 
             if (instance)
-            {
                 AcquireInstances();
-            }
 
-            if (instanceMaterials?.Length > 0)
-            {
-                return instanceMaterials[0];
-            }
-
-            return null;
+            return _instanceMaterials?.Length > 0 ? _instanceMaterials[0] : null;
         }
 
         /// <summary>
-        /// Returns all the instantiated materials of this object, similar to <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>. 
-        /// If any owner is specified the instanced material(s) will not be released until all owners are released. When a material
-        /// is no longer needed ReleaseMaterial should be called with the matching owner.
+        ///     Returns all the instantiated materials of this object, similar to
+        ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>.
+        ///     If any owner is specified the instanced material(s) will not be released until all owners are released. When a
+        ///     material
+        ///     is no longer needed ReleaseMaterial should be called with the matching owner.
         /// </summary>
         /// <param name="owner">An optional owner to track instance ownership.</param>
         /// <param name="instance">Should this acquisition attempt to instance materials?</param>
@@ -61,80 +116,155 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         public Material[] AcquireMaterials(Object owner = null, bool instance = true)
         {
             if (owner != null)
-            {
-                materialOwners.Add(owner);
-            }
+                _materialOwners.Add(owner);
 
             if (instance)
-            {
                 AcquireInstances();
-            }
 
-            return instanceMaterials;
+            return _instanceMaterials;
         }
 
         /// <summary>
-        /// Relinquishes ownership of a material instance. This should be called when a material is no longer needed
-        /// after acquire ownership with AcquireMaterial(s).
+        ///     Relinquishes ownership of a material instance. This should be called when a material is no longer needed
+        ///     after acquire ownership with AcquireMaterial(s).
         /// </summary>
         /// <param name="owner">The same owner which originally acquire ownership via AcquireMaterial(s).</param>
-        /// <param name="instance">Should this acquisition attempt to instance materials?</param>
         /// <param name="autoDestroy">When ownership count hits zero should the MaterialInstance component be destroyed?</param>
         public void ReleaseMaterial(Object owner, bool autoDestroy = true)
         {
-            materialOwners.Remove(owner);
+            _materialOwners.Remove(owner);
 
-            if (autoDestroy && materialOwners.Count == 0)
+            if (!autoDestroy || _materialOwners.Count != 0)
+                return;
+
+            DestroySafe(this);
+
+            // OnDestroy not called on inactive objects
+            if (!gameObject.activeInHierarchy)
+                RestoreRenderer();
+        }
+
+        private void Initialize()
+        {
+            if (_initialized || !CachedRenderer)
+                return;
+
+            // Cache the default materials if ones do not already exist.
+            if (!HasValidMaterial(defaultMaterials))
+                defaultMaterials = CachedSharedMaterials;
+            else if (!_materialsInstanced) // Restore the clone to its initial state.
+                CachedSharedMaterials = defaultMaterials;
+
+            _initialized = true;
+        }
+
+        private void AcquireInstances()
+        {
+            if (!CachedRenderer)
+                return;
+
+            if (!MaterialsMatch(CachedSharedMaterials, _instanceMaterials))
+                CreateInstances();
+        }
+
+        private void CreateInstances()
+        {
+            // Initialize must get called to set the defaultMaterials in case CreateInstances get's invoked before Awake.
+            Initialize();
+
+            DestroyMaterials(_instanceMaterials);
+            _instanceMaterials = InstanceMaterials(defaultMaterials);
+
+            if (CachedRenderer && _instanceMaterials != null)
+                CachedSharedMaterials = _instanceMaterials;
+
+            _materialsInstanced = true;
+        }
+
+        private static bool MaterialsMatch(Material[] a, Material[] b)
+        {
+            if (a?.Length != b?.Length)
+                return false;
+
+            for (var i = 0; i < a?.Length; ++i)
+                if (a[i] != b[i])
+                    return false;
+
+            return true;
+        }
+
+        private static Material[] InstanceMaterials(Material[] source)
+        {
+            if (source == null)
+                return null;
+
+            var output = new Material[source.Length];
+
+            for (var i = 0; i < source.Length; ++i)
             {
-                DestorySafe(this);
+                if (!source[i])
+                    continue;
 
-                // OnDestroy not called on inactive objects
-                if (!gameObject.activeInHierarchy)
-                {
-                    RestoreRenderer();
-                }
+                if (IsInstanceMaterial(source[i]))
+                    Debug.LogWarning(
+                        $"A material ({source[i].name}) which is already instanced was instanced multiple times.");
+
+                output[i] = new Material(source[i]);
+                output[i].name = $"{output[i].name}{InstancePostfix}";
+            }
+
+            return output;
+        }
+
+        private static void DestroyMaterials(Material[] materials)
+        {
+            if (materials == null)
+                return;
+
+            foreach (var material in materials)
+                DestroySafe(material);
+        }
+
+        private static bool IsInstanceMaterial(Material material)
+        {
+            return material && material.name.Contains(InstancePostfix);
+        }
+
+        private static bool HasValidMaterial(Material[] materials)
+        {
+            if (materials == null)
+                return false;
+
+            foreach (var material in materials)
+                if (material)
+                    return true;
+
+            return false;
+        }
+
+        private static void DestroySafe(Object toDestroy)
+        {
+            if (!toDestroy)
+                return;
+
+            if (Application.isPlaying)
+            {
+                Destroy(toDestroy);
+            }
+            else
+            {
+#if UNITY_EDITOR
+                // Let Unity handle unload of unused assets if lifecycle is transitioning from editor to play mode
+                // Defering the call during this transition would destroy reference only after play mode Awake, leading to possible broken material references on TMPro objects
+                if (!EditorApplication.isPlayingOrWillChangePlaymode)
+                    EditorApplication.delayCall += () =>
+                    {
+                        if (toDestroy != null)
+                            DestroyImmediate(toDestroy);
+                    };
+#endif
             }
         }
-
-        /// <summary>
-        /// Returns the first instantiated Material assigned to the renderer, similar to <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see>.
-        /// </summary>
-        public Material Material
-        {
-            get { return AcquireMaterial(); }
-        }
-
-        /// <summary>
-        /// Returns all the instantiated materials of this object, similar to <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>.
-        /// </summary>
-        public Material[] Materials
-        {
-            get { return AcquireMaterials(); }
-        }
-
-        private Renderer CachedRenderer
-        {
-            get
-            {
-                if (cachedRenderer == null)
-                {
-                    cachedRenderer = GetComponent<Renderer>();
-                }
-
-                return cachedRenderer;
-            }
-        }
-
-        private Renderer cachedRenderer = null;
-
-        [SerializeField, HideInInspector]
-        private Material[] defaultMaterials = null;
-        private Material[] instanceMaterials = null;
-        private bool initialized = false;
-        private bool materialsInstanced = false;
-        private readonly HashSet<Object> materialOwners = new HashSet<Object>();
-
-        private const string instancePostfix = " (Instance)";
 
         #region MonoBehaviour Implementation
 
@@ -146,40 +276,34 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private void Update()
         {
             // If the materials get changed via outside of MaterialInstance.
-            var sharedMaterials = CachedRenderer.sharedMaterials;
+            var sharedMaterials = CachedSharedMaterials;
 
-            if (!MaterialsMatch(sharedMaterials, instanceMaterials))
+            if (MaterialsMatch(sharedMaterials, _instanceMaterials))
+                return;
+
+            // Re-create the material instances.
+            var newDefaultMaterials = new Material[sharedMaterials.Length];
+            var min = Math.Min(newDefaultMaterials.Length, defaultMaterials.Length);
+
+            // Copy the old defaults.
+            for (var i = 0; i < min; ++i)
+                newDefaultMaterials[i] = defaultMaterials[i];
+
+            // Patch in the new defaults.
+            for (var i = 0; i < newDefaultMaterials.Length; ++i)
             {
-                // Re-create the material instances.
-                var newDefaultMaterials = new Material[sharedMaterials.Length];
-                var min = Math.Min(newDefaultMaterials.Length, defaultMaterials.Length);
+                var material = sharedMaterials[i];
 
-                // Copy the old defaults.
-                for (var i = 0; i < min; ++i)
-                {
-                    newDefaultMaterials[i] = defaultMaterials[i];
-                }
-
-                // Patch in the new defaults.
-                for (var i = 0; i < newDefaultMaterials.Length; ++i)
-                {
-                    var material = sharedMaterials[i];
-
-                    if (!IsInstanceMaterial(material))
-                    {
-                        newDefaultMaterials[i] = material;
-                    }
-                }
-
-                defaultMaterials = newDefaultMaterials;
-                CreateInstances();
-
-                // Notify owners of the change.
-                foreach (var owner in materialOwners)
-                {
-                    (owner as IMaterialInstanceOwner)?.OnMaterialChanged(this);
-                }
+                if (!IsInstanceMaterial(material))
+                    newDefaultMaterials[i] = material;
             }
+
+            defaultMaterials = newDefaultMaterials;
+            CreateInstances();
+
+            // Notify owners of the change.
+            foreach (var owner in _materialOwners)
+                (owner as IMaterialInstanceOwner)?.OnMaterialChanged(this);
         }
 
         private void OnDestroy()
@@ -189,164 +313,13 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
 
         private void RestoreRenderer()
         {
-            if (CachedRenderer != null && defaultMaterials != null)
-            {
-                CachedRenderer.sharedMaterials = defaultMaterials;
-            }
+            if (CachedRenderer && defaultMaterials != null)
+                CachedSharedMaterials = defaultMaterials;
 
-            DestroyMaterials(instanceMaterials);
-            instanceMaterials = null;
+            DestroyMaterials(_instanceMaterials);
+            _instanceMaterials = null;
         }
 
         #endregion MonoBehaviour Implementation
-
-        private void Initialize()
-        {
-            if (!initialized && CachedRenderer != null)
-            {
-                // Cache the default materials if ones do not already exist.
-                if (!HasValidMaterial(defaultMaterials))
-                {
-                    defaultMaterials = CachedRenderer.sharedMaterials;
-                }
-                else if (!materialsInstanced) // Restore the clone to its initial state.
-                {
-                    CachedRenderer.sharedMaterials = defaultMaterials;
-                }
-
-                initialized = true;
-            }
-        }
-
-        private void AcquireInstances()
-        {
-            if (CachedRenderer != null)
-            {
-                if (!MaterialsMatch(CachedRenderer.sharedMaterials, instanceMaterials))
-                {
-                    CreateInstances();
-                }
-            }
-        }
-
-        private void CreateInstances()
-        {
-            // Initialize must get called to set the defaultMaterials in case CreateInstances get's invoked before Awake.
-            Initialize();
-
-            DestroyMaterials(instanceMaterials);
-            instanceMaterials = InstanceMaterials(defaultMaterials);
-
-            if (CachedRenderer != null && instanceMaterials != null)
-            {
-                CachedRenderer.sharedMaterials = instanceMaterials;
-            }
-
-            materialsInstanced = true;
-        }
-
-        private static bool MaterialsMatch(Material[] a, Material[] b)
-        {
-            if (a?.Length != b?.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < a?.Length; ++i)
-            {
-                if (a[i] != b[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private static Material[] InstanceMaterials(Material[] source)
-        {
-            if (source == null)
-            {
-                return null;
-            }
-
-            var output = new Material[source.Length];
-
-            for (var i = 0; i < source.Length; ++i)
-            {
-                if (source[i] != null)
-                {
-                    if (IsInstanceMaterial(source[i]))
-                    {
-                        Debug.LogWarning($"A material ({source[i].name}) which is already instanced was instanced multiple times.");
-                    }
-
-                    output[i] = new Material(source[i]);
-                    output[i].name += instancePostfix;
-                }
-            }
-
-            return output;
-        }
-
-        private static void DestroyMaterials(Material[] materials)
-        {
-            if (materials != null)
-            {
-                for (var i = 0; i < materials.Length; ++i)
-                {
-                    DestorySafe(materials[i]);
-                }
-            }
-        }
-
-        private static bool IsInstanceMaterial(Material material)
-        {
-            return ((material != null) && material.name.Contains(instancePostfix));
-        }
-
-        private static bool HasValidMaterial(Material[] materials)
-        {
-            if (materials != null)
-            {
-                foreach (var material in materials)
-                {
-                    if (material != null)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        private static void DestorySafe(UnityEngine.Object toDestroy)
-        {
-            if (toDestroy != null)
-            {
-                if (Application.isPlaying)
-                {
-                    Destroy(toDestroy);
-                }
-                else
-                {
-#if UNITY_EDITOR
-                    // Let Unity handle unload of unused assets if lifecycle is transitioning from editor to play mode
-                    // Defering the call during this transition would destroy reference only after play mode Awake, leading to possible broken material references on TMPro objects
-                    if (!EditorApplication.isPlayingOrWillChangePlaymode)
-                    {
-                        EditorApplication.delayCall += () =>
-                        {
-                            if (toDestroy != null)
-                            {
-                                DestroyImmediate(toDestroy);
-                            }
-                        };
-                    }
-#endif
-                }
-            }
-        }
     }
 }

--- a/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
@@ -13,16 +13,16 @@ using UnityEditor;
 namespace Microsoft.MixedReality.Toolkit.Rendering
 {
     /// <summary>
-    ///     The MaterialInstance behavior aides in tracking instance material lifetime and automatically destroys instanced
-    ///     materials for the user.
-    ///     This utility component can be used as a replacement to
-    ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see> or
-    ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>. When
-    ///     invoking Unity's Renderer.material(s), Unity
-    ///     automatically instantiates new materials. It is the caller's responsibility to destroy the materials when a
-    ///     material is no longer needed or the game object is
-    ///     destroyed. The MaterialInstance behavior helps avoid material leaks and keeps material allocation paths consistent
-    ///     during edit and run time.
+    /// The MaterialInstance behavior aides in tracking instance material lifetime and automatically destroys instanced
+    /// materials for the user.
+    /// This utility component can be used as a replacement to
+    /// <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see> or
+    /// <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>. When
+    /// invoking Unity's Renderer.material(s), Unity
+    /// automatically instantiates new materials. It is the caller's responsibility to destroy the materials when a
+    /// material is no longer needed or the game object is
+    /// destroyed. The MaterialInstance behavior helps avoid material leaks and keeps material allocation paths consistent
+    /// during edit and run time.
     /// </summary>
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Rendering/MaterialInstance.html")]
     [ExecuteAlways]
@@ -47,14 +47,14 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private bool _materialsInstanced;
 
         /// <summary>
-        ///     Returns the first instantiated Material assigned to the renderer, similar to
-        ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see>.
+        /// Returns the first instantiated Material assigned to the renderer, similar to
+        /// <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see>.
         /// </summary>
         public Material Material => AcquireMaterial();
 
         /// <summary>
-        ///     Returns all the instantiated materials of this object, similar to
-        ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>.
+        /// Returns all the instantiated materials of this object, similar to
+        /// <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>.
         /// </summary>
         public Material[] Materials => AcquireMaterials();
 
@@ -63,7 +63,9 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             get
             {
                 if (_cachedRenderer)
+                {
                     return _cachedRenderer;
+                }
 
                 _cachedRenderer = GetComponent<Renderer>();
                 _cachedSharedMaterials = _cachedRenderer.sharedMaterials;
@@ -81,13 +83,14 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
                 _cachedRenderer.sharedMaterials = value;
             }
         }
-        
+
+
         /// <summary>
-        ///     Returns the first instantiated Material assigned to the renderer, similar to
-        ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see>.
-        ///     If any owner is specified the instanced material(s) will not be released until all owners are released. When a
-        ///     material
-        ///     is no longer needed ReleaseMaterial should be called with the matching owner.
+        /// Returns the first instantiated Material assigned to the renderer, similar to
+        /// <see href="https://docs.unity3d.com/ScriptReference/Renderer-material.html">Renderer.material</see>.
+        /// If any owner is specified the instanced material(s) will not be released until all owners are released. When a
+        /// material
+        /// is no longer needed ReleaseMaterial should be called with the matching owner.
         /// </summary>
         /// <param name="owner">An optional owner to track instance ownership.</param>
         /// <param name="instance">Should this acquisition attempt to instance materials?</param>
@@ -95,20 +98,24 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         public Material AcquireMaterial(Object owner = null, bool instance = true)
         {
             if (owner != null)
+            {
                 _materialOwners.Add(owner);
+            }
 
             if (instance)
+            {
                 AcquireInstances();
+            }
 
             return _instanceMaterials?.Length > 0 ? _instanceMaterials[0] : null;
         }
 
         /// <summary>
-        ///     Returns all the instantiated materials of this object, similar to
-        ///     <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>.
-        ///     If any owner is specified the instanced material(s) will not be released until all owners are released. When a
-        ///     material
-        ///     is no longer needed ReleaseMaterial should be called with the matching owner.
+        /// Returns all the instantiated materials of this object, similar to
+        /// <see href="https://docs.unity3d.com/ScriptReference/Renderer-materials.html">Renderer.materials</see>.
+        /// If any owner is specified the instanced material(s) will not be released until all owners are released. When a
+        /// material
+        /// is no longer needed ReleaseMaterial should be called with the matching owner.
         /// </summary>
         /// <param name="owner">An optional owner to track instance ownership.</param>
         /// <param name="instance">Should this acquisition attempt to instance materials?</param>
@@ -116,17 +123,21 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         public Material[] AcquireMaterials(Object owner = null, bool instance = true)
         {
             if (owner != null)
+            {
                 _materialOwners.Add(owner);
+            }
 
             if (instance)
+            {
                 AcquireInstances();
+            }
 
             return _instanceMaterials;
         }
 
         /// <summary>
-        ///     Relinquishes ownership of a material instance. This should be called when a material is no longer needed
-        ///     after acquire ownership with AcquireMaterial(s).
+        /// Relinquishes ownership of a material instance. This should be called when a material is no longer needed
+        /// after acquire ownership with AcquireMaterial(s).
         /// </summary>
         /// <param name="owner">The same owner which originally acquire ownership via AcquireMaterial(s).</param>
         /// <param name="autoDestroy">When ownership count hits zero should the MaterialInstance component be destroyed?</param>
@@ -135,25 +146,35 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             _materialOwners.Remove(owner);
 
             if (!autoDestroy || _materialOwners.Count != 0)
+            {
                 return;
+            }
 
             DestroySafe(this);
 
             // OnDestroy not called on inactive objects
             if (!gameObject.activeInHierarchy)
+            {
                 RestoreRenderer();
+            }
         }
 
         private void Initialize()
         {
             if (_initialized || !CachedRenderer)
+            {
                 return;
+            }
 
             // Cache the default materials if ones do not already exist.
             if (!HasValidMaterial(defaultMaterials))
+            {
                 defaultMaterials = CachedSharedMaterials;
+            }
             else if (!_materialsInstanced) // Restore the clone to its initial state.
+            {
                 CachedSharedMaterials = defaultMaterials;
+            }
 
             _initialized = true;
         }
@@ -161,10 +182,14 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private void AcquireInstances()
         {
             if (!CachedRenderer)
+            {
                 return;
+            }
 
             if (!MaterialsMatch(CachedSharedMaterials, _instanceMaterials))
+            {
                 CreateInstances();
+            }
         }
 
         private void CreateInstances()
@@ -176,7 +201,9 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             _instanceMaterials = InstanceMaterials(defaultMaterials);
 
             if (CachedRenderer && _instanceMaterials != null)
+            {
                 CachedSharedMaterials = _instanceMaterials;
+            }
 
             _materialsInstanced = true;
         }
@@ -184,11 +211,15 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private static bool MaterialsMatch(Material[] a, Material[] b)
         {
             if (a?.Length != b?.Length)
+            {
                 return false;
+            }
 
             for (var i = 0; i < a?.Length; ++i)
+            {
                 if (a[i] != b[i])
                     return false;
+            }
 
             return true;
         }
@@ -196,7 +227,9 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private static Material[] InstanceMaterials(Material[] source)
         {
             if (source == null)
+            {
                 return null;
+            }
 
             var output = new Material[source.Length];
 
@@ -206,8 +239,10 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
                     continue;
 
                 if (IsInstanceMaterial(source[i]))
+                {
                     Debug.LogWarning(
                         $"A material ({source[i].name}) which is already instanced was instanced multiple times.");
+                }
 
                 output[i] = new Material(source[i]);
                 output[i].name = $"{output[i].name}{InstancePostfix}";
@@ -219,10 +254,14 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private static void DestroyMaterials(Material[] materials)
         {
             if (materials == null)
+            {
                 return;
+            }
 
             foreach (var material in materials)
+            {
                 DestroySafe(material);
+            }
         }
 
         private static bool IsInstanceMaterial(Material material)
@@ -233,11 +272,15 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private static bool HasValidMaterial(Material[] materials)
         {
             if (materials == null)
+            {
                 return false;
+            }
 
             foreach (var material in materials)
+            {
                 if (material)
                     return true;
+            }
 
             return false;
         }
@@ -245,7 +288,9 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private static void DestroySafe(Object toDestroy)
         {
             if (!toDestroy)
+            {
                 return;
+            }
 
             if (Application.isPlaying)
             {
@@ -279,7 +324,9 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             var sharedMaterials = CachedSharedMaterials;
 
             if (MaterialsMatch(sharedMaterials, _instanceMaterials))
+            {
                 return;
+            }
 
             // Re-create the material instances.
             var newDefaultMaterials = new Material[sharedMaterials.Length];
@@ -287,7 +334,9 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
 
             // Copy the old defaults.
             for (var i = 0; i < min; ++i)
+            {
                 newDefaultMaterials[i] = defaultMaterials[i];
+            }
 
             // Patch in the new defaults.
             for (var i = 0; i < newDefaultMaterials.Length; ++i)
@@ -295,7 +344,9 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
                 var material = sharedMaterials[i];
 
                 if (!IsInstanceMaterial(material))
+                {
                     newDefaultMaterials[i] = material;
+                }
             }
 
             defaultMaterials = newDefaultMaterials;
@@ -303,7 +354,9 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
 
             // Notify owners of the change.
             foreach (var owner in _materialOwners)
+            {
                 (owner as IMaterialInstanceOwner)?.OnMaterialChanged(this);
+            }
         }
 
         private void OnDestroy()
@@ -314,7 +367,9 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private void RestoreRenderer()
         {
             if (CachedRenderer && defaultMaterials != null)
+            {
                 CachedSharedMaterials = defaultMaterials;
+            }
 
             DestroyMaterials(_instanceMaterials);
             _instanceMaterials = null;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -597,7 +597,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                     var oldContainer = transform.Find("Container");
                     scrollContainer = oldContainer.gameObject.AddComponent<ScrollingObjectCollectionContainer>();
-                    return scrollContainer;
                 }
 
                 return scrollContainer;
@@ -634,8 +633,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     clippingObject.transform.parent = transform;
                     clippingObject.transform.localRotation = Quaternion.identity;
                     clippingObject.transform.localPosition = Vector3.zero;
-
-                    return clippingObject;
                 }
 
                 return clippingObject;
@@ -658,8 +655,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 {
                     clipBox = ClippingObject.EnsureComponent<ClippingBox>();
                     clipBox.ClippingSide = ClippingPrimitive.Side.Outside;
-
-                    return clipBox;
                 }
 
                 return clipBox;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
@@ -20,7 +19,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
     ///<remarks>Executing also in edit mode to properly catch and mask any new content added to scroll container.</remarks>
     [ExecuteAlways]
     [AddComponentMenu("Scripts/MRTK/SDK/ScrollingObjectCollection")]
-    [SuppressMessage("ReSharper", "LocalVariableHidesMember")]
     public class ScrollingObjectCollection : MonoBehaviour,
         IMixedRealityPointerHandler,
         IMixedRealitySourceStateHandler,
@@ -56,8 +54,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <remarks>Helpful for controls where you may want pagination or list movement without freeform scrolling.</remarks>
         public bool CanScroll
         {
-            get { return canScroll; }
-            set { canScroll = value; }
+            get => canScroll;
+            set => canScroll = value;
         }
 
         /// <summary>
@@ -70,8 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip(
-            "Edit modes for defining the clipping box masking boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the clipping box object.")]
+        [Tooltip("Edit modes for defining the clipping box masking boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the clipping box object.")]
         private EditMode maskEditMode;
 
         /// <summary>
@@ -79,13 +76,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public EditMode MaskEditMode
         {
-            get { return maskEditMode; }
-            set { maskEditMode = value; }
+            get => maskEditMode;
+            set => maskEditMode = value;
         }
 
         [SerializeField]
-        [Tooltip(
-            "Edit modes for defining the scroll interaction collider boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the collider.")]
+        [Tooltip("Edit modes for defining the scroll interaction collider boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the collider.")]
         private EditMode colliderEditMode;
 
         /// <summary>
@@ -93,12 +89,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public EditMode ColliderEditMode
         {
-            get { return colliderEditMode; }
-            set { colliderEditMode = value; }
+            get => colliderEditMode;
+            set => colliderEditMode = value;
         }
 
         [SerializeField]
-        [HideInInspector]
         private bool maskEnabled = true;
 
         /// <summary>
@@ -106,7 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public bool MaskEnabled
         {
-            get { return maskEnabled; }
+            get => maskEnabled;
             set
             {
                 if (!value && value != wasMaskEnabled)
@@ -124,8 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private bool wasMaskEnabled = true;
 
         [SerializeField]
-        [Tooltip(
-            "The distance, in meters, the current pointer can travel along the scroll direction before triggering a scroll drag.")]
+        [Tooltip("The distance, in meters, the current pointer can travel along the scroll direction before triggering a scroll drag.")]
         [Range(0.0f, 0.2f)]
         private float handDeltaScrollThreshold = 0.02f;
 
@@ -134,13 +128,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float HandDeltaScrollThreshold
         {
-            get { return handDeltaScrollThreshold; }
-            set { handDeltaScrollThreshold = value; }
+            get => handDeltaScrollThreshold;
+            set => handDeltaScrollThreshold = value;
         }
 
         [SerializeField]
-        [Tooltip(
-            "Withdraw amount, in meters, from the front of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip("Withdraw amount, in meters, from the front of the scroll boundary needed to transition from touch engaged to released.")]
         private float releaseThresholdFront = 0.03f;
 
         /// <summary>
@@ -148,13 +141,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float ReleaseThresholdFront
         {
-            get { return releaseThresholdFront; }
-            set { releaseThresholdFront = value; }
+            get => releaseThresholdFront;
+            set => releaseThresholdFront = value;
         }
 
         [SerializeField]
-        [Tooltip(
-            "Withdraw amount, in meters, from the back of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip("Withdraw amount, in meters, from the back of the scroll boundary needed to transition from touch engaged to released.")]
         private float releaseThresholdBack = 0.20f;
 
         /// <summary>
@@ -162,13 +154,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float ReleaseThresholdBack
         {
-            get { return releaseThresholdBack; }
-            set { releaseThresholdBack = value; }
+            get => releaseThresholdBack;
+            set => releaseThresholdBack = value;
         }
 
         [SerializeField]
-        [Tooltip(
-            "Withdraw amount, in meters, from the right or left of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip("Withdraw amount, in meters, from the right or left of the scroll boundary needed to transition from touch engaged to released.")]
         private float releaseThresholdLeftRight = 0.20f;
 
         /// <summary>
@@ -176,13 +167,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float ReleaseThresholdLeftRight
         {
-            get { return releaseThresholdLeftRight; }
-            set { releaseThresholdLeftRight = value; }
+            get => releaseThresholdLeftRight;
+            set => releaseThresholdLeftRight = value;
         }
 
         [SerializeField]
-        [Tooltip(
-            "Withdraw amount, in meters, from the top or bottom of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip("Withdraw amount, in meters, from the top or bottom of the scroll boundary needed to transition from touch engaged to released.")]
         private float releaseThresholdTopBottom = 0.20f;
 
         /// <summary>
@@ -190,13 +180,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float ReleaseThresholdTopBottom
         {
-            get { return releaseThresholdTopBottom; }
-            set { releaseThresholdTopBottom = value; }
+            get => releaseThresholdTopBottom;
+            set => releaseThresholdTopBottom = value;
         }
 
         [SerializeField]
-        [Tooltip(
-            "Distance, in meters, to position a local xy plane used to verify if a touch interaction started in the front of the scroll view.")]
+        [Tooltip("Distance, in meters, to position a local xy plane used to verify if a touch interaction started in the front of the scroll view.")]
         [Range(0.0f, 0.05f)]
         private float frontTouchDistance = 0.005f;
 
@@ -205,8 +194,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float FrontTouchDistance
         {
-            get { return frontTouchDistance; }
-            set { frontTouchDistance = value; }
+            get => frontTouchDistance;
+            set => frontTouchDistance = value;
         }
 
         [SerializeField]
@@ -218,13 +207,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public ScrollDirectionType ScrollDirection
         {
-            get { return scrollDirection; }
-            set { scrollDirection = value; }
+            get => scrollDirection;
+            set => scrollDirection = value;
         }
 
         [SerializeField]
-        [Tooltip(
-            "Toggles whether the scrollingObjectCollection will use the Camera OnPreRender event to manage content visibility.")]
+        [Tooltip("Toggles whether the scrollingObjectCollection will use the Camera OnPreRender event to manage content visibility.")]
         private bool useOnPreRender;
 
         /// <summary>
@@ -236,7 +224,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </remarks>
         public bool UseOnPreRender
         {
-            get { return useOnPreRender; }
+            get => useOnPreRender;
             set
             {
                 if (useOnPreRender == value)
@@ -277,8 +265,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <remarks>Helpful if you want a small movement to fling the list.</remarks>
         public float VelocityMultiplier
         {
-            get { return velocityMultiplier; }
-            set { velocityMultiplier = value; }
+            get => velocityMultiplier;
+            set => velocityMultiplier = value;
         }
 
         [SerializeField]
@@ -292,8 +280,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <remarks>This can't be 0.0f since that won't allow ANY velocity - set <see cref="TypeOfVelocity"/> to <see cref="VelocityType.None"/>. It can't be 1.0f since that won't allow ANY drag.</remarks>
         public float VelocityDampen
         {
-            get { return velocityDampen; }
-            set { velocityDampen = value; }
+            get => velocityDampen;
+            set => velocityDampen = value;
         }
 
         [SerializeField]
@@ -305,8 +293,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public VelocityType TypeOfVelocity
         {
-            get { return typeOfVelocity; }
-            set { typeOfVelocity = value; }
+            get => typeOfVelocity;
+            set => typeOfVelocity = value;
         }
 
         [SerializeField]
@@ -318,8 +306,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public AnimationCurve PaginationCurve
         {
-            get { return paginationCurve; }
-            set { paginationCurve = value; }
+            get => paginationCurve;
+            set => paginationCurve = value;
         }
 
         [SerializeField]
@@ -331,12 +319,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float AnimationLength
         {
-            get { return (animationLength < 0) ? 0 : animationLength; }
-            set { animationLength = value; }
+            get => animationLength < 0 ? 0 : animationLength;
+            set => animationLength = value;
         }
 
-        [Tooltip(
-            "Number of cells in a row on up-down scroll view or number of cells in a column on left-right scroll view.")]
+        [Tooltip("Number of cells in a row on up-down scroll view or number of cells in a column on left-right scroll view.")]
         [SerializeField]
         [FormerlySerializedAs("tiers")]
         [Min(1)]
@@ -347,9 +334,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public int CellsPerTier
         {
-            get { return cellsPerTier; }
+            get => cellsPerTier;
             set
             {
+                if (value <= 0) throw new ArgumentOutOfRangeException(nameof(value));
                 Debug.Assert(value > 0, "Cells per tier should have a positive non zero value");
                 cellsPerTier = Mathf.Max(1, value);
             }
@@ -366,7 +354,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public int TiersPerPage
         {
-            get { return tiersPerPage; }
+            get => tiersPerPage;
             set
             {
                 Debug.Assert(value > 0, "Tiers per page should have a positive non zero value");
@@ -384,7 +372,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float CellWidth
         {
-            get { return cellWidth; }
+            get => cellWidth;
             set
             {
                 Debug.Assert(value > 0, "Cell width should have a positive non zero value");
@@ -402,7 +390,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float CellHeight
         {
-            get { return cellHeight; }
+            get => cellHeight;
             set
             {
                 Debug.Assert(cellHeight > 0, "Cell height should have a positive non zero value");
@@ -420,7 +408,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float CellDepth
         {
-            get { return cellDepth; }
+            get => cellDepth;
             set
             {
                 Debug.Assert(value > 0, "Cell depth should have a positive non zero value");
@@ -429,8 +417,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip(
-            "Multiplier to add more bounce to the overscroll of a list when using VelocityType.FalloffPerFrame or VelocityType.FalloffPerItem.")]
+        [Tooltip("Multiplier to add more bounce to the overscroll of a list when using VelocityType.FalloffPerFrame or VelocityType.FalloffPerItem.")]
         private float bounceMultiplier = 0.1f;
 
         /// <summary>
@@ -438,8 +425,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float BounceMultiplier
         {
-            get { return bounceMultiplier; }
-            set { bounceMultiplier = value; }
+            get => bounceMultiplier;
+            set => bounceMultiplier = value;
         }
 
         // Lerping time interval used for smoothing between positions during scroll drag. Number was empirically defined.
@@ -481,15 +468,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Event that is fired on the target object when the ScrollingObjectCollection is no longer in motion from velocity
         /// </summary>
-        [Tooltip(
-            "Event that is fired on the target object when the ScrollingObjectCollection is no longer in motion from velocity.")]
+        [Tooltip("Event that is fired on the target object when the ScrollingObjectCollection is no longer in motion from velocity.")]
         public UnityEvent OnMomentumEnded = new UnityEvent();
 
         /// <summary>
         /// Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.
         /// </summary>
-        [Tooltip(
-            "Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.")]
+        [Tooltip("Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.")]
         public UnityEvent OnMomentumStarted = new UnityEvent();
 
         [SerializeField]
@@ -1566,24 +1551,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // Using dot product to check if pointer is in front or behind the scroll view plane
 
             var lossyScale = clipBoxTransform.lossyScale;
-            var isUpMagnitudeAboveThreshold =
-                Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBoxTransform.up)) >
-                lossyScale.y / 2 + releaseThresholdTopBottom;
-            var isRightMagnitudeAboveThreshold =
-                Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBoxTransform.right)) >
-                lossyScale.x / 2 + releaseThresholdLeftRight;
-            var isScrollRelease = isUpMagnitudeAboveThreshold || isRightMagnitudeAboveThreshold
-                                                              || (Vector3.Dot(scrollToPointerVector,
-                                                                  transform.forward) > 0
-                                                                  ? Vector3.Magnitude(Vector3.Project(
-                                                                        scrollToPointerVector,
-                                                                        clipBoxTransform.forward)) >
-                                                                    lossyScale.z / 2 + releaseThresholdBack
-                                                                  : Vector3.Magnitude(Vector3.Project(
-                                                                        scrollToPointerVector,
-                                                                        clipBoxTransform.forward)) >
-                                                                    lossyScale.z / 2 + releaseThresholdFront);
-            return isScrollRelease;
+            var isUpMagnitudeAboveThreshold = Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBoxTransform.up)) > lossyScale.y / 2 + releaseThresholdTopBottom;
+            var isRightMagnitudeAboveThreshold = Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBoxTransform.right)) > lossyScale.x / 2 + releaseThresholdLeftRight;
+            var isFrontOrBackMagnitudeAboveThreshold = Vector3.Dot(scrollToPointerVector, transform.forward) > 0 
+                ? Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBoxTransform.forward)) > lossyScale.z / 2 + releaseThresholdBack
+                : Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBoxTransform.forward)) > lossyScale.z / 2 + releaseThresholdFront;
+            return isUpMagnitudeAboveThreshold || isRightMagnitudeAboveThreshold || isFrontOrBackMagnitudeAboveThreshold;
         }
 
         private bool HasPassedThroughFrontPlane(PokePointer pokePointer)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Serialization;
@@ -16,14 +16,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
 {
     /// <summary>
     /// A scrollable frame where content scroll is triggered by manual controller click and drag or according to pagination settings.
-    //// </summary>
+    /// </summary>
     ///<remarks>Executing also in edit mode to properly catch and mask any new content added to scroll container.</remarks>
     [ExecuteAlways]
     [AddComponentMenu("Scripts/MRTK/SDK/ScrollingObjectCollection")]
+    [SuppressMessage("ReSharper", "LocalVariableHidesMember")]
     public class ScrollingObjectCollection : MonoBehaviour,
-            IMixedRealityPointerHandler,
-            IMixedRealitySourceStateHandler,
-            IMixedRealityTouchHandler
+        IMixedRealityPointerHandler,
+        IMixedRealitySourceStateHandler,
+        IMixedRealityTouchHandler
     {
         /// <summary>
         /// How velocity is applied to a <see cref="ScrollingObjectCollection"/> when a scroll is released.
@@ -69,7 +70,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip("Edit modes for defining the clipping box masking boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the clipping box object.")]
+        [Tooltip(
+            "Edit modes for defining the clipping box masking boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the clipping box object.")]
         private EditMode maskEditMode;
 
         /// <summary>
@@ -82,7 +84,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip("Edit modes for defining the scroll interaction collider boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the collider.")]
+        [Tooltip(
+            "Edit modes for defining the scroll interaction collider boundaries. Choose 'Auto' to automatically use pagination values. Choose 'Manual' for enabling direct manipulation of the collider.")]
         private EditMode colliderEditMode;
 
         /// <summary>
@@ -95,6 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
+        [HideInInspector]
         private bool maskEnabled = true;
 
         /// <summary>
@@ -103,12 +107,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public bool MaskEnabled
         {
             get { return maskEnabled; }
-            set 
+            set
             {
                 if (!value && value != wasMaskEnabled)
                 {
                     RestoreContentVisibility();
                 }
+
                 wasMaskEnabled = value;
                 maskEnabled = value;
             }
@@ -119,7 +124,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private bool wasMaskEnabled = true;
 
         [SerializeField]
-        [Tooltip("The distance, in meters, the current pointer can travel along the scroll direction before triggering a scroll drag.")]
+        [Tooltip(
+            "The distance, in meters, the current pointer can travel along the scroll direction before triggering a scroll drag.")]
         [Range(0.0f, 0.2f)]
         private float handDeltaScrollThreshold = 0.02f;
 
@@ -133,8 +139,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip("Withdraw amount, in meters, from the front of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip(
+            "Withdraw amount, in meters, from the front of the scroll boundary needed to transition from touch engaged to released.")]
         private float releaseThresholdFront = 0.03f;
+
         /// <summary>
         /// Withdraw amount, in meters, from the front of the scroll boundary needed to transition from touch engaged to released.
         /// </summary>
@@ -145,8 +153,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip("Withdraw amount, in meters, from the back of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip(
+            "Withdraw amount, in meters, from the back of the scroll boundary needed to transition from touch engaged to released.")]
         private float releaseThresholdBack = 0.20f;
+
         /// <summary>
         /// Withdraw amount, in meters, from the back of the scroll boundary needed to transition from touch engaged to released.
         /// </summary>
@@ -157,8 +167,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip("Withdraw amount, in meters, from the right or left of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip(
+            "Withdraw amount, in meters, from the right or left of the scroll boundary needed to transition from touch engaged to released.")]
         private float releaseThresholdLeftRight = 0.20f;
+
         /// <summary>
         /// Withdraw amount, in meters, from the right or left of the scroll boundary needed to transition from touch engaged to released.
         /// </summary>
@@ -169,8 +181,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip("Withdraw amount, in meters, from the top or bottom of the scroll boundary needed to transition from touch engaged to released.")]
+        [Tooltip(
+            "Withdraw amount, in meters, from the top or bottom of the scroll boundary needed to transition from touch engaged to released.")]
         private float releaseThresholdTopBottom = 0.20f;
+
         /// <summary>
         /// Withdraw amount, in meters, from the top or bottom of the scroll boundary needed to transition from touch engaged to released.
         /// </summary>
@@ -181,9 +195,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip("Distance, in meters, to position a local xy plane used to verify if a touch interaction started in the front of the scroll view.")]
+        [Tooltip(
+            "Distance, in meters, to position a local xy plane used to verify if a touch interaction started in the front of the scroll view.")]
         [Range(0.0f, 0.05f)]
         private float frontTouchDistance = 0.005f;
+
         /// <summary>
         /// Distance, in meters, to position a local xy plane used to verify if a touch interaction started in the front of the scroll view.
         /// </summary>
@@ -207,7 +223,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip("Toggles whether the scrollingObjectCollection will use the Camera OnPreRender event to manage content visibility.")]
+        [Tooltip(
+            "Toggles whether the scrollingObjectCollection will use the Camera OnPreRender event to manage content visibility.")]
         private bool useOnPreRender;
 
         /// <summary>
@@ -222,7 +239,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get { return useOnPreRender; }
             set
             {
-                if (useOnPreRender == value) { return; }
+                if (useOnPreRender == value)
+                {
+                    return;
+                }
 
                 if (cameraMethods == null)
                 {
@@ -291,9 +311,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         [SerializeField]
         [Tooltip("Animation curve for pagination.")]
-        private AnimationCurve paginationCurve = new AnimationCurve(
-                                                                    new Keyframe(0, 0),
-                                                                    new Keyframe(1, 1));
+        private AnimationCurve paginationCurve = new AnimationCurve(new Keyframe(0, 0), new Keyframe(1, 1));
+
         /// <summary>
         /// Animation curve used to interpolate the pagination and movement methods.
         /// </summary>
@@ -316,7 +335,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set { animationLength = value; }
         }
 
-        [Tooltip("Number of cells in a row on up-down scroll view or number of cells in a column on left-right scroll view.")]
+        [Tooltip(
+            "Number of cells in a row on up-down scroll view or number of cells in a column on left-right scroll view.")]
         [SerializeField]
         [FormerlySerializedAs("tiers")]
         [Min(1)]
@@ -327,10 +347,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public int CellsPerTier
         {
-            get
-            {
-                return cellsPerTier;
-            }
+            get { return cellsPerTier; }
             set
             {
                 Debug.Assert(value > 0, "Cells per tier should have a positive non zero value");
@@ -349,10 +366,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public int TiersPerPage
         {
-            get
-            {
-                return tiersPerPage;
-            }
+            get { return tiersPerPage; }
             set
             {
                 Debug.Assert(value > 0, "Tiers per page should have a positive non zero value");
@@ -370,10 +384,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float CellWidth
         {
-            get
-            {
-                return cellWidth;
-            }
+            get { return cellWidth; }
             set
             {
                 Debug.Assert(value > 0, "Cell width should have a positive non zero value");
@@ -391,10 +402,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float CellHeight
         {
-            get
-            {
-                return cellHeight;
-            }
+            get { return cellHeight; }
             set
             {
                 Debug.Assert(cellHeight > 0, "Cell height should have a positive non zero value");
@@ -412,10 +420,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float CellDepth
         {
-            get
-            {
-                return cellDepth;
-            }
+            get { return cellDepth; }
             set
             {
                 Debug.Assert(value > 0, "Cell depth should have a positive non zero value");
@@ -424,7 +429,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Tooltip("Multiplier to add more bounce to the overscroll of a list when using VelocityType.FalloffPerFrame or VelocityType.FalloffPerItem.")]
+        [Tooltip(
+            "Multiplier to add more bounce to the overscroll of a list when using VelocityType.FalloffPerFrame or VelocityType.FalloffPerItem.")]
         private float bounceMultiplier = 0.1f;
 
         /// <summary>
@@ -449,8 +455,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// The UnityEvent type the ScrollingObjectCollection sends.
         /// GameObject is the object the fired the scroll.
         /// </summary>
-        [System.Serializable]
-        public class ScrollEvent : UnityEvent<GameObject> { }
+        [Serializable]
+        public class ScrollEvent : UnityEvent<GameObject>
+        {
+        }
 
         /// <summary>
         /// Event that is fired on the target object when the ScrollingObjectCollection deems event as a Click.
@@ -473,13 +481,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Event that is fired on the target object when the ScrollingObjectCollection is no longer in motion from velocity
         /// </summary>
-        [Tooltip("Event that is fired on the target object when the ScrollingObjectCollection is no longer in motion from velocity.")]
+        [Tooltip(
+            "Event that is fired on the target object when the ScrollingObjectCollection is no longer in motion from velocity.")]
         public UnityEvent OnMomentumEnded = new UnityEvent();
 
         /// <summary>
         /// Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.
         /// </summary>
-        [Tooltip("Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.")]
+        [Tooltip(
+            "Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.")]
         public UnityEvent OnMomentumStarted = new UnityEvent();
 
         [SerializeField]
@@ -491,8 +501,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get
             {
-                var max = (contentBounds == null || contentBounds.size.y <= 0) ? 0 :
-                        Mathf.Max(0, contentBounds.size.y - TiersPerPage * CellHeight);
+                var max = contentBounds.size.y <= 0
+                    ? 0
+                    : Mathf.Max(0, contentBounds.size.y - TiersPerPage * CellHeight);
 
                 if (maskEditMode == EditMode.Auto)
                 {
@@ -515,8 +526,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get
             {
-                var max = (contentBounds == null || contentBounds.size.x <= 0) ? 0 :
-                     Mathf.Max(0, contentBounds.size.x - TiersPerPage * CellWidth);
+                var max = contentBounds.size.x <= 0
+                    ? 0
+                    : Mathf.Max(0, contentBounds.size.x - TiersPerPage * CellWidth);
 
                 if (maskEditMode == EditMode.Auto)
                 {
@@ -534,41 +546,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Index of the first visible cell.
         /// </summary>
-        public int FirstVisibleCellIndex
-        {
-            get
-            {
-                if (scrollDirection == ScrollDirectionType.UpAndDown)
-                {
-                    return (int)Mathf.Ceil(ScrollContainer.transform.localPosition.y / CellHeight) * CellsPerTier;
-                }
-                else
-                {
-                    // Scroll container most to the right local position has x component equals to zero. This value goes negative as scroll container moves to the left. 
-                    return ((int)Mathf.Ceil(Mathf.Abs(ScrollContainer.transform.localPosition.x / CellWidth)) * CellsPerTier);
-                }
-            }
-        }
+        public int FirstVisibleCellIndex => scrollDirection == ScrollDirectionType.UpAndDown
+            ? (int) Mathf.Ceil(ScrollContainer.LocalPosition.y / CellHeight) * CellsPerTier
+            : (int) Mathf.Ceil(Mathf.Abs(ScrollContainer.LocalPosition.x / CellWidth)) * CellsPerTier;
 
+        // Scroll container most to the right local position has x component equals to zero. This value goes negative as scroll container moves to the left.
         /// <summary>
         /// Index of the first hidden cell.
         /// </summary>
-        public int FirstHiddenCellIndex
-        {
-            get
-            {
-                if (scrollDirection == ScrollDirectionType.UpAndDown)
-                {
-                    return ((int)Mathf.Floor(ScrollContainer.transform.localPosition.y / CellHeight) * CellsPerTier) + (TiersPerPage * CellsPerTier);
-                }
-                else
-                {
-                    return ((int)Mathf.Floor(-ScrollContainer.transform.localPosition.x / CellWidth) * CellsPerTier) + (TiersPerPage * CellsPerTier);
-                }
-            }
-        }
+        public int FirstHiddenCellIndex => scrollDirection == ScrollDirectionType.UpAndDown
+            ? (int) Mathf.Floor(ScrollContainer.LocalPosition.y / CellHeight) * CellsPerTier +
+              TiersPerPage * CellsPerTier
+            : (int) Mathf.Floor(-ScrollContainer.LocalPosition.x / CellWidth) * CellsPerTier +
+              TiersPerPage * CellsPerTier;
 
         private BoxCollider scrollingCollider;
+
         /// <summary>
         /// Scrolling interaction collider used to catch pointer and touch events on empty spaces.
         /// </summary>
@@ -576,7 +569,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get
             {
-                if (scrollingCollider == null)
+                if (!scrollingCollider)
                 {
                     scrollingCollider = gameObject.EnsureComponent<BoxCollider>();
                 }
@@ -589,6 +582,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private const float ScrollingColliderDepth = 0.001f;
 
         private NearInteractionTouchable scrollingTouchable;
+
         /// <summary>
         /// Scrolling interaction touchable used to catch touch events on empty spaces.
         /// </summary>
@@ -596,7 +590,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get
             {
-                if (scrollingTouchable == null)
+                if (!scrollingTouchable)
                 {
                     scrollingTouchable = gameObject.EnsureComponent<NearInteractionTouchable>();
                 }
@@ -608,36 +602,25 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// The local position of the moving scroll container. Can be used to represent the container drag displacement.
         /// </summary>
-        public Vector3 ScrollContainerPosition => ScrollContainer.transform.localPosition;
+        public Vector3 ScrollContainerPosition => ScrollContainer.LocalPosition;
 
         // The empty game object that contains our nodes and be scrolled
         [SerializeField]
-        [HideInInspector]
-        private GameObject scrollContainer;
+        private ScrollingObjectCollectionContainer scrollContainer;
 
-        private GameObject ScrollContainer
+        private ScrollingObjectCollectionContainer ScrollContainer
         {
             get
             {
-                if (scrollContainer == null)
-                {
-                    Transform oldContainer = transform.Find("Container");
+                if (scrollContainer)
+                    return scrollContainer;
 
-                    if (oldContainer != null)
-                    {
-                        scrollContainer = oldContainer.gameObject;
-                        Debug.LogWarning(name + " ScrollingObjectCollection found an existing Container object, using it for the list");
-                    }
-                    else
-                    {
-                        scrollContainer = new GameObject();
-                        scrollContainer.name = "Container";
-                        scrollContainer.transform.parent = transform;
-                        scrollContainer.transform.localPosition = Vector3.zero;
-                        scrollContainer.transform.localRotation = Quaternion.identity;
-                    }
-                }
+                scrollContainer = gameObject.GetComponentInChildren<ScrollingObjectCollectionContainer>();
+                if (scrollContainer)
+                    return scrollContainer;
 
+                var oldContainer = transform.Find("Container");
+                scrollContainer = oldContainer.gameObject.AddComponent<ScrollingObjectCollectionContainer>();
                 return scrollContainer;
             }
         }
@@ -654,25 +637,25 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get
             {
-                if (clippingObject == null)
+                if (clippingObject)
+                    return clippingObject;
+
+                var oldClippingObj = transform.Find("Clipping Bounds");
+                if (oldClippingObj)
                 {
-                    Transform oldClippingObj = transform.Find("Clipping Bounds");
-
-                    if (oldClippingObj != null)
-                    {
-                        clippingObject = oldClippingObj.gameObject;
-                        Debug.LogWarning(name + " ScrollingObjectCollection found an existing Clipping object, using it for the list");
-                    }
-                    else
-                    {
-                        clippingObject = new GameObject();
-                    }
-
-                    clippingObject.name = "Clipping Bounds";
-                    clippingObject.transform.parent = transform;
-                    clippingObject.transform.localRotation = Quaternion.identity;
-                    clippingObject.transform.localPosition = Vector3.zero;
+                    clippingObject = oldClippingObj.gameObject;
+                    Debug.LogWarning(
+                        $"{name} ScrollingObjectCollection found an existing Clipping object, using it for the list");
                 }
+                else
+                {
+                    clippingObject = new GameObject();
+                }
+
+                clippingObject.name = "Clipping Bounds";
+                clippingObject.transform.parent = transform;
+                clippingObject.transform.localRotation = Quaternion.identity;
+                clippingObject.transform.localPosition = Vector3.zero;
 
                 return clippingObject;
             }
@@ -683,30 +666,31 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private ClippingBox clipBox;
 
         /// <summary>
-        /// The ScrollingObjectCollection's <see cref="Microsoft.MixedReality.Toolkit.Utilities.ClippingBox"/> 
+        /// The ScrollingObjectCollection's <see cref="Microsoft.MixedReality.Toolkit.Utilities.ClippingBox"/>
         /// that is used for clipping items in and out of the list.
         /// </summary>
         public ClippingBox ClipBox
         {
             get
             {
-                if (clipBox == null)
-                {
-                    clipBox = ClippingObject.EnsureComponent<ClippingBox>();
-                    clipBox.ClippingSide = ClippingPrimitive.Side.Outside;
-                }
+                if (clipBox)
+                    return clipBox;
+
+                clipBox = ClippingObject.EnsureComponent<ClippingBox>();
+                clipBox.ClippingSide = ClippingPrimitive.Side.Outside;
 
                 return clipBox;
             }
         }
-       
+
         // This collider will be used for checking intersection of the scroll visible area with any content collider or renderer bounds.
         private Collider clippingBoundsCollider;
+
         private Collider ClippingBoundsCollider
         {
             get
             {
-                if (clippingBoundsCollider == null)
+                if (!clippingBoundsCollider)
                 {
                     clippingBoundsCollider = ClippingObject.EnsureComponent<BoxCollider>();
                     clippingBoundsCollider.enabled = false;
@@ -730,7 +714,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public bool IsEngaged { get; private set; } = false;
 
         /// <summary>
-        /// Tracks whether the scroll is being dragged due to a controller movement. 
+        /// Tracks whether the scroll is being dragged due to a controller movement.
         /// </summary>
         public bool IsDragging { get; private set; } = false;
 
@@ -753,10 +737,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private Vector3 workingScrollerPos;
 
         // A list of content renderers that need to be added to the clippingBox
-        private List<Renderer> renderersToClip = new List<Renderer>();
+        private HashSet<Renderer> renderersToClip = new HashSet<Renderer>();
 
         // A list of content renderers that need to be removed from the clippingBox
-        private List<Renderer> renderersToUnclip = new List<Renderer>();
+        private HashSet<Renderer> renderersToUnclip = new HashSet<Renderer>();
 
         private IMixedRealityPointer currentPointer;
 
@@ -816,6 +800,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     {
                         OnMomentumStarted.Invoke();
                     }
+
                     previousVelocityState = currentVelocityState;
                     currentVelocityState = value;
                 }
@@ -863,25 +848,31 @@ namespace Microsoft.MixedReality.Toolkit.UI
             var originalRotation = transform.rotation;
             transform.rotation = Quaternion.identity;
 
-            var childrenRenderers = ScrollContainer.GetComponentsInChildren<Renderer>(true);
-            if (childrenRenderers != null)
+            contentBounds = new Bounds
             {
-                contentBounds = new Bounds
-                {
-                    size = Vector3.zero,
-                    center = ClipBox.transform.position
-                };
+                size = Vector3.zero,
+                center = ClipBox.transform.position
+            };
+
+            foreach (var itemMap in ScrollContainer.ItemRenderersMap)
+            {
+                var childrenRenderers = itemMap.Value;
+                if (childrenRenderers == null || childrenRenderers.Length <= 0)
+                    continue;
 
                 foreach (var renderer in childrenRenderers)
                 {
-                    contentBounds.Encapsulate(renderer.bounds);
+                    if (renderer)
+                        contentBounds.Encapsulate(renderer.bounds);
                 }
-               
-                Vector3 localSize;
 
-                localSize.y = SafeDivisionFloat(contentBounds.size.y, transform.lossyScale.y);
-                localSize.x = SafeDivisionFloat(contentBounds.size.x, transform.lossyScale.x);
-                localSize.z = SafeDivisionFloat(contentBounds.size.z, transform.lossyScale.z);
+                var transformLossyScale = transform.lossyScale;
+                var contentBoundsSize = contentBounds.size;
+
+                Vector3 localSize;
+                localSize.y = SafeDivisionFloat(contentBoundsSize.y, transformLossyScale.y);
+                localSize.x = SafeDivisionFloat(contentBoundsSize.x, transformLossyScale.x);
+                localSize.z = SafeDivisionFloat(contentBoundsSize.z, transformLossyScale.z);
 
                 contentBounds.size = localSize;
             }
@@ -900,25 +891,27 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (scrollDirection == ScrollDirectionType.UpAndDown)
             {
-                ScrollingCollider.size = new Vector3(CellWidth * CellsPerTier, CellHeight * TiersPerPage, ScrollingColliderDepth);
+                ScrollingCollider.size = new Vector3(CellWidth * CellsPerTier, CellHeight * TiersPerPage,
+                    ScrollingColliderDepth);
             }
             else
             {
-                ScrollingCollider.size = new Vector3(CellWidth * TiersPerPage, CellHeight * CellsPerTier, ScrollingColliderDepth);
+                ScrollingCollider.size = new Vector3(CellWidth * TiersPerPage, CellHeight * CellsPerTier,
+                    ScrollingColliderDepth);
             }
 
             Vector3 colliderPosition;
             colliderPosition.x = ScrollingCollider.size.x / 2;
-            colliderPosition.y = - ScrollingCollider.size.y / 2;
+            colliderPosition.y = -ScrollingCollider.size.y / 2;
             colliderPosition.z = cellDepth / 2 + ScrollingColliderDepth;
             ScrollingCollider.center = colliderPosition;
 
             Vector2 size = new Vector2(
-                        Math.Abs(Vector3.Dot(ScrollingCollider.size, ScrollingTouchable.LocalRight)),
-                        Math.Abs(Vector3.Dot(ScrollingCollider.size, ScrollingTouchable.LocalUp)));
+                Math.Abs(Vector3.Dot(ScrollingCollider.size, ScrollingTouchable.LocalRight)),
+                Math.Abs(Vector3.Dot(ScrollingCollider.size, ScrollingTouchable.LocalUp)));
 
             Vector3 touchablePosition = colliderPosition;
-            touchablePosition.z = - cellDepth / 2;
+            touchablePosition.z = -cellDepth / 2;
 
             ScrollingTouchable.SetBounds(size);
             ScrollingTouchable.SetLocalCenter(touchablePosition);
@@ -949,8 +942,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                     // Apply the viewable area and column/row multiplier
                     // Use a dummy bounds of one to get the local scale to match;
-                    clippingBounds.size = new Vector3((CellWidth * CellsPerTier), (CellHeight * TiersPerPage), CellDepth);
-                    ClipBox.transform.localScale = new Bounds(Vector3.zero, Vector3.one).GetScaleToMatchBounds(clippingBounds);
+                    clippingBounds.size = new Vector3(CellWidth * CellsPerTier, CellHeight * TiersPerPage, CellDepth);
+                    ClipBox.transform.localScale =
+                        new Bounds(Vector3.zero, Vector3.one).GetScaleToMatchBounds(clippingBounds);
 
                     break;
 
@@ -958,7 +952,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                     // Same as above for L <-> R
                     clippingBounds.size = new Vector3(CellWidth * TiersPerPage, CellHeight * CellsPerTier, CellDepth);
-                    ClipBox.transform.localScale = new Bounds(Vector3.zero, Vector3.one).GetScaleToMatchBounds(clippingBounds);
+                    ClipBox.transform.localScale =
+                        new Bounds(Vector3.zero, Vector3.one).GetScaleToMatchBounds(clippingBounds);
 
                     break;
             }
@@ -989,7 +984,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 // Subscribe to the preRender callback on the main camera so we can intercept it and make sure we catch
                 // any dynamically added content
-                cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
+                if (!cameraMethods)
+                    cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
                 cameraMethods.OnCameraPreRender += OnCameraPreRender;
             }
         }
@@ -1002,12 +998,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private void Update()
         {
             if (!Application.isPlaying)
-            {
                 return;
-            }
 
             // Force the scroll container position if no content
-            if (ScrollContainer.GetComponentInChildren<Renderer>(true) == null)
+            if (ScrollContainer.ItemRenderersMap.Count <= 0)
             {
                 workingScrollerPos = Vector3.zero;
                 ApplyPosition(workingScrollerPos);
@@ -1016,12 +1010,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             // The scroller has detected input and has a valid pointer
-            if (IsEngaged && TryGetPointerPositionOnPlane(out Vector3 currentPointerPos))
+            if (IsEngaged && TryGetPointerPositionOnPlane(out var currentPointerPos))
             {
-                Vector3 handDelta = initialPointerPos - currentPointerPos;
+                var handDelta = initialPointerPos - currentPointerPos;
                 handDelta = transform.InverseTransformDirection(handDelta);
 
-                if (IsDragging && currentPointer != null) // Changing lock after drag started frame to allow for focus provider to move pointer focus to scroll background before locking
+                if (IsDragging && currentPointer != null)
+                    // Changing lock after drag started frame to allow for focus provider to move pointer focus to scroll background before locking
                 {
                     currentPointer.IsFocusLocked = true;
                 }
@@ -1031,7 +1026,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 if (!IsDragging)
                 {
                     // Grab the delta value we care about
-                    float absAxisHandDelta = (scrollDirection == ScrollDirectionType.UpAndDown) ? Mathf.Abs(handDelta.y) : Mathf.Abs(handDelta.x);
+                    var absAxisHandDelta = scrollDirection == ScrollDirectionType.UpAndDown
+                        ? Mathf.Abs(handDelta.y)
+                        : Mathf.Abs(handDelta.x);
 
                     // Catch an intentional finger in scroller to stop momentum, this isn't a drag its definitely a stop
                     if (absAxisHandDelta > handDeltaScrollThreshold)
@@ -1045,7 +1042,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         CurrentVelocityState = VelocityState.Dragging;
 
                         // Reset initialHandPos to prevent the scroller from jumping
-                        initialScrollerPos = workingScrollerPos = ScrollContainer.transform.localPosition;
+                        initialScrollerPos = workingScrollerPos = ScrollContainer.LocalPosition;
                         initialPointerPos = currentPointerPos;
                     }
                 }
@@ -1077,12 +1074,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         // Over damp if scroll position out of bounds
                         if (workingScrollerPos.y > MaxY || workingScrollerPos.y < minY)
                         {
-                            workingScrollerPos.y = MathUtilities.CLampLerp(initialScrollerPos.y - handLocalDelta, minY, MaxY, OverDampLerpInterval);
+                            workingScrollerPos.y = MathUtilities.CLampLerp(initialScrollerPos.y - handLocalDelta, minY,
+                                MaxY, OverDampLerpInterval);
                         }
-                        else 
+                        else
                         {
-                            workingScrollerPos.y = MathUtilities.CLampLerp(initialScrollerPos.y - handLocalDelta, minY, MaxY, DragLerpInterval);
+                            workingScrollerPos.y = MathUtilities.CLampLerp(initialScrollerPos.y - handLocalDelta, minY,
+                                MaxY, DragLerpInterval);
                         }
+
                         workingScrollerPos.x = 0.0f;
                     }
                     else
@@ -1093,12 +1093,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         // Over damp if scroll position out of bounds
                         if (workingScrollerPos.x > maxX || workingScrollerPos.x < MinX)
                         {
-                            workingScrollerPos.x = MathUtilities.CLampLerp(initialScrollerPos.x - handLocalDelta, MinX, maxX, OverDampLerpInterval);
+                            workingScrollerPos.x = MathUtilities.CLampLerp(initialScrollerPos.x - handLocalDelta, MinX,
+                                maxX, OverDampLerpInterval);
                         }
                         else
                         {
-                            workingScrollerPos.x = MathUtilities.CLampLerp(initialScrollerPos.x - handLocalDelta, MinX, maxX, DragLerpInterval);
+                            workingScrollerPos.x = MathUtilities.CLampLerp(initialScrollerPos.x - handLocalDelta, MinX,
+                                maxX, DragLerpInterval);
                         }
+
                         workingScrollerPos.y = 0.0f;
                     }
 
@@ -1111,9 +1114,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     lastPointerPos = currentPointerPos;
                 }
             }
-            else if ((CurrentVelocityState != VelocityState.None 
-                      || previousVelocityState != VelocityState.None) 
-                      && CurrentVelocityState != VelocityState.Animating) // Prevent the Animation coroutine from being overridden
+            else if ((CurrentVelocityState != VelocityState.None || previousVelocityState != VelocityState.None)
+                     && CurrentVelocityState != VelocityState.Animating)
+                // Prevent the Animation coroutine from being overridden
             {
                 // We're not engaged, so handle any not touching behavior
                 HandleVelocityFalloff();
@@ -1123,16 +1126,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             // Setting HasMomentum to true if scroll velocity state has changed or any movement happend during this update
-            if (CurrentVelocityState != VelocityState.None || previousVelocityState != VelocityState.None)
-            {
-                HasMomentum = true;
-            }
-
-            else
-            {
-                HasMomentum = false;
-            }
-
+            HasMomentum = CurrentVelocityState != VelocityState.None || previousVelocityState != VelocityState.None;
             previousVelocityState = CurrentVelocityState;
         }
 
@@ -1200,10 +1194,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             result = Vector3.zero;
 
-            if (((MonoBehaviour)currentPointer) == null)
+            if (!(MonoBehaviour) currentPointer)
             {
                 return false;
             }
+
             if (currentPointer.GetType() == typeof(PokePointer))
             {
                 result = currentPointer.Position;
@@ -1227,13 +1222,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                     HandleFalloffPerFrame();
                     break;
-
-                case VelocityType.FalloffPerItem:
                 default:
 
                     HandleFalloffPerItem();
                     break;
-
                 case VelocityType.NoVelocitySnapToItem:
 
                     CurrentVelocityState = VelocityState.None;
@@ -1243,11 +1235,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     // Round to the nearest cell
                     if (scrollDirection == ScrollDirectionType.UpAndDown)
                     {
-                        workingScrollerPos.y = Mathf.Round(ScrollContainer.transform.localPosition.y / CellHeight) * CellHeight;
+                        workingScrollerPos.y = Mathf.Round(ScrollContainer.LocalPosition.y / CellHeight) *
+                                               CellHeight;
                     }
                     else
                     {
-                        workingScrollerPos.x = Mathf.Round(ScrollContainer.transform.localPosition.x / CellWidth) * CellWidth;
+                        workingScrollerPos.x = Mathf.Round(ScrollContainer.LocalPosition.x / CellWidth) *
+                                               CellWidth;
                     }
 
                     initialScrollerPos = workingScrollerPos;
@@ -1277,19 +1271,18 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 case VelocityState.Calculating:
 
-                    int numSteps;
                     float newPosAfterVelocity;
                     if (scrollDirection == ScrollDirectionType.UpAndDown)
                     {
                         if (avgVelocity == 0.0f)
                         {
                             // Velocity was cleared out so we should just snap
-                            newPosAfterVelocity = ScrollContainer.transform.localPosition.y;
+                            newPosAfterVelocity = ScrollContainer.LocalPosition.y;
                         }
                         else
                         {
                             // Precalculate where the velocity falloff would land our scrollContainer, then round it to the nearest cell so it feels natural
-                            velocitySnapshot = IterateFalloff(avgVelocity, out numSteps);
+                            velocitySnapshot = IterateFalloff(avgVelocity, out _);
                             newPosAfterVelocity = initialScrollerPos.y - velocitySnapshot;
                         }
 
@@ -1302,12 +1295,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         if (avgVelocity == 0.0f)
                         {
                             // Velocity was cleared out so we should just snap
-                            newPosAfterVelocity = ScrollContainer.transform.localPosition.x;
+                            newPosAfterVelocity = ScrollContainer.LocalPosition.x;
                         }
                         else
                         {
                             // Precalculate where the velocity falloff would land our scrollContainer, then round it to the nearest cell so it feels natural
-                            velocitySnapshot = IterateFalloff(avgVelocity, out numSteps);
+                            velocitySnapshot = IterateFalloff(avgVelocity, out _);
                             newPosAfterVelocity = initialScrollerPos.x + velocitySnapshot;
                         }
 
@@ -1316,7 +1309,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         CurrentVelocityState = VelocityState.Resolving;
                     }
 
-                    workingScrollerPos = Solver.SmoothTo(scrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, BounceLerpInterval);
+                    workingScrollerPos = Solver.SmoothTo(ScrollContainer.LocalPosition,
+                        velocityDestinationPos, Time.deltaTime, BounceLerpInterval);
 
                     // Clear the velocity now that we've applied a new position
                     avgVelocity = 0.0f;
@@ -1326,36 +1320,37 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                     if (scrollDirection == ScrollDirectionType.UpAndDown)
                     {
-                        if (ScrollContainer.transform.localPosition.y > MaxY
-                            || ScrollContainer.transform.localPosition.y < minY)
+                        if (ScrollContainer.LocalPosition.y > MaxY
+                            || ScrollContainer.LocalPosition.y < minY)
                         {
                             CurrentVelocityState = VelocityState.Bouncing;
                             velocitySnapshot = 0.0f;
-                            break;
                         }
                         else
                         {
-                            workingScrollerPos = Solver.SmoothTo(ScrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, BounceLerpInterval);
+                            workingScrollerPos = Solver.SmoothTo(ScrollContainer.LocalPosition,
+                                velocityDestinationPos, Time.deltaTime, BounceLerpInterval);
 
                             SnapVelocityFinish();
                         }
                     }
                     else
                     {
-                        if (ScrollContainer.transform.localPosition.x > maxX + (FrontTouchDistance * bounceMultiplier)
-                            || ScrollContainer.transform.localPosition.x < MinX - (FrontTouchDistance * bounceMultiplier))
+                        if (ScrollContainer.LocalPosition.x > maxX + FrontTouchDistance * bounceMultiplier
+                            || ScrollContainer.LocalPosition.x < MinX - FrontTouchDistance * bounceMultiplier)
                         {
                             CurrentVelocityState = VelocityState.Bouncing;
                             velocitySnapshot = 0.0f;
-                            break;
                         }
                         else
                         {
-                            workingScrollerPos = Solver.SmoothTo(ScrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, BounceLerpInterval);
+                            workingScrollerPos = Solver.SmoothTo(ScrollContainer.LocalPosition,
+                                velocityDestinationPos, Time.deltaTime, BounceLerpInterval);
 
                             SnapVelocityFinish();
                         }
                     }
+
                     break;
 
                 case VelocityState.Bouncing:
@@ -1363,12 +1358,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     HandleBounceState();
                     break;
 
-                case VelocityState.None:
                 default:
                     // clean up our position for next frame
                     initialScrollerPos = workingScrollerPos;
                     break;
-
             }
         }
 
@@ -1400,38 +1393,33 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                     if (scrollDirection == ScrollDirectionType.UpAndDown)
                     {
-                        if (ScrollContainer.transform.localPosition.y > MaxY + (FrontTouchDistance * bounceMultiplier)
-                            || ScrollContainer.transform.localPosition.y < minY - (FrontTouchDistance * bounceMultiplier))
+                        if (ScrollContainer.LocalPosition.y > MaxY + FrontTouchDistance * bounceMultiplier
+                            || ScrollContainer.LocalPosition.y < minY - FrontTouchDistance * bounceMultiplier)
                         {
                             CurrentVelocityState = VelocityState.Bouncing;
                             avgVelocity = 0.0f;
                             break;
                         }
-                        else
-                        {
-                            avgVelocity *= velocityDampen;
-                            workingScrollerPos.y = initialScrollerPos.y + avgVelocity;
 
-                            SnapVelocityFinish();
+                        avgVelocity *= velocityDampen;
+                        workingScrollerPos.y = initialScrollerPos.y + avgVelocity;
 
-                        }
+                        SnapVelocityFinish();
                     }
                     else
                     {
-                        if (ScrollContainer.transform.localPosition.x > maxX + (FrontTouchDistance * bounceMultiplier)
-                            || ScrollContainer.transform.localPosition.x < MinX - (FrontTouchDistance * bounceMultiplier))
+                        if (ScrollContainer.LocalPosition.x > maxX + FrontTouchDistance * bounceMultiplier
+                            || ScrollContainer.LocalPosition.x < MinX - FrontTouchDistance * bounceMultiplier)
                         {
                             CurrentVelocityState = VelocityState.Bouncing;
                             avgVelocity = 0.0f;
                             break;
                         }
-                        else
-                        {
-                            avgVelocity *= velocityDampen;
-                            workingScrollerPos.x = initialScrollerPos.x + avgVelocity;
 
-                            SnapVelocityFinish();
-                        }
+                        avgVelocity *= velocityDampen;
+                        workingScrollerPos.x = initialScrollerPos.x + avgVelocity;
+
+                        SnapVelocityFinish();
                     }
 
                     // clean up our position for next frame
@@ -1448,14 +1436,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
-        /// Smooths <see cref="ScrollContainer"/>'s position to the proper clamped edge 
+        /// Smooths <see cref="ScrollContainer"/>'s position to the proper clamped edge
         /// while <see cref="CurrentVelocityState"/> is <see cref="VelocityState.Bouncing"/>.
         /// </summary>
         private void HandleBounceState()
         {
-            Vector3 clampedDest = new Vector3(Mathf.Clamp(ScrollContainer.transform.localPosition.x, MinX, maxX), Mathf.Clamp(ScrollContainer.transform.localPosition.y, minY, MaxY), 0.0f);
-            if ((scrollDirection == ScrollDirectionType.UpAndDown && Mathf.Approximately(ScrollContainer.transform.localPosition.y, clampedDest.y))
-                || (scrollDirection == ScrollDirectionType.LeftAndRight && Mathf.Approximately(ScrollContainer.transform.localPosition.x, clampedDest.x)))
+            var clampedDest = new Vector3(Mathf.Clamp(ScrollContainer.LocalPosition.x, MinX, maxX),
+                Mathf.Clamp(ScrollContainer.LocalPosition.y, minY, MaxY), 0.0f);
+            if (scrollDirection == ScrollDirectionType.UpAndDown &&
+                Mathf.Approximately(ScrollContainer.LocalPosition.y, clampedDest.y)
+                || scrollDirection == ScrollDirectionType.LeftAndRight &&
+                Mathf.Approximately(ScrollContainer.LocalPosition.x, clampedDest.x))
             {
                 CurrentVelocityState = VelocityState.None;
 
@@ -1463,8 +1454,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 initialScrollerPos = workingScrollerPos = clampedDest;
                 return;
             }
-            workingScrollerPos.y = Solver.SmoothTo(ScrollContainer.transform.localPosition, clampedDest, Time.deltaTime, BounceLerpInterval).y;
-            workingScrollerPos.x = Solver.SmoothTo(ScrollContainer.transform.localPosition, clampedDest, Time.deltaTime, BounceLerpInterval).x;
+
+            workingScrollerPos.y = Solver.SmoothTo(ScrollContainer.LocalPosition, clampedDest, Time.deltaTime,
+                BounceLerpInterval).y;
+            workingScrollerPos.x = Solver.SmoothTo(ScrollContainer.LocalPosition, clampedDest, Time.deltaTime,
+                BounceLerpInterval).x;
         }
 
         /// <summary>
@@ -1472,7 +1466,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private void SnapVelocityFinish()
         {
-            if (Vector3.Distance(ScrollContainer.transform.localPosition, workingScrollerPos) > Mathf.Epsilon)
+            if (Vector3.Distance(ScrollContainer.LocalPosition, workingScrollerPos) > Mathf.Epsilon)
             {
                 return;
             }
@@ -1482,11 +1476,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 if (scrollDirection == ScrollDirectionType.UpAndDown)
                 {
                     // Ensure we've actually snapped the position to prevent an extreme in-between state
-                    workingScrollerPos.y = (Mathf.Round(ScrollContainer.transform.localPosition.y / CellHeight)) * CellHeight;
+                    workingScrollerPos.y = Mathf.Round(ScrollContainer.LocalPosition.y / CellHeight) * CellHeight;
                 }
                 else
                 {
-                    workingScrollerPos.x = (Mathf.Round(ScrollContainer.transform.localPosition.x / CellWidth)) * CellWidth;
+                    workingScrollerPos.x = Mathf.Round(ScrollContainer.LocalPosition.x / CellWidth) * CellWidth;
                 }
             }
 
@@ -1503,14 +1497,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private void CalculateVelocity()
         {
             // Update simple velocity
-            TryGetPointerPositionOnPlane(out Vector3 newPos);
+            TryGetPointerPositionOnPlane(out var newPos);
 
-            scrollVelocity = (scrollDirection == ScrollDirectionType.UpAndDown)
-                             ? (newPos.y - lastPointerPos.y) / Time.deltaTime * velocityMultiplier
-                             : (newPos.x - lastPointerPos.x) / Time.deltaTime * velocityMultiplier;
+            scrollVelocity = scrollDirection == ScrollDirectionType.UpAndDown
+                ? (newPos.y - lastPointerPos.y) / Time.deltaTime * velocityMultiplier
+                : (newPos.x - lastPointerPos.x) / Time.deltaTime * velocityMultiplier;
 
             // And filter it...
-            avgVelocity = (avgVelocity * (1.0f - velocityFilterWeight)) + (scrollVelocity * velocityFilterWeight);
+            avgVelocity = avgVelocity * (1.0f - velocityFilterWeight) + scrollVelocity * velocityFilterWeight;
         }
 
         /// <summary>
@@ -1521,7 +1515,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <param name="curve"><see cref="AnimationCurve"/> representing the easing desired</param>
         /// <param name="time">Time for animation, in seconds</param>
         /// <param name="callback">Optional callback action to be invoked after animation coroutine has finished</param>
-        private IEnumerator AnimateTo(Vector3 initialPos, Vector3 finalPos, AnimationCurve curve = null, float? time = null, System.Action callback = null)
+        private IEnumerator AnimateTo(Vector3 initialPos, Vector3 finalPos, AnimationCurve curve = null,
+            float? time = null, Action callback = null)
         {
             if (curve == null)
             {
@@ -1536,8 +1531,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             float counter = 0.0f;
             while (counter <= time)
             {
-                workingScrollerPos = Vector3.Lerp(initialPos, finalPos, curve.Evaluate(counter / (float)time));
-                ScrollContainer.transform.localPosition = workingScrollerPos;
+                workingScrollerPos = Vector3.Lerp(initialPos, finalPos, curve.Evaluate(counter / (float) time));
+                ScrollContainer.LocalPosition = workingScrollerPos;
 
                 counter += Time.deltaTime;
                 yield return null;
@@ -1553,10 +1548,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 workingScrollerPos.x = initialScrollerPos.x = finalPos.x;
             }
 
-            if (callback != null)
-            {
-                callback?.Invoke();
-            }
+            callback?.Invoke();
 
             CurrentVelocityState = VelocityState.None;
             animateScroller = null;
@@ -1567,16 +1559,30 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private bool DetectScrollRelease(Vector3 pointerPos)
         {
-            Vector3 scrollToPointerVector = pointerPos - ClipBox.transform.position;
+            var clipBoxTransform = ClipBox.transform;
+            var scrollToPointerVector = pointerPos - clipBoxTransform.position;
 
             // Projecting vector onto every clip box space coordinate and using clip box lossy scale as reference to dimensions to scroll view visible bounds
             // Using dot product to check if pointer is in front or behind the scroll view plane
-            bool isScrollRelease = Vector3.Magnitude(Vector3.Project(scrollToPointerVector, ClipBox.transform.up)) > ClipBox.transform.lossyScale.y / 2 + releaseThresholdTopBottom
-                                || Vector3.Magnitude(Vector3.Project(scrollToPointerVector, ClipBox.transform.right)) > ClipBox.transform.lossyScale.x / 2 + releaseThresholdLeftRight
 
-                                || (Vector3.Dot(scrollToPointerVector, transform.forward) > 0 ?
-                                        Vector3.Magnitude(Vector3.Project(scrollToPointerVector, ClipBox.transform.forward)) > ClipBox.transform.lossyScale.z / 2 + releaseThresholdBack :
-                                        Vector3.Magnitude(Vector3.Project(scrollToPointerVector, ClipBox.transform.forward)) > ClipBox.transform.lossyScale.z / 2 + releaseThresholdFront);
+            var lossyScale = clipBoxTransform.lossyScale;
+            var isUpMagnitudeAboveThreshold =
+                Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBoxTransform.up)) >
+                lossyScale.y / 2 + releaseThresholdTopBottom;
+            var isRightMagnitudeAboveThreshold =
+                Vector3.Magnitude(Vector3.Project(scrollToPointerVector, clipBoxTransform.right)) >
+                lossyScale.x / 2 + releaseThresholdLeftRight;
+            var isScrollRelease = isUpMagnitudeAboveThreshold || isRightMagnitudeAboveThreshold
+                                                              || (Vector3.Dot(scrollToPointerVector,
+                                                                  transform.forward) > 0
+                                                                  ? Vector3.Magnitude(Vector3.Project(
+                                                                        scrollToPointerVector,
+                                                                        clipBoxTransform.forward)) >
+                                                                    lossyScale.z / 2 + releaseThresholdBack
+                                                                  : Vector3.Magnitude(Vector3.Project(
+                                                                        scrollToPointerVector,
+                                                                        clipBoxTransform.forward)) >
+                                                                    lossyScale.z / 2 + releaseThresholdFront);
             return isScrollRelease;
         }
 
@@ -1589,7 +1595,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Adds list of renderers to the ClippingBox
         /// </summary>
-        private void AddRenderersToClippingObject(List<Renderer> renderers)
+        private void AddRenderersToClippingObject(HashSet<Renderer> renderers)
         {
             foreach (var renderer in renderers)
             {
@@ -1600,7 +1606,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Removes list of renderers from the ClippingBox
         /// </summary>
-        private void RemoveRenderersFromClippingObject(List<Renderer> renderers)
+        private void RemoveRenderersFromClippingObject(HashSet<Renderer> renderers)
         {
             foreach (var renderer in renderers)
             {
@@ -1621,85 +1627,100 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private static int SafeDivisionInt(int numerator, int denominator)
         {
-            return (denominator != 0) ? numerator / denominator : 0;
+            return denominator != 0 ? numerator / denominator : 0;
         }
 
         private float SafeDivisionFloat(float numerator, float denominator)
         {
-            return (denominator != 0) ? numerator / denominator : 0;
+            return denominator != 0 ? numerator / denominator : 0;
         }
 
         /// <summary>
         /// Checks visibility of scroll content by iterating through all content renderers and colliders.
-        /// All inactive content objects and colliders are reactivated during visibility restoration. 
+        /// All inactive content objects and colliders are reactivated during visibility restoration.
         /// </summary>
         private void ManageVisibility(bool isRestoringVisibility = false)
         {
             if (!MaskEnabled && !isRestoringVisibility)
-            {
                 return;
-            }
 
             ClippingBoundsCollider.enabled = true;
-            Bounds clippingThresholdBounds = ClippingBoundsCollider.bounds;
-
-            Renderer[] contentRenderers = ScrollContainer.GetComponentsInChildren<Renderer>(true);
-            List<Renderer> clippedRenderers = ClipBox.GetRenderersCopy().ToList();
 
             // Remove all renderers from clipping primitive that are not part of scroll content
+            var clippedRenderers = ClipBox.Renderers;
             foreach (var clippedRenderer in clippedRenderers)
             {
-                if (clippedRenderer != null && !clippedRenderer.transform.IsChildOf(ScrollContainer.transform))
-                {
-                    if (!clippedRenderer.gameObject.activeSelf)
-                    {
-                        clippedRenderer.gameObject.SetActive(true);
-                    }
+                if (!clippedRenderer || clippedRenderer.transform.IsChildOf(ScrollContainer.transform))
+                    continue;
 
-                    renderersToUnclip.Add(clippedRenderer);
-                }
+                if (!clippedRenderer.gameObject.activeSelf)
+                    clippedRenderer.gameObject.SetActive(true);
+
+                renderersToUnclip.Add(clippedRenderer);
             }
 
             // Check render visibility
-            foreach (var renderer in contentRenderers)
+            ManageRenderersVisibility(isRestoringVisibility);
+
+            // Check collider visibility
+            ManageColliderVisibility(isRestoringVisibility);
+
+            ClippingBoundsCollider.enabled = false;
+
+            if (!isRestoringVisibility)
             {
-                // All content renderers should be added to clipping primitive
-                if (!isRestoringVisibility && MaskEnabled && !clippedRenderers.Contains(renderer))
-                {
-                    renderersToClip.Add(renderer);
-                }
+                ReconcileClippingContent();
+            }
+        }
 
-                // Complete or partialy visible renders should be clipped and its game object should be active
-                if (isRestoringVisibility
-                    || clippingThresholdBounds.ContainsBounds(renderer.bounds) 
-                    || clippingThresholdBounds.Intersects(renderer.bounds)) 
+        private void ManageRenderersVisibility(bool isRestoringVisibility)
+        {
+            var clippingThresholdBounds = ClippingBoundsCollider.bounds;
+            foreach (var contentRenderers in ScrollContainer.ItemRenderersMap.Values)
+            {
+                foreach (var renderer in contentRenderers)
                 {
-                    if (!renderer.gameObject.activeSelf)
+                    if (!renderer)
+                        continue;
+
+                    // All content renderers should be added to clipping primitive
+                    if (!isRestoringVisibility && MaskEnabled)
+                        renderersToClip.Add(renderer);
+
+                    // Complete or partially visible renders should be clipped and its game object should be active
+                    var isInBounds = clippingThresholdBounds.ContainsBounds(renderer.bounds);
+                    var intersects = clippingThresholdBounds.Intersects(renderer.bounds);
+                    if (isRestoringVisibility || isInBounds || intersects)
                     {
-                        renderer.gameObject.SetActive(true);
+                        if (!renderer.gameObject.activeSelf)
+                            renderer.gameObject.SetActive(true);
                     }
-                }
-
-                // Hidden renderer game objects should be inactive
-                else
-                {
-                    if (renderer.gameObject.activeSelf)
+                    else
                     {
-                        renderer.gameObject.SetActive(false);
+                        if (renderer.gameObject.activeSelf)
+                            renderer.gameObject.SetActive(false);
                     }
                 }
             }
+        }
 
-            // Check collider visibility
-            if (Application.isPlaying)
+        private void ManageColliderVisibility(bool isRestoringVisibility)
+        {
+            if (!Application.isPlaying)
+                return;
+
+            // Outer clipping bounds is used to ensure collider has minimum visibility to stay enabled
+            var outerClippingThresholdBounds = ClippingBoundsCollider.bounds;
+            outerClippingThresholdBounds.size *= contentVisibilityThresholdRatio;
+
+            foreach (var itemMap in ScrollContainer.ItemCollidersMap)
             {
-                // Outer clipping bounds is used to ensure collider has minimum visibility to stay enabled
-                Bounds outerClippingThresholdBounds = ClippingBoundsCollider.bounds;
-                outerClippingThresholdBounds.size *= contentVisibilityThresholdRatio;
-
-                var colliders = ScrollContainer.GetComponentsInChildren<Collider>(true);
+                var colliders = itemMap.Value;
                 foreach (var collider in colliders)
                 {
+                    if (!collider)
+                        continue;
+
                     // Disabling content colliders during drag to stop interaction even if game object is inactive
                     if (!isRestoringVisibility && IsDragging)
                     {
@@ -1746,13 +1767,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     collider.enabled = wasColliderEnabled;
                 }
             }
-
-            ClippingBoundsCollider.enabled = false;
-
-            if (!isRestoringVisibility)
-            {
-                ReconcileClippingContent();
-            }
         }
 
         /// <summary>
@@ -1789,19 +1803,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             switch (scrollDirection)
             {
-                case ScrollDirectionType.UpAndDown:
                 default:
 
-                    newScrollPos = new Vector3(ScrollContainer.transform.localPosition.x, workingPos.y, 0.0f);
+                    newScrollPos = new Vector3(ScrollContainer.LocalPosition.x, workingPos.y, 0.0f);
                     break;
 
                 case ScrollDirectionType.LeftAndRight:
 
-                    newScrollPos = new Vector3(workingPos.x, ScrollContainer.transform.localPosition.y, 0.0f);
+                    newScrollPos = new Vector3(workingPos.x, ScrollContainer.LocalPosition.y, 0.0f);
 
                     break;
             }
-            ScrollContainer.transform.localPosition = newScrollPos;
+
+            ScrollContainer.LocalPosition = newScrollPos;
         }
 
         /// <summary>
@@ -1844,7 +1858,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Moves the scroll container to the position that makes the tier with the tierIndex the first in the viewable area
         /// </summary>
-        private void MoveToTier(int tierIndex, bool animateToPosition = true, System.Action callback = null)
+        private void MoveToTier(int tierIndex, bool animateToPosition = true, Action callback = null)
         {
             if (animateScroller != null)
             {
@@ -1879,21 +1893,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 if (animateToPosition)
                 {
-                    animateScroller = AnimateTo(ScrollContainer.transform.localPosition, workingScrollerPos, paginationCurve, animationLength, callback);
+                    animateScroller = AnimateTo(ScrollContainer.LocalPosition, workingScrollerPos,
+                        paginationCurve, animationLength, callback);
                     StartCoroutine(animateScroller);
                 }
                 else
                 {
-                    CurrentVelocityState = VelocityState.None; // Flagging the instant position change to trigger momentum events
+                    // Flagging the instant position change to trigger momentum events
+                    CurrentVelocityState = VelocityState.None;
                     initialScrollerPos = workingScrollerPos;
                 }
 
-                if (callback != null)
-                {
-                    callback?.Invoke();
-                }
+                callback?.Invoke();
             }
-
         }
 
         #endregion private methods
@@ -1961,6 +1973,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 // It's below the visible area
                 isCellVisible = false;
             }
+
             return isCellVisible;
         }
 
@@ -1970,9 +1983,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <param name="numberOfPages">Amount of pages to move by</param>
         /// <param name="animate"> If true, scroller will animate to new position</param>
         /// <param name="callback"> An optional action to pass in to get notified that the <see cref="ScrollingObjectCollection"/> is finished moving</param>
-        public void MoveByPages(int numberOfPages, bool animate = true, System.Action callback = null)
+        public void MoveByPages(int numberOfPages, bool animate = true, Action callback = null)
         {
-            int tierIndex = SafeDivisionInt(FirstVisibleCellIndex, CellsPerTier) + (numberOfPages * TiersPerPage);
+            int tierIndex = SafeDivisionInt(FirstVisibleCellIndex, CellsPerTier) + numberOfPages * TiersPerPage;
 
             MoveToTier(tierIndex, animate, callback);
         }
@@ -1983,7 +1996,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <param name="numberOfTiers">Amount of tiers to move by</param>
         /// <param name="animate">if true, scroller will animate to new position</param>
         /// <param name="callback"> An optional action to pass in to get notified that the <see cref="ScrollingObjectCollection"/> is finished moving</param>
-        public void MoveByTiers(int numberOfTiers, bool animate = true, System.Action callback = null)
+        public void MoveByTiers(int numberOfTiers, bool animate = true, Action callback = null)
         {
             int tierIndex = SafeDivisionInt(FirstVisibleCellIndex, CellsPerTier) + numberOfTiers;
 
@@ -1994,9 +2007,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Moves scroller container to a position where the selected cell is in the first tier of the viewable area.
         /// </summary>
         /// <param name="cellIndex">Index of the cell to move to</param>
-        /// <param name="animate">if true, scroller will animate to new position</param>
+        /// <param name="animateToPosition">if true, scroller will animate to new position</param>
         /// <param name="callback"> An optional action to pass in to get notified that the <see cref="ScrollingObjectCollection"/> is finished moving</param>
-        public void MoveToIndex(int cellIndex, bool animateToPosition = true, System.Action callback = null)
+        public void MoveToIndex(int cellIndex, bool animateToPosition = true, Action callback = null)
         {
             cellIndex = (cellIndex < 0) ? 0 : cellIndex;
             int tierIndex = SafeDivisionInt(cellIndex, CellsPerTier);
@@ -2043,7 +2056,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             var selectedObject = eventData.Pointer.Result?.CurrentPointerTarget;
 
-            if (selectedObject == null || !selectedObject.transform.IsChildOf(transform))
+            if (!selectedObject || !selectedObject.transform.IsChildOf(transform))
             {
                 return;
             }
@@ -2064,7 +2077,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (TryGetPointerPositionOnPlane(out initialPointerPos))
             {
-                initialScrollerPos = ScrollContainer.transform.localPosition;
+                initialScrollerPos = ScrollContainer.LocalPosition;
                 CurrentVelocityState = VelocityState.None;
 
                 IsTouched = false;
@@ -2077,10 +2090,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         /// <inheritdoc/>
         /// Pointer Click handled during Update.
-        void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData) { }
+        void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData)
+        {
+        }
 
         /// <inheritdoc/>
-        void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData) { }
+        void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData)
+        {
+        }
 
         #endregion IMixedRealityPointerHandler implementation
 
@@ -2098,7 +2115,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             PokePointer pokePointer = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
 
             var selectedObject = pokePointer.Result?.CurrentPointerTarget;
-            if (selectedObject == null || !selectedObject.transform.IsChildOf(transform))
+            if (!selectedObject || !selectedObject.transform.IsChildOf(transform))
             {
                 return;
             }
@@ -2118,7 +2135,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 initialPointerPos = currentPointer.Position;
                 initialFocusedObject = selectedObject;
-                initialScrollerPos = ScrollContainer.transform.localPosition;
+                initialScrollerPos = ScrollContainer.LocalPosition;
 
                 IsTouched = true;
                 IsEngaged = true;
@@ -2130,7 +2147,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         /// <inheritdoc/>
         /// Touch release handled during Update.
-        void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData) { }
+        void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData)
+        {
+        }
 
         /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchUpdated(HandTrackingInputEventData eventData)
@@ -2150,7 +2169,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #region IMixedRealitySourceStateHandler implementation
 
-        void IMixedRealitySourceStateHandler.OnSourceDetected(SourceStateEventData eventData) { }
+        void IMixedRealitySourceStateHandler.OnSourceDetected(SourceStateEventData eventData)
+        {
+        }
 
         void IMixedRealitySourceStateHandler.OnSourceLost(SourceStateEventData eventData)
         {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs
@@ -59,12 +59,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void AddItemWithRenderers(GameObject child)
         {
-            if (ItemRenderersMap.ContainsKey(child) && !child)
+            if (!child)
             {
-                ItemRenderersMap.Remove(child);
+                if (ItemRenderersMap.ContainsKey(child))
+                    ItemRenderersMap.Remove(child);
                 return;
             }
-            
+
             if (ItemRenderersMap.ContainsKey(child))
             {
                 ItemRenderersMap[child] = child.GetComponentsInChildren<Renderer>(true);
@@ -76,12 +77,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void AddItemWithColliders(GameObject child)
         {
-            if (ItemCollidersMap.ContainsKey(child) && !child)
+            if (!child)
             {
-                ItemCollidersMap.Remove(child);
+                if (ItemCollidersMap.ContainsKey(child))
+                    ItemCollidersMap.Remove(child);
                 return;
             }
-            
+
+
             if (ItemCollidersMap.ContainsKey(child))
             {
                 ItemCollidersMap[child] = child.GetComponentsInChildren<Collider>(true);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.UI
+{
+    /// <summary>
+    ///     Container for all renderers and colliders used in the ScrollingObjectCollection.
+    ///     It's main purpose is to find and cache those Components.
+    ///     Thanks to that we don't have to run GetComponentsInChildren every frame. 
+    /// </summary>
+    public class ScrollingObjectCollectionContainer : MonoBehaviour
+    {
+        [SerializeField]
+        private GameObject[] children;
+
+        /// <summary>
+        ///     Dictionary containing ScrollingObjectCollection's items child renderers.
+        /// </summary>
+        public Dictionary<GameObject, Renderer[]> ItemRenderersMap { get; } = new Dictionary<GameObject, Renderer[]>();
+
+        /// <summary>
+        ///     Dictionary containing ScrollingObjectCollection's items child colliders.
+        /// </summary>
+        public Dictionary<GameObject, Collider[]> ItemCollidersMap { get; } = new Dictionary<GameObject, Collider[]>();
+
+        /// <summary>
+        ///     Position of the Container.
+        /// </summary>
+        public Vector3 LocalPosition
+        {
+            get => transform.localPosition;
+            set => transform.localPosition = value;
+        }
+
+        private GameObject[] Children
+        {
+            get
+            {
+                var childCount = transform.childCount;
+                if (children == null || children.Length != childCount)
+                {
+                    children = new GameObject[childCount];
+                    for (var i = 0; i < children.Length; ++i)
+                        children[i] = transform.GetChild(i).gameObject;
+                }
+
+                return children;
+            }
+        }
+
+        private void OnTransformChildrenChanged()
+        {
+            foreach (var child in Children)
+            {
+                AddItemWithRenderers(child);
+                AddItemWithColliders(child);
+            }
+        }
+
+        private void AddItemWithRenderers(GameObject child)
+        {
+            if (ItemRenderersMap.ContainsKey(child))
+            {
+                ItemRenderersMap[child] = child.GetComponentsInChildren<Renderer>(true);
+                return;
+            }
+
+            ItemRenderersMap.Add(child, child.GetComponentsInChildren<Renderer>(true));
+        }
+
+        private void AddItemWithColliders(GameObject child)
+        {
+            if (ItemCollidersMap.ContainsKey(child))
+            {
+                ItemCollidersMap[child] = child.GetComponentsInChildren<Collider>(true);
+                return;
+            }
+
+            ItemCollidersMap.Add(child, child.GetComponentsInChildren<Collider>(true));
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs
@@ -59,6 +59,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void AddItemWithRenderers(GameObject child)
         {
+            if (ItemRenderersMap.ContainsKey(child) && !child)
+            {
+                ItemRenderersMap.Remove(child);
+                return;
+            }
+            
             if (ItemRenderersMap.ContainsKey(child))
             {
                 ItemRenderersMap[child] = child.GetComponentsInChildren<Renderer>(true);
@@ -70,6 +76,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void AddItemWithColliders(GameObject child)
         {
+            if (ItemCollidersMap.ContainsKey(child) && !child)
+            {
+                ItemCollidersMap.Remove(child);
+                return;
+            }
+            
             if (ItemCollidersMap.ContainsKey(child))
             {
                 ItemCollidersMap[child] = child.GetComponentsInChildren<Collider>(true);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs
@@ -4,9 +4,9 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.UI
 {
     /// <summary>
-    ///     Container for all renderers and colliders used in the ScrollingObjectCollection.
-    ///     It's main purpose is to find and cache those Components.
-    ///     Thanks to that we don't have to run GetComponentsInChildren every frame. 
+    /// Container for all renderers and colliders used in the ScrollingObjectCollection.
+    /// It's main purpose is to find and cache those Components.
+    /// Thanks to that we don't have to run GetComponentsInChildren every frame. 
     /// </summary>
     public class ScrollingObjectCollectionContainer : MonoBehaviour
     {
@@ -14,17 +14,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private GameObject[] children;
 
         /// <summary>
-        ///     Dictionary containing ScrollingObjectCollection's items child renderers.
+        /// Dictionary containing ScrollingObjectCollection's items child renderers.
         /// </summary>
         public Dictionary<GameObject, Renderer[]> ItemRenderersMap { get; } = new Dictionary<GameObject, Renderer[]>();
 
         /// <summary>
-        ///     Dictionary containing ScrollingObjectCollection's items child colliders.
+        /// Dictionary containing ScrollingObjectCollection's items child colliders.
         /// </summary>
         public Dictionary<GameObject, Collider[]> ItemCollidersMap { get; } = new Dictionary<GameObject, Collider[]>();
 
         /// <summary>
-        ///     Position of the Container.
+        /// Position of the Container.
         /// </summary>
         public Vector3 LocalPosition
         {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollectionContainer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fd149eac48fa471fb1d9b7e79d175867
+timeCreated: 1610632164


### PR DESCRIPTION
## Overview
Performance improvements for CoreServices, ClippingPrimitive and, mostly, for ScrollingObjectCollection.

## Changes
- Mixed Reality Services are now correctly cached inside CoreServices.cs
- ClippingPrimitive now caches Renderers and MaterialInstances instead of asking for them in every frame
- MaterialInstance now caches shared materials
- ScrollingObjectCollection uses ScrollingObjectCollectionContainer to find and work on child Renderers and Colliders
- ScrollingObjectCollectionContainer is responsible for finding and storing references for it's children's renderers and colliders. It creates a small overhead whenever children are added or removed, but vastly enhances performance for each ScrollingObjectCollection Update call.


## Verification
Hi! My name's Daniel and I work for apoQlar GmbH. During one of our technical sprints, we decided to work on performance improvements. Changes that we have introduced have helped us to achieve 60 fps and vastly mitigate GC impact. We hope that you'll find those changes suitable.