### PR TITLE
Fixed the pinch slider prefab to not be offset when rotated in play mode

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Sliders/PinchSlider.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Sliders/PinchSlider.prefab
@@ -901,7 +901,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7307063430522344694}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0125}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7307063430134822103}
@@ -1302,7 +1302,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7307063430758334042}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.0125}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7307063430522344680}


### PR DESCRIPTION
## Overview
Made adjustments to the prefab to ensure that the slider would not get offset after being rotated.
This was done by readjusting the positions of the gameobjects in the hierarchy. 

![FixedPinchSlider](https://user-images.githubusercontent.com/39840334/105610865-f2c29400-5d7f-11eb-9174-67fc103bfc77.gif)

## Changes
- Fixes: #8856


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
