### PR TITLE
Update pipelines to use unitysetup.powershell

### DIFF
--- a/pipelines/templates/assetretargeting.yml
+++ b/pipelines/templates/assetretargeting.yml
@@ -11,8 +11,7 @@ steps:
   displayName: Install unitysetup.powershell
 
 - powershell: |
-    $outDir = "$(Build.ArtifactStagingDirectory)\build"
-    $logFile = New-Item -Path "$outDir\build\retargeting_log.log" -ItemType File -Force
+    $logFile = New-Item -Path "$(Build.ArtifactStagingDirectory)\build\retargeting_log.log" -ItemType File -Force
 
     $method = "Microsoft.MixedReality.Toolkit.MSBuild.AssetScriptReferenceRetargeter.RetargetAssets"
     # Uses unitysetup.powershell
@@ -22,14 +21,13 @@ steps:
     Write-Output '           Unity Build Player Finished               '
     Write-Output '====================================================='
 
-    $unityLogFileName = '$(Build.ArtifactStagingDirectory)\build\build\retargeting_log.log'
-    If (Test-Path $unityLogFileName)
+    If (Test-Path $logFile)
     {
        Write-Output '====================================================='
        Write-Output '           Begin Unity Player Log                    '
        Write-Output '====================================================='
 
-       Get-Content $unityLogFileName
+       Get-Content $logFile
 
        Write-Output '====================================================='
        Write-Output '           End Unity Player Log                      '

--- a/pipelines/templates/assetretargeting.yml
+++ b/pipelines/templates/assetretargeting.yml
@@ -1,64 +1,52 @@
-# [Template] Run Unity asset retargetting for NuGet packages.
+# [Template] Run Unity asset retargeting for NuGet packages.
+
 parameters:
   UnityVersion: ""
 
 steps:
 - powershell: |
-   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   $editor = Get-ChildItem ${Env:${{ parameters.UnityVersion }}} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
-   
-   $outDir = "$(Build.ArtifactStagingDirectory)\build"
-   $logFile = New-Item -Path "$outDir\build\retargeting_log.log" -ItemType File -Force
-   
-   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -batchmode -executeMethod Microsoft.MixedReality.Toolkit.MSBuild.AssetScriptReferenceRetargeter.RetargetAssets -logFile $($logFile.FullName) -nographics -quit" -PassThru
-   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
-   
-   while (-not $proc.HasExited -and $ljob.HasMoreData)
-   {
-       Receive-Job $ljob
-       Start-Sleep -Milliseconds 200
-   }
-   Receive-Job $ljob
-   
-   Stop-Job $ljob
-   
-   Remove-Job $ljob
-   Stop-Process $proc
+    # Some machines require that the protocol be explicitly set to Tls12
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Install-Module -Name UnitySetup -Scope CurrentUser -Force
+  displayName: Install unitysetup.powershell
 
-   Write-Output '====================================================='
-   Write-Output '           Unity Build Player Finished               '
-   Write-Output '====================================================='
+- powershell: |
+    $outDir = "$(Build.ArtifactStagingDirectory)\build"
+    $logFile = New-Item -Path "$outDir\build\retargeting_log.log" -ItemType File -Force
 
-   $unityLogFileName = '$(Build.ArtifactStagingDirectory)\build\build\retargeting_log.log'
-   If (Test-Path $unityLogFileName)
-   {
-      Write-Output '====================================================='
-      Write-Output '           Begin Unity Player Log                    '
-      Write-Output '====================================================='
+    $method = "Microsoft.MixedReality.Toolkit.MSBuild.AssetScriptReferenceRetargeter.RetargetAssets"
+    # Uses unitysetup.powershell
+    Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -ExecuteMethod $method -BatchMode -Quit -Wait -LogFile "$($logFile.FullName)" -AdditionalArguments "-NoGraphics -CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01}"
 
-      Get-Content $unityLogFileName
+    Write-Output '====================================================='
+    Write-Output '           Unity Build Player Finished               '
+    Write-Output '====================================================='
 
-      Write-Output '====================================================='
-      Write-Output '           End Unity Player Log                      '
-      Write-Output '====================================================='
-   }
-   Else
-   {
-      Write-Output 'Unity Player Log missing!'
-   }
+    $unityLogFileName = '$(Build.ArtifactStagingDirectory)\build\build\retargeting_log.log'
+    If (Test-Path $unityLogFileName)
+    {
+       Write-Output '====================================================='
+       Write-Output '           Begin Unity Player Log                    '
+       Write-Output '====================================================='
 
-   Write-Output '====================================================='
-   Write-Output '           Begin Retargeted Directory                '
-   Write-Output '====================================================='
+       Get-Content $unityLogFileName
 
-   cmd /r dir /s/b NuGet
+       Write-Output '====================================================='
+       Write-Output '           End Unity Player Log                      '
+       Write-Output '====================================================='
+    }
+    Else
+    {
+       Write-Output 'Unity Player Log missing!'
+    }
 
-   Write-Output '====================================================='
-   Write-Output '           End Retargeted Directory                  '
-   Write-Output '====================================================='
-   
-   if ($proc.ExitCode -ne 0)
-   {
-       exit $proc.ExitCode
-   }
-  displayName: 'Run Asset Retargetting'
+    Write-Output '====================================================='
+    Write-Output '           Begin Retargeted Directory                '
+    Write-Output '====================================================='
+
+    cmd /r dir /s/b NuGet
+
+    Write-Output '====================================================='
+    Write-Output '           End Retargeted Directory                  '
+    Write-Output '====================================================='
+  displayName: 'Run Asset Retargeting'

--- a/pipelines/templates/generateprojects.yml
+++ b/pipelines/templates/generateprojects.yml
@@ -11,10 +11,22 @@ steps:
   displayName: Install unitysetup.powershell
 
 - powershell: |
-    $outDir = "$(Build.ArtifactStagingDirectory)\build"
-    $logFile = New-Item -Path "$outDir\build\projectgeneration_log.log" -ItemType File -Force
+    $logFile = New-Item -Path "$(Build.ArtifactStagingDirectory)\build\projectgeneration_log.log" -ItemType File -Force
 
     $method = "Microsoft.MixedReality.Toolkit.MSBuild.MSBuildTools.GenerateSDKProjects"
     # Uses unitysetup.powershell
     Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -ExecuteMethod $method -BatchMode -Quit -Wait -LogFile "$($logFile.FullName)" -AdditionalArguments "-NoGraphics -CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01}"
+
+    If (Test-Path $logFile)
+    {
+       Write-Output '====================================================='
+       Write-Output '           Begin Unity Player Log                    '
+       Write-Output '====================================================='
+
+       Get-Content $logFile
+
+       Write-Output '====================================================='
+       Write-Output '           End Unity Player Log                      '
+       Write-Output '====================================================='
+    }
   displayName: 'Generate SDK Projects'

--- a/pipelines/templates/generateprojects.yml
+++ b/pipelines/templates/generateprojects.yml
@@ -1,33 +1,20 @@
 # [Template] Run a Unity script that generates MSBuild projects.
+
 parameters:
   UnityVersion: ""
 
 steps:
 - powershell: |
-   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   $editor = Get-ChildItem ${Env:${{ parameters.UnityVersion }}} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
-   
-   $outDir = "$(Build.ArtifactStagingDirectory)\build"
-   $logFile = New-Item -Path "$outDir\build\projectgeneration_log.log" -ItemType File -Force
-   
-   $method = "Microsoft.MixedReality.Toolkit.MSBuild.MSBuildTools.GenerateSDKProjects"
-   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -batchmode -executeMethod $method -logFile $($logFile.FullName) -nographics -quit" -PassThru
-   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
-   
-   while (-not $proc.HasExited -and $ljob.HasMoreData)
-   {
-       Receive-Job $ljob
-       Start-Sleep -Milliseconds 200
-   }
-   Receive-Job $ljob
-   
-   Stop-Job $ljob
-   
-   Remove-Job $ljob
-   Stop-Process $proc
+    # Some machines require that the protocol be explicitly set to Tls12
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Install-Module -Name UnitySetup -Scope CurrentUser -Force
+  displayName: Install unitysetup.powershell
 
-   if ($proc.ExitCode -ne 0)
-   {
-       exit $proc.ExitCode
-   }
+- powershell: |
+    $outDir = "$(Build.ArtifactStagingDirectory)\build"
+    $logFile = New-Item -Path "$outDir\build\projectgeneration_log.log" -ItemType File -Force
+
+    $method = "Microsoft.MixedReality.Toolkit.MSBuild.MSBuildTools.GenerateSDKProjects"
+    # Uses unitysetup.powershell
+    Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -ExecuteMethod $method -BatchMode -Quit -Wait -LogFile "$($logFile.FullName)" -AdditionalArguments "-NoGraphics -CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01}"
   displayName: 'Generate SDK Projects'

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -33,6 +33,8 @@ parameters:
 
 steps:
 - powershell: |
+    # Some machines require that the protocol be explicitly set to Tls12
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Install-Module UnitySetup -Scope CurrentUser -Force
   displayName: Install unitysetup.powershell
 

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -1,13 +1,35 @@
 # [Template] Compile MRTK inside Unity.
 
-parameters: 
-  Arch: ''  # x86|arm
-  Platform: ''  # UWP|Standalone
-  UnityArgs: 'none' # [optional] additional args passed to Unity
-  ScriptingBackend: 'default'  # [optional] default|.NET
-  PublishArtifacts: false
-  PackagingDir: 'Win32'
-  UnityVersion: ""
+parameters:
+- name: Arch
+  type: string
+  values:
+    - x86
+    - x64
+    - arm
+    - arm64
+- name: Platform
+  type: string
+  values:
+    - UWP
+    - Standalone
+- name: UnityArgs # [optional] additional args passed to Unity
+  type: string
+  default: none
+- name: ScriptingBackend # [optional]
+  type: string
+  default: default
+  values:
+    - default
+    - .NET
+- name: PublishArtifacts
+  type: boolean
+  default: false
+- name: PackagingDir
+  type: string
+  default: Win32
+- name: UnityVersion
+  type: string
 
 steps:
 - powershell: |

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -33,77 +33,68 @@ parameters:
 
 steps:
 - powershell: |
-   $UnityPath = ${Env:${{ parameters.UnityVersion }}}
-   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
-   
-   # The build output goes to a unique combination of Platform + Arch + ScriptingBackend to ensure that
-   # each build will have a fresh destination folder.
-   $outDir = "$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}"
-   $logFile = New-Item -Path "$outDir\build\build.log" -ItemType File -Force
-   $logDirectory = "$outDir\logs"
+    Install-Module UnitySetup -Scope CurrentUser -Force
+  displayName: Install unitysetup.powershell
 
-   $sceneList = "Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
-   
-   $extraArgs = ''
-   If ("${{ parameters.Platform }}" -eq "UWP")
-   {
-       $extraArgs += '-buildTarget WSAPlayer -buildAppx'
-   }
-   ElseIf ("${{ parameters.Platform }}" -eq "Standalone")
-   {
-       $extraArgs += "-buildTarget StandaloneWindows"
-   }
+- powershell: |
+    # The build output goes to a unique combination of Platform + Arch + ScriptingBackend to ensure that
+    # each build will have a fresh destination folder.
+    $outDir = "$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}"
+    $logFile = New-Item -Path "$outDir\build\build.log" -ItemType File -Force
+    $logDirectory = "$outDir\logs"
 
-   If ("${{ parameters.UnityArgs }}" -ne "none")
-   {
-       $extraArgs += " ${{ parameters.UnityArgs }}"
-   }
+    $sceneList = "Assets\MRTK\Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
 
-   If ("${{ parameters.ScriptingBackend }}" -eq ".NET")
-   {
-       $extraArgs += " -scriptingBackend 2"
-   }
+    $extraArgs = ""
+    $buildTarget = "StandaloneWindows"
+    If ("${{ parameters.Platform }}" -eq "UWP")
+    {
+        $buildTarget = WSAPlayer
+        $extraArgs += "-buildAppx"
+    }
+    ElseIf ("${{ parameters.Platform }}" -eq "Standalone" -and "${{ parameters.Arch }}" -eq "x64")
+    {
+        $buildTarget += "64"
+    }
 
-   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -${{ parameters.Arch }} -buildOutput $outDir $extraArgs -CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01} -logDirectory $logDirectory" -PassThru
-   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
-   
-   while (-not $proc.HasExited -and $ljob.HasMoreData)
-   {
-       Receive-Job $ljob
-       Start-Sleep -Milliseconds 200
-   }
-   Receive-Job $ljob
-   
-   Stop-Job $ljob
-   
-   Remove-Job $ljob
-   Stop-Process $proc
+    If ("${{ parameters.UnityArgs }}" -ne "none")
+    {
+        $extraArgs += " ${{ parameters.UnityArgs }}"
+    }
 
