### PR TITLE
Added checks for null for XRGeneralSettings.Instance and XRGeneralSettings.Instance.Manager

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -62,14 +62,14 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// </summary>
         /// <param name="loaderName">The string name to compare against the active loader.</param>
         /// <returns>True if the active loader has the same name as the parameter.</returns>
-        protected virtual bool IsLoaderActive(string loaderName) => XRGeneralSettings.Instance.Manager.activeLoader != null && XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
+        protected virtual bool IsLoaderActive(string loaderName) => XRGeneralSettings.Instance?.Manager?.activeLoader != null && XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
 
         /// <summary>
         /// Checks if the active loader is of a specific type. Used in cases where the loader class is accessible, like OculusLoader.
         /// </summary>
         /// <typeparam name="T">The loader class type to check against the active loader.</typeparam>
         /// <returns>True if the active loader is of the specified type.</returns>
-        protected virtual bool IsLoaderActive<T>() where T : XRLoader => XRGeneralSettings.Instance.Manager.activeLoader is T;
+        protected virtual bool IsLoaderActive<T>() where T : XRLoader => XRGeneralSettings.Instance?.Manager?.activeLoader is T;
 #endif // XR_MANAGEMENT_ENABLED
 
         private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] XRSDKDeviceManager.Update");

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -62,14 +62,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// </summary>
         /// <param name="loaderName">The string name to compare against the active loader.</param>
         /// <returns>True if the active loader has the same name as the parameter.</returns>
-        protected virtual bool IsLoaderActive(string loaderName) => XRGeneralSettings.Instance?.Manager?.activeLoader != null && XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
+        protected virtual bool IsLoaderActive(string loaderName) => XRGeneralSettings.Instance != null && XRGeneralSettings.Instance.Manager != null &&
+            XRGeneralSettings.Instance.Manager.activeLoader != null && XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
 
         /// <summary>
         /// Checks if the active loader is of a specific type. Used in cases where the loader class is accessible, like OculusLoader.
         /// </summary>
         /// <typeparam name="T">The loader class type to check against the active loader.</typeparam>
         /// <returns>True if the active loader is of the specified type.</returns>
-        protected virtual bool IsLoaderActive<T>() where T : XRLoader => XRGeneralSettings.Instance?.Manager?.activeLoader is T;
+        protected virtual bool IsLoaderActive<T>() where T : XRLoader => XRGeneralSettings.Instance != null && XRGeneralSettings.Instance.Manager != null && XRGeneralSettings.Instance.Manager.activeLoader is T;
 #endif // XR_MANAGEMENT_ENABLED
 
         private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] XRSDKDeviceManager.Update");


### PR DESCRIPTION
## Overview
Previously users would get a NullPointerException followed up other non-crashing errors when running in editor while targetting a platform which uses XRSDK. This fix prevents the propogation of errors in editor

## Changes
- Fixes: #9469
