### PR TITLE
Update Asset Retargeter to bypass Interactive Element

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -64,6 +64,8 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         // This is the known Unity-defined script fileId
         private const string ScriptFileIdConstant = "11500000";
 
+        private const string OculusProfileGUID = "4f726b4cb3605994fac74d508110ec62";
+
         [MenuItem("Mixed Reality Toolkit/MSBuild/Assets/Retarget To DLL")]
         public static void RetargetAssets()
         {
@@ -239,9 +241,11 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                             }
                             else if (nonClassDictionary.ContainsKey(guid))
                             {
-                                // this guid bypasses throwing the exception. The reason for this is that there is currently an asset (DefaultOculusXRSDKDeviceManagerProfile.asset) that is reliant
+                                // The OculusProfileGUID bypasses throwing the exception. The reason for this is that there is currently an asset (DefaultOculusXRSDKDeviceManagerProfile.asset) that is reliant
                                 // on Unity 2019+ specific code (OculusXRSDKDeviceManagerProfile.cs), which causes CI to fail since it's running on Unity 2018.
-                                if (guid != "4f726b4cb3605994fac74d508110ec62")
+
+                                // Also bypass this exception for scripts in an InteractiveElement directory as those files are only supported in Unity 2019.
+                                if (guid != OculusProfileGUID && !filePath.Contains("InteractiveElement"))
                                 {
                                     throw new InvalidDataException($"A script without a class ({nonClassDictionary[guid]}) is being processed.");
                                 }


### PR DESCRIPTION
## Overview

Add condition to bypass an exception in the Asset Retargeter.  Interactive Element is only supported in Unity 2019.