### PR TITLE
Add Runtime Spatial Mesh Prefab field to the Windows Mixed Reality Spatial Mesh Observer Profile

### DIFF
--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
@@ -89,7 +89,52 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 
         public PhysicMaterial PhysicsMaterial => physicsMaterial;
 
-        
+        [SerializeField]
+        [Tooltip("Optional prefab that is added to the runtime spatial mesh hierarchy.  This prefab will only" +
+            " be instantiated and appended to the hierarchy in a build, the behavior associated with this property is not" + 
+            " enabled in editor.\n" +
+            "\n" +
+            "Default Runtime Spatial Awareness Hierarchy: \n" +
+            "\n" +
+            "Spatial Awareness System \n" +
+            "   Windows Mixed Reality Spatial Mesh Observer\n" +
+            "       Spatial Mesh - ID\n" +
+            "       Spatial Mesh - ID\n" +
+            "       ...\n" +
+            "\n" +
+            "Runtime Spatial Awareness Hierarchy with this prefab:\n" +
+            "\n" +
+            "Spatial Awareness System \n" +
+            "   Runtime Spatial Mesh Prefab\n" +
+            "       Windows Mixed Reality Spatial Mesh Observer\n" +
+            "           Spatial Mesh - ID\n" +
+            "           Spatial Mesh - ID\n" +
+            "            ...\n")]
+        private GameObject runtimeSpatialMeshPrefab = null;
+
+        /// <summary>
+        /// Optional prefab that is added to the runtime spatial mesh hierarchy.  This prefab will only
+        /// be instantiated and appended to the hierarchy in a build, the behavior associated with this property is not 
+        /// enabled in editor.
+        /// 
+        /// Runtime Spatial Awareness Hierarchy without this prefab:
+        /// 
+        /// Spatial Awareness System 
+        ///     Windows Mixed Reality Spatial Mesh Observer
+        ///         Spatial Mesh - ID
+        ///         Spatial Mesh - ID
+        ///         ...
+        ///         
+        /// Runtime Spatial Awareness Hierarchy with this prefab:
+        /// 
+        /// Spatial Awareness System 
+        ///         Runtime Spatial Mesh Prefab
+        ///             Windows Mixed Reality Spatial Mesh Observer
+        ///                 Spatial Mesh - ID
+        ///                 Spatial Mesh - ID
+        ///                 ...
+        /// </summary>
+        public GameObject RuntimeSpatialMeshPrefab => runtimeSpatialMeshPrefab;
 
         #endregion IMixedRealitySpatialAwarenessMeshObserver settings
     }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
