### PR TITLE
Adds groundwork for migrating projects off NuGet to UPM/.unitypackages

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
         private const string OculusProfileGUID = "4f726b4cb3605994fac74d508110ec62";
 
-        [MenuItem("Mixed Reality Toolkit/MSBuild/Assets/Retarget To DLL")]
+        [Obsolete("Obsolete and removed after deprecation of the NuGet distribution. Use RetargetAssetsToScript() to retarget to script GUIDs.")]
         public static void RetargetAssets()
         {
             try

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         private static readonly HashSet<string> ExcludedYamlAssetExtensions = new HashSet<string> { ".jpg", ".csv", ".meta", ".pfx", ".txt", ".nuspec", ".asmdef", ".yml", ".cs", ".md", ".json", ".ttf", ".png", ".shader", ".wav", ".bin", ".gltf", ".glb", ".fbx", ".pdf", ".cginc", ".rsp", ".xml", ".targets", ".props", ".template", ".csproj", ".sln", ".psd", ".room" };
         private static readonly HashSet<string> ExcludedSuffixFromCopy = new HashSet<string>() { ".cs", ".cs.meta", ".asmdef", ".asmdef.meta" };
 
-        private static Dictionary<string, string> nonClassDictionary = new Dictionary<string, string>(); // Guid, FileName
+        private static readonly Dictionary<string, string> nonClassDictionary = new Dictionary<string, string>(); // Guid, FileName
 
         // This is the known Unity-defined script fileId
         private const string ScriptFileIdConstant = "11500000";

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -139,6 +139,25 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 }
             }
 
+            string filePath = null;
+            string[] arguments = Environment.GetCommandLineArgs();
+
+            for (int i = 0; i < arguments.Length; ++i)
+            {
+                switch (arguments[i])
+                {
+                    case "-dictionaryFileOutput":
+                        filePath = arguments[++i];
+                        break;
+
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(filePath))
+            {
+                File.WriteAllLines(filePath, remapDictionary.Select(x => $"{x.Value.Item2} | {x.Key}, {ScriptFileIdConstant}"));
+            }
+
             ProcessYAMLAssets(allFilesUnderAssets, Application.dataPath.Replace("Assets", "NuGet/Content"), remapDictionary, compiledClassReferences);
         }
 

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         private static readonly HashSet<string> ExcludedYamlAssetExtensions = new HashSet<string> { ".jpg", ".csv", ".meta", ".pfx", ".txt", ".nuspec", ".asmdef", ".yml", ".cs", ".md", ".json", ".ttf", ".png", ".shader", ".wav", ".bin", ".gltf", ".glb", ".fbx", ".pdf", ".cginc", ".rsp", ".xml", ".targets", ".props", ".template", ".csproj", ".sln", ".psd", ".room" };
         private static readonly HashSet<string> ExcludedSuffixFromCopy = new HashSet<string>() { ".cs", ".cs.meta", ".asmdef", ".asmdef.meta" };
 
-        private static readonly Dictionary<string, string> nonClassDictionary = new Dictionary<string, string>(); // Guid, FileName
+        private static readonly Dictionary<string, string> nonClassDictionary = new Dictionary<string, string>(); // GUID, FileName
 
         // This is the known Unity-defined script fileId
         private const string ScriptFileIdConstant = "11500000";
@@ -109,7 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             Dictionary<string, ClassInformation> scriptFilesReferences = ProcessScripts(allFilesUnderAssets);
             Debug.Log($"Found {scriptFilesReferences.Count} script file references.");
 
-            // DLL name to Guid
+            // DLL name to GUID
             Dictionary<string, string> asmDefMappings = RetrieveAsmDefGuids(allFilesUnderAssets);
 
             Dictionary<string, AssemblyInformation> compiledClassReferences = ProcessCompiledDLLs("PackagedAssemblies", Application.dataPath.Replace("Assets", "NuGet/Plugins/EditorPlayer"), asmDefMappings);
@@ -149,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             Dictionary<string, ClassInformation> scriptFilesReferences = ProcessScripts(allFilesUnderAssets);
             Debug.Log($"Found {scriptFilesReferences.Count} script file references.");
 
