### PR TITLE
Re-enabling shader inspector for later properties.

### DIFF
--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -713,6 +713,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             materialEditor.EnableInstancingField();
 
+            GUI.enabled = true;
+
             materialEditor.ShaderProperty(stencil, Styles.stencil);
 
             if (PropertyEnabled(stencil))

--- a/Assets/MRTK/Examples/Demos/UX/Dialog/Scripts/DialogExampleController.cs
+++ b/Assets/MRTK/Examples/Demos/UX/Dialog/Scripts/DialogExampleController.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenConfirmationDialogLarge()
         {
-            Dialog.Open(DialogPrefabLarge, DialogButtonType.OK, "Confirmation Dialog, Large, Far", "This is an example of a large dialog with only one button, placed at near interaction range", false);
+            Dialog.Open(DialogPrefabLarge, DialogButtonType.OK, "Confirmation Dialog, Large, Far", "This is an example of a large dialog with only one button, placed at far interaction range", false);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenChoiceDialogLarge()
         {
-            Dialog myDialog = Dialog.Open(DialogPrefabLarge, DialogButtonType.Yes | DialogButtonType.No, "Choice Dialog, Large, Near", "This is an example of a large dialog with a choice message for the user, placed at far interaction range", true);
+            Dialog myDialog = Dialog.Open(DialogPrefabLarge, DialogButtonType.Yes | DialogButtonType.No, "Choice Dialog, Large, Near", "This is an example of a large dialog with a choice message for the user, placed at near interaction range", true);
             if (myDialog != null)
             {
                 myDialog.OnClosed += OnClosedDialogEvent;
@@ -96,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenConfirmationDialogSmall()
         {
-            Dialog.Open(DialogPrefabSmall, DialogButtonType.OK, "Confirmation Dialog, Small, Far", "This is an example of a small dialog with only one button, placed at near interaction range", false);
+            Dialog.Open(DialogPrefabSmall, DialogButtonType.OK, "Confirmation Dialog, Small, Far", "This is an example of a small dialog with only one button, placed at far interaction range", false);
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenChoiceDialogSmall()
         {
-            Dialog myDialog = Dialog.Open(DialogPrefabSmall, DialogButtonType.Yes | DialogButtonType.No, "Choice Dialog, Small, Near", "This is an example of a small dialog with a choice message for the user, placed at far interaction range", true);
+            Dialog myDialog = Dialog.Open(DialogPrefabSmall, DialogButtonType.Yes | DialogButtonType.No, "Choice Dialog, Small, Near", "This is an example of a small dialog with a choice message for the user, placed at near interaction range", true);
             if (myDialog != null)
             {
                 myDialog.OnClosed += OnClosedDialogEvent;

--- a/Assets/MRTK/Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Build.Editor
                      xmlns:mobile='http://schemas.microsoft.com/appx/manifest/mobile/windows10'
                      IgnorableNamespaces='uap uap2 uap3 uap4 mp mobile iot'
                      xmlns='http://schemas.microsoft.com/appx/manifest/foundation/windows10'>
-              <Identity Name='Microsoft.MixedReality.Toolkit' Publisher='CN=Microsoft' Version='2.6.0.0' />
+              <Identity Name='Microsoft.MixedReality.Toolkit' Publisher='CN=Microsoft' Version='2.7.0.0' />
               <mp:PhoneIdentity PhoneProductId='85c8bcd4-fbac-44ed-adf6-bfc01242a27f' PhonePublisherId='00000000-0000-0000-0000-000000000000' />
               <Properties>
                 <DisplayName>MixedRealityToolkit</DisplayName>

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -118,7 +118,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.6.0
+  bundleVersion: 2.7.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -687,7 +687,7 @@ PlayerSettings:
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: Microsoft.MixedReality.Toolkit
-  metroPackageVersion: 2.6.0.0
+  metroPackageVersion: 2.7.0.0
   metroCertificatePath: Assets/WSATestCertificate.pfx
   metroCertificatePassword: 
   metroCertificateSubject: Microsoft

--- a/pipelines/config/settings.yml
+++ b/pipelines/config/settings.yml
@@ -12,7 +12,7 @@ variables:
   # match (see scripts/packaging/versionmetadata.ps1)
   # ProjectSettings/ProjectSettings.asset:  bundleVersion: x.x.x
   # ProjectSettings/ProjectSettings.asset:  metroPackageVersion: x.x.x.0
-  MRTKVersion: 2.6.0
+  MRTKVersion: 2.7.0
   MRTKReleaseTag: ''  # final version component, e.g. 'RC2.1' or empty string
   ToolsRepoName: mixedrealitytoolkit.build
   ToolsDir: $(Build.SourcesDirectory)\$(ToolsRepoName)


### PR DESCRIPTION
## Overview

This is a small fix to an issue found by @cre8ivepark where `Enable Stencil Testing` and `Ignore Z Scale` would be disabled in the UI when `Enable GPU Instancing` was also disabled in the UI. These should be mutually exclusive. 

![2021-02-19 12_56_36-Unity 2018 4 31f1 -  PREVIEW PACKAGES IN USE  - HandInteractionExamples unity - ](https://user-images.githubusercontent.com/13305729/108569056-1a921280-72c0-11eb-8ff3-b5c7439928b7.png)

The inspector should now look like this:
![image](https://user-images.githubusercontent.com/13305729/108569386-a99f2a80-72c0-11eb-8cc0-cefe4b94cbc0.png)

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
