### PR TITLE
Docs Migration redirect URLs

### DIFF
--- a/Documentation/GettingStartedWithMRTKAndXRSDK.md
+++ b/Documentation/GettingStartedWithMRTKAndXRSDK.md
@@ -1,5 +1,11 @@
 # Getting started with MRTK and XR SDK
 
+> [!CAUTION]
+># We've moved! 
+>See this page on the ***[new docs website](https:docs.microsoft.com/windows/mixed-reality/mrtk-unity/configuration/getting-started-with-mrtk-and-xrsdk)***.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
+
 XR SDK is Unity's [new XR pipeline in Unity 2019.3 and beyond](https://blogs.unity3d.com/2020/01/24/unity-xr-platform-updates/). In Unity 2019, it provides an alternative to the existing XR pipeline. In Unity 2020, it will become the only XR pipeline in Unity.
 
 ## Prerequisites

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -8,6 +8,8 @@ ms.localizationpriority: low
 keywords: Unity,HoloLens, HoloLens 2, Mixed Reality, development, MRTK,
 ---
 
-# We've moved! 
-
-Check out our new [docs landing page](WelcomeToMRTK.md) to get started with MRTK in Unity!
+> [!CAUTION]
+># We've moved! 
+>We have a ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/welcome-to-mrtk)*** for Mixed Reality Toolkit Documentation.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!

--- a/Documentation/Input/HandTracking.md
+++ b/Documentation/Input/HandTracking.md
@@ -1,5 +1,11 @@
 # Hand tracking
 
+> [!CAUTION]
+># We've moved! 
+>See this page on the ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/hand-tracking)***.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
+
 ## Hand tracking profile
 
 The _Hand Tracking profile_ is found under the _Input System profile_. It contains settings for customizing hand representation.

--- a/Documentation/Input/Pointers.md
+++ b/Documentation/Input/Pointers.md
@@ -1,4 +1,9 @@
 # Pointers
+> [!CAUTION]
+># We've moved! 
+>See this page on the ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/pointers)***.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
 
 ![Pointer](../../Documentation/Images/Pointers/MRTK_Pointer_Main.png)
 

--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -11,6 +11,12 @@ keywords: Unity,HoloLens, HoloLens 2, Mixed Reality, development, MRTK,
 # Installation guide
 
 > [!CAUTION]
+># We've moved! 
+>See this page on the ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/install-the-tools)***.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
+
+> [!IMPORTANT]
 > If you're new to MRTK or Mixed Reality development in Unity, we recommend you start at the beginning of our [Unity development journey](https://docs.microsoft.com/windows/mixed-reality/unity-development-overview?tabs=mrtk%2Chl2). The Unity development journey is the **recommended starting point for MRTK**, specifically created to walk you through the installation, core concepts, and usage of MRTK in Unity.
 
 ## Prerequisites

--- a/Documentation/README_Button.md
+++ b/Documentation/README_Button.md
@@ -1,5 +1,11 @@
 # Button
 
+> [!CAUTION]
+># We've moved! 
+>See this page on the ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/ux-building-blocks/button)***.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
+
 ![Button](../Documentation/Images/Button/MRTK_Button_Main.png)
 
 A button gives the user a way to trigger an immediate action. It is one of the most foundational components in mixed reality. MRTK provides various types of button prefabs.

--- a/Documentation/README_MRTKStandardShader.md
+++ b/Documentation/README_MRTKStandardShader.md
@@ -1,5 +1,11 @@
 # MRTK Standard Shader
 
+> [!CAUTION]
+># We've moved! 
+>See this page on the ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/rendering/mrtk-standard-shader)***.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
+
 ![Standard shader examples](../Documentation/Images/MRTKStandardShader/MRTK_StandardShader.jpg)
 
 MRTK Standard shading system utilizes a single, flexible shader that can achieve visuals similar to Unity's Standard Shader, implement [Fluent Design System](https://www.microsoft.com/design/fluent/) principles, and remain performant on mixed reality devices.

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -1,4 +1,9 @@
 # Solvers
+> [!CAUTION]
+># We've moved! 
+>See this page on the ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/ux-building-blocks/solvers/solver)***.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
 
 ![Solver](Images/Solver/MRTK_Solver_Main.png)
 

--- a/Documentation/WelcomeToMRTK.md
+++ b/Documentation/WelcomeToMRTK.md
@@ -10,6 +10,12 @@ keywords: Unity,HoloLens, HoloLens 2, Mixed Reality, development, MRTK,
 
 # Welcome to MRTK
 
+> [!CAUTION]
+># We've moved! 
+>We have a ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/welcome-to-mrtk)*** for Mixed Reality Toolkit Documentation.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
+
 ![MRTK Logo](../Documentation/Images/MRTK_Logo_Rev.png)
 
 The Mixed Reality Toolkit (MRTK) is a cross-platform toolkit for building Mixed Reality experiences for Virtual Reality (VR) and Augmented Reality (AR). 

--- a/Documentation/usingupm.md
+++ b/Documentation/usingupm.md
@@ -1,5 +1,11 @@
 # Mixed Reality Toolkit and Unity Package Manager
 
+> [!CAUTION]
+># We've moved! 
+>See this page on the ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/configuration/usingupm)***.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
+
 Starting with version 2.5.0, using the [Mixed Reality Feature Tool](https://aka.ms/MRFeatureToolDocs), the Microsoft Mixed Reality Toolkit integrates with the Unity Package Manager (UPM) when using Unity 2019.4 and newer.
 
 ## Using the Mixed Reality Feature Tool

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 ![Mixed Reality Toolkit](Documentation/Images/Logo_MRTK_Unity_Banner.png)
 
+> [!CAUTION]
+># We've moved! 
+>We have a ***[new docs website](https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/welcome-to-mrtk)*** for Mixed Reality Toolkit Documentation.
+>We've moved so we can provide you with a better docs experience. We will no longer be maintaing documentation on Github.
+>Check out the new site to get started with MRTK in Unity!
+
+
+
 # What is the Mixed Reality Toolkit
 
 MRTK-Unity is a Microsoft-driven project that provides a set of components and features, used to accelerate cross-platform MR app development in Unity. Here are some of its functions:


### PR DESCRIPTION
## Overview
Added redirect URLs for popular docs pages.
- General landing pages link to the new "Welcome to MRTK" page.
- Popular conceptual docs link to their corresponding URL.
- URLs won't work until new docs pages go live

## Changes
- Fixes: # .
![image](https://user-images.githubusercontent.com/30964480/108437089-7b0e4a80-7201-11eb-8612-c927a4b33b0f.png)

