### PR TITLE
Fix XR SDK with HP motion controller

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/HPMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/HPMotionController.cs
@@ -7,9 +7,7 @@ using Unity.Profiling;
 using UnityEngine.XR;
 
 #if HP_CONTROLLER_ENABLED
-using Microsoft.MixedReality.Input;
-using MotionControllerHandedness = Microsoft.MixedReality.Input.Handedness;
-using Handedness = Microsoft.MixedReality.Toolkit.Utilities.Handedness;
+using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality


### PR DESCRIPTION
## Overview

When testing 2.6 stabilization, I realized I accidentally removed a namespace in https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9106. 