### PR TITLE
Update Authors.md and add Python script for auto-generating using pygithub

### DIFF
--- a/Documentation/Authors.md
+++ b/Documentation/Authors.md
@@ -2,103 +2,130 @@
 
 The Microsoft Mixed Reality Toolkit is a collaborative project containing contributions from individuals around the world. Our sincere thanks to all who have, and continue to contribute.
 
-- a-iafrate
 - achaperon
-- AdamMitchell-ms
-- againstlightning
-- alandergrouse
-- Alex Cooper
-- Alexees
-- andreiborodin
+- Adam Mitchell (AdamMitchell-ms)
+- Addison Linville (radicalad)
+- ADP-JoNeff
+- afarchy
+- Against Lightning XR (againstlightning)
+- alandergrouse (alandergrouse)
+- Alex Floyd (elbuhofantasma)
+- Alexander Seeck (Alexees)
+- Andrew Hall (ryzngard)
+- Anton Zachesov (googlan)
+- Anuraag Puri (anuraag016)
 - artsouflMS
-- Austin Ha
-- Bertrand Oustrière
-- Bertrand75014
-- brandf
-- Cameron-Micka
+- Ben Godard (genbod)
+- Bernadette Thalhammer (thalbern)
+- Bertrand Oustrière (BertrandOustriere)
+- Blake Gross (blgrossMS)
+- Brandon Furtwangler (brandf)
+- Bryan Truong (bhtruong93)
+- C. M. Barth (chrisfromwork)
+- Cameron (Cameron-Micka)
+- cartwrightluke
+- Casey Crabb (ptc-ccrabb)
 - CDiaz-MS
-- chbecker-ms
-- chrisfromwork
+- cefoot
+- cellarmation
 - CoPrez
-- cre8ivepark
-- danielhofmann-ms
-- davidkline-ms
+- Cristiano Carvalheiro (ccarvalheiro)
+- Daniel Hofmann (danielhofmann-ms)
+- David Evans (phosphoer)
+- David Johnson (djohnsomsft)
+- David Kline (davidkline-ms)
+- deibich
 - deibu
-- derekfreed
-- dfields-msft
-- Ecnassianer
-- elbuhofantasma
-- ericob
-- fast-slow-still
-- ForrestTrepte
-- FreakTheMighty
-- gejohnst
-- gilbdev
-- googlan
-- graycelee
-- Jarodshow
-- jbienzms
-- Jerome Humbert
-- jganser
-- johnppella
-- JonathanPalmerGD
-- JoeyBytes
-- julenka
+- Derek (derekfreed)
+- Dino Fejzagić (FejZa)
+- Dirk Songür (DirkSonguer)
+- DominicAglialoro
+- Eric Carter (Ecnassianer)
+- Eric Fiscus (MRW-Eric)
+- Eric O'Brien (ericob)
+- Eric Provencher (provencher)
+- etiennemargraff (meulta)
+- Eusebiu Marcu (eusebiu)
+- Evan Tice (in2dair)
+- Finn Sinclair (Zee2)
+- Florian Jasche (FlorianJa)
+- Forrest Trepte (ForrestTrepte)
+- Francesco Clasadonte (klasaf)
+- gauravb4
+- George Johnston (gejohnst)
+- gilbdev (gilbdev)
+- Grace Lee (grayclee)
+- Graham Bury (grbury)
+- Harrison Ferrone (hferrone)
+- Harrison Yu (harrisonyu)
+- hybridherbst
+- Hyung-il Kim (hyungilkim)
+- Jared Bienz [MSFT] (jbienzms)
+- Jarod (Jarodshow)
+- Jerome Humbert (djee-ms)
+- Jesse Vander Does (FreakTheMighty)
+- John (johnppella)
+- Jon Palmer (JonathanPalmerGD)
+- Jonathan Dana (Nakda)
+- Joost van Schaik (LocalJoost)
+- Josh Wittner (jwittner)
 - julesra
+- Julia Schwarz (julenka)
 - julianloehr-kg
-- jwittner
-- Kent1LG
-- keveleigh
-- killerantz
-- Kjakubzak
+- Ken Jakubzak (KenJakubzak)
+- Kent1 (Kent1LG)
+- Kevin Kennedy (KevinKennedy)
+- Kevin Semple (polar-kev)
+- kircher1
+- kiyasu (holohiko)
+- Kjakubzak (Kjakubzak)
+- Kurtis (keveleigh)
 - LaneMax
-- LocalJoost
-- luis-valverde-ms
-- lukastonneMS
-- macborow
-- marek-stoj
-- matthejo
+- Lars Simkins (Railboy)
+- Luis Valverde (luval-microsoft)
+- Luis Valverde (luis-valverde-ms)
+- Lukas Tönne (lukastoenneMS)
+- Maciej Borowik (macborow)
+- Malcolm Tyrrell (MalcolmTyrrell)
+- Marek Stój (marek-stoj)
+- Mark Finch (fast-slow-still)
+- Matteo Valoriani (mvaloriani)
+- Matthew Johnson (matthejo)
 - MaxWang-MS
-- MenelvagorMilsom
-- michael-house
-- mpkoz
-- MRW-Eric
+- michael (insominx)
+- Michael House (michael-house)
+- Michael Kozlowski (mpkoz)
 - ms738
-- mvaloriani
-- myrandaGoesToSpace
-- Nakda
-- Nick K.
-- Norbert Nemec
-- paco-ms
-- phosphoer
-- pinkwerks
-- polar-kev
-- provencher
-- Quentin LG
-- radicalad
-- Railboy
+- Myranda (myrandaGoesToSpace)
+- Nathan Ostrander (naostranMS)
+- Niall Milsom (MenelvagorMilsom)
+- omanuke
+- Oscar Salandin (ossala)
+- PatientEz
 - ritijain