-            // DLL name to Guid
+            // DLL name to GUID
             Dictionary<string, string> asmDefMappings = RetrieveAsmDefGuids(allFilesUnderAssets);
 
             Dictionary<string, AssemblyInformation> compiledClassReferences = ProcessCompiledDLLs("PackagedAssemblies", Application.dataPath.Replace("Assets", "NuGet/Plugins/EditorPlayer"), asmDefMappings);
@@ -193,7 +193,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 string guid = File.ReadAllLines($"{asmdefFile}.meta")[1].Substring(6);
                 if (!Guid.TryParse(guid, out Guid _))
                 {
-                    throw new InvalidDataException("AsmDef meta file must have changed, as we can no longer parse a guid out of it.");
+                    throw new InvalidDataException("AsmDef meta file must have changed, as we can no longer parse a GUID out of it.");
                 }
                 guid = CycleGuidForward(guid);
                 dllGuids.Add($"{dllName}.dll", guid);
@@ -202,8 +202,8 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             return dllGuids;
         }
 
-        /// <param name="remapDictionary">Script file guid references to final editor DLL guid and fileID.</param>
-        /// <param name="dllGuids">DLL name to DLL file guid mapping.</param>
+        /// <param name="remapDictionary">Script file GUID references to final editor DLL GUID and fileID.</param>
+        /// <param name="assemblyInformation">DLL name to DLL file GUID mapping.</param>
         private static void ProcessYAMLAssets(string[] allFilePaths, string outputDirectory, Dictionary<string, Tuple<string, long>> remapDictionary, Dictionary<string, AssemblyInformation> assemblyInformation)
         {
             if (Directory.Exists(outputDirectory))
@@ -289,7 +289,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                             Match regexResults = Regex.Match(line, Utilities.MetaFileGuidRegex);
                             if (!regexResults.Success || regexResults.Groups.Count != 2 || !regexResults.Groups[1].Success || regexResults.Groups[1].Captures.Count != 1)
                             {
-                                throw new InvalidDataException($"Failed to find the guid in line: {line}.");
+                                throw new InvalidDataException($"Failed to find the GUID in line: {line}.");
                             }
 
                             string guid = regexResults.Groups[1].Captures[0].Value;
@@ -372,8 +372,8 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                             else
                             {
                                 nonClassDictionary.Add(guid, Path.GetFileName(filePath));
-                                // anborod: This warning is very noisy, and often is correct due to "interface", "abstract", "enum" classes that won't return type with call to GetClass above.
-                                // To turn it on, we should do extra checking, but removing for now.
+                                // This warning is very noisy, and often is correct due to "interface", "abstract", "enum" classes that won't return type with call to GetClass above.
+                                // Turn this on for extra debugging.
                                 // Debug.LogWarning($"Found script that we can't get type from: {monoScript.name}");
                             }
                         }
@@ -423,7 +423,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                     {
                         if (!asmDefMappings.TryGetValue($"{dll.name}.dll", out string newDllGuid))
                         {
-                            throw new InvalidOperationException($"No guid based on .asmdef was generated for DLL '{dll.name}'.");
+                            throw new InvalidOperationException($"No GUID based on .asmdef was generated for DLL '{dll.name}'.");
                         }
 
                         AssemblyInformation assemblyInformation = new AssemblyInformation(dll.name, newDllGuid);
@@ -599,28 +599,28 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 throw new FileNotFoundException("Could not find sample editor dll.meta template.");
             }
 
-            if (!TemplateFiles.Instance.PluginMetaTemplatePaths.TryGetValue(BuildTargetGroup.WSA, out FileInfo uapMetaFile))
+            if (!TemplateFiles.Instance.PluginMetaTemplatePaths.TryGetValue(BuildTargetGroup.WSA, out FileInfo uwpMetaFile))
             {
-                throw new FileNotFoundException("Could not find sample editor dll.meta template.");
+                throw new FileNotFoundException("Could not find sample UWP dll.meta template.");
             }
 
             if (!TemplateFiles.Instance.PluginMetaTemplatePaths.TryGetValue(BuildTargetGroup.Standalone, out FileInfo standaloneMetaFile))
             {
-                throw new FileNotFoundException("Could not find sample editor dll.meta template.");
+                throw new FileNotFoundException("Could not find sample standalone dll.meta template.");
             }
 
             if (!TemplateFiles.Instance.PluginMetaTemplatePaths.TryGetValue(BuildTargetGroup.Android, out FileInfo androidMetaFile))
             {
-                throw new FileNotFoundException("Could not find sample editor dll.meta template.");
+                throw new FileNotFoundException("Could not find sample Android dll.meta template.");
             }
 
             if (!TemplateFiles.Instance.PluginMetaTemplatePaths.TryGetValue(BuildTargetGroup.iOS, out FileInfo iOSMetaFile))
             {
-                throw new FileNotFoundException("Could not find sample editor dll.meta template.");
+                throw new FileNotFoundException("Could not find sample iOS dll.meta template.");
             }
 
             string editorMetaFileTemplate = File.ReadAllText(editorMetaFile.FullName);
