### PR TITLE
Decouple dragging events from Select action. 

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -41,13 +41,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected MixedRealityInputAction pointerAction = MixedRealityInputAction.None;
 
         [SerializeField]
-        [Tooltip("The action that will enable the raise the input drag event for this pointer.")]
-        protected MixedRealityInputAction dragAction = MixedRealityInputAction.None;
+        [Tooltip("The action that will enable the raise the input grab event for this pointer.")]
+        protected MixedRealityInputAction grabAction = MixedRealityInputAction.None;
 
         /// <summary>
-        /// True if drag is pressed right now
+        /// True if grab is pressed right now
         /// </summary>
-        protected bool IsDragPressed = false;
+        protected bool IsGrabPressed = false;
 
         [SerializeField]
         [Tooltip("Does the interaction require hold?")]
@@ -181,7 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected override void OnDisable()
         {
-            if (IsSelectPressed || IsDragPressed)
+            if (IsSelectPressed || IsGrabPressed)
             {
                 CoreServices.InputSystem?.RaisePointerUp(this, pointerAction, Handedness);
             }
@@ -190,7 +190,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             IsHoldPressed = false;
             IsSelectPressed = false;
-            IsDragPressed = false;
+            IsGrabPressed = false;
             HasSelectPressedOnce = false;
             BaseCursor?.SetVisibility(false);
 
@@ -291,7 +291,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     return true;
                 }
 
-                if (IsSelectPressed || IsDragPressed)
+                if (IsSelectPressed || IsGrabPressed)
                 {
                     return true;
                 }
@@ -403,11 +403,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnPostSceneQueryPerfMarker.Auto())
             {
-                if (dragAction != MixedRealityInputAction.None && InputSourceParent.SourceType == InputSourceType.Controller)
+                if (grabAction != MixedRealityInputAction.None && InputSourceParent.SourceType == InputSourceType.Controller)
                 {
-                    if (IsDragPressed)
+                    if (IsGrabPressed)
                     {
-                        CoreServices.InputSystem.RaisePointerDragged(this, dragAction, Handedness);
+                        CoreServices.InputSystem.RaisePointerDragged(this, grabAction, Handedness);
                     }
                 }
                 else
@@ -504,13 +504,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         CoreServices.InputSystem.RaisePointerUp(this, pointerAction, Handedness);
                     }
 
-                    if (IsDragPressed)
+                    if (IsGrabPressed)
                     {
-                        CoreServices.InputSystem.RaisePointerUp(this, dragAction, Handedness);
+                        CoreServices.InputSystem.RaisePointerUp(this, grabAction, Handedness);
                     }
 
                     IsSelectPressed = false;
-                    IsDragPressed = false;
+                    IsGrabPressed = false;
                 }
             }
         }
@@ -537,14 +537,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         IsHoldPressed = false;
                     }
 
-                    if (dragAction != MixedRealityInputAction.None &&
+                    if (grabAction != MixedRealityInputAction.None &&
                         eventData.InputSource.SourceType == InputSourceType.Controller &&
-                        eventData.MixedRealityInputAction == dragAction)
+                        eventData.MixedRealityInputAction == grabAction)
                     {
-                        IsDragPressed = false;
+                        IsGrabPressed = false;
 
-                        CoreServices.InputSystem.RaisePointerClicked(this, dragAction, 0, Handedness);
-                        CoreServices.InputSystem.RaisePointerUp(this, dragAction, Handedness);
+                        CoreServices.InputSystem.RaisePointerClicked(this, grabAction, 0, Handedness);
+                        CoreServices.InputSystem.RaisePointerUp(this, grabAction, Handedness);
                     }
 
                     if (eventData.MixedRealityInputAction == pointerAction)
@@ -576,15 +576,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         IsHoldPressed = true;
                     }
 
