### PR TITLE
Update build scripts to allow for arbitrary VS versions

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/MSBuildMRTKTemplates/WSA.Player.Template.props.template
+++ b/Assets/MRTK/Tools/MSBuild/MSBuildMRTKTemplates/WSA.Player.Template.props.template
@@ -16,6 +16,11 @@
 
   <!-- This is for successful building step from dotnet cli -->
   <Choose>
+    <When Condition="'$(XamlTargetsPathOverride)'!= ''">
+      <PropertyGroup>
+        <LanguageTargets>$(XamlTargetsPathOverride)\Microsoft.Windows.UI.Xaml.CSharp.targets</LanguageTargets>
+      </PropertyGroup>
+    </When>
     <When Condition="'$(MSBuildExtensionsPathOverride)'!= ''">
       <PropertyGroup>
         <LanguageTargets>$(MSBuildExtensionsPathOverride)\Microsoft\WindowsXaml\v15.0\Microsoft.Windows.UI.Xaml.CSharp.targets</LanguageTargets>

--- a/NuGet/BuildSource.proj
+++ b/NuGet/BuildSource.proj
@@ -1,8 +1,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <ProjectReferences  Include="..\MSBuild\Projects\MixedRealityToolkit.sln"/>
+    <ProjectReferences Include="..\MSBuild\Projects\MixedRealityToolkit.sln"/>
   </ItemGroup>
+
+  <PropertyGroup>
+    <XamlTargetsPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\WindowsXaml\v16.0</XamlTargetsPath>
+  </PropertyGroup>
 
   <Target Name="BuildStandaloneEditor">
     <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=InEditor;Platform=WindowsStandalone32;BuildProjectReferences=false;GenerateDocumentationFile=true">
@@ -27,7 +31,7 @@
       <Output TaskParameter="TargetOutputs" ItemName="BuildAndroidPlayerOutputs" />
     </MSBuild>
   </Target>
-  
+
   <Target Name="BuildIOSPlayer">
     <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=IOS;BuildProjectReferences=false;GenerateDocumentationFile=true">
       <Output TaskParameter="TargetOutputs" ItemName="BuildIOSPlayerOutputs" />
@@ -35,7 +39,7 @@
   </Target>
 
   <Target Name="BuildWSAPlayer">
-    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WSA;BuildProjectReferences=false;MSBuildExtensionsPathOverride=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild;GenerateDocumentationFile=true">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WSA;BuildProjectReferences=false;XamlTargetsPathOverride=$(XamlTargetsPath);GenerateDocumentationFile=true">
       <Output TaskParameter="TargetOutputs" ItemName="BuildWSAPlayerOutputs" />
     </MSBuild>
   </Target>

--- a/NuGet/BuildSource.proj
+++ b/NuGet/BuildSource.proj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <XamlTargetsPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\WindowsXaml\v16.0</XamlTargetsPath>
+    <XamlTargetsPath>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\WindowsXaml\v15.0</XamlTargetsPath>
   </PropertyGroup>
 
   <Target Name="BuildStandaloneEditor">

--- a/NuGet/BuildSource.proj
+++ b/NuGet/BuildSource.proj
@@ -35,7 +35,7 @@
   </Target>
 
   <Target Name="BuildWSAPlayer">
-    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WSA;BuildProjectReferences=false;MSBuildExtensionsPathOverride=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild;GenerateDocumentationFile=true">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WSA;BuildProjectReferences=false;MSBuildExtensionsPathOverride=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild;GenerateDocumentationFile=true">
       <Output TaskParameter="TargetOutputs" ItemName="BuildWSAPlayerOutputs" />
     </MSBuild>
   </Target>

--- a/scripts/packaging/createnugetpackages.ps1
+++ b/scripts/packaging/createnugetpackages.ps1
@@ -15,15 +15,13 @@
 param(
     [string]$OutputDirectory = ".\artifacts",
     [ValidatePattern("^\d+\.\d+\.\d+$")]
-    [string]$Version,
-    [string]$UnityDirectory
+    [string]$Version = "0.0.0",
+    [Parameter(Mandatory=$true)]
+    [string]$UnityDirectory,
+    [string]$VisualStudioDirectory = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"
 )
 
 Write-Verbose "Reconciling Unity binary:"
-if (-not $UnityDirectory) {
-    throw "-UnityDirectory is a required flag"
-}
-
 $unityEditor = Get-ChildItem $UnityDirectory -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
 if (-not $unityEditor) {
     throw "Unable to find the unity editor executable in $UnityDirectory"
@@ -98,7 +96,13 @@ try {
         exit($lastexitcode)
     }
     Write-Output "============ Building Player WSA ============ "
-    dotnet msbuild .\BuildSource.proj -target:BuildWSAPlayer  > "Logs\Build.Player.WSA.$($Version).log"
+    if ($VisualStudioDirectory -match "2019") {
+        $VisualStudioDirectory = Join-Path $VisualStudioDirectory "MSBuild\Microsoft\WindowsXaml\v16.0"
+    }
+    else {
+        $VisualStudioDirectory = Join-Path $VisualStudioDirectory "MSBuild\Microsoft\WindowsXaml\v15.0"
+    }
+    dotnet msbuild .\BuildSource.proj -target:BuildWSAPlayer /p:XamlTargetsPath=$VisualStudioDirectory > "Logs\Build.Player.WSA.$($Version).log"
     if ($lastexitcode -ge 1) {
         Write-Error "Building Player WSA Failed! See log file for more information $(Get-Location)\Logs\Build.Player.WSA.$($Version).log";
         exit($lastexitcode)

--- a/scripts/packaging/createnugetpackages.ps1
+++ b/scripts/packaging/createnugetpackages.ps1
@@ -18,7 +18,7 @@ param(
     [string]$Version = "0.0.0",
     [Parameter(Mandatory=$true)]
     [string]$UnityDirectory,
-    [string]$VisualStudioDirectory = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"
+    [string]$VisualStudioDirectory = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise"
 )
 
 Write-Verbose "Reconciling Unity binary:"


### PR DESCRIPTION
## Overview

This change allows a user to pass an arbitrary VS path instead of it being hardcoded.
Also updates to use Visual Studio 2019.

@MaxWang-MS, do you think this will affect the docs binary generation scripts?

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6996
