### PR TITLE
Actually cache handJointService in SolverHandler

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -255,7 +255,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         private float lastUpdateTime;
 
         private IMixedRealityHandJointService HandJointService
-            => handJointService ?? CoreServices.GetInputSystemDataProvider<IMixedRealityHandJointService>();
+            => handJointService ?? (handJointService = CoreServices.GetInputSystemDataProvider<IMixedRealityHandJointService>());
 
         private IMixedRealityHandJointService handJointService = null;
 


### PR DESCRIPTION
## Overview

There was a backing field, but it was never actually set. This now prevents the property from calling `CoreServices.GetInputSystemDataProvider` every time.