+- Robert Onulak (Ziugy)
+- Roberto Sonnino (robertos)
 - RogPodge
-- Rosthouse
-- ryzngard
-- safacero
-- sgwin
-- SimonDarksideJ
-- sloh-ms
+- Roland Smeenk (rolandsmeenk)
+- Rosthouse (Rosthouse)
+- rwinj
+- Sarah (SarahSexton)
+- SGHolospace
+- Shawn Gwin (sgwin)
+- Shinya Tachihara (decoc)
+- Simon (Darkside) Jackson (SimonDarksideJ)
 - sostel
-- srinjoym
-- stefan.wasserbauer
-- StephenHodgson
-- TakahiroMiyaura
-- tarukosu
-- thalbern
-- tonyambrus
-- Troy-Ferrell
-- vaoliva
-- wassx
-- Weasy666
-- witian
-- wiwei
-- xwipeoutx
-- Yoyozilla
-- Zee2
+- Stefan Wasserbauer (wassx)
+- Stephen Hodgson (StephenHodgson)
+- Steve Leigh (xwipeoutx)
+- Sue Loh [MS] (sloh-ms)
+- tarukosu (tarukosu)
+- Tim Gerken (timGerken)
+- Todd Williams (killerantz)
+- Troy Ferrell (Troy-Ferrell)
+- Vanessa Oliva (vaoliva)
+- Weasy (Weasy666)
+- Will (wiwei)
+- William Tian (witian)
+- Yoon Park (cre8ivepark)
+- yoyo (Yoyozilla)

--- a/scripts/ci/contributors.py
+++ b/scripts/ci/contributors.py
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# A script that will write out the list of authors to a MarkDown file for committing to the MRTK repo.
+#
+# Uses pygithub. Requires a GitHub PAT.
+
+import argparse
+from github import Github
+from github.Repository import Repository
+
+AUTHORS_PAGE_HEADER = "# Authors\n\nThe Microsoft Mixed Reality Toolkit is a collaborative project containing contributions from individuals around the world. Our sincere thanks to all who have, and continue to contribute."
+
+args_parser = argparse.ArgumentParser()
+args_parser.add_argument('--repo', type=str, required=True)
+args_parser.add_argument('--file_header', type=str)
+args_parser.add_argument('--file_location', type=str)
+args_parser.add_argument('--pat', type=str, required=True)
+args = args_parser.parse_args()
+
+def get_all_authors(github_repo: Repository) -> str:
+    authors = github_repo.get_contributors()
+    # Sort alphabetically by name or login if no name is present
+    authors = sorted(authors, key=lambda author: str.lower(author.login) if author.name is None else str.lower(author.name))
+    author_list = ""
+    for author in authors:
+        if author.name is None:
+            author_list += "- " + author.login + "\n"
+        else:
+            author_list += "- " + author.name + " (" + author.login + ")\n"
+    return author_list
+
+def main(args):
+    github_access = Github(args.pat)
+    github_repo = github_access.get_repo(args.repo)
+    author_list = get_all_authors(github_repo)
+
+    f = open("Authors.md" if args.file_location is None else args.file_location, "w", encoding="utf-8")
+    f.write((AUTHORS_PAGE_HEADER if args.file_header is None else args.file_header) + "\n\n" + author_list)
+    f.close()
+
+if __name__ == '__main__':
+    main(args)

--- a/scripts/ci/mergetool.py
+++ b/scripts/ci/mergetool.py
@@ -9,6 +9,8 @@
 import argparse
 import git
 from github import Github
+from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 PULL_REQUEST_TITLE_TEMPLATE = "Branch synchronization: {0} --> {1}"
 PULL_REQUEST_DESCRIPTION = "This is a pull request initiated by an automated process to keep {0} and {1} in sync"
@@ -22,7 +24,7 @@ args_parser.add_argument('--label', type=str, required=True)
 args_parser.add_argument('--pat', type=str, required=True)
 args = args_parser.parse_args()
 
-def get_num_diffs(source_branch, destination_branch):
+def get_num_diffs(source_branch: str, destination_branch: str) -> int:
     repo = git.Repo(args.repo_path)
     repo.git.checkout(source_branch)
     repo.git.checkout(destination_branch)
@@ -30,7 +32,7 @@ def get_num_diffs(source_branch, destination_branch):
     destination_branch_head = repo.heads[args.destination_branch]
     return len(destination_branch_head.commit.diff(source_branch_head.commit))
 
-def get_existing_pull_request(github_repo, search_label):
+def get_existing_pull_request(github_repo: Repository, search_label: str) -> PullRequest:
     pull_requests = github_repo.get_pulls()
     for pull_request in pull_requests:
         for label in pull_request.labels:
@@ -38,7 +40,7 @@ def get_existing_pull_request(github_repo, search_label):
                 return pull_request
     return None
 
-def create_pull_request(github_repo, source_branch, destination_branch, label):
+def create_pull_request(github_repo: Repository, source_branch: str, destination_branch: str, label: str):
     print('Creating pull request...')
     pull_request = github_repo.create_pull(
         title=PULL_REQUEST_TITLE_TEMPLATE.format(source_branch, destination_branch),


### PR DESCRIPTION
## Overview

Adds a Python script for auto-generating our Authors.md file. I'm also going to create a GitHub Action or Azure Pipeline to auto-run this every so often.

Uses pygithub to grab the contributors list from the repo, then sorts alphabetically by name, if present, or login, if name isn't present. Writes out into the MarkDown file formatted according to our existing file.

Also, this PR updates the Authors.md file according to the output of this new script.