### PR TITLE
Improved button config helper Quality of Life.

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -20,7 +20,8 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
         private const string customIconSetsFolderName = "CustomIconSets";
         private const string customIconUpgradeMessage = "This button appears to have a custom icon material. This is no longer required for custom icons.\n\n" +
             "We recommend upgrading the buttons in your project by installing the Microsoft.MixedRealityToolkit.Unity.Tools package and using the Migration Tool.";
-        private const string missingIconWarningMessage = "The icon used by this button's custom material was not found in the icon set.";
+        private const string missingIconWarningMessage = "The icon used by this button was not found in the icon set. You can see the icon currently being used is in the field below:";
+        private const string missingCharIconWarningMessage = "The icon used by this button was not found in the icon set. It may be part of another char icon font that was previously part of this icon set";
         private const string customIconSetCreatedMessage = "A new icon set has been created to hold your button's custom icons. It has been saved to:\n\n{0}";
         private const string upgradeDocUrl = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_Button.html#how-to-change-the-icon-and-text";
 
@@ -279,19 +280,40 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
             }
 
             EditorGUILayout.Space();
+
             EditorGUILayout.PropertyField(iconSetProp);
-            if (iconSet != null)
+
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button(EditorGUIUtility.IconContent("d_Refresh"), EditorStyles.miniButtonRight, GUILayout.Width(24f)))
             {
-                Sprite newIconSprite;
-                if (iconSet.EditorDrawSpriteIconSelector(currentIconSprite, out newIconSprite, 1))
-                {
-                    iconSpriteProp.objectReferenceValue = newIconSprite;
-                    cb.SetSpriteIcon(newIconSprite);
-                }
+                iconSet.UpdateSpriteIconTextures();
             }
-            else
+            EditorGUILayout.EndHorizontal();
+            if (iconSet == null)
             {
                 EditorGUILayout.HelpBox("No icon set assigned. You can specify custom icons manually by assigning them to the field below:", MessageType.Info);
+                EditorGUILayout.PropertyField(iconQuadTextureProp);
+                return;
+            }
+            if (iconSet.SpriteIcons == null || iconSet.SpriteIcons.Length == 0)
+            {
+                EditorGUILayout.HelpBox("No sprite icons assigned to the icon set. You can specify custom icons manually by assigning them to the field below:", MessageType.Info);
+                EditorGUILayout.PropertyField(iconQuadTextureProp);
+                return;
+            }
+
+            Sprite newIconSprite;
+            bool foundSprite;
+            if (iconSet.EditorDrawSpriteIconSelector(currentIconSprite, out foundSprite, out newIconSprite, 1))
+            {
+                iconSpriteProp.objectReferenceValue = newIconSprite;
+                cb.SetSpriteIcon(newIconSprite);
+            }
+
+            if (!foundSprite)
+            {
+                EditorGUILayout.HelpBox(missingIconWarningMessage, MessageType.Warning);
                 EditorGUILayout.PropertyField(iconSpriteProp);
             }
         }
@@ -324,24 +346,30 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(iconSetProp);
-            if (iconSet != null)
-            {
-                Texture newIconTexture;
-                bool foundTexture;
-                if (iconSet.EditorDrawQuadIconSelector(currentIconTexture, out foundTexture, out newIconTexture, 1))
-                {
-                    iconQuadTextureProp.objectReferenceValue = newIconTexture;
-                    cb.SetQuadIcon(newIconTexture);
-                }
-
-                if (!foundTexture)
-                {
-                    EditorGUILayout.HelpBox(missingIconWarningMessage, MessageType.Warning);
-                }
-            }
-            else
+            if (iconSet == null)
             {
                 EditorGUILayout.HelpBox("No icon set assigned. You can specify custom icons manually by assigning them to the field below:", MessageType.Info);
+                EditorGUILayout.PropertyField(iconQuadTextureProp);
+                return;
+            }
+            if (iconSet.QuadIcons == null || iconSet.QuadIcons.Length == 0)
+            {
+                EditorGUILayout.HelpBox("No quad icons assigned to the icon set. You can specify custom icons manually by assigning them to the field below:", MessageType.Info);
+                EditorGUILayout.PropertyField(iconQuadTextureProp);
+                return;
+            }
+
+            Texture newIconTexture;
+            bool foundTexture;
+            if (iconSet.EditorDrawQuadIconSelector(currentIconTexture, out foundTexture, out newIconTexture, 1))
+            {
+                iconQuadTextureProp.objectReferenceValue = newIconTexture;
+                cb.SetQuadIcon(newIconTexture);
+            }
+
+            if (!foundTexture)
+            {
+                EditorGUILayout.HelpBox(missingIconWarningMessage, MessageType.Warning);
                 EditorGUILayout.PropertyField(iconQuadTextureProp);
             }
         }
