### PR TITLE
Add option to enable and disable visibility of teleport cursor when l…

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/TeleportPointerInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/TeleportPointerInspector.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
     [CustomEditor(typeof(TeleportPointer))]
     public class TeleportPointerInspector : LinePointerInspector
     {
+        private SerializedProperty hotSpotCursorVisibility;
         private SerializedProperty teleportAction;
         private SerializedProperty inputThreshold;
         private SerializedProperty angleOffset;
@@ -32,6 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
             DrawBasePointerActions = false;
             base.OnEnable();
 
+            hotSpotCursorVisibility = serializedObject.FindProperty("hotSpotCursorVisibility");
             teleportAction = serializedObject.FindProperty("teleportAction");
             inputThreshold = serializedObject.FindProperty("inputThreshold");
             angleOffset = serializedObject.FindProperty("angleOffset");
@@ -60,6 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
             if (teleportPointerFoldout)
             {
                 EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(hotSpotCursorVisibility);
                 EditorGUILayout.PropertyField(teleportAction);
                 EditorGUILayout.PropertyField(inputThreshold);
                 EditorGUILayout.PropertyField(angleOffset);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -40,11 +40,19 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         /// </summary>
         public MixedRealityInputAction TeleportInputAction => teleportAction;
 
+        [SerializeField]
+        [Tooltip("Teleport Pointer Cursor visibility when a hotspot is in focus")]
+        private bool hotSpotCursorVisibility = true;
+
         /// <summary>
         /// Teleport pointer cursor visibility if pointer is focused on hotspot
         /// </summary>
-        public bool TeleportHotSpotCursorVisibility { get; set; } = true;
-        
+        public bool TeleportHotSpotCursorVisibility
+        {
+            get => hotSpotCursorVisibility;
+            set => hotSpotCursorVisibility = value;
+        }
+
         [SerializeField]
         [Range(0f, 1f)]
         [Tooltip("The threshold amount for joystick input (Dead Zone)")]
@@ -335,7 +343,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 
                         // Clamp the end of the parabola to the result hit's point
                         LineBase.LineEndClamp = LineBase.GetNormalizedLengthFromWorldLength(clearWorldLength, LineCastResolution);
-                        if (TeleportHotSpotCursorVisibility)
+                        if (hotSpotCursorVisibility)
                         {
                             BaseCursor?.SetVisibility(TeleportSurfaceResult == TeleportSurfaceResult.Valid || TeleportSurfaceResult == TeleportSurfaceResult.HotSpot);
                         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -40,6 +40,11 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         /// </summary>
         public MixedRealityInputAction TeleportInputAction => teleportAction;
 
+        /// <summary>
+        /// Teleport pointer cursor visibility if pointer is focused on hotspot
+        /// </summary>
+        public bool TeleportHotSpotCursorVisibility { get; set; } = true;
+        
         [SerializeField]
         [Range(0f, 1f)]
         [Tooltip("The threshold amount for joystick input (Dead Zone)")]
@@ -330,7 +335,14 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 
                         // Clamp the end of the parabola to the result hit's point
                         LineBase.LineEndClamp = LineBase.GetNormalizedLengthFromWorldLength(clearWorldLength, LineCastResolution);
-                        BaseCursor?.SetVisibility(TeleportSurfaceResult == TeleportSurfaceResult.Valid || TeleportSurfaceResult == TeleportSurfaceResult.HotSpot);
+                        if (TeleportHotSpotCursorVisibility)
+                        {
+                            BaseCursor?.SetVisibility(TeleportSurfaceResult == TeleportSurfaceResult.Valid || TeleportSurfaceResult == TeleportSurfaceResult.HotSpot);
+                        }
+                        else
+                        {
+                            BaseCursor?.SetVisibility(TeleportSurfaceResult == TeleportSurfaceResult.Valid);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
## Overview
Gives the option to enable or disable the visualization of the teleport cursor when looking at a hotspot. With the current implementation, there is no way to disable the cursor visibility because it is set to true on OnPostSceneQuery(). Useful for cases where cursor visibility can be disabled for other forms of visual feedback from the hotspot.

## Changes
- Fixes: # .