### PR TITLE
Primary Cursor and InputAction's Profile fixes

### DIFF
--- a/Assets/MRTK/Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityInputSimulationProfile.asset
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityInputSimulationProfile.asset
@@ -34,7 +34,7 @@ MonoBehaviour:
   currentControlMode: 0
   fastControlKey:
     bindingType: 2
-    code: 305
+    code: 303
   controlSlowSpeed: 1
   controlFastSpeed: 5
   moveHorizontal: Horizontal
@@ -43,7 +43,7 @@ MonoBehaviour:
   lookHorizontal: AXIS_4
   lookVertical: AXIS_5
   defaultEyeGazeSimulationMode: 0
-  defaultControllerSimulationMode: 1
+  defaultControllerSimulationMode: 2
   toggleLeftControllerKey:
     bindingType: 2
     code: 116

--- a/Assets/MRTK/Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityInputSimulationProfile.asset
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityInputSimulationProfile.asset
@@ -43,7 +43,7 @@ MonoBehaviour:
   lookHorizontal: AXIS_4
   lookVertical: AXIS_5
   defaultEyeGazeSimulationMode: 0
-  defaultControllerSimulationMode: 2
+  defaultControllerSimulationMode: 1
   toggleLeftControllerKey:
     bindingType: 2
     code: 116

--- a/Assets/MRTK/Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
@@ -22,13 +22,21 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         {
             if (CursorHighlight != null)
             {
-                // For this example scene, do not highlight a non-BaseControllerPointer if it becomes the primary pointer. 
-                // This is due to the non-standard way that controller pointers manage their respective cursors.
-                // In particular, the GGV pointer defers it's cursor management to the GazeProvider, which has it's own internal pointer definition as well
-                // In the future, the pointer/cursor relationship will be reworked and standardized to remove this awkward set of co-dependencies
-                if (newPointer != null && newPointer is BaseControllerPointer)
+                if (newPointer != null)
                 {
-                    Transform parentTransform = newPointer.BaseCursor.TryGetMonoBehaviour(out MonoBehaviour baseCursor) ? baseCursor.transform : null;
+                    Transform parentTransform = null;
+
+                    // For this example scene, use special logic if a GGVPointer becomes the primary pointer. 
+                    // In particular, the GGV pointer defers it's cursor management to the GazeProvider, which has it's own internal pointer definition as well
+                    // In the future, the pointer/cursor relationship will be reworked and standardized to remove this awkward set of co-dependencies
+                    if (newPointer is GGVPointer)
+                    {
+                        parentTransform = CoreServices.InputSystem.GazeProvider.GazePointer.BaseCursor.TryGetMonoBehaviour(out MonoBehaviour baseCursor) ? baseCursor.transform : null;
+                    }
+                    else
+                    {
+                        parentTransform = newPointer.BaseCursor.TryGetMonoBehaviour(out MonoBehaviour baseCursor) ? baseCursor.transform : null;
+                    }
 
                     // If there's no cursor try using the controller pointer transform instead
                     if (parentTransform == null)

--- a/Assets/MRTK/Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
@@ -22,7 +22,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         {
             if (CursorHighlight != null)
             {
-                if (newPointer != null)
+                // For this example scene, do not highlight a non-BaseControllerPointer if it becomes the primary pointer. 
+                // This is due to the non-standard way that controller pointers manage their respective cursors.
+                // In particular, the GGV pointer defers it's cursor management to the GazeProvider, which has it's own internal pointer definition as well
+                // In the future, the pointer/cursor relationship will be reworked and standardized to remove this awkward set of co-dependencies
+                if (newPointer != null && newPointer is BaseControllerPointer)
                 {
                     Transform parentTransform = newPointer.BaseCursor.TryGetMonoBehaviour(out MonoBehaviour baseCursor) ? baseCursor.transform : null;
 


### PR DESCRIPTION
## Overview
Adds a workaround for the issue described in **#9367**. Because of how the gaze cursor is handled in relation to the GGVPointer and the GazeProvider, there is no straightforward catchall solution for this at the moment, so we some implementation specific workaround code for now. We're hoping to have a more catch-all fix as we work towards separating out the co-dependencies between cursors and pointers in the current MRTK.

This PR also fixes issue **#9369** in the InputActions scene but fixing the InputAction profile

## Changes
- Fixes: #9367, #9369
