### PR TITLE
Create internal access to non-DotNetWinRT HolographicFrame

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/Definitions/ProjectionOverride.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/Definitions/ProjectionOverride.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
             CameraCache.Main.SetStereoProjectionMatrix(Camera.StereoscopicEye.Left, leftProj);
             CameraCache.Main.SetStereoProjectionMatrix(Camera.StereoscopicEye.Right, rightProj);
 
-            HolographicFrame holographicFrame = WindowsMixedRealityUtilities.CurrentHolographicFrame;
+            HolographicFrame holographicFrame = WindowsMixedRealityUtilities.CurrentWindowsHolographicFrame;
             if (holographicFrame != null)
             {
                 HolographicFramePrediction prediction = holographicFrame.CurrentPrediction;

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
@@ -145,6 +145,28 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         private static SpatialCoordinateSystem spatialCoordinateSystem = null;
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
+#if WINDOWS_UWP
+        /// <summary>
+        /// Access the underlying native current holographic frame.
+        /// </summary>
+        /// <remarks>
+        /// <para>Changing the state of the native objects received via this API may cause unpredictable
+        /// behavior and rendering artifacts, especially if Unity also reasons about that same state.</para>
+        /// </remarks>
+        internal static global::Windows.Graphics.Holographic.HolographicFrame CurrentWindowsHolographicFrame
+        {
+            get
+            {
+                if (UtilitiesProvider == null || UtilitiesProvider.IHolographicFramePtr == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                return Marshal.GetObjectForIUnknown(UtilitiesProvider.IHolographicFramePtr) as global::Windows.Graphics.Holographic.HolographicFrame;
+            }
+        }
+#endif // WINDOWS_UWP
+
         [Obsolete("Use the System.Numerics.Vector3 extension method ToUnityVector3 instead.")]
         public static UnityEngine.Vector3 SystemVector3ToUnity(System.Numerics.Vector3 vector)
         {


### PR DESCRIPTION
## Overview

Create internal access to non-DotNetWinRT HolographicFrame, even when DotNetWinRT is installed. This prevents a build issue when DotNetWinRT is installed, as not all types or methods needed for reading mode are yet defined there.

## Changes

- Fixes: https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=16589&view=logs&j=ae5f814d-d003-5afd-2125-fa0189ea8658&t=83fc26c9-1bf2-50a8-274a-0ed525137015&l=3509