### PR TITLE
Update to be compatible with multiple OpenXR package versions

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
@@ -28,6 +28,11 @@
             "define": "MSFT_OPENXR"
         },
         {
+            "name": "com.microsoft.mixedreality.openxr",
+            "expression": "[0.1.0,0.1.3)",
+            "define": "MSFT_OPENXR_PRE_013"
+        },
+        {
             "name": "com.unity.xr.openxr",
             "expression": "",
             "define": "UNITY_OPENXR"

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -11,7 +11,8 @@ using UnityEngine;
 using UnityEngine.XR;
 
 #if MSFT_OPENXR
-using Microsoft.MixedReality.OpenXR.Preview;
+using Microsoft.MixedReality.OpenXR;
+using Preview = Microsoft.MixedReality.OpenXR.Preview;
 #endif // MSFT_OPENXR
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
@@ -33,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             : base(trackingState, controllerHandedness, inputSource, interactions, new ArticulatedHandDefinition(inputSource, controllerHandedness))
         {
 #if MSFT_OPENXR
-            handTracker = new HandTracker(controllerHandedness == Utilities.Handedness.Left ? MixedReality.OpenXR.Preview.Handedness.Left : MixedReality.OpenXR.Preview.Handedness.Right, HandPoseType.Tracked);
+            handTracker = new Preview.HandTracker(controllerHandedness == Utilities.Handedness.Left ? Preview.Handedness.Left : Preview.Handedness.Right, Preview.HandPoseType.Tracked);
 #endif // MSFT_OPENXR
         }
 
@@ -42,17 +43,17 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
         protected readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
 
-        private static readonly HandFinger[] handFingers = Enum.GetValues(typeof(HandFinger)) as HandFinger[];
-        private readonly List<Bone> fingerBones = new List<Bone>();
-
         private Vector3 currentPointerPosition = Vector3.zero;
         private Quaternion currentPointerRotation = Quaternion.identity;
         private MixedRealityPose currentPointerPose = MixedRealityPose.ZeroIdentity;
 
 #if MSFT_OPENXR
-        private static readonly HandJoint[] HandJoints = Enum.GetValues(typeof(HandJoint)) as HandJoint[];
-        private readonly HandTracker handTracker = null;
-        private readonly HandJointLocation[] locations = new HandJointLocation[HandTracker.JointCount];
+        private static readonly Preview.HandJoint[] HandJoints = Enum.GetValues(typeof(Preview.HandJoint)) as Preview.HandJoint[];
+        private readonly Preview.HandTracker handTracker = null;
+        private readonly Preview.HandJointLocation[] locations = new Preview.HandJointLocation[Preview.HandTracker.JointCount];
+#else
+        private static readonly HandFinger[] handFingers = Enum.GetValues(typeof(HandFinger)) as HandFinger[];
+        private readonly List<Bone> fingerBones = new List<Bone>();
 #endif // MSFT_OPENXR
 
         #region IMixedRealityHand Implementation
@@ -196,12 +197,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                         HandDefinition?.UpdateCurrentIndexPose(interactionMapping);
                         break;
                     case DeviceInputType.SpatialPointer:
-                        if (inputDevice.TryGetFeatureValue(Input.CustomUsages.PointerPosition, out currentPointerPosition))
+                        if (inputDevice.TryGetFeatureValue(CustomUsages.PointerPosition, out currentPointerPosition))
                         {
                             currentPointerPose.Position = MixedRealityPlayspace.TransformPoint(currentPointerPosition);
                         }
 
-                        if (inputDevice.TryGetFeatureValue(Input.CustomUsages.PointerRotation, out currentPointerRotation))
+                        if (inputDevice.TryGetFeatureValue(CustomUsages.PointerRotation, out currentPointerRotation))
                         {
                             currentPointerPose.Rotation = MixedRealityPlayspace.Rotation * currentPointerRotation;
                         }
@@ -233,11 +234,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             using (UpdateHandDataPerfMarker.Auto())
             {
 #if MSFT_OPENXR
+#if MSFT_OPENXR_PRE_013
+                if (handTracker != null && handTracker.TryLocateHandJoints(Preview.FrameTime.OnUpdate, locations))
+#else
                 if (handTracker != null && handTracker.TryLocateHandJoints(FrameTime.OnUpdate, locations))
+#endif // MSFT_OPENXR_PRE_013
                 {
-                    foreach (HandJoint handJoint in HandJoints)
+                    foreach (Preview.HandJoint handJoint in HandJoints)
                     {
-                        HandJointLocation handJointLocation = locations[(int)handJoint];
+                        Preview.HandJointLocation handJointLocation = locations[(int)handJoint];
 
                         // We want input sources to follow the playspace, so fold in the playspace transform here to
                         // put the pose into world space.
@@ -272,41 +277,41 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         }
 
 #if MSFT_OPENXR
-        private TrackedHandJoint ConvertToTrackedHandJoint(HandJoint handJoint)
+        private TrackedHandJoint ConvertToTrackedHandJoint(Preview.HandJoint handJoint)
         {
             switch (handJoint)
             {
-                case HandJoint.Palm: return TrackedHandJoint.Palm;
-                case HandJoint.Wrist: return TrackedHandJoint.Wrist;
+                case Preview.HandJoint.Palm: return TrackedHandJoint.Palm;
+                case Preview.HandJoint.Wrist: return TrackedHandJoint.Wrist;
 
-                case HandJoint.ThumbMetacarpal: return TrackedHandJoint.ThumbMetacarpalJoint;
-                case HandJoint.ThumbProximal: return TrackedHandJoint.ThumbProximalJoint;
-                case HandJoint.ThumbDistal: return TrackedHandJoint.ThumbDistalJoint;
-                case HandJoint.ThumbTip: return TrackedHandJoint.ThumbTip;
+                case Preview.HandJoint.ThumbMetacarpal: return TrackedHandJoint.ThumbMetacarpalJoint;
+                case Preview.HandJoint.ThumbProximal: return TrackedHandJoint.ThumbProximalJoint;
+                case Preview.HandJoint.ThumbDistal: return TrackedHandJoint.ThumbDistalJoint;
+                case Preview.HandJoint.ThumbTip: return TrackedHandJoint.ThumbTip;
 
-                case HandJoint.IndexMetacarpal: return TrackedHandJoint.IndexMetacarpal;
-                case HandJoint.IndexProximal: return TrackedHandJoint.IndexKnuckle;
-                case HandJoint.IndexIntermediate: return TrackedHandJoint.IndexMiddleJoint;
-                case HandJoint.IndexDistal: return TrackedHandJoint.IndexDistalJoint;
-                case HandJoint.IndexTip: return TrackedHandJoint.IndexTip;
+                case Preview.HandJoint.IndexMetacarpal: return TrackedHandJoint.IndexMetacarpal;
+                case Preview.HandJoint.IndexProximal: return TrackedHandJoint.IndexKnuckle;
+                case Preview.HandJoint.IndexIntermediate: return TrackedHandJoint.IndexMiddleJoint;
+                case Preview.HandJoint.IndexDistal: return TrackedHandJoint.IndexDistalJoint;
+                case Preview.HandJoint.IndexTip: return TrackedHandJoint.IndexTip;
 
-                case HandJoint.MiddleMetacarpal: return TrackedHandJoint.MiddleMetacarpal;
-                case HandJoint.MiddleProximal: return TrackedHandJoint.MiddleKnuckle;
-                case HandJoint.MiddleIntermediate: return TrackedHandJoint.MiddleMiddleJoint;
-                case HandJoint.MiddleDistal: return TrackedHandJoint.MiddleDistalJoint;
-                case HandJoint.MiddleTip: return TrackedHandJoint.MiddleTip;
+                case Preview.HandJoint.MiddleMetacarpal: return TrackedHandJoint.MiddleMetacarpal;
+                case Preview.HandJoint.MiddleProximal: return TrackedHandJoint.MiddleKnuckle;
+                case Preview.HandJoint.MiddleIntermediate: return TrackedHandJoint.MiddleMiddleJoint;
+                case Preview.HandJoint.MiddleDistal: return TrackedHandJoint.MiddleDistalJoint;
+                case Preview.HandJoint.MiddleTip: return TrackedHandJoint.MiddleTip;
 
-                case HandJoint.RingMetacarpal: return TrackedHandJoint.RingMetacarpal;
-                case HandJoint.RingProximal: return TrackedHandJoint.RingKnuckle;
-                case HandJoint.RingIntermediate: return TrackedHandJoint.RingMiddleJoint;
-                case HandJoint.RingDistal: return TrackedHandJoint.RingDistalJoint;
-                case HandJoint.RingTip: return TrackedHandJoint.RingTip;
+                case Preview.HandJoint.RingMetacarpal: return TrackedHandJoint.RingMetacarpal;
+                case Preview.HandJoint.RingProximal: return TrackedHandJoint.RingKnuckle;
+                case Preview.HandJoint.RingIntermediate: return TrackedHandJoint.RingMiddleJoint;
+                case Preview.HandJoint.RingDistal: return TrackedHandJoint.RingDistalJoint;
+                case Preview.HandJoint.RingTip: return TrackedHandJoint.RingTip;
 
-                case HandJoint.LittleMetacarpal: return TrackedHandJoint.PinkyMetacarpal;
-                case HandJoint.LittleProximal: return TrackedHandJoint.PinkyKnuckle;
-                case HandJoint.LittleIntermediate: return TrackedHandJoint.PinkyMiddleJoint;
-                case HandJoint.LittleDistal: return TrackedHandJoint.PinkyDistalJoint;
-                case HandJoint.LittleTip: return TrackedHandJoint.PinkyTip;
+                case Preview.HandJoint.LittleMetacarpal: return TrackedHandJoint.PinkyMetacarpal;
+                case Preview.HandJoint.LittleProximal: return TrackedHandJoint.PinkyKnuckle;
+                case Preview.HandJoint.LittleIntermediate: return TrackedHandJoint.PinkyMiddleJoint;
+                case Preview.HandJoint.LittleDistal: return TrackedHandJoint.PinkyDistalJoint;
+                case Preview.HandJoint.LittleTip: return TrackedHandJoint.PinkyTip;
 
                 default: return TrackedHandJoint.None;
             }


### PR DESCRIPTION
## Overview

`FrameTime` was graduated from the Preview namespace, so this change brings us into compliance with the obsolete warning.

## Changes

- Fixes: #9289 