-   Write-Output '====================================================='
-   Write-Output '           Unity Build Player Finished               '
-   Write-Output '====================================================='
+    If ("${{ parameters.ScriptingBackend }}" -eq ".NET")
+    {
+        $extraArgs += " -scriptingBackend 2"
+    }
 
-   If (Test-Path $logFile.FullName)
-   {
-      Write-Output '====================================================='
-      Write-Output '           Begin Unity Player Log                    '
-      Write-Output '====================================================='
+    $method = "Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild"
+    # Uses unitysetup.powershell
+    Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -ExecuteMethod $method -BatchMode -Quit -Wait -LogFile "$($logFile.FullName)" -BuildTarget $buildTarget -OutputPath "$outDir" -AdditionalArguments "$extraArgs -sceneList $sceneList -${{ parameters.Arch }} -logDirectory $logDirectory -CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01}"
 
-      Get-Content $logFile.FullName
+    Write-Output '====================================================='
+    Write-Output '           Unity Build Player Finished               '
+    Write-Output '====================================================='
 
-      Write-Output '====================================================='
-      Write-Output '           End Unity Player Log                      '
-      Write-Output '====================================================='
-   }
-   Else
-   {
-      Write-Output 'Unity Player Log Missing!'
-   }
+    If (Test-Path $logFile.FullName)
+    {
+       Write-Output '====================================================='
+       Write-Output '           Begin Unity Player Log                    '
+       Write-Output '====================================================='
 
-   # The NuGet and AppX logs are only relevant for UWP builds.
-   If ("${{ parameters.Platform }}" -eq "UWP")
-   {
+       Get-Content $logFile.FullName
+
+       Write-Output '====================================================='
+       Write-Output '           End Unity Player Log                      '
+       Write-Output '====================================================='
+    }
+    Else
+    {
+       Write-Output 'Unity Player Log Missing!'
+    }
+
+    # The NuGet and AppX logs are only relevant for UWP builds.
+    If ("${{ parameters.Platform }}" -eq "UWP")
+    {
         $nugetRestoreLogFileName = "$logDirectory\nugetRestore.log"
         If (Test-Path $nugetRestoreLogFileName)
         {
@@ -139,12 +130,7 @@ steps:
         {
             Write-Output "AppX Build Log Missing $appxBuildLogFileName!"
         }
-   }
-
-   If ($proc.ExitCode -ne 0)
-   {
-       exit $proc.ExitCode
-   }
+    }
   displayName: "Build ${{ parameters.Platform }} ${{ parameters.Arch }} ${{ parameters.ScriptingBackend }}"
 
 - task: PowerShell@2

--- a/pipelines/templates/tests.yml
+++ b/pipelines/templates/tests.yml
@@ -5,53 +5,27 @@ parameters:
 
 steps:
 - powershell: |
-   $UnityPath = ${Env:${{ parameters.UnityVersion }}}
-   $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
-   
-   Write-Host "======================= EditMode Tests ======================="
-   
-   $logFile = New-Item -Path .\editmode-test-run.log -ItemType File -Force
-   
-   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform EditMode -batchMode -buildTarget StandaloneWindows -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
-   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
-   
-   while (-not $proc.HasExited -and $ljob.HasMoreData)
-   {
-       Receive-Job $ljob
-       Start-Sleep -Milliseconds 200
-   }
-   Receive-Job $ljob
-   
-   Stop-Job $ljob
-   
-   Remove-Job $ljob
-   Stop-Process $proc
+    # Some machines require that the protocol be explicitly set to Tls12
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Install-Module -Name UnitySetup -Scope CurrentUser -Force
+  displayName: Install unitysetup.powershell
 
+- powershell: |
+    Write-Host "======================= EditMode Tests ======================="
+
+    $logFile = New-Item -Path .\editmode-test-run.log -ItemType File -Force
+
+    # Uses unitysetup.powershell
+    Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -RunTests -TestPlatform EditMode -EditorTestsResultFile ".\test-editmode-default.xml" -BatchMode -Wait -LogFile "$($logFile.FullName)" -BuildTarget StandaloneWindows64 -AdditionalArguments "-CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01}"
   displayName: 'Run EditMode tests'
 
 - powershell: |
-   $UnityPath = ${Env:${{ parameters.UnityVersion }}}
-   $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
-   
-   Write-Host "======================= PlayMode Tests ======================="
-   
-   $logFile = New-Item -Path .\playmode-test-run.log -ItemType File -Force
-   
-   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform PlayMode -batchMode -buildTarget StandaloneWindows -logFile $($logFile.Name) -editorTestsResultFile .\test-playmode-default.xml" -PassThru
-   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
-   
-   while (-not $proc.HasExited -and $ljob.HasMoreData)
-   {
-       Receive-Job $ljob
-       Start-Sleep -Milliseconds 200
-   }
-   Receive-Job $ljob
-   
-   Stop-Job $ljob
-   
-   Remove-Job $ljob
-   Stop-Process $proc
+    Write-Host "======================= PlayMode Tests ======================="
 
+    $logFile = New-Item -Path .\playmode-test-run.log -ItemType File -Force
+
+    # Uses unitysetup.powershell
+    Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -RunTests -TestPlatform PlayMode -EditorTestsResultFile ".\test-playmode-default.xml" -BatchMode -Wait -LogFile "$($logFile.FullName)" -BuildTarget StandaloneWindows64 -AdditionalArguments "-CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01}"
   displayName: 'Run PlayMode tests'
 
 - task: PublishTestResults@2


### PR DESCRIPTION
## Overview

Uses https://github.com/microsoft/unitysetup.powershell for finding and running Unity instances, instead of searching the file tree manually.

Build errors are caught like https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=16847&view=logs&j=ac44c712-4e8b-53f6-2852-2edd3c73b43a&t=ee209e73-1529-516b-c222-0767be9b653d

## Changes

- Fixes: #7554