### PR TITLE
Add Near Interaction Support foldout to ObjectManipulator inspector

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         bool oneHandedFoldout = true;
         bool twoHandedFoldout = true;
         bool constraintsFoldout = true;
-        bool nearInteractionFoldout = false;
+        bool nearInteractionFoldout = true;
         bool physicsFoldout = true;
         bool smoothingFoldout = true;
         bool eventsFoldout = true;
@@ -103,13 +103,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.PropertyField(allowFarManipulation);
 
             // Near Interaction Support foldout
-            nearInteractionFoldout = EditorGUILayout.Foldout(nearInteractionFoldout, "Near Interaction Support", false);
+            nearInteractionFoldout = EditorGUILayout.Foldout(nearInteractionFoldout, "Near Interaction Support", true);
 
             if (nearInteractionFoldout)
             {
                 if (instance.GetComponent<NearInteractionGrabbable>() == null)
                 {
-                    EditorGUILayout.HelpBox("By default, ObjectManipulator is a far interaction component.  Add a NearInteractionGrabbable component to enable near interaction support.", MessageType.Info);
+                    EditorGUILayout.HelpBox($"By default, {nameof(ObjectManipulator)} only responds to far interaction input.  Add a {nameof(NearInteractionGrabbable)} component to enable near interaction support.", MessageType.Warning);
 
                     if (GUILayout.Button("Add Near Interaction Grabbable"))
                     {
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
                 else
                 {
-                    EditorGUILayout.HelpBox("A NearInteractionGrabbable is attached to this object, near interaction support is enabled.", MessageType.Info);
+                    EditorGUILayout.HelpBox($"A {nameof(NearInteractionGrabbable)} is attached to this object, near interaction support is enabled.", MessageType.Info);
                 }
             }
 

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
@@ -17,6 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     [CanEditMultipleObjects]
     public class ObjectManipulatorInspector : UnityEditor.Editor
     {
+        private ObjectManipulator instance;
         private SerializedProperty hostTransform;
         private SerializedProperty manipulationType;
         private SerializedProperty allowFarManipulation;
@@ -48,12 +50,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         bool oneHandedFoldout = true;
         bool twoHandedFoldout = true;
         bool constraintsFoldout = true;
+        bool nearInteractionFoldout = false;
         bool physicsFoldout = true;
         bool smoothingFoldout = true;
         bool eventsFoldout = true;
 
         public void OnEnable()
         {
+            instance = target as ObjectManipulator;
+
             // General properties
             hostTransform = serializedObject.FindProperty("hostTransform");
             manipulationType = serializedObject.FindProperty("manipulationType");
@@ -96,6 +101,26 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.PropertyField(hostTransform);
             EditorGUILayout.PropertyField(manipulationType);
             EditorGUILayout.PropertyField(allowFarManipulation);
+
+            // Near Interaction Support foldout
+            nearInteractionFoldout = EditorGUILayout.Foldout(nearInteractionFoldout, "Near Interaction Support", false);
+
+            if (nearInteractionFoldout)
+            {
+                if (instance.GetComponent<NearInteractionGrabbable>() == null)
+                {
+                    EditorGUILayout.HelpBox("By default, ObjectManipulator is a far interaction component.  Add a NearInteractionGrabbable component to enable near interaction support.", MessageType.Info);
+
+                    if (GUILayout.Button("Add Near Interaction Grabbable"))
+                    {
+                        instance.gameObject.AddComponent<NearInteractionGrabbable>();
+                    }
+                }
+                else
+                {
+                    EditorGUILayout.HelpBox("A NearInteractionGrabbable is attached to this object, near interaction support is enabled.", MessageType.Info);
+                }
+            }
 
             var handedness = (ManipulationHandFlags)manipulationType.intValue;
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -419,6 +419,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 constraintsManager = gameObject.EnsureComponent<ConstraintManager>();
             }
+
+            if (!AllowFarManipulation && GetComponent<NearInteractionGrabbable>() == null)
+            {
+                Debug.LogError($"AllowFarManipulation is false and a NearInteractionGrabbable component is not attached to {gameObject.name}. " +
+                " To enable near interaction support, attach a NearInteractionGrabbable component to this object.");
+            }
         }
 
         #endregion
@@ -559,8 +565,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (eventData.used ||
                     (!allowFarManipulation && eventData.Pointer as IMixedRealityNearPointer == null))
             {
-                Debug.LogError("AllowFarManipulation is false and a NearInteractionGrabbable component is not attached to this object. " +
-                    " To enable near interaction support, attach a NearInteractionGrabbable component to this object.");
                 return;
             }
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -425,7 +425,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (children.Length == 0)
             {
-                Debug.LogWarning($"Near interactions are not enabled for {gameObject.name}. To enable near interactions, add a " +
+                Debug.Log($"Near interactions are not enabled for {gameObject.name}. To enable near interactions, add a " +
                     $"{nameof(NearInteractionGrabbable)} component to {gameObject.name} or to a child object of {gameObject.name} that contains a collider.");
             }
         }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -420,10 +420,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 constraintsManager = gameObject.EnsureComponent<ConstraintManager>();
             }
 
-            if (!AllowFarManipulation && GetComponent<NearInteractionGrabbable>() == null)
+            // Get child objects with NearInteractionGrabbable attached
+            var children = GetComponentsInChildren<NearInteractionGrabbable>();
+
+            if (children.Length == 0)
             {
-                Debug.LogError($"AllowFarManipulation is false and a NearInteractionGrabbable component is not attached to {gameObject.name}. " +
-                " To enable near interaction support, attach a NearInteractionGrabbable component to this object.");
+                Debug.LogWarning($"Near interactions are not enabled for {gameObject.name}. To enable near interactions, add a " +
+                    $"{nameof(NearInteractionGrabbable)} component to {gameObject.name} or to a child object of {gameObject.name} that contains a collider.");
             }
         }
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -559,6 +559,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (eventData.used ||
                     (!allowFarManipulation && eventData.Pointer as IMixedRealityNearPointer == null))
             {
+                Debug.LogError("AllowFarManipulation is false and a NearInteractionGrabbable component is not attached to this object. " +
+                    " To enable near interaction support, attach a NearInteractionGrabbable component to this object.");
                 return;
             }
 


### PR DESCRIPTION
## Overview

Added a Near Interaction Support foldout to the Object Manipulator inspector to indicate the need for the NearInteractionGrabbable component for enabling near interaction support. 

Also added error message to ObjectManipulator if AllowFarManipulation is false and a NearInteractionGrabbable is not attached. 

### Inspector Appearance

#### Foldout Closed
![image](https://user-images.githubusercontent.com/53493796/105074530-545fc700-5a3d-11eb-9dec-1cd8c06d2e49.png)

#### Foldout Open
![image](https://user-images.githubusercontent.com/53493796/105074626-778a7680-5a3d-11eb-8b87-de4dd580f66e.png)

#### Foldout after NearInteractionGrabbable is attached
![image](https://user-images.githubusercontent.com/53493796/105074717-9426ae80-5a3d-11eb-802e-2df123ac83ac.png)


## Changes
- Fixes: #8083 
