### PR TITLE
Allow controllers to rotate object manipulators

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -262,8 +262,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (UpdateCurrentTeleportPosePerfMarker.Auto())
             {
-                MixedRealityInputAction teleportAction = MixedRealityInputAction.None;
-
                 // Check if we're focus locked or near something interactive to avoid teleporting unintentionally.
                 bool anyPointersLockedWithHand = false;
                 for (int i = 0; i < InputSource?.Pointers?.Length; i++)

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -397,8 +397,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private bool IsOneHandedManipulationEnabled => manipulationType.HasFlag(ManipulationHandFlags.OneHanded) && pointerIdToPointerMap.Count == 1;
         private bool IsTwoHandedManipulationEnabled => manipulationType.HasFlag(ManipulationHandFlags.TwoHanded) && pointerIdToPointerMap.Count > 1;
 
-        private Quaternion LeftHandRotation;
-        private Quaternion RightHandRotation;
+        private Quaternion leftHandRotation;
+        private Quaternion rightHandRotation;
 
         #endregion Private Properties
 
@@ -1000,10 +1000,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             switch (pointer.Controller.ControllerHandedness)
             {
                 case Handedness.Left:
-                    rotation = LeftHandRotation;
+                    rotation = leftHandRotation;
                     break;
                 case Handedness.Right:
-                    rotation = RightHandRotation;
+                    rotation = rightHandRotation;
                     break;
                 default:
                     return false;
@@ -1042,10 +1042,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             switch (eventData.Controller.ControllerHandedness)
             {
                 case Handedness.Left:
-                    LeftHandRotation = eventData.SourceData.Rotation;
+                    leftHandRotation = eventData.SourceData.Rotation;
                     break;
                 case Handedness.Right:
-                    RightHandRotation = eventData.SourceData.Rotation;
+                    rightHandRotation = eventData.SourceData.Rotation;
                     break;
                 default:
                     break;

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -997,7 +997,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private bool TryGetGripRotation(IMixedRealityPointer pointer, out Quaternion rotation)
         {
             rotation = Quaternion.identity;
-            switch (pointer.Controller.ControllerHandedness)
+            switch (pointer.Controller?.ControllerHandedness)
             {
                 case Handedness.Left:
                     rotation = leftHandRotation;
@@ -1039,7 +1039,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public void OnSourcePoseChanged(SourcePoseEventData<MixedRealityPose> eventData)
         {
-            switch (eventData.Controller.ControllerHandedness)
+            switch (eventData.Controller?.ControllerHandedness)
             {
                 case Handedness.Left:
                     leftHandRotation = eventData.SourceData.Rotation;


### PR DESCRIPTION
## Overview
Previously, only controllers with the spatial grip inputType could rotate object manipulators via 1-handed or 2-handed interactions. This PR allows for all kinds of controllers which raise source pose events to manipulate those objects.

Old behavior on Quest: https://streamable.com/07fvq0

New behavior on Quest: https://streamable.com/5x912h

## Changes
- Fixes: #9109

