### PR TITLE
add note of tools package requirement for optimize window

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
@@ -108,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             if (!MixedRealityOptimizeUtils.IsOptimalRenderingPath())
             {
-                Debug.LogWarning($"XR stereo rendering mode not set to <b>{RenderingMode}</b>. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance");
+                Debug.LogWarning($"XR stereo rendering mode not set to <b>{RenderingMode}</b>. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance.\nPlease note: The Mixed Reality Toolkit Tools package is required to use the Optimize Window.");
             }
 
             // If targeting Windows Mixed Reality platform
@@ -117,23 +117,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 if (!MixedRealityOptimizeUtils.IsDepthBufferSharingEnabled())
                 {
                     // If depth buffer sharing not enabled, advise to enable setting
-                    Debug.LogWarning("<b>Depth Buffer Sharing</b> is not enabled to improve hologram stabilization. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance");
+                    Debug.LogWarning("<b>Depth Buffer Sharing</b> is not enabled to improve hologram stabilization. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance.\nPlease note: The Mixed Reality Toolkit Tools package is required to use the Optimize Window.");
                 }
 
                 if (!MixedRealityOptimizeUtils.IsWMRDepthBufferFormat16bit())
                 {
                     // If depth format is 24-bit, advise to consider 16-bit for performance.
-                    Debug.LogWarning("<b>Depth Buffer Sharing</b> has 24-bit depth format selected. Consider using 16-bit for performance. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance");
+                    Debug.LogWarning("<b>Depth Buffer Sharing</b> has 24-bit depth format selected. Consider using 16-bit for performance. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance.\nPlease note: The Mixed Reality Toolkit Tools package is required to use the Optimize Window.");
                 }
 
                 if (!UwpRecommendedAudioSpatializers.Contains(SpatializerUtilities.CurrentSpatializer))
                 {
-                    Debug.LogWarning($"This application is not using the recommended <b>Audio Spatializer Plugin</b>. Go to <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i> and select one of the following: {string.Join(", ", UwpRecommendedAudioSpatializers)}.");
+                    Debug.Log($"This application is not using the recommended <b>Audio Spatializer Plugin</b>. Go to <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i> and select one of the following: {string.Join(", ", UwpRecommendedAudioSpatializers)}.");
                 }
             }
             else if (SpatializerUtilities.CurrentSpatializer == null)
             {
-                Debug.LogWarning($"This application is not using an <b>Audio Spatializer Plugin</b>. Go to <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i> and select one of the available options.");
+                Debug.Log($"This application is not using an <b>Audio Spatializer Plugin</b>. Go to <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i> and select one of the available options.");
             }
         }
 

--- a/Assets/MRTK/Core/Utilities/Editor/ScriptedImporterAssetReimporter.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/ScriptedImporterAssetReimporter.cs
@@ -41,12 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                         assetsAttemptedToReimport[asset] = ++numAttempts;
 
-                        if (numAttempts <= 3)
-                        {
-                            Debug.Log($"Asset '{asset}' appears to have failed importing, will attempt to re-import. Attempt: {numAttempts}");
-                            AssetDatabase.ImportAsset(asset);
-                        }
-                        else
+                        if (numAttempts == 3)
                         {
                             Debug.LogWarning($"Asset '{asset}' appears to have failed the re-import 3 times, will not try again.");
                         }

--- a/Assets/MRTK/Core/Utilities/Editor/ScriptedImporterAssetReimporter.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/ScriptedImporterAssetReimporter.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                         if (numAttempts <= 3)
                         {
-                            Debug.LogWarning($"Asset '{asset}' appears to have failed importing, will attempt to re-import. Attempt: {numAttempts}");
+                            Debug.Log($"Asset '{asset}' appears to have failed importing, will attempt to re-import. Attempt: {numAttempts}");
                             AssetDatabase.ImportAsset(asset);
                         }
                         else

--- a/Assets/MRTK/Core/Utilities/Editor/ScriptedImporterAssetReimporter.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/ScriptedImporterAssetReimporter.cs
@@ -41,7 +41,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                         assetsAttemptedToReimport[asset] = ++numAttempts;
 
-                        if (numAttempts == 3)
+                        if (numAttempts <= 3)
+                        {
+                            AssetDatabase.ImportAsset(asset);
+                        }
+                        else
                         {
                             Debug.LogWarning($"Asset '{asset}' appears to have failed the re-import 3 times, will not try again.");
                         }

--- a/Documentation/Tools/OptimizeWindow.md
+++ b/Documentation/Tools/OptimizeWindow.md
@@ -1,6 +1,6 @@
 # Optimize window
 
-The MRTK Optimize Window is a utility to help automate and inform in the process of configuring a mixed reality project for best [performance](../Performance/PerfGettingStarted.md) in Unity. This tool generally focuses on rendering configurations that when set to the correct preset can save milliseconds of processing.
+The MRTK Optimize Window is a utility to help automate and inform in the process of configuring a mixed reality project for best [performance](../Performance/PerfGettingStarted.md) in Unity. This tool generally focuses on rendering configurations that when set to the correct preset can save milliseconds of processing. The utility is included with the `Microsoft.MixedReality.Toolkit.Unity.Tools` package.
 
 The *Active Build Target* is the [build platform currently targeted](https://docs.unity3d.com/Manual/BuildSettings.html) by the project for compiling.
 


### PR DESCRIPTION
This change fixes #7897 by adding "Please note: The Mixed Reality Toolkit Tools package is required to use the Optimize Window." to the debug log messages related to the optimize window.

It also changes the warning about no spatializer to a simple message and fixes: #7949 