### PR TITLE
Removed arkit and arcore due to incompatible gradle versions

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,9 +2,7 @@
   "dependencies": {
     "com.unity.package-manager-ui": "2.0.13",
     "com.unity.textmeshpro": "1.4.1",
-    "com.unity.xr.arcore": "2.1.2",
     "com.unity.xr.arfoundation": "1.5.0-preview.6",
-    "com.unity.xr.arkit": "2.1.2",
     "com.unity.xr.openvr.standalone": "1.0.5",
     "com.unity.xr.windowsmr.metro": "1.0.21",
     "com.unity.modules.ai": "1.0.0",


### PR DESCRIPTION
## Overview
When building for Oculus Quest, you will encounter gradle build errors and be unable to deploy due to incompatible gradle versions, ARCore requires minimum 5.6.4 while the Unity android defaults are 5.1.1

https://stackoverflow.com/questions/64381387/cant-compile-unity-project-with-arcore-sdk-problem-with-gradle

Since we don't use ARCore or ARKit directly in MRTK, this PR removes our dependency on those 2 packages to make the Oculus Quest experience less painful, and to allow our users to not have to discover this quirk themselves.
