### PR TITLE
Refactor non-Unity validation out into new template

### DIFF
--- a/pipelines/pr-2019.yaml
+++ b/pipelines/pr-2019.yaml
@@ -27,11 +27,6 @@ jobs:
       buildUWPX86: false
       buildUWPArm: false
       buildUWPDotNet: false
-      # For mrtk_pr builds, validation scripts (code and docs) should be scoped to only
-      # the set of changed files, so that we can save some time. There's no need to
-      # check unchanged files for code style/doc style violations.
-      # Temporarily commented out due to VM issue.
-      # scopedValidation: true
       UnityVersion: $(Unity2019Version)
 
   - template: templates/end.yml

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -3,40 +3,38 @@
 variables:
 - template: config/settings.yml
 
-stages:
-- stage: PRValidation
-  jobs:
-  - job: CodeValidation
-    pool:
-      vmImage: windows-2019
-    steps:
-    - template: templates/validation.yml
-      parameters:
-        # For mrtk_pr builds, validation scripts (code and docs) should be scoped to only
-        # the set of changed files, so that we can save some time. There's no need to
-        # check unchanged files for code style/doc style violations.
-        scopedValidation: true
-  - job: UnityBuild
-    timeoutInMinutes: 90
-    pool:
-      name: On-Prem Unity
-      demands:
-      - ${{ variables.Unity2018Version }}
-      - COG-UnityCache-WUS2-01
-      - SDK_18362 -equals TRUE
-    steps:
-    - template: templates/common.yml
-      parameters:
-        # For mrtk_pr builds, don't build all flavors to reduce the amount of time
-        # taken for each validation run. With this configuration, only the Standalone
-        # configuration is built.
-        # Note that all of the flavors are still built during the rolling CI.
-        # If there are failures in rolling CI in any of these tasks, we should re-enable
-        # the specific flavors below that are experiencing failures in CI (for example,
-        # if we're actively working on features that have a lot of churn on underlying
-        # WMR APIs, buildUWPArm would be a good candidate to re-enable)
-        buildUWPX86: false
-        buildUWPArm: false
-        buildUWPDotNet: false
-        UnityVersion: $(Unity2018Version)
-    - template: templates/end.yml
+jobs:
+- job: CodeValidation
+  pool:
+    vmImage: windows-2019
+  steps:
+  - template: templates/validation.yml
+    parameters:
+      # For mrtk_pr builds, validation scripts (code and docs) should be scoped to only
+      # the set of changed files, so that we can save some time. There's no need to
+      # check unchanged files for code style/doc style violations.
+      scopedValidation: true
+- job: UnityBuild
+  timeoutInMinutes: 90
+  pool:
+    name: On-Prem Unity
+    demands:
+    - ${{ variables.Unity2018Version }}
+    - COG-UnityCache-WUS2-01
+    - SDK_18362 -equals TRUE
+  steps:
+  - template: templates/common.yml
+    parameters:
+      # For mrtk_pr builds, don't build all flavors to reduce the amount of time
+      # taken for each validation run. With this configuration, only the Standalone
+      # configuration is built.
+      # Note that all of the flavors are still built during the rolling CI.
+      # If there are failures in rolling CI in any of these tasks, we should re-enable
+      # the specific flavors below that are experiencing failures in CI (for example,
+      # if we're actively working on features that have a lot of churn on underlying
+      # WMR APIs, buildUWPArm would be a good candidate to re-enable)
+      buildUWPX86: false
+      buildUWPArm: false
+      buildUWPDotNet: false
+      UnityVersion: $(Unity2018Version)
+  - template: templates/end.yml

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -3,34 +3,40 @@
 variables:
 - template: config/settings.yml
 
