### PR TITLE
Update XR SDK loader checking in data providers

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -6,13 +6,16 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.XRSDK.Input;
 using System;
 using System.Linq;
-using System.Collections.Generic;
-#if OCULUSINTEGRATION_PRESENT
-using Unity.XR.Oculus;
-#endif
-using UnityEngine;
 using UnityEngine.XR;
+
+#if OCULUSINTEGRATION_PRESENT
+using System.Collections.Generic;
+#if OCULUS_ENABLED
+using Unity.XR.Oculus;
+#endif // OCULUS_ENABLED
+using UnityEngine;
 using UnityEngine.XR.Management;
+#endif // OCULUSINTEGRATION_PRESENT
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
 {
@@ -55,13 +58,10 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         private OVRCameraRig cameraRig;
 
         private OVRHand rightHand;
-        private OVRMeshRenderer rightMeshRenderer;
         private OVRSkeleton rightSkeleton;
 
         private OVRHand leftHand;
-        private OVRMeshRenderer leftMeshRenderer;
         private OVRSkeleton leftSkeleton;
-
 
         /// <summary>
         /// The profile that contains settings for the Oculus XRSDK Device Manager input data provider.  This profile is nested under 
@@ -144,8 +144,8 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         public override void Enable()
         {
             base.Enable();
-            
             if (!XRGeneralSettings.Instance.Manager.loaders.Any(l => l is OculusLoader loader && loader.displaySubsystem != null))
+
             {
                 return;
             }
@@ -159,6 +159,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         public override void Update()
         {
             base.Update();
+
             if (OVRPlugin.GetHandTrackingEnabled())
             {
                 UpdateHands();
@@ -203,7 +204,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
             }
 
             bool useAvatarHands = SettingsProfile.RenderAvatarHandsInsteadOfController;
-            // If using Avatar hands, de-activate ovr controller rendering
+            // If using Avatar hands, deactivate ovr controller rendering
             foreach (var controllerHelper in cameraRig.gameObject.GetComponentsInChildren<OVRControllerHelper>())
             {
                 controllerHelper.gameObject.SetActive(!useAvatarHands);
@@ -280,8 +281,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
             var pointers = RequestPointers(SupportedControllerType.ArticulatedHand, handedness);
             var inputSourceType = InputSourceType.Hand;
 
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-            var inputSource = inputSystem?.RequestNewGenericInputSource($"Oculus Quest {handedness} Hand", pointers, inputSourceType);
+            var inputSource = Service?.RequestNewGenericInputSource($"Oculus Quest {handedness} Hand", pointers, inputSourceType);
 
 
             OculusHand handDevice = new OculusHand(TrackingState.Tracked, handedness, inputSource);
@@ -292,7 +292,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
                 handDevice.InputSource.Pointers[i].Controller = handDevice;
             }
 
-            inputSystem?.RaiseSourceDetected(handDevice.InputSource, handDevice);
+            Service?.RaiseSourceDetected(handDevice.InputSource, handDevice);
 
             trackedHands.Add(handedness, handDevice);
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -5,7 +5,6 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.XRSDK.Input;
 using System;
-using System.Linq;
 using UnityEngine.XR;
 
 #if OCULUSINTEGRATION_PRESENT
@@ -14,7 +13,6 @@ using System.Collections.Generic;
 using Unity.XR.Oculus;
 #endif // OCULUS_ENABLED
 using UnityEngine;
-using UnityEngine.XR.Management;
 #endif // OCULUSINTEGRATION_PRESENT
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
@@ -140,15 +138,31 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         #endregion Controller Utilities
 
 #if OCULUSINTEGRATION_PRESENT
+        private bool? isActiveLoader = null;
+        private bool IsActiveLoader
+        {
+            get
+            {
+#if OCULUS_ENABLED
+                if (!isActiveLoader.HasValue)
+                {
+                    isActiveLoader = IsLoaderActive<OculusLoader>();
+                }
+#endif // OCULUS_ENABLED
+
+                return isActiveLoader ?? false;
+            }
+        }
+
         /// <inheritdoc/>
         public override void Enable()
         {
-            base.Enable();
-            if (!XRGeneralSettings.Instance.Manager.loaders.Any(l => l is OculusLoader loader && loader.displaySubsystem != null))
-
+            if (!IsActiveLoader)
             {
                 return;
             }
+
+            base.Enable();
 
             SetupInput();
             ConfigurePerformancePreferences();
@@ -158,6 +172,11 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         /// <inheritdoc/>
         public override void Update()
         {
+            if (!IsEnabled)
+            {
+                return;
+            }
+
             base.Update();
 
             if (OVRPlugin.GetHandTrackingEnabled())

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -7,11 +7,12 @@ using Microsoft.MixedReality.Toolkit.XRSDK.Input;
 using System;
 using UnityEngine.XR;
 
-#if OCULUSINTEGRATION_PRESENT
-using System.Collections.Generic;
 #if OCULUS_ENABLED
 using Unity.XR.Oculus;
 #endif // OCULUS_ENABLED
+
+#if OCULUSINTEGRATION_PRESENT
+using System.Collections.Generic;
 using UnityEngine;
 #endif // OCULUSINTEGRATION_PRESENT
 
@@ -137,7 +138,6 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
 
         #endregion Controller Utilities
 
-#if OCULUSINTEGRATION_PRESENT
         private bool? isActiveLoader = null;
         private bool IsActiveLoader
         {
@@ -159,16 +159,19 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         {
             if (!IsActiveLoader)
             {
+                IsEnabled = false;
                 return;
             }
 
             base.Enable();
 
+#if OCULUSINTEGRATION_PRESENT
             SetupInput();
             ConfigurePerformancePreferences();
+#endif // OCULUSINTEGRATION_PRESENT
         }
 
-
+#if OCULUSINTEGRATION_PRESENT
         /// <inheritdoc/>
         public override void Update()
         {
@@ -349,6 +352,6 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         }
 
         #endregion
-#endif
+#endif // OCULUSINTEGRATION_PRESENT
     }
 }

--- a/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
@@ -5,6 +5,7 @@
         "Microsoft.MixedReality.OpenXR",
         "Microsoft.MixedReality.Toolkit",
         "Microsoft.MixedReality.Toolkit.Providers.XRSDK",
+        "Unity.XR.Management",
         "Unity.XR.OpenXR"
     ],
     "includePlatforms": [

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -8,6 +8,10 @@ using System;
 using Unity.Profiling;
 using UnityEngine.XR;
 
+#if UNITY_OPENXR
+using UnityEngine.XR.OpenXR;
+#endif // UNITY_OPENXR
+
 namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 {
     [MixedRealityDataProvider(
@@ -28,6 +32,34 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             string name = null,
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(inputSystem, name, priority, profile) { }
+
+        private bool? isActiveLoader = null;
+        private bool IsActiveLoader
+        {
+            get
+            {
+#if UNITY_OPENXR
+                if (!isActiveLoader.HasValue)
+                {
+                    isActiveLoader = IsLoaderActive<OpenXRLoader>();
+                }
+#endif // UNITY_OPENXR
+
+                return isActiveLoader ?? false;
+            }
+        }
+
+        /// <inheritdoc />
+        public override void Enable()
+        {
+            if (!IsActiveLoader)
+            {
+                IsEnabled = false;
+                return;
+            }
+
+            base.Enable();
+        }
 
         #region Controller Utilities
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/MRTK.WMR.XRSDK.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/MRTK.WMR.XRSDK.asmdef
@@ -4,8 +4,7 @@
         "Microsoft.MixedReality.Toolkit",
         "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared",
         "Microsoft.MixedReality.Toolkit.Providers.XRSDK",
-        "Unity.XR.WindowsMixedReality",
-        "Unity.XR.Management"
+        "Unity.XR.WindowsMixedReality"
     ],
     "includePlatforms": [
         "Editor",

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -4,23 +4,16 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Windows.Utilities;
+using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 using Microsoft.MixedReality.Toolkit.XRSDK.Input;
 using System;
-using System.Linq;
-using System.Collections.Generic;
-using UnityEngine;
 using UnityEngine.XR;
-using UnityEngine.XR.Management;
-#if WMR_ENABLED
-using UnityEngine.XR.WindowsMR;
-#endif
-using Unity.Profiling;
-using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 
 #if HP_CONTROLLER_ENABLED
 using Microsoft.MixedReality.Input;
 using MotionControllerHandedness = Microsoft.MixedReality.Input.Handedness;
-using Handedness = Microsoft.MixedReality.Toolkit.Utilities.Handedness;
+using System.Collections.Generic;
+using Unity.Profiling;
 #endif
 
 #if WINDOWS_UWP
@@ -72,7 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             {
                 return;
             }
-#endif
+#endif // WMR_ENABLED
 
             if (WindowsMixedRealityUtilities.UtilitiesProvider == null)
             {
@@ -87,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             motionControllerWatcher.MotionControllerAdded += AddTrackedMotionController;
             motionControllerWatcher.MotionControllerRemoved += RemoveTrackedMotionController;
             var nowait = motionControllerWatcher.StartAsync();
-#endif
+#endif // HP_CONTROLLER_ENABLED
         }
 
         /// <inheritdoc />
@@ -161,7 +154,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         private readonly Dictionary<uint, MotionControllerState> trackedMotionControllerStates = new Dictionary<uint, MotionControllerState>();
 
         private readonly Dictionary<uint, GenericXRSDKController> activeMotionControllers = new Dictionary<uint, GenericXRSDKController>();
-#endif
+#endif // HP_CONTROLLER_ENABLED
 
         #endregion IMixedRealityCapabilityCheck Implementation
 
@@ -177,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             {
                 return null;
             }
-#endif
+#endif // WMR_ENABLED
 
             using (GetOrAddControllerPerfMarker.Auto())
             {
@@ -228,29 +221,25 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 }
             }
         }
-#endif
 
-#if HP_CONTROLLER_ENABLED
-        // Creates a unique key for the controller based on it's vendor ID, product ID, version number, and handedness
+        // Creates a unique key for the controller based on its vendor ID, product ID, version number, and handedness
         private uint GetControllerId(uint handedness)
         {
             return handedness;
         }
 
-#if HP_CONTROLLER_ENABLED
         private uint GetControllerId(MotionController mc)
         {
-            var handedness = ((uint)(mc.Handedness == MotionControllerHandedness.Right ? 2 : (mc.Handedness == MotionControllerHandedness.Left ? 1 : 0)));
+            var handedness = (uint)(mc.Handedness == MotionControllerHandedness.Right ? 2 : (mc.Handedness == MotionControllerHandedness.Left ? 1 : 0));
             return GetControllerId(handedness);
         }
-#endif
 
         private uint GetControllerId(InputDevice inputDevice)
         {
-            var handedness = ((uint)(inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Right) ? 2 : inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Left) ? 1 : 0));
+            var handedness = (uint)(inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Right) ? 2 : (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Left) ? 1 : 0));
             return GetControllerId(handedness);
         }
-#endif
+#endif // HP_CONTROLLER_ENABLED
 
         /// <inheritdoc />
         protected override Type GetControllerType(SupportedControllerType supportedControllerType)
@@ -260,7 +249,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             {
                 return null;
             }
-#endif
+#endif // WMR_ENABLED
+
             switch (supportedControllerType)
             {
                 case SupportedControllerType.WindowsMixedReality:

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -55,10 +55,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         {
             get
             {
+#if WMR_ENABLED
                 if (!isActiveLoader.HasValue)
                 {
                     isActiveLoader = IsLoaderActive("Windows MR Loader");
                 }
+#endif // WMR_ENABLED
 
                 return isActiveLoader ?? false;
             }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -50,7 +50,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(inputSystem, name, priority, profile) { }
 
-#if WMR_ENABLED
         private bool? isActiveLoader = null;
         private bool IsActiveLoader
         {
@@ -58,28 +57,23 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             {
                 if (!isActiveLoader.HasValue)
                 {
-                    isActiveLoader = IsLoaderActive("WindowsMRLoader");
+                    isActiveLoader = IsLoaderActive("Windows MR Loader");
                 }
 
                 return isActiveLoader ?? false;
             }
         }
-#endif // WMR_ENABLED
 
         #region IMixedRealityDeviceManager Interface
-
-#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
-        private IMixedRealityGazeProviderHeadOverride mixedRealityGazeProviderHeadOverride = null;
 
         /// <inheritdoc />
         public override void Enable()
         {
-#if WMR_ENABLED
             if (!IsActiveLoader)
             {
+                IsEnabled = false;
                 return;
             }
-#endif // WMR_ENABLED
 
             base.Enable();
 
@@ -88,7 +82,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 WindowsMixedRealityUtilities.UtilitiesProvider = new XRSDKWindowsMixedRealityUtilitiesProvider();
             }
 
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
             mixedRealityGazeProviderHeadOverride = Service?.GazeProvider as IMixedRealityGazeProviderHeadOverride;
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
 #if HP_CONTROLLER_ENABLED
             // Listens to events to track the HP Motion Controller
@@ -98,6 +94,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             var nowait = motionControllerWatcher.StartAsync();
 #endif // HP_CONTROLLER_ENABLED
         }
+
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+        private IMixedRealityGazeProviderHeadOverride mixedRealityGazeProviderHeadOverride = null;
 
         /// <inheritdoc />
         public override void Update()
@@ -186,13 +185,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
         protected override GenericXRSDKController GetOrAddController(InputDevice inputDevice)
         {
-#if WMR_ENABLED
-            if (!IsActiveLoader)
-            {
-                return null;
-            }
-#endif // WMR_ENABLED
-
             using (GetOrAddControllerPerfMarker.Auto())
             {
                 GenericXRSDKController detectedController = base.GetOrAddController(inputDevice);
@@ -265,13 +257,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         protected override Type GetControllerType(SupportedControllerType supportedControllerType)
         {
-#if WMR_ENABLED
-            if (!IsActiveLoader)
-            {
-                return null;
-            }
-#endif // WMR_ENABLED
-
             switch (supportedControllerType)
             {
                 case SupportedControllerType.WindowsMixedReality:

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -165,6 +165,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             return false;
         }
 
+        #endregion IMixedRealityCapabilityCheck Implementation
+
+        #region Controller Utilities
+
 #if HP_CONTROLLER_ENABLED
         private MotionControllerWatcher motionControllerWatcher;
 
@@ -174,13 +178,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         private readonly Dictionary<uint, MotionControllerState> trackedMotionControllerStates = new Dictionary<uint, MotionControllerState>();
 
         private readonly Dictionary<uint, GenericXRSDKController> activeMotionControllers = new Dictionary<uint, GenericXRSDKController>();
-#endif // HP_CONTROLLER_ENABLED
 
-        #endregion IMixedRealityCapabilityCheck Implementation
-
-        #region Controller Utilities
-
-#if HP_CONTROLLER_ENABLED
         private static readonly ProfilerMarker GetOrAddControllerPerfMarker = new ProfilerMarker("[MRTK] WindwosMixedRealityXRSDKDeviceManager.GetOrAddController");
 
         protected override GenericXRSDKController GetOrAddController(InputDevice inputDevice)

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -50,6 +50,22 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(inputSystem, name, priority, profile) { }
 
+#if WMR_ENABLED
+        private bool? isActiveLoader = null;
+        private bool IsActiveLoader
+        {
+            get
+            {
+                if (!isActiveLoader.HasValue)
+                {
+                    isActiveLoader = IsLoaderActive("WindowsMRLoader");
+                }
+
+                return isActiveLoader ?? false;
+            }
+        }
+#endif // WMR_ENABLED
+
         #region IMixedRealityDeviceManager Interface
 
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
@@ -58,14 +74,14 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         public override void Enable()
         {
-            base.Enable();
-
 #if WMR_ENABLED
-            if (!XRGeneralSettings.Instance.Manager.loaders.Any(l => l is WindowsMRLoader loader && loader.displaySubsystem != null))
+            if (!IsActiveLoader)
             {
                 return;
             }
 #endif // WMR_ENABLED
+
+            base.Enable();
 
             if (WindowsMixedRealityUtilities.UtilitiesProvider == null)
             {
@@ -86,6 +102,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         public override void Update()
         {
+            if (!IsEnabled)
+            {
+                return;
+            }
+
             // Override gaze before base.Update() updates the controllers
             if (mixedRealityGazeProviderHeadOverride != null && mixedRealityGazeProviderHeadOverride.UseHeadGazeOverride && WindowsMixedRealityUtilities.SpatialCoordinateSystem != null)
             {
@@ -166,7 +187,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         protected override GenericXRSDKController GetOrAddController(InputDevice inputDevice)
         {
 #if WMR_ENABLED
-            if (!XRGeneralSettings.Instance.Manager.loaders.Any(l => l is WindowsMRLoader loader && loader.displaySubsystem != null))
+            if (!IsActiveLoader)
             {
                 return null;
             }
@@ -245,7 +266,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         protected override Type GetControllerType(SupportedControllerType supportedControllerType)
         {
 #if WMR_ENABLED
-            if (!XRGeneralSettings.Instance.Manager.loaders.Any(l => l is WindowsMRLoader loader && loader.displaySubsystem != null))
+            if (!IsActiveLoader)
             {
                 return null;
             }

--- a/Assets/MRTK/Providers/XRSDK/MRTK.XRSDK.asmdef
+++ b/Assets/MRTK/Providers/XRSDK/MRTK.XRSDK.asmdef
@@ -2,6 +2,7 @@
     "name": "Microsoft.MixedReality.Toolkit.Providers.XRSDK",
     "references": [
         "Microsoft.MixedReality.Toolkit",
+        "Unity.XR.Management",
         "UnityEngine.SpatialTracking"
     ],
     "includePlatforms": [],
@@ -18,6 +19,11 @@
             "name": "com.unity.xr.legacyinputhelpers",
             "expression": "",
             "define": "SPATIALTRACKING_ENABLED"
+        },
+        {
+            "name": "com.unity.xr.management",
+            "expression": "",
+            "define": "XR_MANAGEMENT_ENABLED"
         }
     ],
     "noEngineReferences": false

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -79,6 +79,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         {
             using (UpdatePerfMarker.Auto())
             {
+                if (!IsEnabled)
+                {
+                    return;
+                }
+
                 base.Update();
 
                 if (XRSubsystemHelpers.InputSubsystem == null || !XRSubsystemHelpers.InputSubsystem.running)

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -46,16 +46,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         private readonly List<InputDevice> inputDevicesSubset = new List<InputDevice>();
         private readonly List<InputDevice> lastInputDevices = new List<InputDevice>();
 
-        private List<InputDeviceCharacteristics> GenericDesiredInputCharacteristics = new List<InputDeviceCharacteristics>()
+        protected virtual List<InputDeviceCharacteristics> DesiredInputCharacteristics { get; set; } = new List<InputDeviceCharacteristics>()
         {
             InputDeviceCharacteristics.Controller,
             InputDeviceCharacteristics.HandTracking
         };
-        protected virtual List<InputDeviceCharacteristics> DesiredInputCharacteristics
-        {
-            get { return GenericDesiredInputCharacteristics; }
-            set { GenericDesiredInputCharacteristics = value; }
-        }
 
         private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] XRSDKDeviceManager.Update");
 
@@ -163,7 +158,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                 Type controllerType = GetControllerType(currentControllerType);
 
                 if (controllerType == null)
+                {
                     return null;
+                }
 
                 InputSourceType inputSourceType = GetInputSourceType(currentControllerType);
 

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -9,6 +9,10 @@ using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR;
 
+#if XR_MANAGEMENT_ENABLED
+using UnityEngine.XR.Management;
+#endif // XR_MANAGEMENT_ENABLED
+
 namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
 {
     /// <summary>
@@ -51,6 +55,22 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
             InputDeviceCharacteristics.Controller,
             InputDeviceCharacteristics.HandTracking
         };
+
+#if XR_MANAGEMENT_ENABLED
+        /// <summary>
+        /// Checks if the active loader has a specific name. Used in cases where the loader class is internal, like WindowsMRLoader.
+        /// </summary>
+        /// <param name="loaderName">The string name to compare against the active loader.</param>
+        /// <returns>True if the active loader has the same name as the parameter.</returns>
+        protected virtual bool IsLoaderActive(string loaderName) => XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
+
+        /// <summary>
+        /// Checks if the active loader is of a specific type. Used in cases where the loader class is accessible, like OculusLoader.
+        /// </summary>
+        /// <typeparam name="T">The loader class type to check against the active loader.</typeparam>
+        /// <returns>True if the active loader is of the specified type.</returns>
+        protected virtual bool IsLoaderActive<T>() where T : XRLoader => XRGeneralSettings.Instance.Manager.activeLoader is T;
+#endif // XR_MANAGEMENT_ENABLED
 
         private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] XRSDKDeviceManager.Update");
 


### PR DESCRIPTION
## Overview

Reworks some of the contributions from #9249 to support more cases and rely more on the new (in 2.6) service state tracking.
Now, we ensure `IsEnabled` is set to false if we aren't the provider for the active loader. Then from there, any `Update`s are blocked on that bool. This required a rework of the `#if`s in some of the code, to scope them down a bit and expose more non-platform-specific backing code, because we don't want the `IsEnabled` flag to accidentally be enabled just because the expected package isn't installed.

## Changes

- Fixes: Build issue with WMR XR SDK due to reference to internal WindowsMRLoader class