@@ -12,7 +12,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor.SpatialAwareness
 {
     [CustomEditor(typeof(MixedRealitySpatialAwarenessMeshObserverProfile))]
     public class MixedRealitySpatialAwarenessMeshObserverProfileInspector : BaseMixedRealityToolkitConfigurationProfileInspector
-    {
+    { 
+        private SerializedProperty runtimeSpatialMeshPrefab;
+
         // General settings
         private SerializedProperty startupBehavior;
         private SerializedProperty observationExtents;
@@ -62,6 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor.SpatialAwareness
             displayOption = serializedObject.FindProperty("displayOption");
             visibleMaterial = serializedObject.FindProperty("visibleMaterial");
             occlusionMaterial = serializedObject.FindProperty("occlusionMaterial");
+            runtimeSpatialMeshPrefab = serializedObject.FindProperty("runtimeSpatialMeshPrefab");
         }
 
         public override void OnInspectorGUI()
@@ -74,6 +77,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor.SpatialAwareness
             using (new EditorGUI.DisabledGroupScope(IsProfileLock((BaseMixedRealityProfile)target)))
             {
                 serializedObject.Update();
+
+                EditorGUILayout.PropertyField(runtimeSpatialMeshPrefab);
+                EditorGUILayout.Space();
 
                 EditorGUILayout.LabelField("General Settings", EditorStyles.boldLabel);
                 {

--- a/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
@@ -352,5 +352,42 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         }
 
         #endregion IMixedRealitySpatialMeshObserver Implementation
+
+        /// <summary>
+        /// Instantiates and appends a prefab to the Runtime (on device and not in editor) 
+        /// Spatial Awareness hierarchy. 
+        /// 
+        /// The default structure of the Spatial Awareness System:
+        /// 
+        /// Spatial Awareness System 
+        ///     Windows Mixed Reality Spatial Mesh Observer
+        ///         Spatial Mesh - ID
+        ///         Spatial Mesh - ID
+        ///         ...
+        /// 
+        /// If the Runtime Spatial Mesh Prefab field is not null, this method adds the prefab 
+        /// between the Spatial Awareness System and the Windows Mixed Reality Spatial Mesh Observer which results in this structure:
+        /// 
+        /// Spatial Awareness System 
+        ///         Runtime Spatial Mesh Prefab
+        ///             Windows Mixed Reality Spatial Mesh Observer
+        ///                 Spatial Mesh - ID
+        ///                 Spatial Mesh - ID
+        ///                 ...
+        /// </summary>
+        protected void AddRuntimeSpatialMeshPrefabToHierarchy()
+        {
+            if (RuntimeSpatialMeshPrefab != null)
+            {
+                GameObject spatialMeshPrefab = GameObject.Instantiate(RuntimeSpatialMeshPrefab, SpatialAwarenessSystem.SpatialAwarenessObjectParent.transform);
+
+                if (spatialMeshPrefab.transform.position != Vector3.zero)
+                {
+                    spatialMeshPrefab.transform.position = Vector3.zero;
+                }
+
+                ObservedObjectParent.transform.SetParent(spatialMeshPrefab.transform, false);
+            }
+        }
     }
 }

--- a/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
@@ -70,6 +70,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             RecalculateNormals = profile.RecalculateNormals;
             TrianglesPerCubicMeter = profile.TrianglesPerCubicMeter;
             VisibleMaterial = profile.VisibleMaterial;
+
+            RuntimeSpatialMeshPrefab = profile.RuntimeSpatialMeshPrefab;
         }
 
         private static readonly ProfilerMarker ApplyUpdatedMeshDisplayOptionPerfMarker = new ProfilerMarker("[MRTK] BaseSpatialMeshObserver.ApplyUpdatedMeshDisplayOption");
@@ -330,6 +332,21 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
                     {
                         ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions.Visible);
                     }
+                }
+            }
+        }
+
+        private GameObject runtimeSpatialMeshPrefab = null;
+
+        /// <inheritdoc />
+        public GameObject RuntimeSpatialMeshPrefab
+        {
+            get { return runtimeSpatialMeshPrefab; }
+            set
+            {
+                if (value != runtimeSpatialMeshPrefab)
+                {
+                    runtimeSpatialMeshPrefab = value;
                 }
             }
         }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -720,43 +720,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
             }
         }
 
-        /// <summary>
-        /// Instantiates and appends a prefab to the Runtime (on device and not in editor) 
-        /// Spatial Awareness hierarchy. 
-        /// 
-        /// The default structure of the Spatial Awareness System:
-        /// 
-        /// Spatial Awareness System 
-        ///     Windows Mixed Reality Spatial Mesh Observer
-        ///         Spatial Mesh - ID
-        ///         Spatial Mesh - ID
-        ///         ...
-        /// 
-        /// If the Runtime Spatial Mesh Prefab field is not null, this method adds the prefab 
-        /// between the Spatial Awareness System and the Windows Mixed Reality Spatial Mesh Observer which results in this structure:
-        /// 
-        /// Spatial Awareness System 
-        ///         Runtime Spatial Mesh Prefab
-        ///             Windows Mixed Reality Spatial Mesh Observer
-        ///                 Spatial Mesh - ID
-        ///                 Spatial Mesh - ID
-        ///                 ...
-        /// </summary>
-        private void AddRuntimeSpatialMeshPrefabToHierarchy()
-        {
-            if (RuntimeSpatialMeshPrefab != null)
-            {
-                GameObject spatialMeshPrefab = GameObject.Instantiate(RuntimeSpatialMeshPrefab, SpatialAwarenessSystem.SpatialAwarenessObjectParent.transform);
-                
-                if (spatialMeshPrefab.transform.position != Vector3.zero)
-                {
-                    spatialMeshPrefab.transform.position = Vector3.zero;
-                }
-
-                ObservedObjectParent.transform.SetParent(spatialMeshPrefab.transform, false);
-            }
-        }
-
 #endif // UNITY_WSA
 
         #endregion Helpers

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -175,6 +175,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                     UnityEditor.PlayerSettings.WSACapability.SpatialPerception,
                     this.GetType());
 #endif
