### PR TITLE
Fix BoundsControl incorrectly calculates world space center of bounds

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -784,7 +784,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 // also only use proximity effect if nothing is being dragged or grabbed
                 if (!wireframeOnly && currentPointer == null)
                 {
-                    proximityEffect.UpdateScaling(Vector3.Scale(TargetBounds.center, TargetBounds.gameObject.transform.lossyScale) + Target.transform.position, currentBoundsExtents);
+                    proximityEffect.UpdateScaling(TargetBounds.transform.TransformPoint(TargetBounds.center), currentBoundsExtents);
                 }
             }
         }


### PR DESCRIPTION
## Overview
This PR fixes the currently incorrect calculation of the center of bounds in world space.

## Changes
- Fixes: #9366