### PR TITLE
Add scale to MRTransform ToString()

### DIFF
--- a/Assets/MRTK/Core/Definitions/Utilities/MixedRealityTransform.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/MixedRealityTransform.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         public override string ToString()
         {
-            return $"{pose.Position} | {pose.Rotation}";
+            return $"{pose.Position} | {pose.Rotation} | {scale}";
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

Adds the scale to `ToString()` to properly print the full state of the transform.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9536