-                    if (dragAction != MixedRealityInputAction.None &&
+                    if (grabAction != MixedRealityInputAction.None &&
                         eventData.InputSource.SourceType == InputSourceType.Controller &&
-                        eventData.MixedRealityInputAction == dragAction)
+                        eventData.MixedRealityInputAction == grabAction)
                     {
-                        IsDragPressed = true;
+                        IsGrabPressed = true;
 
                         if (IsInteractionEnabled)
                         {
-                            CoreServices.InputSystem.RaisePointerDown(this, dragAction, Handedness);
+                            CoreServices.InputSystem.RaisePointerDown(this, grabAction, Handedness);
                         }
                     }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -403,7 +403,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnPostSceneQueryPerfMarker.Auto())
             {
-                if (dragAction != MixedRealityInputAction.None)
+                if (dragAction != MixedRealityInputAction.None && InputSourceParent.SourceType == InputSourceType.Controller)
                 {
                     if (IsDragPressed)
                     {
@@ -537,7 +537,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         IsHoldPressed = false;
                     }
 
-                    if (eventData.MixedRealityInputAction == dragAction && dragAction != MixedRealityInputAction.None)
+                    if (dragAction != MixedRealityInputAction.None &&
+                        eventData.InputSource.SourceType == InputSourceType.Controller &&
+                        eventData.MixedRealityInputAction == dragAction)
                     {
                         IsDragPressed = false;
 
@@ -574,7 +576,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         IsHoldPressed = true;
                     }
 
-                    if (eventData.MixedRealityInputAction == dragAction && dragAction != MixedRealityInputAction.None)
+                    if (dragAction != MixedRealityInputAction.None &&
+                        eventData.InputSource.SourceType == InputSourceType.Controller &&
+                        eventData.MixedRealityInputAction == dragAction)
                     {
                         IsDragPressed = true;
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -182,12 +182,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     // We hit something
                     clearWorldLength = Result.Details.RayDistance;
-                    lineColor = IsSelectPressed ? LineColorSelected : LineColorValid;
+                    lineColor = IsSelectPressed || IsDragPressed ? LineColorSelected : LineColorValid;
                 }
                 else
                 {
                     clearWorldLength = DefaultPointerExtent;
-                    lineColor = IsSelectPressed ? LineColorSelected : LineColorNoTarget;
+                    lineColor = IsSelectPressed || IsDragPressed ? LineColorSelected : LineColorNoTarget;
                 }
 
                 if (IsFocusLocked)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -182,12 +182,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     // We hit something
                     clearWorldLength = Result.Details.RayDistance;
-                    lineColor = IsSelectPressed || IsDragPressed ? LineColorSelected : LineColorValid;
+                    lineColor = IsSelectPressed || IsGrabPressed ? LineColorSelected : LineColorValid;
                 }
                 else
                 {
                     clearWorldLength = DefaultPointerExtent;
-                    lineColor = IsSelectPressed || IsDragPressed ? LineColorSelected : LineColorNoTarget;
+                    lineColor = IsSelectPressed || IsGrabPressed ? LineColorSelected : LineColorNoTarget;
                 }
 
                 if (IsFocusLocked)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
@@ -39,6 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private float endPointLerp = 0.66f;
 
         private bool wasSelectPressed = false;
+        private bool wasDragPressed = false;
 
         [Header("Obsolete Settings")]
 
@@ -100,11 +101,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     return;
                 }
 
-                if (wasSelectPressed != IsSelectPressed)
+                if (wasSelectPressed != IsSelectPressed || wasDragPressed != IsDragPressed)
                 {
                     wasSelectPressed = IsSelectPressed;
+                    wasDragPressed = IsDragPressed;
 
-                    var currentMaterial = IsSelectPressed ? lineMaterialSelected : lineMaterialNoTarget;
+                    var currentMaterial = IsSelectPressed || IsDragPressed ? lineMaterialSelected : lineMaterialNoTarget;
 
                     for (int i = 0; i < LineRenderers.Length; i++)
                     {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private float endPointLerp = 0.66f;
 
         private bool wasSelectPressed = false;
-        private bool wasDragPressed = false;
+        private bool wasGrabPressed = false;
 
         [Header("Obsolete Settings")]
 
@@ -101,10 +101,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     return;
                 }
 
-                if (wasSelectPressed != IsSelectPressed || wasDragPressed != IsGrabPressed)
+                if (wasSelectPressed != IsSelectPressed || wasGrabPressed != IsGrabPressed)
                 {
                     wasSelectPressed = IsSelectPressed;
-                    wasDragPressed = IsGrabPressed;
+                    wasGrabPressed = IsGrabPressed;
 
                     var currentMaterial = IsSelectPressed || IsGrabPressed ? lineMaterialSelected : lineMaterialNoTarget;
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
@@ -101,12 +101,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     return;
                 }
 
-                if (wasSelectPressed != IsSelectPressed || wasDragPressed != IsDragPressed)
+                if (wasSelectPressed != IsSelectPressed || wasDragPressed != IsGrabPressed)
                 {
                     wasSelectPressed = IsSelectPressed;
-                    wasDragPressed = IsDragPressed;
+                    wasDragPressed = IsGrabPressed;
 
-                    var currentMaterial = IsSelectPressed || IsDragPressed ? lineMaterialSelected : lineMaterialNoTarget;
+                    var currentMaterial = IsSelectPressed || IsGrabPressed ? lineMaterialSelected : lineMaterialNoTarget;
 
                     for (int i = 0; i < LineRenderers.Length; i++)
                     {


### PR DESCRIPTION
## Overview
This enables Select to be performed with one button (Thumb stick/Touchpad) and dragging with another (e.g. Trigger).

## Changes
- pointer controller enhancements.
