### PR TITLE
Update CI to run non-Unity validation on "regular" windows-2019 VMs

### DIFF
--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -6,7 +6,13 @@ variables:
   value: false
 
 jobs:
-- job: DailyUnity2019Validation
+- job: CodeValidation
+  pool:
+      vmImage: windows-2019
+  steps:
+    - template: templates/validation.yml
+    
+- job: Unity2019Validation
   timeoutInMinutes: 120
   pool:
     name: On-Prem Unity
@@ -22,7 +28,7 @@ jobs:
       UnityVersion: $(Unity2019Version)
       MRTKVersion: $(MRTKVersion)
 
-- job: DailyUnity2018Validation
+- job: Unity2018Validation
   timeoutInMinutes: 120
   pool:
     name: On-Prem Unity

--- a/pipelines/ci-packaging-dontpublish.yml
+++ b/pipelines/ci-packaging-dontpublish.yml
@@ -4,7 +4,13 @@ variables:
 - template: config/settings.yml
 
 jobs:
-- job: CIDeveloperValidation
+- job: CodeValidation
+  pool:
+    vmImage: windows-2019
+  steps:
+  - template: templates/validation.yml
+
+- job: UnityValidation
   timeoutInMinutes: 90
   pool:
     name: On-Prem Unity

--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -4,7 +4,13 @@ variables:
 - template: config/settings.yml
 
 jobs:
-- job: CIDeveloperValidation
+- job: CodeValidation
+  pool:
+    vmImage: windows-2019
+  steps:
+  - template: templates/validation.yml
+
+- job: UnityValidation
   timeoutInMinutes: 90
   pool:
     name: Analog N-1

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -6,7 +6,13 @@ variables:
   value: false
 
 jobs:
-- job: CIDeveloperValidation
+- job: CodeValidation
+  pool:
+    vmImage: windows-2019
+  steps:
+  - template: templates/validation.yml
+
+- job: DeveloperValidation
   timeoutInMinutes: 120
   pool:
     name: On-Prem Unity

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -14,7 +14,8 @@ jobs:
       # the set of changed files, so that we can save some time. There's no need to
       # check unchanged files for code style/doc style violations.
       scopedValidation: true
-- job: UnityBuild
+
+- job: UnityValidation
   timeoutInMinutes: 90
   pool:
     name: On-Prem Unity

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -6,7 +6,6 @@ parameters:
   MRTKVersion: ""
 
 steps:
-- template: validation.yml
 - template: common.yml
   parameters:
     buildUWPDotNet: false

--- a/pipelines/templates/validation.yml
+++ b/pipelines/templates/validation.yml
@@ -1,4 +1,5 @@
 # [Template] Validation tasks that don't require Unity.
+
 parameters:
   # If true, validation scripts will only be run on the set of changed files
   # associated with a given pull request. Note that this is only valid to use


### PR DESCRIPTION
## Overview

Follow-up to #9242, to use the new non-Unity validation template on regular windows VMs in CI as well as PR validation. This should help speed up CI a bit, as global code validation takes ~10 minutes and can now happen in parallel.