### PR TITLE
[Stabilization 2.6.0] NearMenuExamples: 1m auto follow example toggle pin state is not updated when auto follow is triggered.

### DIFF
--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/NearMenuExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/NearMenuExamples.unity
@@ -1561,6 +1561,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
         type: 3}
+      propertyPath: autoFollowTriggered.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
       propertyPath: autoFollowAtDistance
       value: 1
       objectReference: {fileID: 0}
@@ -1587,6 +1592,31 @@ PrefabInstance:
     - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
         type: 3}
       propertyPath: AutoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: autoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: autoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: autoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 706985583}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: autoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: set_IsToggled
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: autoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 6598990276302686905, guid: d82e2f09994ad2f4fb43359bfb977f64,

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/NearMenuExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/NearMenuExamples.unity
@@ -1325,6 +1325,18 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
+--- !u!114 &706985583 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4669628316120752027, guid: d82e2f09994ad2f4fb43359bfb977f64,
+    type: 3}
+  m_PrefabInstance: {fileID: 733202134}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1410eac1ae94b4d4492a09cc368e152c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &733202134
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1544,8 +1556,38 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
         type: 3}
+      propertyPath: AutoFollowTriggered.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
       propertyPath: autoFollowAtDistance
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: AutoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: AutoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: AutoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 706985583}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: AutoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: set_IsToggled
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252562206259159235, guid: d82e2f09994ad2f4fb43359bfb977f64,
+        type: 3}
+      propertyPath: AutoFollowTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 6598990276302686905, guid: d82e2f09994ad2f4fb43359bfb977f64,
         type: 3}
@@ -2241,7 +2283,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.36580002, y: 0.1139}
+  m_AnchoredPosition: {x: 0.36580002, y: 0.1267}
   m_SizeDelta: {x: 20, y: 5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1233641387
@@ -2291,8 +2333,8 @@ MonoBehaviour:
   m_outlineColor:
     serializedVersion: 2
     rgba: 4278190080
-  m_fontSize: 10
-  m_fontSizeBase: 10
+  m_fontSize: 14
+  m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -2308,7 +2350,7 @@ MonoBehaviour:
   m_enableWordWrapping: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
-  m_firstOverflowCharacterIndex: -1
+  m_firstOverflowCharacterIndex: 35
   m_linkedTextComponent: {fileID: 0}
   m_isLinkedTextComponent: 0
   m_isTextTruncated: 0
@@ -2329,7 +2371,7 @@ MonoBehaviour:
   m_firstVisibleCharacter: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: -0.38412845, y: 0, z: 0.7812635, w: 2.0167203}
+  m_margin: {x: -0.38412845, y: 0, z: -4.01685, w: 2.0167203}
   m_textInfo:
     textComponent: {fileID: 1233641387}
     characterCount: 69
@@ -2910,6 +2952,8 @@ MonoBehaviour:
   moveLerpTime: 0.001
   rotateLerpTime: 0.001
   scaleLerpTime: 0.001
+  enableConstraints: 1
+  constraintsManager: {fileID: 0}
   elasticsManager: {fileID: 0}
   onManipulationStarted:
     m_PersistentCalls:

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using System.Collections;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -117,6 +118,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private RadialView radialView = null;
         private Coroutine autoFollowDistanceCheck = null;
 
+        [Header("Events")]
+        /// <summary>
+        /// Event that gets fired when auto follow is triggered
+        /// </summary>
+        public UnityEvent AutoFollowTriggered = new UnityEvent();
+
+
         #region MonoBehaviour Implementation
 
         private void Awake()
@@ -203,6 +211,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         if ((mainCamera.transform.position - autoFollowTransformTarget.position).sqrMagnitude >= autoFollowDistanceSq)
                         {
                             SetFollowMeBehavior(true);
+                            AutoFollowTriggered?.Invoke();
                         }
                     }
                 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
@@ -118,11 +118,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private RadialView radialView = null;
         private Coroutine autoFollowDistanceCheck = null;
 
-        [Header("Events")]
+        [SerializeField]
+        [Tooltip("Event that gets fired when auto follow is triggered.")]
+        private UnityEvent autoFollowTriggered = new UnityEvent();
         /// <summary>
-        /// Event that gets fired when auto follow is triggered
+        /// Event that gets fired when auto follow is triggered.
         /// </summary>
-        public UnityEvent AutoFollowTriggered = new UnityEvent();
+        public UnityEvent AutoFollowTriggered
+        {
+            get => autoFollowTriggered;
+            set => autoFollowTriggered = value;
+        }
 
 
         #region MonoBehaviour Implementation


### PR DESCRIPTION
## Overview
[Stabilization 2.6.0] NearMenuExamples: 1m auto follow example toggle pin state is not updated when auto follow is triggered.
Fix: Added 'Auto Follow Trigger' event to the FollwMeToggle script. Toggle Pin button using this event properly.

## Before: Pin button is not toggled on auto follow
https://user-images.githubusercontent.com/13754172/108447107-26c09600-7214-11eb-9fcc-becaf748244d.mp4

## After: Pin button is properly toggled on auto follow
https://user-images.githubusercontent.com/13754172/108447172-46f05500-7214-11eb-9087-ad94436d6621.mp4

![2021-02-18 17_59_12-MRTK260Stabilization - Microsoft Visual Studio](https://user-images.githubusercontent.com/13754172/108449119-c6cbee80-7217-11eb-91f1-ee58da5c1106.png)


## Changes
- Fixes: #9335



