### PR TITLE
Leap Motion Unity Modules Support for version 4.6.0, 4.7.0 and 4.7.1 

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         private static bool isLeapRecognizedByMRTK = false;
 
         // The current supported Leap Core Assets version numbers.
-        private static string[] leapCoreAssetsVersionsSupported = new string[] { "4.5.0", "4.5.1" };
+        private static string[] leapCoreAssetsVersionsSupported = new string[] { "4.5.0", "4.5.1", "4.6.0", "4.7.0", "4.7.1" };
 
         // The current Leap Core Assets version in this project
         private static string currentLeapCoreAssetsVersion = "";
@@ -214,6 +214,14 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         {
             string leapCoreAsmDefPath = Path.Combine(Application.dataPath, pathDifference, "LeapMotion", "LeapMotion.asmdef");
 
+            // If the Leap Unity Modules version is 4.7.1, then do not add the LeapMotion.asmdef because it already exists in the package
+            FileInfo[] leapMotionAsmDefFile = FileUtilities.FindFilesInAssets("LeapMotion.asmdef");
+
+            if (leapMotionAsmDefFile.Length != 0)
+            {
+                return;
+            }
+
             // If the asmdef has already been created then do not create another one
             if (!File.Exists(leapCoreAsmDefPath))
             {
@@ -232,6 +240,11 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                 if (currentLeapCoreAssetsVersion == "4.5.1")
                 {
                     leapAsmDef.AddReference("LeapMotion.LeapCSharp");
+
+                    // If the unity modules version is 4.6.0 or 4.7.0 then add SpatialTracking as a reference
+#if UNITY_2019_3_OR_NEWER
+                    leapAsmDef.AddReference("UnityEngine.SpatialTracking");
+#endif
                 }
 
                 leapAsmDef.Save(leapCoreAsmDefPath);
@@ -271,7 +284,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                         };
 
                         // Add the LeapMotion.LeapCSharp assembly definition to the leap motion tests assembly definition
-                        if (currentLeapCoreAssetsVersion == "4.5.1" && leapAsmDef.Key == "LeapMotion.Core.Tests.Editor")
+                        if (currentLeapCoreAssetsVersion == "4.5.1" && (leapAsmDef.Key == "LeapMotion.Core.Tests.Editor" || leapAsmDef.Key == "LeapMotion.Core.Editor"))
                         {
                             leapEditorAsmDef.AddReference("LeapMotion.LeapCSharp");
                         }

--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -41,6 +41,12 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         // The Leap Unity Modules version 4.7.1 already contains a LeapMotion.asmdef file at this path
         private static string leapAsmDefPath_471 = "LeapMotion/Core/Scripts/LeapMotion.asmdef";
 
+        // This path is used to determine if the Leap Motion Unity Modules is version 4.7.0
+        private static string leapTestsPath_470 = "LeapMotion/Core/Editor/Tests";
+
+        // This path is used to determine if the Leap Motion Unity Modules is version 4.6.0 or 4.5.1
+        private static string leapXRPath_451 = "LeapMotion/Core/Scripts/XR/LeapXRPinchLocomotion.cs";
+
         // Array of paths to Leap Motion testing directories that will be removed from the project.
         // Make sure each test directory ends with '/'
         // These paths only need to be deleted if the Leap Core Assets version is 4.4.0
@@ -126,6 +132,8 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
 
                 if (isLeapCoreAssetsVersionSupported)
                 {
+                    Debug.Log($"Integrating the Leap Motion Unity Modules Version {currentLeapCoreAssetsVersion} with MRTK");
+
                     RemoveTestingFolders();
                     AddAndUpdateAsmDefs();
                     AddLeapEditorAsmDefs();
@@ -161,6 +169,32 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                         if (line.Contains(versionNumberSupported))
                         {
                             currentLeapCoreAssetsVersion = versionNumberSupported;
+
+                            // The Leap Motion Unity modules Version.txt has remained 4.5.1 across versions 4.6.0, 4.7.0 and 4.7.1, check for the presence
+                            // of certian paths to infer the version number.
+
+                            // This path is only present in 4.7.1
+                            string leap471Path = Path.Combine(Application.dataPath, pathDifference, leapAsmDefPath_471);
+
+                            // This path is present in versions 4.7.0 and 4.7.1
+                            string testDirectoryPath = Path.Combine(Application.dataPath, pathDifference, leapTestsPath_470);
+
+                            // This path is present in 4.6.0 and not 4.5.1
+                            string xrPath = Path.Combine(Application.dataPath, pathDifference, leapXRPath_451);
+
+                            if (File.Exists(leap471Path))
+                            {
+                                currentLeapCoreAssetsVersion = "4.7.1";
+                            }
+                            else if (!File.Exists(leap471Path) && Directory.Exists(testDirectoryPath))
+                            {
+                                currentLeapCoreAssetsVersion = "4.7.0";
+                            }
+                            else if (!File.Exists(leap471Path) && !Directory.Exists(testDirectoryPath) && File.Exists(xrPath))
+                            {
+                                currentLeapCoreAssetsVersion = "4.6.0";
+                            }
+
                             return true;
                         }
                     }
@@ -217,14 +251,9 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         {
             string leapCoreAsmDefPath = Path.Combine(Application.dataPath, pathDifference, "LeapMotion", "LeapMotion.asmdef");
 
-            // The Leap Unity Modules version is 4.7.1 already contains a LeapMotion.asmdef 
-            string leap471Path = Path.Combine(Application.dataPath, pathDifference, leapAsmDefPath_471);
-
-            // If the LeapMotion.asmdef is present, then the Leap Unity Modules version is 4.7.1 and the other
-            // LeapMotion.asmdef file does not need to be created. 
-            if (File.Exists(leap471Path))
+            // If the Leap Unity Modules version is 4.7.1, the LeapMotion.asmdef file does not need to be created
+            if (currentLeapCoreAssetsVersion == "4.7.1")
             {
-                currentLeapCoreAssetsVersion = "4.7.1";
                 return;
             }
 
@@ -243,7 +272,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
 
                 // An assembly definition was added to the Leap Core Assets in version 4.5.1
                 // The LeapMotion.LeapCSharp assembly definition is added as a reference at the root of the Core Assets
-                if (currentLeapCoreAssetsVersion == "4.5.1")
+                if (currentLeapCoreAssetsVersion == "4.5.1" || currentLeapCoreAssetsVersion == "4.6.0" || currentLeapCoreAssetsVersion == "4.7.0")
                 {
                     leapAsmDef.AddReference("LeapMotion.LeapCSharp");
 
@@ -290,7 +319,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                         };
 
                         // Add the LeapMotion.LeapCSharp assembly definition to the leap motion tests assembly definition
-                        if ((currentLeapCoreAssetsVersion == "4.5.1" || currentLeapCoreAssetsVersion == "4.7.1") && (leapAsmDef.Key == "LeapMotion.Core.Tests.Editor" || leapAsmDef.Key == "LeapMotion.Core.Editor"))
+                        if ((currentLeapCoreAssetsVersion == "4.5.1" || currentLeapCoreAssetsVersion == "4.6.0" || currentLeapCoreAssetsVersion == "4.7.0" || currentLeapCoreAssetsVersion == "4.7.1") && (leapAsmDef.Key == "LeapMotion.Core.Tests.Editor" || leapAsmDef.Key == "LeapMotion.Core.Editor"))
                         {
                             leapEditorAsmDef.AddReference("LeapMotion.LeapCSharp");
                         }

--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -38,6 +38,9 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         // The path difference between the root of assets and the root of the Leap Motion Core Assets.
         private static string pathDifference = "";
 
+        // The Leap Unity Modules version 4.7.1 already contains a LeapMotion.asmdef file at this path
+        private static string leapAsmdefPath_471 = "LeapMotion/Core/Scripts/LeapMotion.asmdef";
+
         // Array of paths to Leap Motion testing directories that will be removed from the project.
         // Make sure each test directory ends with '/'
         // These paths only need to be deleted if the Leap Core Assets version is 4.4.0
@@ -214,11 +217,14 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         {
             string leapCoreAsmDefPath = Path.Combine(Application.dataPath, pathDifference, "LeapMotion", "LeapMotion.asmdef");
 
-            // If the Leap Unity Modules version is 4.7.1, then do not add the LeapMotion.asmdef because it already exists in the package
-            FileInfo[] leapMotionAsmDefFile = FileUtilities.FindFilesInAssets("LeapMotion.asmdef");
+            // The Leap Unity Modules version is 4.7.1 already contains a LeapMotion.asmdef 
+            string leap471Path = Path.Combine(Application.dataPath, pathDifference, "Plugins", leapAsmdefPath_471);
 
-            if (leapMotionAsmDefFile.Length != 0)
+            // If the LeapMotion.asmdef is present, then the Leap Unity Modules version is 4.7.1 and the other
+            // LeapMotion.asmdef file does not need to be created. 
+            if (File.Exists(leap471Path))
             {
+                currentLeapCoreAssetsVersion = "4.7.1";
                 return;
             }
 
@@ -284,7 +290,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                         };
 
                         // Add the LeapMotion.LeapCSharp assembly definition to the leap motion tests assembly definition
-                        if (currentLeapCoreAssetsVersion == "4.5.1" && (leapAsmDef.Key == "LeapMotion.Core.Tests.Editor" || leapAsmDef.Key == "LeapMotion.Core.Editor"))
+                        if ((currentLeapCoreAssetsVersion == "4.5.1"|| currentLeapCoreAssetsVersion == "4.7.1") && (leapAsmDef.Key == "LeapMotion.Core.Tests.Editor" || leapAsmDef.Key == "LeapMotion.Core.Editor"))
                         {
                             leapEditorAsmDef.AddReference("LeapMotion.LeapCSharp");
                         }

--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         private static string leapTestsPath_470 = "LeapMotion/Core/Editor/Tests";
 
         // This path is used to determine if the Leap Motion Unity Modules is version 4.6.0 or 4.5.1
-        private static string leapXRPath_451 = "LeapMotion/Core/Scripts/XR/LeapXRPinchLocomotion.cs";
+        private static string leapXRPath_460 = "LeapMotion/Core/Scripts/XR/LeapXRPinchLocomotion.cs";
 
         // Array of paths to Leap Motion testing directories that will be removed from the project.
         // Make sure each test directory ends with '/'
@@ -171,7 +171,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                             currentLeapCoreAssetsVersion = versionNumberSupported;
 
                             // The Leap Motion Unity modules Version.txt has remained 4.5.1 across versions 4.6.0, 4.7.0 and 4.7.1, check for the presence
-                            // of certian paths to infer the version number.
+                            // of certain paths to infer the version number.
 
                             // This path is only present in 4.7.1
                             string leap471Path = Path.Combine(Application.dataPath, pathDifference, leapAsmDefPath_471);
@@ -180,7 +180,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                             string testDirectoryPath = Path.Combine(Application.dataPath, pathDifference, leapTestsPath_470);
 
                             // This path is present in 4.6.0 and not 4.5.1
-                            string xrPath = Path.Combine(Application.dataPath, pathDifference, leapXRPath_451);
+                            string xrPath = Path.Combine(Application.dataPath, pathDifference, leapXRPath_460);
 
                             if (File.Exists(leap471Path))
                             {

--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         private static string pathDifference = "";
 
         // The Leap Unity Modules version 4.7.1 already contains a LeapMotion.asmdef file at this path
-        private static string leapAsmdefPath_471 = "LeapMotion/Core/Scripts/LeapMotion.asmdef";
+        private static string leapAsmDefPath_471 = "LeapMotion/Core/Scripts/LeapMotion.asmdef";
 
         // Array of paths to Leap Motion testing directories that will be removed from the project.
         // Make sure each test directory ends with '/'
@@ -218,7 +218,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             string leapCoreAsmDefPath = Path.Combine(Application.dataPath, pathDifference, "LeapMotion", "LeapMotion.asmdef");
 
             // The Leap Unity Modules version is 4.7.1 already contains a LeapMotion.asmdef 
-            string leap471Path = Path.Combine(Application.dataPath, pathDifference, "Plugins", leapAsmdefPath_471);
+            string leap471Path = Path.Combine(Application.dataPath, pathDifference, leapAsmDefPath_471);
 
             // If the LeapMotion.asmdef is present, then the Leap Unity Modules version is 4.7.1 and the other
             // LeapMotion.asmdef file does not need to be created. 
@@ -290,7 +290,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                         };
 
                         // Add the LeapMotion.LeapCSharp assembly definition to the leap motion tests assembly definition
-                        if ((currentLeapCoreAssetsVersion == "4.5.1"|| currentLeapCoreAssetsVersion == "4.7.1") && (leapAsmDef.Key == "LeapMotion.Core.Tests.Editor" || leapAsmDef.Key == "LeapMotion.Core.Editor"))
+                        if ((currentLeapCoreAssetsVersion == "4.5.1" || currentLeapCoreAssetsVersion == "4.7.1") && (leapAsmDef.Key == "LeapMotion.Core.Tests.Editor" || leapAsmDef.Key == "LeapMotion.Core.Editor"))
                         {
                             leapEditorAsmDef.AddReference("LeapMotion.LeapCSharp");
                         }


### PR DESCRIPTION
## Overview

Adds support for the 4.6.0, 4.7.0, 4.7.1 [Leap Motion Unity Modules](https://github.com/leapmotion/UnityModules/releases). The latest version MRTK currently supports is 4.5.1. 

## Testing Items
[Leap Modules Version 4.6.0](https://github.com/leapmotion/UnityModules/releases/tag/UM-4.6.0) 
- [x] Unity 2018.4
- [x] Unity 2019.4
- [x] Unity 2020

[Leap Modules Version 4.7.0](https://github.com/leapmotion/UnityModules/releases/tag/UM-4.7.0) 
- [x] Unity 2018.4
- [x] Unity 2019.4
- [x] Unity 2020

[Leap Modules Version 4.7.1](https://github.com/leapmotion/UnityModules/releases/tag/UM-4.7.1)
- [x] Unity 2018.4
- [x] Unity 2019.4
- [x] Unity 2020

An item to note is that Leap has not updated the Version.txt since 4.5.1: https://github.com/leapmotion/UnityModules/blob/release-4.7.0/Assets/Plugins/LeapMotion/Core/Version.txt. The version.txt for 4.6.0, 4.7.0, and 4.7.1 has 4.5.1 listed. 

- [x] Determine conditions for determining the difference between the 4.5.1, 4.6.0 and 4.7.0 Unity Modules without the Version.txt 

## Changes
- Fixes: #8928 
