### PR TITLE
Ignore xcopy error for xml files to resolve CI issue

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/MSBuildMRTKTemplates/SDKProjectTemplate.csproj.template
+++ b/Assets/MRTK/Tools/MSBuild/MSBuildMRTKTemplates/SDKProjectTemplate.csproj.template
@@ -150,7 +150,7 @@
   </Target>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y $(TargetDir)$(TargetName).dll $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y $(TargetDir)$(TargetName).pdb $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y /c $(TargetDir)$(TargetName).xml $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\" />
+    <Exec Command="xcopy /y $(TargetDir)$(TargetName).dll $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y $(TargetDir)$(TargetName).pdb $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y $(TargetDir)$(TargetName).xml $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\ || set errorlevel=0" />
   </Target>
 
 </Project>

--- a/Assets/MRTK/Tools/MSBuild/MSBuildMRTKTemplates/SDKProjectTemplate.csproj.template
+++ b/Assets/MRTK/Tools/MSBuild/MSBuildMRTKTemplates/SDKProjectTemplate.csproj.template
@@ -150,7 +150,7 @@
   </Target>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y $(TargetDir)$(TargetName).dll $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y $(TargetDir)$(TargetName).pdb $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y $(TargetDir)$(TargetName).xml $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\" />
+    <Exec Command="xcopy /y $(TargetDir)$(TargetName).dll $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y $(TargetDir)$(TargetName).pdb $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\&#xD;&#xA;xcopy /y /c $(TargetDir)$(TargetName).xml $(PublishOutputPath)$(UnityConfiguration)\$(UnityPlatform)\" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Overview
Currently due to the way CI is set up the XML files are not produced causing the xcopy command to fail. This PR fixes the issue by suppressing the copy error on XML files.