### PR TITLE
Manually update cached main camera

### DIFF
--- a/Assets/MRTK/Core/Utilities/CameraCache.cs
+++ b/Assets/MRTK/Core/Utilities/CameraCache.cs
@@ -52,9 +52,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
                 // Cache the main camera
                 cachedCamera = mainCamera;
-
                 return cachedCamera;
             }
+        }
+
+        /// <summary>
+        /// Manually update the cached main camera 
+        /// </summary>
+        public static void UpdateCachedMainCamera(Camera camera)
+        {
+            cachedCamera = camera;
         }
     }
 }


### PR DESCRIPTION
## Overview
There is no option to set cached maincamera externally.

Scenario where there are multiple cameras in the scene and they interchange role as main camera when needed. At the moment there is no option to set them manually. Giving an option to set them would be nice.

## Changes
- Fixes: # .
- Manually update the cached main camera

## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