-            string uapMetaFileTemplate = File.ReadAllText(uapMetaFile.FullName);
+            string uapMetaFileTemplate = File.ReadAllText(uwpMetaFile.FullName);
             string standaloneMetaFileTemplate = File.ReadAllText(standaloneMetaFile.FullName);
             string androidMetaFileTemplate = File.ReadAllText(androidMetaFile.FullName);
             string iOSMetaFileTemplate = File.ReadAllText(iOSMetaFile.FullName);
@@ -633,16 +633,16 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             foreach (KeyValuePair<AssemblyInformation, FileInfo[]> mapping in mappings)
             {
-                // Editor is guid + 1; which has done when we processed Editor DLLs
-                // Standalone is guid + 2
-                // UAP is guid + 3
+                // Editor is GUID + 1; which has done when we processed Editor DLLs
+                // Standalone is GUID + 2
+                // UAP is GUID + 3
                 // Editor PDB is + 4
-                // Standalone PDB is +5
-                // UAP PDB is +6
-                // Android is guid + 7
-                // iOS is guid + 8
-                // Android PDB is +9
-                // iOS  PDB is +10
+                // Standalone PDB is + 5
+                // UAP PDB is + 6
+                // Android is GUID + 7
+                // iOS is GUID + 8
+                // Android PDB is + 9
+                // iOS PDB is + 10
                 string templateToUse = editorMetaFileTemplate;
                 foreach (FileInfo file in mapping.Value)
                 {
@@ -741,7 +741,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             StringBuilder guidBuilder = new StringBuilder();
             guid = guid.ToLower();
 
-            // Add one to each hexit in the guid to make it unique, but also reproducible
+            // Add one to each hexit in the GUID to make it unique, but also reproducible
             foreach (char hexit in guid)
             {
                 switch (hexit)

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
         private const string YamlPrefix = "%YAML 1.1";
 
-        private static readonly Dictionary<string, string> sourceToOutputFolders = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> SourceToOutputFolders = new Dictionary<string, string>
         {
             { "MSBuild/Publish/Player/Android", "AndroidPlayer" },
             { "MSBuild/Publish/Player/iOS", "iOSPlayer" },
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         private static readonly HashSet<string> ExcludedYamlAssetExtensions = new HashSet<string> { ".jpg", ".csv", ".meta", ".pfx", ".txt", ".nuspec", ".asmdef", ".yml", ".cs", ".md", ".json", ".ttf", ".png", ".shader", ".wav", ".bin", ".gltf", ".glb", ".fbx", ".pdf", ".cginc", ".rsp", ".xml", ".targets", ".props", ".template", ".csproj", ".sln", ".psd", ".room" };
         private static readonly HashSet<string> ExcludedSuffixFromCopy = new HashSet<string>() { ".cs", ".cs.meta", ".asmdef", ".asmdef.meta" };
 
-        private static readonly Dictionary<string, string> nonClassDictionary = new Dictionary<string, string>(); // GUID, FileName
+        private static readonly Dictionary<string, string> NonClassDictionary = new Dictionary<string, string>(); // GUID, FileName
 
         // This is the known Unity-defined script fileId
         private const string ScriptFileIdConstant = "11500000";
@@ -297,7 +297,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                             {
                                 line = Regex.Replace(line, @"fileID: \d+, guid: \w+", $"fileID: {tuple.Item2}, guid: {tuple.Item1}");
                             }
-                            else if (nonClassDictionary.ContainsKey(guid))
+                            else if (NonClassDictionary.ContainsKey(guid))
                             {
                                 // The OculusProfileGUID bypasses throwing the exception. The reason for this is that there is currently an asset (DefaultOculusXRSDKDeviceManagerProfile.asset) that is reliant
                                 // on Unity 2019+ specific code (OculusXRSDKDeviceManagerProfile.cs), which causes CI to fail since it's running on Unity 2018.
@@ -305,7 +305,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                                 // Also bypass this exception for scripts in an InteractiveElement directory as those files are only supported in Unity 2019.
                                 if (guid != OculusProfileGUID && !filePath.Contains("InteractiveElement"))
                                 {
-                                    throw new InvalidDataException($"A script without a class ({nonClassDictionary[guid]}) is being processed.");
+                                    throw new InvalidDataException($"A script without a class ({NonClassDictionary[guid]}) is being processed.");
                                 }
                             }
                             else
@@ -371,7 +371,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                             }
                             else
                             {
-                                nonClassDictionary.Add(guid, Path.GetFileName(filePath));
+                                NonClassDictionary.Add(guid, Path.GetFileName(filePath));
                                 // This warning is very noisy, and often is correct due to "interface", "abstract", "enum" classes that won't return type with call to GetClass above.
                                 // Turn this on for extra debugging.
                                 // Debug.LogWarning($"Found script that we can't get type from: {monoScript.name}");
@@ -520,7 +520,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
         private static void CopyPluginContents(string outputPath)
         {
-            foreach (KeyValuePair<string, string> sourceToOutputPair in sourceToOutputFolders)
+            foreach (KeyValuePair<string, string> sourceToOutputPair in SourceToOutputFolders)
             {
                 DirectoryInfo directory = new DirectoryInfo(Application.dataPath.Replace("Assets", sourceToOutputPair.Key));
                 if (!directory.Exists)

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -365,7 +365,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                         if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(monoScript, out string guid, out long fileId))
                         {
                             Type type = monoScript.GetClass();
-                            if (type != null)
+                            if (type != null && typeof(Component).IsAssignableFrom(type) && !type.IsAbstract)
                             {
                                 toReturn.Add(type.FullName, new ClassInformation() { Name = type.Name, Namespace = type.Namespace, FileId = fileId, Guid = guid, ExecutionOrder = MonoImporter.GetExecutionOrder(monoScript) });
                             }
@@ -445,7 +445,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                                 {
                                     throw new InvalidDataException($"Type {type.Name} is not a member of an approved (typically, 'Microsoft.MixedReality.Toolkit') namespace");
                                 }
-                                else
+                                else if (typeof(Component).IsAssignableFrom(type) && !type.IsAbstract)
                                 {
                                     assemblyInformation.CompiledClasses.Add(type.FullName, new ClassInformation() { Name = type.Name, Namespace = type.Namespace, FileId = fileId, Guid = newDllGuid });
                                 }

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -305,7 +305,8 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                     Match regexResults = Regex.Match(line, scriptRemapping ? Utilities.MetaFileIdRegex : Utilities.MetaFileGuidRegex);
                     if (!regexResults.Success || regexResults.Groups.Count != 2 || !regexResults.Groups[1].Success || regexResults.Groups[1].Captures.Count != 1)
                     {
-                        throw new InvalidDataException($"Failed to find the ID in line: {line}.");
+                        Debug.LogWarning($"Failed to find the ID in {Path.GetFileName(filePath)} in line: {line}.");
+                        continue;
                     }
 
                     string id = regexResults.Groups[1].Captures[0].Value;
@@ -325,7 +326,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                             throw new InvalidDataException($"A script without a class ({NonClassDictionary[id]}) is being processed.");
                         }
                     }
-                    else if (id != ScriptFileIdConstant)
+                    else if (id != ScriptFileIdConstant && !scriptRemapping)
                     {
                         // Switch to error later
                         Debug.LogWarning($"Couldn't find a script remap for {id} in file: '{filePath}' at line '{lineNum}'.");

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -161,6 +161,12 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 string filePath = Path.Combine(folderPath, GUIDDictionaryFileName);
                 Debug.Log($"Writing remapping dictionary to {filePath}");
                 File.WriteAllLines(filePath, remapDictionary.Select(x => $"{x.Value.Item2} | {x.Key}, {ScriptFileIdConstant}"));
+                if (filePath.Contains("Assets"))
+                {
+                    string nugetFilePath = filePath.Replace("Assets", "NuGet/Content");
+                    Debug.Log($"Copying remapping dictionary to {nugetFilePath}");
+                    File.Copy(filePath, nugetFilePath, true);
+                }
             }
         }
 

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -56,8 +56,8 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             { "MSBuild/Publish/Player/WindowsStandalone32", "StandalonePlayer" },
         };
 
-        private static readonly HashSet<string> ExcludedYamlAssetExtensions = new HashSet<string> { ".jpg", ".csv", ".meta", ".pfx", ".txt", ".nuspec", ".asmdef", ".yml", ".cs", ".md", ".json", ".ttf", ".png", ".shader", ".wav", ".bin", ".gltf", ".glb", ".fbx", ".pdf", ".cginc", ".rsp", ".xml", ".targets", ".props", ".template", ".csproj", ".sln", ".psd", ".room" };
-        private static readonly HashSet<string> ExcludedSuffixFromCopy = new HashSet<string>() { ".cs", ".cs.meta", ".asmdef", ".asmdef.meta" };
+        private static readonly HashSet<string> ExcludedYamlAssetExtensions = new HashSet<string> { ".jpg", ".csv", ".meta", ".pfx", ".txt", ".nuspec", ".asmdef", ".yml", ".cs", ".md", ".json", ".ttf", ".png", ".shader", ".wav", ".bin", ".gltf", ".glb", ".fbx", ".pdf", ".cginc", ".rsp", ".xml", ".targets", ".props", ".template", ".csproj", ".sln", ".psd", ".room", ".sentinel", ".npmignore", ".bytes" };
+        private static readonly HashSet<string> ExcludedSuffixFromCopy = new HashSet<string>() { ".cs", ".cs.meta", ".asmdef", ".asmdef.meta", ".rsp" };
 
         private static readonly Dictionary<string, string> NonClassDictionary = new Dictionary<string, string>(); // GUID, FileName
 

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -140,6 +140,8 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 }
             }
 
