### PR TITLE
Update versioning step pre-packaging in pipeline

### DIFF
--- a/Assets/MRTK/StandardAssets/License.txt
+++ b/Assets/MRTK/StandardAssets/License.txt
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Assets/MRTK/StandardAssets/License.txt.meta
+++ b/Assets/MRTK/StandardAssets/License.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 71bd273a5d69263419ca8e4c5d03ffed
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -20,7 +20,6 @@ jobs:
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2019Version)
-      MRTKVersion: $(MRTKVersion)
 
 - job: DailyUnity2018Validation
   timeoutInMinutes: 120
@@ -35,4 +34,3 @@ jobs:
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2018Version)
-      MRTKVersion: $(MRTKVersion)

--- a/pipelines/ci-packaging-dontpublish.yml
+++ b/pipelines/ci-packaging-dontpublish.yml
@@ -18,4 +18,3 @@ jobs:
       packagingEnabled: true
       packagePublishing: false
       UnityVersion: $(Unity2018Version)
-      MRTKVersion: $(MRTKVersion)

--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -18,4 +18,3 @@ jobs:
       packagingEnabled: true
       packagePublishing: true
       UnityVersion: $(Unity2018VersionInternal)
-      MRTKVersion: $(MRTKVersion)

--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -18,4 +18,3 @@ jobs:
       packagingEnabled: true
       packagePublishing: true
       UnityVersion: $(Unity2018Version)
-      MRTKVersion: $(MRTKVersion)

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -19,4 +19,3 @@ jobs:
     parameters:
       packagingEnabled: false
       UnityVersion: $(Unity2018Version)
-      MRTKVersion: $(MRTKVersion)

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -1,9 +1,9 @@
-# CI build for developer builds.
+# [Template] CI build for developer builds.
+
 parameters:
   packagingEnabled: true
   packagePublishing: true
   UnityVersion: ""
-  MRTKVersion: ""
 
 steps:
 - template: validation.yml
@@ -12,8 +12,6 @@ steps:
     buildUWPDotNet: false
     UnityVersion: ${{ parameters.UnityVersion }}
 - template: tasks/versionmetadata.yml
-  parameters:
-    MRTKVersion: ${{ parameters.MRTKVersion }}
 - template: compilemsbuild.yml
   parameters:
     UnityVersion: ${{ parameters.UnityVersion }}

--- a/pipelines/templates/common-Unity2019.yml
+++ b/pipelines/templates/common-Unity2019.yml
@@ -1,4 +1,5 @@
 # [Template] Common build tasks shared between CI builds and PR validation.
+
 parameters:
   UnityVersion: ""
 

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -1,4 +1,5 @@
 # [Template] Common build tasks shared between CI builds and PR validation.
+
 parameters:
   UnityVersion: ""
   buildStandalone: true

--- a/pipelines/templates/end.yml
+++ b/pipelines/templates/end.yml
@@ -3,12 +3,11 @@
 steps:
 # Clean up after build: terminate Unity process if it is still running
 - powershell: |
-   $unityProcess = Get-Process -Name Unity -ErrorAction SilentlyContinue
-   if ($unityProcess)
-   {
-       Write-Host "Closing Unity Process"
-       Stop-Process $unityProcess
-   }
-   
+    $unityProcess = Get-Process -Name Unity -ErrorAction SilentlyContinue
+    if ($unityProcess)
+    {
+        Write-Host "Closing Unity Process"
+        Stop-Process $unityProcess
+    }
   displayName: 'Close Unity'
   condition: always()

--- a/pipelines/templates/tasks/signing.yml
+++ b/pipelines/templates/tasks/signing.yml
@@ -8,6 +8,6 @@ steps:
   inputs:
     signConfigXml: ${{ parameters.ConfigName }}
     inPathRoot: $(Build.SourcesDirectory)
-    outPathRoot: $(Build.SourcesDirectory)  
+    outPathRoot: $(Build.SourcesDirectory)
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/pipelines/templates/tasks/versionmetadata.yml
+++ b/pipelines/templates/tasks/versionmetadata.yml
@@ -1,6 +1,6 @@
 parameters:
   # The MRTK Version to use (i.e. 2.3.0).
