### PR TITLE
Added decrement function to ColorChanger

### DIFF
--- a/Assets/MRTK/Examples/Common/Scripts/ColorChanger.cs
+++ b/Assets/MRTK/Examples/Common/Scripts/ColorChanger.cs
@@ -37,6 +37,21 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
                 }
             }
         }
+        
+        /// <summary>
+        /// Decrements to the previous material in the input list of materials and applies it to the renderer.
+        /// </summary>
+        public void Decrement()
+        {
+            if (mats != null && mats.Length > 0)
+            {
+                cur = (cur - 1 + mats.Length) % mats.Length;
+                if (rend != null)
+                {
+                    rend.material = mats[cur];
+                }
+            }
+        }
 
         /// <summary>
         /// Sets a random color on the renderer's material.


### PR DESCRIPTION
## Overview
A single function add to a sample class.
It has an increment function but lacks a decrement function.

## Changes
Fixes #9202 

## Verification

I do not think this needs anything more than visual verification. I tested it locally and it works

The only 'change' is this line as a way to 'decrement and loop when below zero'
cur = (cur - 1 + mats.Length) % mats.Length;
If there are 5 items in mats:
Cur starts at 4:
4 - 1 + 5= 8 % 5 become 3 (a normal decrement operation)
Cur starts at 0
0 - 1 + 5 % 5 becomes 4 (the last index of the array)
