### PR TITLE
Ensure async operations on progress indicators don't wait on animations if the object is hidden

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorObjectDisplay.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorObjectDisplay.cs
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             float startTime = Time.unscaledTime;
             float openScale = 0f;
-            while (openScale < 1)
+            while (openScale < 1 && isActiveAndEnabled)
             {
                 openScale = openCurve.Evaluate(Time.unscaledTime - startTime);
                 scaleTargetObject.transform.localScale = Vector3.one * currentScale * openScale;
@@ -133,7 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             float startTime = Time.unscaledTime;
             float closeScale = 1f;
-            while (closeScale > 0)
+            while (closeScale > 0 && isActiveAndEnabled)
             {
                 closeScale = closeCurve.Evaluate(Time.unscaledTime - startTime);
                 scaleTargetObject.transform.localScale = Vector3.one * currentScale * closeScale;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             StopOrbs();
 
-            while (!hasAnimationFinished)
+            while (!hasAnimationFinished && isActiveAndEnabled)
             {
                 await Task.Yield();
             }


### PR DESCRIPTION
## Overview
If a UI task is awaiting on a progress indicator to close (e.g. to perform an animation) and the object is hidden (disabled/deactivated), the CloseAsync() method will never return, causing the progress indicator to be forever stuck.

Async/awaitable logic should not depend on the animations while the object is visible, since the object might be hidden by some other piece of code before the animation completes, blocking the async operation forever.

This change makes the progress indicators short circuit their waiting logic if the underlying object is disabled or deactivated, not delaying any processing due to invisible animations.

## Changes
- Fixes: #9462 

## Verification
See #9462 for repro steps. Verified on Editor.