### PR TITLE
Fixed Object Manipulator Rotation for Leap Hands

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
@@ -247,6 +247,8 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
                 pointerPose.Position = ray.origin;
                 pointerPose.Rotation = Quaternion.LookRotation(ray.direction);
             }
+        
+            CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, gripPose);
 
             for (int i = 0; i < Interactions?.Length; i++)
             {


### PR DESCRIPTION
## Overview
Leap Articulated Hands now raise the "SourcePoseChanged" Event, allowing them to work with Object Manipulator Rotation again.


## Changes
- Fixes: #9474

@CDiaz-MS when you get a chance can you confirm the fix?