### PR TITLE
enable handphysics asm on any platform

### DIFF
--- a/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsService.cs
+++ b/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
     /// A simple service that creates KinematicRigidbodies on fingertips for physics interactions.
     /// </summary>
     [MixedRealityExtensionService(
-        SupportedPlatforms.WindowsUniversal,
+        (SupportedPlatforms)(-1),
         "Hand Physics Service",
         "HandPhysicsService/Profiles/DefaultHandPhysicsServiceProfile.asset",
         "MixedRealityToolkit.Extensions",

--- a/Assets/MRTK/Extensions/HandPhysicsService/MRTK.HandPhysics.asmdef
+++ b/Assets/MRTK/Extensions/HandPhysicsService/MRTK.HandPhysics.asmdef
@@ -4,17 +4,12 @@
         "Microsoft.MixedReality.Toolkit",
         "Unity.TextMeshPro"
     ],
-    "includePlatforms": [
-        "Android",
-        "Editor",
-        "WSA"
-    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }

--- a/Assets/MRTK/Extensions/HandPhysicsService/Profiles/HandPhysicsMixedRealityRegisteredServiceProvidersProfile.asset
+++ b/Assets/MRTK/Extensions/HandPhysicsService/Profiles/HandPhysicsMixedRealityRegisteredServiceProvidersProfile.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
         Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
     componentName: HandPhysicsService
     priority: 10
-    runtimePlatform: 1272
+    runtimePlatform: -1
     configurationProfile: {fileID: 11400000, guid: 236baf35803f73342b69c842fe4afb1c,
       type: 2}


### PR DESCRIPTION
This change addresses #9322 by enabling the hand physics extension assembly to load on any target platform.  when originally written, the only mrtk supported platform with hand support was HoloLens 2. Since then, Leap Motion and Quest have been added. 
