### PR TITLE
Build Deploy Window: detect Windows 10 SDK installation path by checking registry fix #9146

### DIFF
--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -19,7 +19,6 @@ using UnityEditor;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 using FileInfo = System.IO.FileInfo;
-using Microsoft.Win32;
 
 namespace Microsoft.MixedReality.Toolkit.Build.Editor
 {
@@ -1389,12 +1388,13 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private void LoadWindowsSdkPaths()
         {
-            string win10KitsPath;
+            string win10KitsPath = WINDOWS_10_KITS_DEFAULT_PATH;
+#if UNITY_EDITOR_WIN
             // Windows 10 sdk might not be installed on C: drive.
             // Try to detect the installation path by checking the registry.
             try 
             {
-                var registryKey = Registry.LocalMachine.OpenSubKey(WINDOWS_10_KITS_PATH_REGISTRY_PATH);
+                var registryKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(WINDOWS_10_KITS_PATH_REGISTRY_PATH);
                 var registryValue = registryKey.GetValue(WINDOWS_10_KITS_PATH_REGISTRY_KEY) as string;
                 win10KitsPath = Path.Combine(registryValue, WINDOWS_10_KITS_PATH_POSTFIX);
             }
@@ -1403,6 +1403,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 Debug.LogWarning($"Could not find the Windows 10 SDK installation path via registry. Reverting to default path. {e}");
                 win10KitsPath = WINDOWS_10_KITS_DEFAULT_PATH;
             }
+#endif
             var windowsSdkPaths = Directory.GetDirectories(win10KitsPath);
             for (int i = 0; i < windowsSdkPaths.Length; i++)
             {

--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -19,6 +19,7 @@ using UnityEditor;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 using FileInfo = System.IO.FileInfo;
+using Microsoft.Win32;
 
 namespace Microsoft.MixedReality.Toolkit.Build.Editor
 {
@@ -77,6 +78,15 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         private static readonly List<string> AppPackageDirectories = new List<string>(0);
 
         private const string BuildWindowTabKey = "_BuildWindow_Tab";
+        
+        private const string WINDOWS_10_KITS_PATH_REGISTRY_PATH = @"SOFTWARE\Microsoft\Windows Kits\Installed Roots";
+        
+        private const string WINDOWS_10_KITS_PATH_REGISTRY_KEY = "KitsRoot10";
+        
+        private const string WINDOWS_10_KITS_PATH_POSTFIX = "Lib";
+        
+        private const string WINDOWS_10_KITS_DEFAULT_PATH = @"C:\Program Files (x86)\Windows Kits\10\Lib";
+        
 
         #endregion Constants and Readonly Values
 
@@ -1379,7 +1389,21 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private void LoadWindowsSdkPaths()
         {
-            var windowsSdkPaths = Directory.GetDirectories(@"C:\Program Files (x86)\Windows Kits\10\Lib");
+            string win10KitsPath;
+            // Windows 10 sdk might not be installed on C: drive.
+            // Try to detect the installation path by checking the registry.
+            try 
+            {
+                var registryKey = Registry.LocalMachine.OpenSubKey(WINDOWS_10_KITS_PATH_REGISTRY_PATH);
+                var registryValue = registryKey.GetValue(WINDOWS_10_KITS_PATH_REGISTRY_KEY) as string;
+                win10KitsPath = Path.Combine(registryValue, WINDOWS_10_KITS_PATH_POSTFIX);
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning($"Could not find the Windows 10 SDK installation path via registry. Reverting to default path. {e}");
+                win10KitsPath = WINDOWS_10_KITS_DEFAULT_PATH;
+            }
+            var windowsSdkPaths = Directory.GetDirectories(win10KitsPath);
             for (int i = 0; i < windowsSdkPaths.Length; i++)
             {
                 windowsSdkVersions.Add(new Version(windowsSdkPaths[i].Substring(windowsSdkPaths[i].LastIndexOf(@"\", StringComparison.Ordinal) + 1)));


### PR DESCRIPTION
## Overview

BuildDeployWindow would produce an error when Windows 10 SDK was installed on any disk other than C:\.
This was due to a hard-coded path in the script.

This PR remedies that by checking the registry first to obtain the actual installation path.

## Changes
- Fixes: #9146

## Verification
- Install Windows 10 Sdk (10.0.18368) and other necessary tools on D: drive
- Try to build project with build window
