### PR TITLE
Re-enabling shader inspector for later properties.

### DIFF
--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -713,6 +713,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             materialEditor.EnableInstancingField();
 
+            GUI.enabled = true;
+
             materialEditor.ShaderProperty(stencil, Styles.stencil);
 
             if (PropertyEnabled(stencil))


### PR DESCRIPTION
## Overview

This is a small fix to an issue found by @cre8ivepark where `Enable Stencil Testing` and `Ignore Z Scale` would be disabled in the UI when `Enable GPU Instancing` was also disabled in the UI. These should be mutually exclusive. 

![2021-02-19 12_56_36-Unity 2018 4 31f1 -  PREVIEW PACKAGES IN USE  - HandInteractionExamples unity - ](https://user-images.githubusercontent.com/13305729/108569056-1a921280-72c0-11eb-8ff3-b5c7439928b7.png)

The inspector should now look like this:
![image](https://user-images.githubusercontent.com/13305729/108569386-a99f2a80-72c0-11eb-8cc0-cefe4b94cbc0.png)

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
