### PR TITLE
Fix two bounds control related issues

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Slate/Slate.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Slate/Slate.prefab
@@ -1026,6 +1026,7 @@ GameObject:
   - component: {fileID: 1720691180653164336}
   - component: {fileID: 8573989461166582953}
   - component: {fileID: 8306022778500059610}
+  - component: {fileID: 8892923248051100357}
   m_Layer: 0
   m_Name: Slate
   m_TagString: Untagged
@@ -1067,6 +1068,9 @@ MonoBehaviour:
   autoFollowAtDistance: 0
   autoFollowDistance: 2
   autoFollowTransformTarget: {fileID: 0}
+  autoFollowTriggered:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &7779420039263858274
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1259,6 +1263,20 @@ MonoBehaviour:
   scaleMinimum: 0.3
   scaleMaximum: 5
   relativeToInitialState: 1
+--- !u!114 &8892923248051100357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7779420039263858270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5afd5316c63705643b3daba5a6e923bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTetherWhenManipulating: 0
+  IsBoundsHandles: 0
 --- !u!1 &8623592401023769555
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/TranslationHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/TranslationHandles.cs
@@ -46,11 +46,11 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             // Align handle with its edge assuming that the prefab is initially aligned with the up direction 
             if (VisualUtils.FaceAxisType[handleIndex] == CardinalAxisType.X)
             {
-                return Quaternion.FromToRotation(Vector3.up, directionSign * Vector3.right);
+                return Quaternion.FromToRotation(Vector3.forward, directionSign * Vector3.right);
             }
             else if (VisualUtils.FaceAxisType[handleIndex] == CardinalAxisType.Z)
             {
-                return Quaternion.FromToRotation(Vector3.up, directionSign * Vector3.forward);
+                return Quaternion.FromToRotation(Vector3.forward, directionSign * Vector3.forward);
             }
             else // y axis
             {


### PR DESCRIPTION
## Overview
This PR fixes the issue of the translation handles of bounds control having wrong rotation and the issue of some slates cannot be scaled with near interaction.

## Changes
- Fixes: #9334 and #9346.

## Verification
Please see the issues above for steps to verify these fixes.