-jobs:
-- job: PRValidation
-  timeoutInMinutes: 90
-  pool:
-    name: On-Prem Unity
-    demands:
-    - ${{ variables.Unity2018Version }}
-    - COG-UnityCache-WUS2-01
-    - SDK_18362 -equals TRUE
-  steps:
-  - template: templates/common.yml
-    parameters:
-      # For mrtk_pr builds, don't build all flavors to reduce the amount of time
-      # taken for each validation run. With this configuration, only the Standalone
-      # configuration is built.
-      # Note that all of the flavors are still built during the rolling CI.
-      # If there are failures in rolling CI in any of these tasks, we should re-enable
-      # the specific flavors below that are experiencing failures in CI (for example,
-      # if we're actively working on features that have a lot of churn on underlying
-      # WMR APIs, buildUWPArm would be a good candidate to re-enable)
-      buildUWPX86: false
-      buildUWPArm: false
-      buildUWPDotNet: false
-      # For mrtk_pr builds, validation scripts (code and docs) should be scoped to only
-      # the set of changed files, so that we can save some time. There's no need to
-      # check unchanged files for code style/doc style violations.
-      # Temporarily commented out due to VM issue.
-      # scopedValidation: true
-      UnityVersion: $(Unity2018Version)
-
-  - template: templates/end.yml
+stages:
+- stage: PRValidation
+  jobs:
+  - job: CodeValidation
+    pool:
+      vmImage: windows-2019
+    steps:
+    - template: templates/validation.yml
+      parameters:
+        # For mrtk_pr builds, validation scripts (code and docs) should be scoped to only
+        # the set of changed files, so that we can save some time. There's no need to
+        # check unchanged files for code style/doc style violations.
+        scopedValidation: true
+  - job: UnityBuild
+    timeoutInMinutes: 90
+    pool:
+      name: On-Prem Unity
+      demands:
+      - ${{ variables.Unity2018Version }}
+      - COG-UnityCache-WUS2-01
+      - SDK_18362 -equals TRUE
+    steps:
+    - template: templates/common.yml
+      parameters:
+        # For mrtk_pr builds, don't build all flavors to reduce the amount of time
+        # taken for each validation run. With this configuration, only the Standalone
+        # configuration is built.
+        # Note that all of the flavors are still built during the rolling CI.
+        # If there are failures in rolling CI in any of these tasks, we should re-enable
+        # the specific flavors below that are experiencing failures in CI (for example,
+        # if we're actively working on features that have a lot of churn on underlying
+        # WMR APIs, buildUWPArm would be a good candidate to re-enable)
+        buildUWPX86: false
+        buildUWPArm: false
+        buildUWPDotNet: false
+        UnityVersion: $(Unity2018Version)
+    - template: templates/end.yml

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -6,6 +6,7 @@ parameters:
   MRTKVersion: ""
 
 steps:
+- template: validation.yml
 - template: common.yml
   parameters:
     buildUWPDotNet: false

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -6,40 +6,8 @@ parameters:
   buildUWPDotNet: true
   buildUWPX86: true
   runTests: true
-  # If true, validation scripts will be run on code and docs changes. By default
-  # validation will run on every single line of code and docs. It's possible to
-  # scope this to only changed files within a given pull request by using
-  # the scopedValidation parameter below.
-  validateCode: true
-  # If true, validation scripts will only be run on the set of changed files
-  # associated with a given pull request. Note that this is only valid to use
-  # for pull request validation, since this functionality requires a pull request
-  # ID in order to determine the two commits to diff. Only relevant if validateCode
-  # is true.
-  scopedValidation: false
 
 steps:
-# Generate the list of changed files in this pull request.
-- ${{ if and(eq(parameters.validateCode, true), eq(parameters.scopedValidation, true)) }}:
-  - template: tasks/githubchanges.yml
-    parameters:
-      changesFile: '$(Build.ArtifactStagingDirectory)\build\changedfiles.txt'
-
-# Validate that the code doesn't contain common issues
-- ${{ if eq(parameters.validateCode, true) }}:
-  - template: tasks/validatecode.yml
-    parameters:
-      scopedValidation: ${{ parameters.scopedValidation }}
-      changesFile: '$(Build.ArtifactStagingDirectory)\build\changedfiles.txt'
-
-# Validate that no assets take dependencies on files that are not in the appropriate package.
-# For example, files in the Extensions package are not to take a dependency on a file in the Examples package.
-- ${{ if eq(parameters.validateCode, true) }}:
-  - template: tasks/validateassets.yml
-    parameters:
-      scopedValidation: ${{ parameters.scopedValidation }}
-      changesFile: '$(Build.ArtifactStagingDirectory)\build\changedfiles.txt'
-
 # Build Standalone x64.
 # This must happen before tests run, because if the build fails and tests attempt
 # to get run, Unity will hang showing a dialog (even when in batch mode).

