### PR TITLE
Update mergetool to monitor merges from stabilization to dev

### DIFF
--- a/pipelines/mergetool.yml
+++ b/pipelines/mergetool.yml
@@ -13,10 +13,10 @@ trigger: none
 parameters:
 - name: sourceBranch
   type: string
-  default: mrtk_development
+  default: prerelease/2.6.0_stabilization
 - name: destinationBranch
   type: string
-  default: feature/interactive_element
+  default: mrtk_development
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
## Overview

Now that the interactive element feature branch has been merged in, we no longer need to update it from dev. Luckily, we newly have a need to keep the dev branch in-sync with the stabilization branch! This PR updates the pipeline to monitor that instead.