### PR TITLE
Fix wrong field reference in BaseWindowsMixedRealityCameraSettings

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         /// </summary>
         private void InitializeProjectionOverride()
         {
-            if (reprojectionUpdater == null && Profile != null && Profile.ReadingModeEnabled)
+            if (projectionOverride == null && Profile != null && Profile.ReadingModeEnabled)
             {
                 projectionOverride = CameraCache.Main.EnsureComponent<ProjectionOverride>();
                 projectionOverride.ReadingModeEnabled = Profile.ReadingModeEnabled;


### PR DESCRIPTION
## Overview

This method was checking the wrong field for null to initialize `ProjectionOverride`