+            ProcessYAMLAssets(allFilesUnderAssets, Application.dataPath.Replace("Assets", "NuGet/Content"), remapDictionary, compiledClassReferences);
+
             string folderPath = null;
             string[] arguments = Environment.GetCommandLineArgs();
 
@@ -156,10 +158,10 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             if (!string.IsNullOrWhiteSpace(folderPath))
             {
-                File.WriteAllLines(Path.Combine(folderPath, GUIDDictionaryFileName), remapDictionary.Select(x => $"{x.Value.Item2} | {x.Key}, {ScriptFileIdConstant}"));
+                string filePath = Path.Combine(folderPath, GUIDDictionaryFileName);
+                Debug.Log($"Writing remapping dictionary to {filePath}");
+                File.WriteAllLines(filePath, remapDictionary.Select(x => $"{x.Value.Item2} | {x.Key}, {ScriptFileIdConstant}"));
             }
-
-            ProcessYAMLAssets(allFilesUnderAssets, Application.dataPath.Replace("Assets", "NuGet/Content"), remapDictionary, compiledClassReferences);
         }
 
         private static void RunRetargetToScript()

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -326,13 +326,13 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                         // Also bypass this exception for scripts in an InteractiveElement directory as those files are only supported in Unity 2019.
                         if (id != OculusProfileGUID && !filePath.Contains("InteractiveElement"))
                         {
-                            throw new InvalidDataException($"A script without a class ({NonClassDictionary[id]}) is being processed.");
+                            throw new InvalidDataException($"A script without a class ({NonClassDictionary[id]}) is being processed on {Path.GetFileName(filePath)}.");
                         }
                     }
