### PR TITLE
Add Microsoft.MixedReality.Toolkit.PlaneFinding to exclusion list

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -26,6 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             "Windows.UI.Input.Spatial",
             "LeapMotion",
             "LeapMotion.LeapCSharp",
+            "Microsoft.MixedReality.Toolkit.PlaneFinding",
 #if UNITY_2019_3_OR_NEWER
             "Oculus.VR",
             "Oculus.VR.Editor",


### PR DESCRIPTION
## Overview

This optional dependency was added in #9225, so we need to tell the project generator to ignore it. 

## Changes
- Fixes: https://microsoft.visualstudio.com/Analog/_build/results?buildId=31350849&view=logs&j=00a17365-9fc3-5f6d-b77f-ab9491956439&t=0ca905f7-f9e2-5349-86e3-35e9a0856f8c