@@ -377,22 +405,27 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(iconSetProp);
-            if (iconSet != null)
-            {
-                uint newIconChar;
-                if (iconSet.EditorDrawCharIconSelector(currentIconChar, out newIconChar, 1))
-                {
-                    iconCharProp.longValue = newIconChar;
-                    SerializedObject iconSetObject = new SerializedObject(iconSet);
-                    SerializedProperty charIconFontProp = iconSetObject.FindProperty("charIconFont");
-                    iconFontProp.objectReferenceValue = charIconFontProp.objectReferenceValue;
-                    cb.SetCharIcon(newIconChar);
-                }
-            }
-            else
+            if (iconSet == null)
             {
                 EditorGUILayout.HelpBox("No icon set assigned. You can specify custom icons manually by assigning them to the field below:", MessageType.Info);
                 EditorGUILayout.PropertyField(iconQuadTextureProp);
+                return;
+            }
+
+            uint newIconChar;
+            bool foundChar;
+            if (iconSet.EditorDrawCharIconSelector(currentIconChar, out foundChar, out newIconChar, 1))
+            {
+                iconCharProp.longValue = newIconChar;
+                SerializedObject iconSetObject = new SerializedObject(iconSet);
+                SerializedProperty charIconFontProp = iconSetObject.FindProperty("charIconFont");
+                iconFontProp.objectReferenceValue = charIconFontProp.objectReferenceValue;
+                cb.SetCharIcon(newIconChar);
+
+                if (!foundChar)
+                {
+                    EditorGUILayout.HelpBox(missingCharIconWarningMessage, MessageType.Warning);
+                }
             }
         }
     }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -223,9 +223,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Draws a selectable grid of character icons.
         /// </summary>
         /// <returns>True if a new icon was selected.</returns>