-  MRTKVersion: ''
+  MRTKVersion: $(MRTKVersion)
 
 steps:
 - task: PowerShell@2

--- a/scripts/packaging/versionmetadata.ps1
+++ b/scripts/packaging/versionmetadata.ps1
@@ -3,7 +3,7 @@
 
 <#
 .SYNOPSIS
-    Adds version metadata to the MRTK prior to building and packagine.
+    Adds version metadata to the MRTK prior to building and packaging.
 .DESCRIPTION
     This script represents a step in the build process where certain version
     metadata is added to specific locations in the code, such that the ultimately
@@ -27,7 +27,7 @@
     ProjectSettings/ProjectSettings.asset, which are ultimately not consumed by
     consumers, but should stay in sync for consistency's sake)
 
-    A generaly note on how to update the version values:
+    A general note on how to update the version values:
     There are three locations to update:
     pipelines/config/settings.yml (MRTKVersion)
     ProjectSettings/ProjectSettings.asset (bundleVersion, metroPackageVersion)
@@ -35,7 +35,7 @@
     They should have the same value (except metroPackageVersion which will contain
     one more trailing .0 value)
 .EXAMPLE
-    .\versiondata.ps1 -Directory c:\path\to\mrtkroot -Version 2.5.0
+    .\versionmetadata.ps1 -Directory c:\path\to\mrtkroot -Version 2.5.0
 #>
 param(
     # The root directory of the MRTK (i.e. the folder that contains the Assets/
@@ -66,6 +66,7 @@ function AddVersionTxt {
             "Assets/MRTK/Providers",
             "Assets/MRTK/SDK",
             "Assets/MRTK/Services",
+            "Assets/MRTK/StandardAssets",
             "Assets/MRTK/Tests",
             "Assets/MRTK/Tools"
         )
@@ -126,8 +127,8 @@ function AddAssemblyInfo {
             # ends up looking reasonable.
             $copyright = 
 @"
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 "@
 
             $content =
@@ -140,7 +141,7 @@ function AddAssemblyInfo {
 "@
 
             # If the AssemblyInfo already exists, then we should check that it doesn't already contain
-            # a version - this would be bad as we'd duply-define the version
+            # a version - this would be bad as we'd doubly-define the version
             if (Test-Path -Path $filename) {
                 if (Get-Content $filename | Select-String "AssemblyVersion") {
                     $containsIssue = $true

--- a/scripts/packaging/versionmetadata.ps1
+++ b/scripts/packaging/versionmetadata.ps1
@@ -83,38 +83,6 @@ function AddVersionTxt {
 .SYNOPSIS
     Adds AssemblyInfo.cs files to all locations within the Assets/ folder that
     have an .asmdef file.
-#>
-function AddVersionTxt {
-    [CmdletBinding()]
-    param(
-        [string]$Directory,
-        [string]$Version
-    )
-    process {
-        $locations = @(
-            "Assets/MRTK/Core",
-            "Assets/MRTK/Examples",
-            "Assets/MRTK/Extensions",
-            "Assets/MRTK/Providers",
-            "Assets/MRTK/SDK",
-            "Assets/MRTK/Services",
-            "Assets/MRTK/Tests",
-            "Assets/MRTK/Tools"
-        )
-
-        $content = "Microsoft Mixed Reality Toolkit $Version"
-        foreach ($location in $locations) {
-            $filename = Join-Path -Path $location -ChildPath "Version.txt"
-            Set-Content -Path $filename -Value $content
-            Write-Host "Added Version.txt at $filename"
-        }
-    }
-}
-
-<#
-.SYNOPSIS
-    Adds AssemblyInfo.cs files to all locations within the Assets/ folder that
-    have an .asmdef file.
 
     If AssemblyInfo.cs already exists, this will instead just add the version
     information to the file.


### PR DESCRIPTION
## Overview

* Adds StandardAssets to the version script, as it was missing
* Adds a License.txt file to the StandardAssets to match the other top level MRTK folder
* Updates the versioning template to use the global MRTK version by default