### PR TITLE
Add Set Visual Configuration test to Bounds Control Tests

### DIFF
--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -2507,6 +2507,37 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test creating an new instance of a scriptable configuration and setting it.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator SetVisualConfiguration()
+        {
+            BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+
+            // Create new scriptable
+            BoxDisplayConfiguration boxDisplayConfiguration = ScriptableObject.CreateInstance<BoxDisplayConfiguration>();
+            yield return null;
+
+            // Set the material property of the new scriptable
+            boxDisplayConfiguration.BoxMaterial = testMaterial;
+            yield return null;
+
+            // Set new scriptable
+            boundsControl.BoxDisplayConfig = boxDisplayConfiguration;
+            yield return null;
+
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+
+            Transform boxVisual = rigRoot.transform.Find("box display");
+            Assert.IsNotNull(boxVisual, "box visual couldn't be found");
+
+            // Make sure the new scriptable visuals have been applied to the object
+            Assert.AreEqual(boxVisual.GetComponent<Renderer>().material.color, testMaterial.color);
+        }
+
+        /// <summary>
         /// Returns the AABB of the bounds control rig (corners, edges)
         /// that make up the bounds control by using the positions of the corners
         /// </summary>

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -2509,11 +2509,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// Test creating an new instance of a scriptable configuration and setting it.
         /// </summary>
-        /// <returns></returns>
         [UnityTest]
         public IEnumerator SetVisualConfiguration()
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+
+            Assert.AreNotEqual(GetBoxVisual(boundsControl).GetComponent<Renderer>().material.color, testMaterial.color);
 
             // Create new scriptable
             BoxDisplayConfiguration boxDisplayConfiguration = ScriptableObject.CreateInstance<BoxDisplayConfiguration>();
@@ -2527,14 +2528,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             boundsControl.BoxDisplayConfig = boxDisplayConfiguration;
             yield return null;
 
+            // Make sure the new scriptable visuals have been applied to the object
+            Assert.AreEqual(GetBoxVisual(boundsControl).GetComponent<Renderer>().material.color, testMaterial.color);
+        }
+
+        private Transform GetBoxVisual(BoundsControl boundsControl)
+        {
             GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
             Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
 
             Transform boxVisual = rigRoot.transform.Find("box display");
             Assert.IsNotNull(boxVisual, "box visual couldn't be found");
 
-            // Make sure the new scriptable visuals have been applied to the object
-            Assert.AreEqual(boxVisual.GetComponent<Renderer>().material.color, testMaterial.color);
+            return boxVisual;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -2514,6 +2514,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
 
+            // Make sure the material on the object has not been applied 
             Assert.AreNotEqual(GetBoxVisual(boundsControl).GetComponent<Renderer>().material.color, testMaterial.color);
 
             // Create new scriptable
@@ -2532,6 +2533,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(GetBoxVisual(boundsControl).GetComponent<Renderer>().material.color, testMaterial.color);
         }
 
+        // Returns the "box display" transform in the bounds control rig
         private Transform GetBoxVisual(BoundsControl boundsControl)
         {
             GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;


### PR DESCRIPTION
## Overview

Adds a test for the changes in #9045 which involves setting a new visual configuration scriptable object during runtime. 

## Changes
- Fixes: #9099 
