### PR TITLE
remove null propagation with unity object

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -154,7 +154,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <inheritdoc/>
         protected override IMixedRealityServiceConfiguration GetDataProviderConfiguration(int index)
         {
-            var configurations = (target as MixedRealityCameraProfile)?.SettingsConfigurations;
+            var profile = target as MixedRealityCameraProfile;
+            var configurations = (profile != null) ? profile.SettingsConfigurations : null;
             if (configurations != null && index >= 0 && index < configurations.Length)
             {
                 return configurations[index];

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpatialAwarenessSystemProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpatialAwarenessSystemProfileInspector.cs
@@ -73,7 +73,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness.Editor
         /// <inheritdoc/>
         protected override IMixedRealityServiceConfiguration GetDataProviderConfiguration(int index)
         {
-            var configurations = (target as MixedRealitySpatialAwarenessSystemProfile)?.ObserverConfigurations;
+            var profile = target as MixedRealitySpatialAwarenessSystemProfile;
+            var configurations = (profile != null) ? profile.ObserverConfigurations : null;
             if (configurations != null && index >= 0 && index < configurations.Length)
             {
                 return configurations[index];

--- a/Assets/MRTK/Examples/Demos/UX/BoundingBox/Scripts/BoundingBoxExampleTest.cs
+++ b/Assets/MRTK/Examples/Demos/UX/BoundingBox/Scripts/BoundingBoxExampleTest.cs
@@ -187,7 +187,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
                     var cubechild = GameObject.CreatePrimitive(PrimitiveType.Cube);
                     cubechild.transform.localPosition = Random.insideUnitSphere + cubePosition + forwardOffset;
                     cubechild.transform.rotation = Quaternion.Euler(Random.insideUnitSphere * 360f);
-                    cubechild.transform.parent = lastParent ?? multiRoot.transform;
+                    cubechild.transform.parent = (lastParent != null) ? lastParent : multiRoot.transform;
                     float baseScale = lastParent == null ? 0.1f : 1f;
                     cubechild.transform.localScale = new Vector3(baseScale, baseScale, baseScale);
                     lastParent = cubechild.transform;

--- a/Assets/MRTK/Examples/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
+++ b/Assets/MRTK/Examples/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
@@ -190,7 +190,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
                     var cubechild = GameObject.CreatePrimitive(PrimitiveType.Cube);
                     cubechild.transform.localPosition = Random.insideUnitSphere + cubePosition + forwardOffset;
                     cubechild.transform.rotation = Quaternion.Euler(Random.insideUnitSphere * 360f);
-                    cubechild.transform.parent = lastParent ?? multiRoot.transform;
+                    cubechild.transform.parent = (lastParent != null) ? lastParent : multiRoot.transform;
                     float baseScale = lastParent == null ? 0.1f : 1f;
                     cubechild.transform.localScale = new Vector3(baseScale, baseScale, baseScale);
                     lastParent = cubechild.transform;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
@@ -27,8 +27,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             profilerButton.IsToggled = (CoreServices.DiagnosticsSystem?.ShowProfiler).GetValueOrDefault(false);
             handRayButton.IsToggled = PointerUtils.GetPointerBehavior<ShellHandRayPointer>(Handedness.Any, InputSourceType.Hand) != PointerBehavior.AlwaysOff;
-            handMeshButton.IsToggled = (CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile.EnableHandMeshVisualization).GetValueOrDefault(false);
-            handJointsButton.IsToggled = (CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile.EnableHandJointVisualization).GetValueOrDefault(false);
+
+            MixedRealityHandTrackingProfile handProfile = null;
+            if ((CoreServices.InputSystem != null) &&
+                (CoreServices.InputSystem.InputSystemProfile != null))
+            {
+                handProfile = CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile;
+            }
+            handMeshButton.IsToggled = (handProfile != null) ? handProfile.EnableHandMeshVisualization : false;
+            handJointsButton.IsToggled = (handProfile != null) ? handProfile.EnableHandJointVisualization : false;
         }
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
@@ -29,8 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             handRayButton.IsToggled = PointerUtils.GetPointerBehavior<ShellHandRayPointer>(Handedness.Any, InputSourceType.Hand) != PointerBehavior.AlwaysOff;
 
             MixedRealityHandTrackingProfile handProfile = null;
-            if ((CoreServices.InputSystem != null) &&
-                (CoreServices.InputSystem.InputSystemProfile != null))
+            if (CoreServices.InputSystem?.InputSystemProfile != null)
             {
                 handProfile = CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile;
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
@@ -32,7 +32,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public void OnToggleHandJoint()
         {
-            MixedRealityHandTrackingProfile handTrackingProfile = CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile;
+            MixedRealityHandTrackingProfile handTrackingProfile = null;
+
+            if ((CoreServices.InputSystem != null) &&
+                (CoreServices.InputSystem.InputSystemProfile != null) &&
+                (CoreServices.InputSystem.InputSystemProfile != null))
+            {
+                handTrackingProfile = CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile;
+            }
+
             if (handTrackingProfile != null)
             {
                 handTrackingProfile.EnableHandJointVisualization = !handTrackingProfile.EnableHandJointVisualization;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
@@ -35,7 +35,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             MixedRealityHandTrackingProfile handTrackingProfile = null;
 
             if ((CoreServices.InputSystem != null) &&
-                (CoreServices.InputSystem.InputSystemProfile != null) &&
                 (CoreServices.InputSystem.InputSystemProfile != null))
             {
                 handTrackingProfile = CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/ToggleHandVisualisation.cs
@@ -34,8 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             MixedRealityHandTrackingProfile handTrackingProfile = null;
 
-            if ((CoreServices.InputSystem != null) &&
-                (CoreServices.InputSystem.InputSystemProfile != null))
+            if (CoreServices.InputSystem?.InputSystemProfile != null)
             {
                 handTrackingProfile = CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile;
             }

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -1281,7 +1281,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 initialHandPosition = new Vector3(0, 0, 0f);
             // this is specific to scale handles
             Transform scaleHandle = boundsControl.gameObject.transform.Find("rigRoot/corner_3");
-            Transform proximityScaledVisual = scaleHandle.GetChild(0)?.GetChild(0);
+            Transform proximityScaledVisual = (scaleHandle.GetChild(0) != null) ? scaleHandle.GetChild(0).GetChild(0) : null;
             var frontRightCornerPos = scaleHandle.position; // front right corner is corner 
             Assert.IsNotNull(proximityScaledVisual, "Couldn't get visual gameobject for scale handle");
             Assert.IsTrue(proximityScaledVisual.name == "visuals", "scale visual has unexpected name");
@@ -1339,7 +1339,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             ScaleHandlesConfiguration scaleHandleConfig = boundsControl.ScaleHandlesConfig;
             Vector3 defaultHandleSize = Vector3.one * scaleHandleConfig.HandleSize;
             Transform scaleHandle = boundsControl.gameObject.transform.Find("rigRoot/corner_3");
-            Transform proximityScaledVisual = scaleHandle.GetChild(0)?.GetChild(0);
+            Transform proximityScaledVisual = (scaleHandle.GetChild(0) != null) ? scaleHandle.GetChild(0).GetChild(0) : null;
             var frontRightCornerPos = scaleHandle.position;
             // check far scale applied
             ProximityEffectConfiguration proximityConfig = boundsControl.HandleProximityEffectConfig;

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -1253,7 +1253,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Transform expectedTransform = null;
             if (testData.handler.TrackedTargetType == TrackedObjectType.ControllerRay)
             {
-                expectedTransform = PointerUtils.GetPointer<LinePointer>(hand)?.transform;
+                LinePointer pointer = PointerUtils.GetPointer<LinePointer>(hand);
+                expectedTransform = (pointer != null) ? pointer.transform : null;
             }
             else
             {


### PR DESCRIPTION
This change cleans up null propagation and null coalescence usages with Unity objects. 

Recommend taking for 2.6 as it should resolve potential race condition bugs based on when Unity objects actually get set to null.