+            // If we aren't using a HoloLens or there isn't an XR device present, return.
+            if (observer == null || HolographicSettings.IsDisplayOpaque || !XRDevice.isPresent) { return; }
+
+            if (RuntimeSpatialMeshPrefab != null)
+            {
+                AddRuntimeSpatialMeshPrefabToHierarchy();
+            }
         }
 
         private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealitySpatialMeshObserver.Update");
@@ -712,6 +719,44 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                 }
             }
         }
+
+        /// <summary>
+        /// Instantiates and appends a prefab to the Runtime (on device and not in editor) 
+        /// Spatial Awareness hierarchy. 
+        /// 
+        /// The default structure of the Spatial Awareness System:
+        /// 
+        /// Spatial Awareness System 
+        ///     Windows Mixed Reality Spatial Mesh Observer
+        ///         Spatial Mesh - ID
+        ///         Spatial Mesh - ID
+        ///         ...
+        /// 
+        /// If the Runtime Spatial Mesh Prefab field is not null, this method adds the prefab 
+        /// between the Spatial Awareness System and the Windows Mixed Reality Spatial Mesh Observer which results in this structure:
+        /// 
+        /// Spatial Awareness System 
+        ///         Runtime Spatial Mesh Prefab
+        ///             Windows Mixed Reality Spatial Mesh Observer
+        ///                 Spatial Mesh - ID
+        ///                 Spatial Mesh - ID
+        ///                 ...
+        /// </summary>
+        private void AddRuntimeSpatialMeshPrefabToHierarchy()
+        {
+            if (RuntimeSpatialMeshPrefab != null)
+            {
+                GameObject spatialMeshPrefab = GameObject.Instantiate(RuntimeSpatialMeshPrefab, SpatialAwarenessSystem.SpatialAwarenessObjectParent.transform);
+                
+                if (spatialMeshPrefab.transform.position != Vector3.zero)
+                {
+                    spatialMeshPrefab.transform.position = Vector3.zero;
+                }
+
+                ObservedObjectParent.transform.SetParent(spatialMeshPrefab.transform, false);
+            }
+        }
+
 #endif // UNITY_WSA
 
         #endregion Helpers

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -506,5 +506,17 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         }
 
         #endregion Helpers
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            if (SpatialAwarenessSystem == null || XRSubsystemHelpers.MeshSubsystem == null) { return; }
+
+            if (RuntimeSpatialMeshPrefab != null)
+            {
+                AddRuntimeSpatialMeshPrefabToHierarchy();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Overview

Adding a component to the runtime spatial mesh is currently only achievable via script:

```
CoreServices.SpatialAwarenessSystem.SpatialAwarenessObjectParent.AddComponent<>()
```

This PR adds a field in the Spatial Observer Profile that enables users to add componets to a prefab in editor, which will then be appended to the runtime spatial awareness hierarchy. 

![image](https://user-images.githubusercontent.com/53493796/106309939-a95ac480-6217-11eb-853d-ac785b1a85c0.png)

Default Runtime Spatial Awareness Hierarchy:
```
 Spatial Awareness System 
     Windows Mixed Reality Spatial Mesh Observer
         Spatial Mesh - ID
         Spatial Mesh - ID
         ...
```

Runtime Spatial Awareness Hierarchy with new prefab:
```
 Spatial Awareness System 
     Runtime Spatial Mesh Prefab
         Windows Mixed Reality Spatial Mesh Observer
             Spatial Mesh - ID
             Spatial Mesh - ID
             ...
```

The motivation for this change is to enable an easier path for configuring components for the runtime spatial mesh.  This issue was raised during the pulse shader work.

## Changes
- Fixes: #9179

## Verification

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