-        public bool EditorDrawCharIconSelector(uint currentChar, out uint newChar, int indentLevel = 0)
+        public bool EditorDrawCharIconSelector(uint currentChar, out bool foundChar, out uint newChar, int indentLevel = 0)
         {
             newChar = 0;
+            foundChar = false;
+            int currentSelection = -1;
 
             if (charIconFont == null)
             {
@@ -233,7 +235,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return false;
             }
 
-            int currentSelection = -1;
             for (int i = 0; i < charIcons.Length; i++)
             {
                 if (charIcons[i].Character == currentChar)
@@ -246,7 +247,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             using (new EditorGUI.IndentLevelScope(indentLevel))
             {
                 int column = 0;
-                int newSelection = -1;
+                int newSelection = currentSelection;
 
                 if (charIcons.Length > 0)
                 {
@@ -282,9 +283,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     EditorGUILayout.LabelField("(No icons in set)");
                 }
 
-                if (newSelection >= 0 && newSelection != currentSelection)
+                if (newSelection >= 0)
                 {
-                    newChar = charIcons[newSelection].Character;
+                    foundChar = true;
+                    if (newSelection != currentSelection)
+                    {
+                        newChar = charIcons[newSelection].Character;
+                    }
                 }
             }
 
@@ -295,11 +300,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Draws a selectable grid of sprite icons.
         /// </summary>
         /// <returns>True if a new icon was selected.</returns>
-        public bool EditorDrawSpriteIconSelector(Sprite currentSprite, out Sprite newSprite, int indentLevel = 0)
+        public bool EditorDrawSpriteIconSelector(Sprite currentSprite, out bool foundSprite, out Sprite newSprite, int indentLevel = 0)
         {
             newSprite = null;
-
             int currentSelection = -1;
+            foundSprite = false;
+
             for (int i = 0; i < spriteIcons.Length; i++)
             {
                 if (spriteIcons[i] == currentSprite)
@@ -311,11 +317,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (spriteIconTextures == null || spriteIconTextures.Length != spriteIcons.Length)
             {
-                spriteIconTextures = new Texture[spriteIcons.Length];
-                for (int i = 0; i < spriteIcons.Length; i++)
-                {
-                    spriteIconTextures[i] = GetTextureFromSprite(spriteIcons[i]);
-                }
+                UpdateSpriteIconTextures();
             }
 
             using (new EditorGUI.IndentLevelScope(indentLevel))
@@ -328,13 +330,37 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 var maxWidth = GUILayout.MaxWidth(maxButtonSize * maxButtonsPerColumn);
                 int newSelection = GUILayout.SelectionGrid(currentSelection, spriteIconTextures, maxButtonsPerColumn, maxHeight, maxWidth);
 #endif
-                if (newSelection >= 0 && newSelection != currentSelection)
+                if (newSelection >= 0)
                 {
-                    newSprite = spriteIcons[newSelection];
+                    foundSprite = true;
+                    if (newSelection != currentSelection)
+                    {
+                        newSprite = spriteIcons[newSelection];
+                    }
                 }
             }
 
             return newSprite != null;
+        }
+
+        public void UpdateSpriteIconTextures()
+        {
+            if(spriteIcons != null)
+            {
+                spriteIconTextures = new Texture[spriteIcons.Length];
+                for (int i = 0; i < spriteIcons.Length; i++)
+                {
+                    try
+                    {
+                        spriteIconTextures[i] = GetTextureFromSprite(spriteIcons[i]);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogError("There was an issue processing the Sprite Icons of this IconSet. Ensure that your IconSet is configured properly");
+                        throw e;
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -543,7 +569,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     using (new EditorGUI.IndentLevelScope(1))
                     {
                         spriteIconsProp.isExpanded = true;
+
+                        // Check if the sprite Icons were udpated
+                        EditorGUI.BeginChangeCheck();
                         EditorGUILayout.PropertyField(spriteIconsProp, true);
+                        // End the code block and update the label if a change occurred
+                        if (EditorGUI.EndChangeCheck())
+                        {
+                            serializedObject.ApplyModifiedProperties();
+                            bis.UpdateSpriteIconTextures();
+                        }
                     }
                 }
 #if UNITY_2019_3_OR_NEWER

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -343,6 +343,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return newSprite != null;
         }
 
+
+        /// <summary>
+        /// Updates the cached sprite icon textures to the latest textures in spriteIcons
+        /// </summary>
         public void UpdateSpriteIconTextures()
         {
             if(spriteIcons != null)


### PR DESCRIPTION
## Overview
Fixes several issues where the button config helper was not clear with whether the materials on objects were derived from the current icon sets. In addition, added warnings for when certain kinds of iconsets were not loaded, and fixed issues where the icon sets would not load properly in the editor, while also adding the option for users to automatically refresh the sprite icons view

![diff1](https://user-images.githubusercontent.com/39840334/106550980-3cc71a80-64e2-11eb-83f6-e6363f90505c.PNG)
![diff2](https://user-images.githubusercontent.com/39840334/106550982-3df84780-64e2-11eb-992b-0fed3d352758.PNG)
![warningscompiled](https://user-images.githubusercontent.com/39840334/106550986-3fc20b00-64e2-11eb-9043-1fdd230baecd.png)
![DisappearSpriteTextureFix](https://user-images.githubusercontent.com/39840334/106550992-40f33800-64e2-11eb-9064-80e0e162619d.gif)

## Changes
- Fixes: #9142, #9061