--- a/pipelines/templates/tasks/githubchanges.yml
+++ b/pipelines/templates/tasks/githubchanges.yml
@@ -10,7 +10,6 @@ steps:
     targetType: filePath
     filePath: ./scripts/ci/githubchanges.ps1
     arguments: >
-      -PullRequestId: $(System.PullRequest.PullRequestNumber)
       -TargetBranch: '$(System.PullRequest.TargetBranch)'
       -OutputFile: '${{ parameters.changesFile }}'
       -RepoRoot: '$(Build.SourcesDirectory)'

--- a/pipelines/templates/validation.yml
+++ b/pipelines/templates/validation.yml
@@ -1,0 +1,28 @@
+# [Template] Validation tasks that don't require Unity.
+parameters:
+  # If true, validation scripts will only be run on the set of changed files
+  # associated with a given pull request. Note that this is only valid to use
+  # for pull request validation, since this functionality requires a pull request
+  # ID in order to determine the two commits to diff. Only relevant if validateCode
+  # is true.
+  scopedValidation: false
+
+steps:
+# Generate the list of changed files in this pull request.
+- ${{ if eq(parameters.scopedValidation, true) }}:
+  - template: tasks/githubchanges.yml
+    parameters:
+      changesFile: '$(Build.ArtifactStagingDirectory)\build\changedfiles.txt'
+
+# Validate that the code doesn't contain common issues
+- template: tasks/validatecode.yml
+  parameters:
+    scopedValidation: ${{ parameters.scopedValidation }}
+    changesFile: '$(Build.ArtifactStagingDirectory)\build\changedfiles.txt'
+
+# Validate that no assets take dependencies on files that are not in the appropriate package.
+# For example, files in the Extensions package are not to take a dependency on a file in the Examples package.
+- template: tasks/validateassets.yml
+  parameters:
+    scopedValidation: ${{ parameters.scopedValidation }}
+    changesFile: '$(Build.ArtifactStagingDirectory)\build\changedfiles.txt'

--- a/scripts/ci/githubchanges.ps1
+++ b/scripts/ci/githubchanges.ps1
@@ -66,18 +66,11 @@ $gitDir = Join-Path -Path $RepoRoot -ChildPath ".git"
 # both branches to exist in order to make this happen.
 # Uses a shallow fetch (i.e. depth=1) because only the latest commit from the target branch is
 # needed to do the diff.
-git --git-dir=$gitDir --work-tree=$RepoRoot  fetch --depth=1 --force --tags --prune --progress --no-recurse-submodules origin $TargetBranch
+git --git-dir=$gitDir --work-tree=$RepoRoot fetch --depth=1 --force --tags --prune --progress --no-recurse-submodules origin $TargetBranch
 
 # The set of changed files is the diff between the target branch and the pull request
