### PR TITLE
Removed the ability for users to set a TypeReferenceProperty to None

### DIFF
--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -290,7 +290,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             var menu = new GenericMenu();
 
-            if(types.Count == 0)
+            if (types.Count == 0)
             {
                 menu.AddItem(new GUIContent("No types available"), selectedType == null, OnSelectedTypeName, null);
             }

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -289,17 +289,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static void DisplayDropDown(Rect position, List<Type> types, Type selectedType, TypeGrouping grouping)
         {
             var menu = new GenericMenu();
-            menu.AddItem(new GUIContent("(None)"), selectedType == null, OnSelectedTypeName, null);
-            menu.AddSeparator(string.Empty);
 
-            for (int i = 0; i < types.Count; ++i)
+            if(types.Count == 0)
             {
-                string menuLabel = FormatGroupedTypeName(types[i], grouping);
+                menu.AddItem(new GUIContent("No types available"), selectedType == null, OnSelectedTypeName, null);
+            }
+            else
+            {
+                for (int i = 0; i < types.Count; ++i)
+                {
+                    string menuLabel = FormatGroupedTypeName(types[i], grouping);
 
-                if (string.IsNullOrEmpty(menuLabel)) { continue; }
+                    if (string.IsNullOrEmpty(menuLabel)) { continue; }
 
-                var content = new GUIContent(menuLabel);
-                menu.AddItem(content, types[i] == selectedType, OnSelectedTypeName, types[i]);
+                    var content = new GUIContent(menuLabel);
+                    menu.AddItem(content, types[i] == selectedType, OnSelectedTypeName, types[i]);
+                }
             }
 
             menu.DropDown(position);

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -17,7 +17,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [AddComponentMenu("Scripts/MRTK/Services/GazeProvider")]
     public class GazeProvider :
         InputSystemGlobalHandlerListener,
-        IMixedRealityGazeProvider,
         IMixedRealityGazeProviderHeadOverride,
         IMixedRealityEyeGazeProvider,
         IMixedRealityInputHandler


### PR DESCRIPTION
## Overview
Setting a type reference property to (None) always results in undesired behavior or unpleasant experience for developers. This PR removes this option, ensuring that the type reference property is always set to something.

This PR also fixes a redundant interface declaration with the GazeProvider class.

old:
![types1](https://user-images.githubusercontent.com/39840334/110373340-3f96bd00-8004-11eb-92c6-4dfde07abe22.png)

new:
![types2](https://user-images.githubusercontent.com/39840334/110373366-445b7100-8004-11eb-840d-a29831eb5284.png)

In the case where there are no types which implement the interface we are looking for (This is a very rare edge case and we shouldn't be hitting this in the first place)
![types3](https://user-images.githubusercontent.com/39840334/110373376-47566180-8004-11eb-94ff-49d01648555a.png)


## Changes
Part of the work done for #8910

