### PR TITLE
Fix for eye gaze pinch controls and fix pointer naming bug

### DIFF
--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/MoveObjByEyeGaze.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/MoveObjByEyeGaze.cs
@@ -282,7 +282,8 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
         void IMixedRealitySourceStateHandler.OnSourceLost(SourceStateEventData eventData)
         {
-            if (IsActiveHand(eventData.InputSource.SourceName))
+            if ((currEngagedHand == Handedness.Right && eventData.Controller.ControllerHandedness == Handedness.Right) ||
+                (currEngagedHand == Handedness.Left && eventData.Controller.ControllerHandedness == Handedness.Left))
             {
                 HandDrag_Stop();
             }
@@ -290,7 +291,8 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
         void IMixedRealityPointerHandler.OnPointerUp(MixedRealityPointerEventData eventData)
         {
-            if (IsActiveHand(eventData.InputSource.SourceName))
+            if ((currEngagedHand == Handedness.Right && eventData.Handedness == Handedness.Right) ||
+                (currEngagedHand == Handedness.Left && eventData.Handedness == Handedness.Left))
             {
                 HandDrag_Stop();
             }
@@ -298,7 +300,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
         void IMixedRealityPointerHandler.OnPointerDown(MixedRealityPointerEventData eventData)
         {
-            if (SetActiveHand(eventData.InputSource.SourceName))
+
+            if (currEngagedHand == Handedness.None)
+            {
+                currEngagedHand = eventData.Handedness;
+            }
+
+            if (currEngagedHand != Handedness.None)
             {
                 HandDrag_Start();
             }
@@ -306,38 +314,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
         void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData) { }
         #endregion
-
-        private bool SetActiveHand(string sourcename)
-        {
-            if (currEngagedHand == Handedness.None)
-            {
-                if ((sourcename == "Right Hand") || (sourcename == "Mixed Reality Controller Right"))
-                {
-                    currEngagedHand = Handedness.Right;
-                }
-                else if ((sourcename == "Left Hand") || (sourcename == "Mixed Reality Controller Left"))
-                {
-                    currEngagedHand = Handedness.Left;
-                }
-
-                if (currEngagedHand != Handedness.None)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private bool IsActiveHand(string sourcename)
-        {
-
-            if (((currEngagedHand == Handedness.Right) && ((sourcename == "Right Hand") || (sourcename == "Mixed Reality Controller Right"))) ||
-                ((currEngagedHand == Handedness.Left) && ((sourcename == "Left Hand") || (sourcename == "Mixed Reality Controller Left"))))
-            {
-                return true;
-            }
-            return false;
-        }
 
         /// <summary>
         /// Start moving the target using your hands.

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 if (cursorInstance != null)
                 {
-                    cursorInstance.name = $"{Handedness}_{name}_Cursor";
+                    cursorInstance.name = $"{name}_Cursor";
 
                     BaseCursor oldC = BaseCursor as BaseCursor;
                     if (oldC != null && enabled)
@@ -168,6 +168,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             await EnsureInputSystemValid();
 
+            // Setting the pointerName
+            PointerName = $"{Handedness}_{gameObject.name}";
+
             // We've been destroyed during the await.
             if (this == null)
             {
@@ -227,7 +230,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 if (base.Controller != null && this != null)
                 {
-                    PointerName = $"{Handedness}_{gameObject.name}";
                     InputSourceParent = base.Controller.InputSource;
                     SetCursor();
                 }


### PR DESCRIPTION
## Overview
Previously, the eye gaze controls were broken and would not let the users pinch to manipulate objects. This PR fixes this by removing the hard-coded dependency on controller names, and it also fixes a bug introduced with pointer naming

old naming:
![NamingOld](https://user-images.githubusercontent.com/39840334/108896790-318b7a00-75ca-11eb-852f-a1d2f845609f.gif)

new naming:
![NamingNew](https://user-images.githubusercontent.com/39840334/108896795-34866a80-75ca-11eb-828a-0cfc957779c9.gif)

## Changes
- Fixes: #9336


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