-# branch that was checked out locally. Note that the format of the pull request branch
-# (i.e. "pull/$PullRequestId/merge") is based on the format that Azure DevOps does for its
-# local checkout of the pull request code.
-# WARNING: This is a loose dependency on Azure DevOps git checkout mechanism - if this errors out
-# we'd likely need to another fetch. Something like:
-#
-# git fetch origin pull/$PullRequestId/head:local_branch
-# $changedFiles=$(git --git-dir=$gitDir --work-tree=$RepoRoot diff --name-only local_branch origin/$TargetBranch 2>&1)
-$changedFiles=$(git --git-dir=$gitDir --work-tree=$RepoRoot diff --name-only pull/$PullRequestId/merge origin/$TargetBranch 2>&1)
+# branch that was checked out locally.
+$changedFiles=$(git --git-dir=$gitDir --work-tree=$RepoRoot diff --name-only ..origin/$TargetBranch 2>&1)
 
 foreach ($changedFile in $changedFiles) {
     $joinedPath = Join-Path -Path $RepoRoot -ChildPath $changedFile

--- a/scripts/ci/githubchanges.ps1
+++ b/scripts/ci/githubchanges.ps1
@@ -31,19 +31,18 @@ param(
     [string]$TargetBranch,
 
     # The output filename (e.g. c:\path\to\output.txt)
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [string]$OutputFile,
 
     # The root folder of the repo (e.g. c:\repo)
     # This primarily used to filter out files that were deleted.
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [string]$RepoRoot
 )
 
 # The pull request ID might not be present (i.e. this is an adhoc build being spun up)
 # and the target branch might not be set in which case there's nothing to validate.
-if ([string]::IsNullOrWhiteSpace($TargetBranch))
-{
+if ([string]::IsNullOrWhiteSpace($TargetBranch)) {
     Write-Warning "TargetBranch isn't specified, skipping."
     exit 0;
 }
@@ -67,7 +66,7 @@ git --git-dir=$gitDir --work-tree=$RepoRoot fetch --depth=1 --force --tags --pru
 
 # The set of changed files is the diff between the target branch and the pull request
 # branch that was checked out locally.
-$changedFiles=$(git --git-dir=$gitDir --work-tree=$RepoRoot diff --name-only ..origin/$TargetBranch 2>&1)
+$changedFiles = $(git --git-dir=$gitDir --work-tree=$RepoRoot diff --name-only ..origin/$TargetBranch 2>&1)
 
 foreach ($changedFile in $changedFiles) {
     $joinedPath = Join-Path -Path $RepoRoot -ChildPath $changedFile

--- a/scripts/ci/githubchanges.ps1
+++ b/scripts/ci/githubchanges.ps1
@@ -3,11 +3,11 @@
 
 <#
 .SYNOPSIS
-    This script generates a list of changed files in a given pull request and outputs
+    This script generates a list of changed files in the locally checked out branch and outputs
     that list to a file.
 .DESCRIPTION
     Generates a file containing a list of all modified files (added/modified) in
-    the given pull request. The output file contains a list that is newline delimited, for
+    the checked out branch. The output file contains a list that is newline delimited, for
     example:
 
     Assets/MixedRealityToolkit.SDK/AssemblyInfo.cs
@@ -19,17 +19,14 @@
 
     Note that this script assumes that the local git repo doesn't already contain the
     target branch (e.g. mrtk_development). This is what happens by default on Azure DevOps
-    pipeline integrations with Github pull requests.
+    pipeline integrations with GitHub pull requests.
 
     In particular, this will checkout (via this command:
     git fetch --force --tags --prune --progress --no-recurse-submodules origin $(System.PullRequest.TargetBranch))
 .EXAMPLE
-    .\githubchanges.ps1 -OutputFile c:\path\to\changes\file.txt -PullRequestId 1234 -RepoRoot c:\path\to\mrtk -TargetBranch mrtk_development
+    .\githubchanges.ps1 -OutputFile c:\path\to\changes\file.txt -RepoRoot c:\path\to\mrtk -TargetBranch mrtk_development
 #>
 param(
-    # The ID of the pull request. (e.g. 1234)
-    [string]$PullRequestId,
-
     # The target branch that the pull request will merge into (e.g. mrtk_development)
     [string]$TargetBranch,
 
@@ -45,9 +42,9 @@ param(
 
 # The pull request ID might not be present (i.e. this is an adhoc build being spun up)
 # and the target branch might not be set in which case there's nothing to validate.
-if ([string]::IsNullOrEmpty($PullRequestId) -or [string]::IsNullOrEmpty($TargetBranch))
+if ([string]::IsNullOrWhiteSpace($TargetBranch))
 {
-    Write-Warning "PullRequestId or TargetBranch aren't specified, skipping."
+    Write-Warning "TargetBranch isn't specified, skipping."
     exit 0;
 }
 


### PR DESCRIPTION
## Overview

This allows these tasks to run on a the generic pool of machines, instead of taking up time on the special hosted machines with Unity installed.

This PR also fixes the issue with scoped code validation we've been having. Turns out, ADO changed the name of the branch they check out during PR validation. Instead of relying on a branch name, I updated the script to just use whatever branch is checked out (which will be the PR branch).

Fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8975