### PR TITLE
Debug -> UnityEngine.Debug in OculusXRSDKDeviceManager

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         public override void Initialize()
         {
             base.Initialize();
-            Debug.Log(@"Detected a potential deployment issue for the Oculus Quest. In order to use hand tracking with the Oculus Quest, download the Oculus Integration Package from the Unity Asset Store and run the Integration tool before deploying.
+            UnityEngine.Debug.Log(@"Detected a potential deployment issue for the Oculus Quest. In order to use hand tracking with the Oculus Quest, download the Oculus Integration Package from the Unity Asset Store and run the Integration tool before deploying.
 The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules</i>");
         }
 #endif


### PR DESCRIPTION
## Overview

This `#if` block was missing a namespace

## Changes
- Fixes: #9372 