-                    else if (id != ScriptFileIdConstant && !scriptRemapping)
+                    else if (!scriptRemapping)
                     {
                         // Switch to error later
-                        Debug.LogWarning($"Couldn't find a script remap for {id} in file: '{filePath}' at line '{lineNum}'.");
+                        Debug.LogWarning($"Couldn't find a script remap for {id} in file: '{Path.GetFileName(filePath)}' at line '{lineNum}'.");
                     }
                 }
                 else if (line.Contains(ScriptFileIdConstant))
@@ -388,7 +388,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                         if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(monoScript, out string guid, out long fileId))
                         {
                             Type type = monoScript.GetClass();
-                            if (type != null && typeof(Component).IsAssignableFrom(type) && !type.IsAbstract)
+                            if (type != null && typeof(Object).IsAssignableFrom(type) && !type.IsAbstract)
                             {
                                 toReturn.Add(type.FullName, new ClassInformation() { Name = type.Name, Namespace = type.Namespace, FileId = fileId, Guid = guid, ExecutionOrder = MonoImporter.GetExecutionOrder(monoScript) });
                             }
@@ -468,7 +468,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                                 {
                                     throw new InvalidDataException($"Type {type.Name} is not a member of an approved (typically, 'Microsoft.MixedReality.Toolkit') namespace");
                                 }
-                                else if (typeof(Component).IsAssignableFrom(type) && !type.IsAbstract)
+                                else if (typeof(Object).IsAssignableFrom(type) && !type.IsAbstract)
                                 {
                                     assemblyInformation.CompiledClasses.Add(type.FullName, new ClassInformation() { Name = type.Name, Namespace = type.Namespace, FileId = fileId, Guid = newDllGuid });
                                 }

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -181,7 +181,14 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             Dictionary<string, Tuple<string, long>> remapDictionary = ReadDictionaryFile(File.ReadLines(Path.GetFullPath(AssetDatabase.GUIDToAssetPath(dictionaryPaths[0]))));
 
-            ProcessYAMLAssets(remapDictionary);
+            if (remapDictionary.Count > 0)
+            {
+                ProcessYAMLAssets(remapDictionary);
+            }
+            else
+            {
+                Debug.LogError("No valid dictionary mapping file was found.");
+            }
         }
 
         private static Dictionary<string, Tuple<string, long>> ReadDictionaryFile(IEnumerable<string> dictionaryFileLines)
