### PR TITLE
Typo fixes in tooltips

### DIFF
--- a/Assets/MRTK/Examples/Demos/UX/Dialog/Scripts/DialogExampleController.cs
+++ b/Assets/MRTK/Examples/Demos/UX/Dialog/Scripts/DialogExampleController.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenConfirmationDialogLarge()
         {
-            Dialog.Open(DialogPrefabLarge, DialogButtonType.OK, "Confirmation Dialog, Large, Far", "This is an example of a large dialog with only one button, placed at near interaction range", false);
+            Dialog.Open(DialogPrefabLarge, DialogButtonType.OK, "Confirmation Dialog, Large, Far", "This is an example of a large dialog with only one button, placed at far interaction range", false);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenChoiceDialogLarge()
         {
-            Dialog myDialog = Dialog.Open(DialogPrefabLarge, DialogButtonType.Yes | DialogButtonType.No, "Choice Dialog, Large, Near", "This is an example of a large dialog with a choice message for the user, placed at far interaction range", true);
+            Dialog myDialog = Dialog.Open(DialogPrefabLarge, DialogButtonType.Yes | DialogButtonType.No, "Choice Dialog, Large, Near", "This is an example of a large dialog with a choice message for the user, placed at near interaction range", true);
             if (myDialog != null)
             {
                 myDialog.OnClosed += OnClosedDialogEvent;
@@ -96,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenConfirmationDialogSmall()
         {
-            Dialog.Open(DialogPrefabSmall, DialogButtonType.OK, "Confirmation Dialog, Small, Far", "This is an example of a small dialog with only one button, placed at near interaction range", false);
+            Dialog.Open(DialogPrefabSmall, DialogButtonType.OK, "Confirmation Dialog, Small, Far", "This is an example of a small dialog with only one button, placed at far interaction range", false);
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenChoiceDialogSmall()
         {
-            Dialog myDialog = Dialog.Open(DialogPrefabSmall, DialogButtonType.Yes | DialogButtonType.No, "Choice Dialog, Small, Near", "This is an example of a small dialog with a choice message for the user, placed at far interaction range", true);
+            Dialog myDialog = Dialog.Open(DialogPrefabSmall, DialogButtonType.Yes | DialogButtonType.No, "Choice Dialog, Small, Near", "This is an example of a small dialog with a choice message for the user, placed at near interaction range", true);
             if (myDialog != null)
             {
                 myDialog.OnClosed += OnClosedDialogEvent;


### PR DESCRIPTION
## Overview
4 Tooltips had typos about the placement for near/far interaction.

## Changes
- Fixes: Adjusted tooltips to correspond to values of variables used in code.


## Verification
No functional changes are made, but the near / far adjustment can be verified by checking the value of `bool placeForNearInteraction` in the parameters of `Dialog.Open(..., bool placeForNearInteraction)`, where false corresponds to far, and true to near. The title tooltips already correctly reflect this as well, so this is a very minor change.
