### PR TITLE
Update legacy and XR SDK implementation for renderViewportScaleSlider

### DIFF
--- a/Assets/MRTK/Examples/Demos/ReadingMode/Scripts/ReadingModeSceneBehavior.cs
+++ b/Assets/MRTK/Examples/Demos/ReadingMode/Scripts/ReadingModeSceneBehavior.cs
@@ -3,15 +3,9 @@
 
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.UI;
-using UnityEngine;
-
-#if UNITY_2019_3_OR_NEWER
 using Microsoft.MixedReality.Toolkit.Utilities;
-#endif // UNITY_2019_3_OR_NEWER
-
-#if !UNITY_2020_1_OR_NEWER
+using UnityEngine;
 using UnityEngine.XR;
-#endif // !UNITY_2020_1_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos.ReadingMode
 {
@@ -35,20 +29,10 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.ReadingMode
 
             previousSliderValue = renderViewportScaleSlider.SliderValue;
 
-#if UNITY_2019_3_OR_NEWER
-            if (XRSubsystemHelpers.DisplaySubsystem != null)
-            {
-                XRSubsystemHelpers.DisplaySubsystem.scaleOfAllViewports = Mathf.Max(renderViewportScaleSlider.SliderValue, MinScale);
-                return;
-            }
-#endif // UNITY_2019_3_OR_NEWER
-
-#if !UNITY_2020_1_OR_NEWER
-            if (XRDevice.isPresent)
+            if (DeviceUtility.IsPresent)
             {
                 XRSettings.renderViewportScale = Mathf.Max(renderViewportScaleSlider.SliderValue, MinScale);
             }
-#endif // !UNITY_2020_1_OR_NEWER
         }
 
         public void EnableReadingMode()


### PR DESCRIPTION
## Overview

`XRSubsystemHelpers.DisplaySubsystem.scaleOfAllViewports` doesn't appear to do anything (yet?). This change aligns the implementation to `XRSettings.renderViewportScale` across both legacy and XR SDK while the other method is investigated.

Follow-up to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9398
