### PR TITLE
Change the handling of missing assemblies in build script

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/CSProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/CSProjectInfo.cs
@@ -160,6 +160,11 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
         private void AddDependency<T>(List<CSProjectDependency<T>> items, T referenceInfo) where T : ReferenceItemInfo
         {
+            if (referenceInfo == null)
+            {
+                return;
+            }
+            
             items.Add(new CSProjectDependency<T>(referenceInfo,
                 new HashSet<BuildTarget>(InEditorPlatforms.Keys.Intersect(referenceInfo.InEditorPlatforms.Keys)),
                 new HashSet<BuildTarget>(PlayerPlatforms.Keys.Intersect(referenceInfo.PlayerPlatforms.Keys))));


### PR DESCRIPTION
## Overview

Currently we maintain a two sets that contain all the packages that we are not including when generating the binaries for API reference docs. Some of those packages are MRTK ones that only need to be excluded because they apply to specific versions of Unity. The rest are excluded because they are external-to-MRTK packages and we do not have the source. Right now both sets of packages are being tracked and we have to edit the sets once a new external reference is added into an asmdef file. This PR removes the need of tracking the second kind of packages and consolidates the two sets into one so that we do not have to modify the set as often.