### PR TITLE
Fix OpenXR on UWP

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 #if UNITY_OPENXR
                 if (!isActiveLoader.HasValue)
                 {
-                    isActiveLoader = IsLoaderActive<OpenXRLoader>();
+                    isActiveLoader = IsLoaderActive<OpenXRLoader>() || IsLoaderActive<OpenXRLoaderNoPreInit>();
                 }
 #endif // UNITY_OPENXR
 

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 #if UNITY_OPENXR
                 if (!isActiveLoader.HasValue)
                 {
-                    isActiveLoader = IsLoaderActive<OpenXRLoader>() || IsLoaderActive<OpenXRLoaderNoPreInit>();
+                    isActiveLoader = IsLoaderActive<OpenXRLoaderBase>();
                 }
 #endif // UNITY_OPENXR
 


### PR DESCRIPTION
## Overview

On UWP, the type is now OpenXRLoaderNoPreInit. This line is updated to refer to the shared base class.