### PR TITLE
Add null check for XR not initialized

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// </summary>
         /// <param name="loaderName">The string name to compare against the active loader.</param>
         /// <returns>True if the active loader has the same name as the parameter.</returns>
-        protected virtual bool IsLoaderActive(string loaderName) => XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
+        protected virtual bool IsLoaderActive(string loaderName) => XRGeneralSettings.Instance.Manager.activeLoader != null && XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
 
         /// <summary>
         /// Checks if the active loader is of a specific type. Used in cases where the loader class is accessible, like OculusLoader.


### PR DESCRIPTION
## Overview

When XR is disabled, `XRGeneralSettings.Instance.Manager.activeLoader` is null, so we were causing a null ref in the WMR provider which cascaded into the Oculus provider not running through its init fully.

Fixing this null check prevented the reported errors.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9392
