### PR TITLE
Only update renderViewPortScale if an XR device is present

### DIFF
--- a/Assets/MRTK/Examples/Demos/ReadingMode/Scripts/ReadingModeSceneBehavior.cs
+++ b/Assets/MRTK/Examples/Demos/ReadingMode/Scripts/ReadingModeSceneBehavior.cs
@@ -4,7 +4,14 @@
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.UI;
 using UnityEngine;
+
+#if UNITY_2019_3_OR_NEWER
+using Microsoft.MixedReality.Toolkit.Utilities;
+#endif // UNITY_2019_3_OR_NEWER
+
+#if !UNITY_2020_1_OR_NEWER
 using UnityEngine.XR;
+#endif // !UNITY_2020_1_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos.ReadingMode
 {
@@ -16,12 +23,31 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.ReadingMode
         [SerializeField]
         private PinchSlider renderViewportScaleSlider = null;
 
+        private float previousSliderValue = -1;
+
         private void Update()
         {
-            if (renderViewportScaleSlider != null)
+            if (renderViewportScaleSlider == null || renderViewportScaleSlider.SliderValue == previousSliderValue)
+            {
+                return;
+            }
+
+            previousSliderValue = renderViewportScaleSlider.SliderValue;
+
+#if UNITY_2019_3_OR_NEWER
+            if (XRSubsystemHelpers.DisplaySubsystem != null)
+            {
+                XRSubsystemHelpers.DisplaySubsystem.scaleOfAllViewports = renderViewportScaleSlider.SliderValue;
+                return;
+            }
+#endif // UNITY_2019_3_OR_NEWER
+
+#if !UNITY_2020_1_OR_NEWER
+            if (XRDevice.isPresent)
             {
                 XRSettings.renderViewportScale = renderViewportScaleSlider.SliderValue;
             }
+#endif // !UNITY_2020_1_OR_NEWER
         }
 
         public void EnableReadingMode()

--- a/Assets/MRTK/Examples/Demos/ReadingMode/Scripts/ReadingModeSceneBehavior.cs
+++ b/Assets/MRTK/Examples/Demos/ReadingMode/Scripts/ReadingModeSceneBehavior.cs
@@ -24,6 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.ReadingMode
         private PinchSlider renderViewportScaleSlider = null;
 
         private float previousSliderValue = -1;
+        private const float MinScale = 0.001f;
 
         private void Update()
         {
@@ -37,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.ReadingMode
 #if UNITY_2019_3_OR_NEWER
             if (XRSubsystemHelpers.DisplaySubsystem != null)
             {
-                XRSubsystemHelpers.DisplaySubsystem.scaleOfAllViewports = renderViewportScaleSlider.SliderValue;
+                XRSubsystemHelpers.DisplaySubsystem.scaleOfAllViewports = Mathf.Max(renderViewportScaleSlider.SliderValue, MinScale);
                 return;
             }
 #endif // UNITY_2019_3_OR_NEWER
@@ -45,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.ReadingMode
 #if !UNITY_2020_1_OR_NEWER
             if (XRDevice.isPresent)
             {
-                XRSettings.renderViewportScale = renderViewportScaleSlider.SliderValue;
+                XRSettings.renderViewportScale = Mathf.Max(renderViewportScaleSlider.SliderValue, MinScale);
             }
 #endif // !UNITY_2020_1_OR_NEWER
         }


### PR DESCRIPTION
## Overview

Previously, XRSettings was trying to change some values when it didn't actually have an underlying XR session. This change makes it so we only try to change the scale if an XRDevice is actually present.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9340, #9386

