### PR TITLE
Clean up extra uses of #pragma warning disable

### DIFF
--- a/Assets/MRTK/Core/Utilities/WindowsApiChecker.cs
+++ b/Assets/MRTK/Core/Utilities/WindowsApiChecker.cs
@@ -21,11 +21,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
     /// </remarks>
     public static class WindowsApiChecker
     {
+        [Obsolete("The CheckApiContracts method is obsolete (and should not need to be called manually regardless) and will be removed from a future version of MRTK. Please use IsMethodAvailable(), IsPropertyAvailable() or IsTypeAvailable().")]
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void CheckApiContracts()
         {
             // Disable the obsolete warning to enable setting the properties for legacy code.
-#pragma warning disable 0618
 #if WINDOWS_UWP
             UniversalApiContractV8_IsAvailable = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8);
             UniversalApiContractV7_IsAvailable = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7);
@@ -41,7 +41,6 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
             UniversalApiContractV4_IsAvailable = false;
             UniversalApiContractV3_IsAvailable = false;
 #endif // WINDOWS_UWP
-#pragma warning restore 0618
         }
 
         /// <summary>

--- a/Assets/MRTK/Services/InputSystem/InputSystemGlobalListener.cs
+++ b/Assets/MRTK/Services/InputSystem/InputSystemGlobalListener.cs
@@ -22,9 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (CoreServices.InputSystem != null && !lateInitialize)
             {
-#pragma warning disable 0618
                 CoreServices.InputSystem.Register(gameObject);
-#pragma warning restore 0618
             }
         }
 
@@ -41,17 +39,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 lateInitialize = false;
-#pragma warning disable 0618
                 CoreServices.InputSystem.Register(gameObject);
-#pragma warning restore 0618
             }
         }
 
         protected virtual void OnDisable()
         {
-#pragma warning disable 0618
             CoreServices.InputSystem?.Unregister(gameObject);
-#pragma warning restore 0618
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

The code looks a bit cleaner when we don't need to have `#pragma warning disable` all over, and I think adding additional `Obsolete` tags where necessary is a more visible and actionable approach.