### PR TITLE
Move NuGet steps out of general CI

### DIFF
--- a/pipelines/ci-packaging-dontpublish.yml
+++ b/pipelines/ci-packaging-dontpublish.yml
@@ -21,6 +21,4 @@ jobs:
   steps:
   - template: templates/ci-common.yml
     parameters:
-      packagingEnabled: true
-      packagePublishing: false
       UnityVersion: $(Unity2018Version)

--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -23,6 +23,10 @@ jobs:
   steps:
   - template: templates/ci-common.yml
     parameters:
-      packagingEnabled: true
-      packagePublishing: true
       UnityVersion: $(Unity2018VersionInternal)
+
+  - template: compilemsbuild.yml
+    parameters:
+      UnityVersion: $(Unity2018VersionInternal)
+  - template: tasks/pack-nuget.yml
+  - template: tasks/publish-nuget.yml

--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -15,6 +15,10 @@ jobs:
   steps:
   - template: templates/ci-common.yml
     parameters:
-      packagingEnabled: true
-      packagePublishing: true
       UnityVersion: $(Unity2018Version)
+
+  - template: compilemsbuild.yml
+    parameters:
+      UnityVersion: $(Unity2018Version)
+  - template: tasks/pack-nuget.yml
+  - template: tasks/publish-nuget.yml

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -2,7 +2,6 @@
 
 parameters:
   packagingEnabled: true
-  packagePublishing: true
   UnityVersion: ""
 
 steps:
@@ -11,14 +10,8 @@ steps:
     buildUWPDotNet: false
     UnityVersion: ${{ parameters.UnityVersion }}
 - template: tasks/versionmetadata.yml
-- template: compilemsbuild.yml
-  parameters:
-    UnityVersion: ${{ parameters.UnityVersion }}
 - ${{ if eq(parameters.packagingEnabled, true) }}:
   - template: tasks/pack-unitypackages.yml
     parameters:
       UnityVersion: ${{ parameters.UnityVersion }}
-  - template: tasks/pack-nuget.yml
-  - ${{ if eq(parameters.packagePublishing, true) }}:
-    - template: tasks/publish-nuget.yml
 - template: end.yml


### PR DESCRIPTION
## Overview

Move NuGet steps out of general CI, since we've deprecated this distribution method. We no longer need to spend this time spinning on the public VMs (which also run PR validation).