@@ -191,8 +198,14 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             foreach (string line in dictionaryFileLines)
             {
                 string[] split = line.Split('|');
-                string[] split2 = split[1].Split(',');
-                returnDictionary.Add(split[0].Trim(), new Tuple<string, long>(split2[0].Trim(), long.Parse(split2[1].Trim())));
+                if (split.Length == 2)
+                {
+                    string[] split2 = split[1].Split(',');
+                    if (split2.Length == 2)
+                    {
+                        returnDictionary.Add(split[0].Trim(), new Tuple<string, long>(split2[0].Trim(), long.Parse(split2[1].Trim())));
+                    }
+                }
             }
 
             return returnDictionary;

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -342,7 +342,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 // { fileID: 11500000, guid: 83d9acc7968244a8886f3af591305bcb, type: 3}
             }
 
-            if (fileEdited)
+            if (fileEdited || !scriptRemapping)
             {
                 File.WriteAllLines(targetPath, fileLines);
             }

--- a/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
@@ -56,6 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         public static string MSBuildOutputFolder { get; } = GetNormalizedPath(ProjectPath + MSBuildFolderName, true);
         public static string PackagesCopyPath { get; } = Path.Combine(MSBuildOutputFolder, PackagesCopyFolderName);
         public const string MetaFileGuidRegex = @"guid:\s*([0-9a-fA-F]{32})";
+        public const string MetaFileIdRegex = @"fileID:\s*(-?[0-9]+)";
 
         private static readonly string packagesPath;
 
