### PR TITLE
Update #define to include SCENE_UNDERSTANDING_PRESENT

### DIFF
--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
@@ -279,7 +279,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
         /// <inheritdoc/>
         public void SaveScene(string filenamePrefix)
         {
-#if WINDOWS_UWP
+#if WINDOWS_UWP && SCENE_UNDERSTANDING_PRESENT
             SaveToFile(filenamePrefix);
 #else // WINDOWS_UWP
             Debug.LogWarning("SaveScene() only supported at runtime! Ignoring request.");


### PR DESCRIPTION
## Overview

This method doesn't exist unless `SCENE_UNDERSTANDING_PRESENT` is true.

## Changes
- Fixes: https://microsoft.visualstudio.com/Analog/_build/results?buildId=31113603&view=logs&j=ae5f814d-d003-5afd-2125-fa0189ea8658&t=b9749889-d1f2-55ee-d51f-1633d691309c&l=2778
