### PR TITLE
Clipping primitive now removes OnPreRender event upon deletion

### DIFF
--- a/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
@@ -84,7 +84,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
                 }
 
-                if(useOnPreRender != value)
+                if (useOnPreRender != value)
                 {
                     if (value)
                     {

--- a/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
@@ -195,6 +195,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     RemoveRenderer(renderers.Count - 1);
                 }
             }
+
+            UseOnPreRender = false;
         }
 
         /// <summary>

--- a/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
@@ -84,16 +84,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
                 }
 
-                if (value)
+                if(useOnPreRender != value)
                 {
-                    cameraMethods.OnCameraPreRender += OnCameraPreRender;
-                }
-                else
-                {
-                    cameraMethods.OnCameraPreRender -= OnCameraPreRender;
-                }
+                    if (value)
+                    {
+                        cameraMethods.OnCameraPreRender += OnCameraPreRender;
+                    }
+                    else if (!value)
+                    {
+                        cameraMethods.OnCameraPreRender -= OnCameraPreRender;
+                    }
 
-                useOnPreRender = value;
+                    useOnPreRender = value;
+                }
             }
         }
 
@@ -195,8 +198,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     RemoveRenderer(renderers.Count - 1);
                 }
             }
-
-            UseOnPreRender = false;
         }
 
         /// <summary>
@@ -242,7 +243,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             if (cameraMethods != null)
             {
-                cameraMethods.OnCameraPreRender -= OnCameraPreRender;
+                UseOnPreRender = false;
             }
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -1478,6 +1478,43 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual((handTouchDelta - scrollView.HandDeltaScrollThreshold) / newScale, scrollView.ScrollContainerPosition.y, 0.005, "Scroll drag amount was not 1:1");
         }
 
+        /// <summary>
+        /// Tests that no errors are raised after the scrolling object collection is removed from the scene
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScrollViewCleanup()
+        {
+            // Setting up a vertical 1x2 scroll view with three pressable buttons items
+            var contentItems = InstantiatePrefabItems(AssetDatabase.GUIDToAssetPath(PressableHololens2PrefabGuid), 3);
+
+            GridObjectCollection objectCollection = InstantiateObjectCollection(contentItems,
+                                                                                LayoutOrder.ColumnThenRow,
+                                                                                LayoutAnchor.UpperLeft,
+                                                                                1,
+                                                                                Vector3.forward,
+                                                                                Quaternion.identity,
+                                                                                0.032f,
+                                                                                0.032f);
+
+            ScrollingObjectCollection scrollView = InstantiateScrollView(1,
+                                                                         2,
+                                                                         objectCollection.CellWidth,
+                                                                         objectCollection.CellHeight,
+                                                                         0.016f,
+                                                                         Vector3.forward,
+                                                                         Quaternion.identity);
+            scrollView.AddContent(objectCollection.gameObject);
+
+            PressableButton button1Component = contentItems[0].GetComponentInChildren<PressableButton>();
+
+            Assert.IsNotNull(button1Component);
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            Object.Destroy(scrollView.gameObject);
+
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+        }
+
         #endregion Tests
 
         #region Utilities


### PR DESCRIPTION
## Overview
Clipping primitive now unregisters its event upon deletion, which fixes a series of null reference exceptions that would get raised otherwise.

## Changes
Fixes #9450 