@@ -118,7 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 while (!reader.EndOfStream)
                 {
                     string line = reader.ReadLine();
-                    Match match = Regex.Match(line, Utilities.MetaFileGuidRegex);
+                    Match match = Regex.Match(line, MetaFileGuidRegex);
 
                     if (match.Success)
                     {

--- a/Assets/MRTK/Tools/MSBuild/mrtk_guid_remapping_dictionary.txt
+++ b/Assets/MRTK/Tools/MSBuild/mrtk_guid_remapping_dictionary.txt
@@ -1,0 +1,1 @@
+This file is intentionally left blank. It will be filled in during the build pipeline. It exists to maintain a stable meta file and GUID.

--- a/Assets/MRTK/Tools/MSBuild/mrtk_guid_remapping_dictionary.txt.meta
+++ b/Assets/MRTK/Tools/MSBuild/mrtk_guid_remapping_dictionary.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bf5f763b2c6af9f4a875045818936836
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tools/MixedReality.Toolkit.Tools.nuspec
+++ b/Assets/MRTK/Tools/MixedReality.Toolkit.Tools.nuspec
@@ -27,6 +27,7 @@
     <file src="..\..\MRTK\Core\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Tools.targets" />
 
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tools.*" target="Plugins\" />
+    <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.MSBuild.*" target="Plugins\" />
     <file src="..\..\..\..\Assets\MRTK\Tools\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Tools" />
   </files>
 </package>

--- a/pipelines/templates/tasks/assetretargeting.yml
+++ b/pipelines/templates/tasks/assetretargeting.yml
@@ -16,7 +16,7 @@ steps:
     $method = "Microsoft.MixedReality.Toolkit.MSBuild.AssetScriptReferenceRetargeter.RetargetAssets"
     # Uses unitysetup.powershell
     try {
-      Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -ExecuteMethod $method -BatchMode -Quit -Wait -LogFile "$($logFile.FullName)" -AdditionalArguments "-NoGraphics -CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01}"
+      Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -ExecuteMethod $method -BatchMode -Quit -Wait -LogFile "$($logFile.FullName)" -AdditionalArguments "-NoGraphics -CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01} -dictionaryFileOutputFolder `"$(Build.SourcesDirectory)/NuGet/Content/MRTK/Tools/MSBuild`""
     }
     finally {
       if (Test-Path $logFile)

--- a/pipelines/templates/tasks/assetretargeting.yml
+++ b/pipelines/templates/tasks/assetretargeting.yml
@@ -16,7 +16,7 @@ steps:
     $method = "Microsoft.MixedReality.Toolkit.MSBuild.AssetScriptReferenceRetargeter.RetargetAssets"
     # Uses unitysetup.powershell
     try {
-      Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -ExecuteMethod $method -BatchMode -Quit -Wait -LogFile "$($logFile.FullName)" -AdditionalArguments "-NoGraphics -CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01} -dictionaryFileOutputFolder `"$(Build.SourcesDirectory)/NuGet/Content/MRTK/Tools/MSBuild`""
+      Start-UnityEditor -Project "$(Get-Location)" -Version ${{ parameters.UnityVersion }} -ExecuteMethod $method -BatchMode -Quit -Wait -LogFile "$($logFile.FullName)" -AdditionalArguments "-NoGraphics -CacheServerIPAddress ${Env:COG-UnityCache-WUS2-01} -dictionaryFileOutputFolder `"$(Build.SourcesDirectory)/Assets/MRTK/Tools/MSBuild`""
     }
     finally {
       if (Test-Path $logFile)

--- a/pipelines/templates/tasks/publish-nuget.yml
+++ b/pipelines/templates/tasks/publish-nuget.yml
@@ -13,6 +13,7 @@ steps:
 
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2 # NuGetCommand
   displayName: 'NuGet push'
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
   inputs:
     command: push
     packagesToPush: '${{ parameters.packageLocation }}/**/*.nupkg;!${{ parameters.packageLocation }}/**/*.symbols.nupkg'

--- a/pipelines/templates/tasks/publish-upm.yml
+++ b/pipelines/templates/tasks/publish-upm.yml
@@ -3,6 +3,7 @@
 steps:
 - task: PowerShell@2
   displayName: 'UPM packages to registry'
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
   inputs:
     targetType: filePath
     filePath: ./scripts/packaging/publishupmpackages.ps1


### PR DESCRIPTION
## Overview

This change writes out a txt file during our pipelines to make the mappings between the NuGet GUIDs and the script GUIDs accessible. It also adds a pop-up window for choosing a dictionary file, if multiple exist, and applying it to the codebase:

![image](https://user-images.githubusercontent.com/3580640/109356405-82eb7180-7835-11eb-8ffc-f5887fa41f0f.png)


Also:
1. Updates the remapping to only look for `UnityEngine.Object`s, since prefabs retain their GUIDs across distributions.
2. Clean-up and formatting