### PR TITLE
Add support for motion controller models at runtime in WMR/XRSDK

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationSetting.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationSetting.cs
@@ -21,6 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="controllerType">Controller Type to instantiate at runtime.</param>
         /// <param name="handedness">The designated hand that the device is managing.</param>
         /// <param name="overrideModel">The controller model prefab to be rendered.</param>
+        [Obsolete("This constructor doesn't need to be called directly.")]
         public MixedRealityControllerVisualizationSetting(string description, Type controllerType, Handedness handedness = Handedness.None, GameObject overrideModel = null) : this()
         {
             this.description = description;

--- a/Assets/MRTK/Core/Providers/BaseController.cs
+++ b/Assets/MRTK/Core/Providers/BaseController.cs
@@ -234,13 +234,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <returns>True if a model was successfully loaded or model rendering is disabled. False if a model tried to load but failed.</returns>
         protected virtual bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)
         {
-            GameObject controllerModel = null;
-
             if (GetControllerVisualizationProfile() == null ||
                 !GetControllerVisualizationProfile().RenderMotionControllers)
             {
                 return true;
             }
+
+            GameObject controllerModel = null;
 
             // If a specific controller template wants to override the global model, assign that instead.
             if (IsControllerMappingEnabled() &&

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/Extensions/WindowsExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/Extensions/WindowsExtensions.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 #if WINDOWS_UWP
+using Windows.Perception;
 using Windows.UI.Input.Spatial;
 #elif DOTNETWINRT_PRESENT
+using Microsoft.Windows.Perception;
 using Microsoft.Windows.UI.Input.Spatial;
 #endif
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
@@ -36,6 +39,61 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                 default:
                     return Handedness.None;
             }
+        }
+
+        /// <summary>
+        /// Tries to get an active SpatialInteractionSource with the corresponding handedness and input source type.
+        /// </summary>
+        /// <param name="handedness">The handedness of the source to get.</param>
+        /// <param name="inputSourceType">The input source type of the source to get.</param>
+        /// <returns>The input source or null if none could be found.</returns>
+        public static SpatialInteractionSource GetSpatialInteractionSource(Handedness handedness, InputSourceType inputSourceType)
+        {
+            SpatialInteractionSourceHandedness sourceHandedness;
+            switch (handedness)
+            {
+                default:
+                    sourceHandedness = SpatialInteractionSourceHandedness.Unspecified;
+                    break;
+                case Handedness.Left:
+                    sourceHandedness = SpatialInteractionSourceHandedness.Left;
+                    break;
+                case Handedness.Right:
+                    sourceHandedness = SpatialInteractionSourceHandedness.Right;
+                    break;
+            }
+
+            SpatialInteractionSourceKind sourceKind;
+            switch (inputSourceType)
+            {
+                default:
+                    sourceKind = SpatialInteractionSourceKind.Other;
+                    break;
+                case InputSourceType.Controller:
+                    sourceKind = SpatialInteractionSourceKind.Controller;
+                    break;
+                case InputSourceType.Hand:
+                    sourceKind = SpatialInteractionSourceKind.Hand;
+                    break;
+            }
+
+            System.Collections.Generic.IReadOnlyList<SpatialInteractionSourceState> sourceStates =
+                WindowsMixedRealityUtilities.SpatialInteractionManager?.GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(System.DateTimeOffset.UtcNow));
+
+            if (sourceStates == null)
+            {
+                return null;
+            }
+
+            foreach (SpatialInteractionSourceState sourceState in sourceStates)
+            {
+                if (sourceState.Source.Handedness == sourceHandedness && sourceState.Source.Kind == sourceKind)
+                {
+                    return sourceState.Source;
+                }
+            }
+
+            return null;
         }
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
     }

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/MRTK.WMR.Shared.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/MRTK.WMR.Shared.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared",
     "references": [
-        "Microsoft.MixedReality.Toolkit"
+        "Microsoft.MixedReality.Toolkit",
+        "Microsoft.MixedReality.Toolkit.Gltf"
     ],
     "includePlatforms": [
         "Editor",

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
@@ -25,24 +25,26 @@ using System.Threading.Tasks;
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 {
     /// <summary>
-    /// Queries the hand mesh data that an articulated hand on HoloLens 2 can provide.
+    /// Queries the WinRT APIs for a renderable controller model.
     /// </summary>
     public class WindowsMixedRealityControllerModelProvider
     {
+        public WindowsMixedRealityControllerModelProvider(Handedness handedness)
+        {
+            this.handedness = handedness;
 
 #if WINDOWS_UWP
-        public WindowsMixedRealityControllerModelProvider(BaseController controller, SpatialInteractionSourceState spatialInteractionSourceState)
-        {
-            this.controller = controller;
-            this.spatialInteractionSourceState = spatialInteractionSourceState;
+            spatialInteractionSource = WindowsExtensions.GetSpatialInteractionSource(handedness, InputSourceType.Controller);
+#endif // WINDOWS_UWP
         }
 
         public bool UnableToGenerateSDKModel;
+        private readonly Handedness handedness;
 
         private readonly BaseController controller;
         private IMixedRealityInputSource InputSource => controller.InputSource;
-        private Handedness Handedness => controller.ControllerHandedness;
         private SpatialInteractionSourceState spatialInteractionSourceState;
+#if WINDOWS_UWP
 
         private static readonly Dictionary<string, GameObject> controllerModelDictionary = new Dictionary<string, GameObject>(0);
 
@@ -87,7 +89,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                     var visualizationProfile = CoreServices.InputSystem?.InputSystemProfile.ControllerVisualizationProfile;
                     if (visualizationProfile != null)
                     {
-                        var visualizationType = visualizationProfile.GetControllerVisualizationTypeOverride(GetType(), Handedness);
+                        var visualizationType = visualizationProfile.GetControllerVisualizationTypeOverride(GetType(), handedness);
                         if (visualizationType != null)
                         {
                             // Set the platform controller model to not be destroyed when the source is lost. It'll be disabled instead,

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
@@ -23,14 +23,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
     {
         public WindowsMixedRealityControllerModelProvider(Handedness handedness)
         {
-            this.handedness = handedness;
-
 #if WINDOWS_UWP
             spatialInteractionSource = WindowsExtensions.GetSpatialInteractionSource(handedness, InputSourceType.Controller);
 #endif // WINDOWS_UWP
         }
-
-        private readonly Handedness handedness;
 
 #if WINDOWS_UWP
         private readonly SpatialInteractionSource spatialInteractionSource;
@@ -40,9 +36,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         /// <summary>
         /// Attempts to load the glTF controller model from the Windows SDK.
         /// </summary>
-        /// <param name="controllerType">The type this model is being requested for. Used to obtain the correct controller visualization script from the controller visualization profile.</param>
         /// <returns>The controller model as a GameObject or null if it was unobtainable.</returns>
-        public async Task<GameObject> TryGenerateControllerModelFromPlatformSDK(Type controllerType)
+        public async Task<GameObject> TryGenerateControllerModelFromPlatformSDK()
         {
             if (spatialInteractionSource == null)
             {
@@ -82,33 +77,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                 gltfGameObject = await gltfObject.ConstructAsync();
                 if (gltfGameObject != null)
                 {
-                    var visualizationProfile = CoreServices.InputSystem?.InputSystemProfile.ControllerVisualizationProfile;
-                    if (visualizationProfile != null)
-                    {
-                        var visualizationType = visualizationProfile.GetControllerVisualizationTypeOverride(controllerType, handedness);
-                        if (visualizationType != null)
-                        {
-                            // Set the platform controller model to not be destroyed when the source is lost. It'll be disabled instead,
-                            // and re-enabled when the same controller is re-detected.
-                            if (gltfGameObject.AddComponent(visualizationType.Type) is IMixedRealityControllerPoseSynchronizer visualizer)
-                            {
-                                visualizer.DestroyOnSourceLost = false;
-                            }
-
-                            ControllerModelDictionary.Add(GenerateKey(spatialInteractionSource), gltfGameObject);
-                            return gltfGameObject;
-                        }
-                        else
-                        {
-                            Debug.LogError("Controller visualization type not defined for controller visualization profile");
-                            UnityEngine.Object.Destroy(gltfGameObject);
-                            gltfGameObject = null;
-                        }
-                    }
-                    else
-                    {
-                        Debug.LogError("Failed to obtain a controller visualization profile");
-                    }
+                    ControllerModelDictionary.Add(GenerateKey(spatialInteractionSource), gltfGameObject);
                 }
             }
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
@@ -112,7 +112,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 
         private string GenerateKey(SpatialInteractionSource spatialInteractionSource)
         {
-            return spatialInteractionSource.Id + "/" + spatialInteractionSource.Kind + "/" + spatialInteractionSource.Handedness;
+            return spatialInteractionSource.Controller.VendorId + "/" + spatialInteractionSource.Controller.ProductId + "/" + spatialInteractionSource.Controller.Version + "/" + spatialInteractionSource.Handedness;
         }
 #endif // WINDOWS_UWP
     }

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization;
+using System;
+
+#if UNITY_WSA
+using System.Collections.Generic;
+using Unity.Profiling;
+using UnityEngine;
+using UnityEngine.XR.WSA.Input;
+using Windows.UI.Input.Spatial;
+#endif
+
+#if WINDOWS_UWP
+using Microsoft.MixedReality.Toolkit.Windows.Input;
+using Windows.Storage.Streams;
+using Windows.UI.Input.Spatial;
+using System.Threading.Tasks;
+#endif
+
+
+namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
+{
+    /// <summary>
+    /// Queries the hand mesh data that an articulated hand on HoloLens 2 can provide.
+    /// </summary>
+    public class WindowsMixedRealityControllerModelProvider
+    {
+
+#if WINDOWS_UWP
+        public WindowsMixedRealityControllerModelProvider(BaseController controller, SpatialInteractionSourceState spatialInteractionSourceState)
+        {
+            this.controller = controller;
+            this.spatialInteractionSourceState = spatialInteractionSourceState;
+        }
+
+        public bool UnableToGenerateSDKModel;
+
+        private readonly BaseController controller;
+        private IMixedRealityInputSource InputSource => controller.InputSource;
+        private Handedness Handedness => controller.ControllerHandedness;
+        private SpatialInteractionSourceState spatialInteractionSourceState;
+
+        private static readonly Dictionary<string, GameObject> controllerModelDictionary = new Dictionary<string, GameObject>(0);
+
+        public async Task<GameObject> TryGenerateControllerModelFromPlatformSDK()
+        {
+            // First see if we've generated this model before and if we can return it
+            GameObject controllerModel;
+
+            if (controllerModelDictionary.TryGetValue(GenerateKey(spatialInteractionSourceState), out controllerModel))
+            {
+                UnableToGenerateSDKModel = false;
+                controllerModel.SetActive(true);
+                return controllerModel;
+            }
+
+            Debug.Log("Trying to load controller model from platform SDK");
+            byte[] fileBytes = null;
+
+            var controllerModelStream = await spatialInteractionSourceState.Source.Controller.TryGetRenderableModelAsync();
+            if (controllerModelStream == null ||
+                controllerModelStream.Size == 0)
+            {
+                Debug.LogError("Failed to obtain controller model from driver");
+            }
+            else
+            {
+                fileBytes = new byte[controllerModelStream.Size];
+                using (DataReader reader = new DataReader(controllerModelStream))
+                {
+                    await reader.LoadAsync((uint)controllerModelStream.Size);
+                    reader.ReadBytes(fileBytes);
+                }
+            }
+
+            GameObject gltfGameObject = null;
+            if (fileBytes != null)
+            {
+                var gltfObject = GltfUtility.GetGltfObjectFromGlb(fileBytes);
+                gltfGameObject = await gltfObject.ConstructAsync();
+                if (gltfGameObject != null)
+                {
+                    var visualizationProfile = CoreServices.InputSystem?.InputSystemProfile.ControllerVisualizationProfile;
+                    if (visualizationProfile != null)
+                    {
+                        var visualizationType = visualizationProfile.GetControllerVisualizationTypeOverride(GetType(), Handedness);
+                        if (visualizationType != null)
+                        {
+                            // Set the platform controller model to not be destroyed when the source is lost. It'll be disabled instead,
+                            // and re-enabled when the same controller is re-detected.
+                            if (gltfGameObject.AddComponent(visualizationType.Type) is IMixedRealityControllerPoseSynchronizer visualizer)
+                            {
+                                visualizer.DestroyOnSourceLost = false;
+                            }
+
+                            controllerModelDictionary.Add(GenerateKey(spatialInteractionSourceState), gltfGameObject);
+                            return gltfGameObject;
+                        }
+                        else
+                        {
+                            Debug.LogError("Controller visualization type not defined for controller visualization profile");
+                            UnityEngine.Object.Destroy(gltfGameObject);
+                            gltfGameObject = null;
+                        }
+                    }
+                    else
+                    {
+                        Debug.LogError("Failed to obtain a controller visualization profile");
+                    }
+                }
+            }
+
+            // record whether or not we were able to succesfully generate the controller model
+            UnableToGenerateSDKModel = gltfGameObject == null;
+            return null;
+        }
+
+        private string GenerateKey(SpatialInteractionSourceState spatialInteractionSourceState)
+        {
+            return spatialInteractionSourceState.Source.Id + "/" + spatialInteractionSourceState.Source.Kind + "/" + spatialInteractionSourceState.Source.Handedness;
+        }
+#endif // WINDOWS_UWP
+    }
+}

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs
@@ -37,7 +37,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 
         private static readonly Dictionary<string, GameObject> ControllerModelDictionary = new Dictionary<string, GameObject>(2);
 
-        public async Task<GameObject> TryGenerateControllerModelFromPlatformSDK()
+        /// <summary>
+        /// Attempts to load the glTF controller model from the Windows SDK.
+        /// </summary>
+        /// <param name="controllerType">The type this model is being requested for. Used to obtain the correct controller visualization script from the controller visualization profile.</param>
+        /// <returns>The controller model as a GameObject or null if it was unobtainable.</returns>
+        public async Task<GameObject> TryGenerateControllerModelFromPlatformSDK(Type controllerType)
         {
             if (spatialInteractionSource == null)
             {
@@ -80,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                     var visualizationProfile = CoreServices.InputSystem?.InputSystemProfile.ControllerVisualizationProfile;
                     if (visualizationProfile != null)
                     {
-                        var visualizationType = visualizationProfile.GetControllerVisualizationTypeOverride(GetType(), handedness);
+                        var visualizationType = visualizationProfile.GetControllerVisualizationTypeOverride(controllerType, handedness);
                         if (visualizationType != null)
                         {
                             // Set the platform controller model to not be destroyed when the source is lost. It'll be disabled instead,

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs.meta
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityControllerModelProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b431bdd80ee9634b96cf117c4dd56e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/HPMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/HPMotionController.cs
@@ -30,9 +30,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public HPMotionController(
             TrackingState trackingState,
             Handedness controllerHandedness,
+            InteractionSource interactionSource,
             IMixedRealityInputSource inputSource = null,
             MixedRealityInteractionMapping[] interactions = null)
-            : base(trackingState, controllerHandedness, new HPMotionControllerDefinition(controllerHandedness), inputSource, interactions)
+            : base(trackingState, controllerHandedness, interactionSource, new HPMotionControllerDefinition(controllerHandedness), inputSource, interactions)
         {
 #if HP_CONTROLLER_ENABLED
             InputHandler = new HPMotionControllerInputHandler(controllerHandedness, inputSource, Interactions);

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/HPMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/HPMotionController.cs
@@ -30,10 +30,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public HPMotionController(
             TrackingState trackingState,
             Handedness controllerHandedness,
-            InteractionSource interactionSource,
             IMixedRealityInputSource inputSource = null,
-            MixedRealityInteractionMapping[] interactions = null)
-            : base(trackingState, controllerHandedness, interactionSource, new HPMotionControllerDefinition(controllerHandedness), inputSource, interactions)
+            MixedRealityInteractionMapping[] interactions = null,
+            WindowsMixedRealityControllerModelProvider visualizationProvider = null)
+            : base(trackingState, controllerHandedness, new HPMotionControllerDefinition(controllerHandedness), inputSource, interactions, visualizationProvider)
         {
 #if HP_CONTROLLER_ENABLED
             InputHandler = new HPMotionControllerInputHandler(controllerHandedness, inputSource, Interactions);

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/HPMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/HPMotionController.cs
@@ -31,9 +31,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             TrackingState trackingState,
             Handedness controllerHandedness,
             IMixedRealityInputSource inputSource = null,
-            MixedRealityInteractionMapping[] interactions = null,
-            WindowsMixedRealityControllerModelProvider visualizationProvider = null)
-            : base(trackingState, controllerHandedness, new HPMotionControllerDefinition(controllerHandedness), inputSource, interactions, visualizationProvider)
+            MixedRealityInteractionMapping[] interactions = null)
+            : base(trackingState, controllerHandedness, new HPMotionControllerDefinition(controllerHandedness), inputSource, interactions)
         {
 #if HP_CONTROLLER_ENABLED
             InputHandler = new HPMotionControllerInputHandler(controllerHandedness, inputSource, Interactions);

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -256,7 +256,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 controllerModelProvider = new WindowsMixedRealityControllerModelProvider(ControllerHandedness);
             }
 
-            UnityEngine.GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK();
+            UnityEngine.GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK(GetType());
 
             if (controllerModel != null)
             {

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -294,8 +294,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     base.TryRenderControllerModel(GetType(), InputSource.SourceType);
                 }
 
-                // If we didn't successfully set up the model and add it to the hierarchy (which returns early), destroy it.
-                UnityEngine.Object.Destroy(controllerModel);
+                // If we didn't successfully set up the model and add it to the hierarchy (which returns early), set it inactive.
+                controllerModel.SetActive(false);
             }
         }
 #endif

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -37,9 +37,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             TrackingState trackingState,
             Handedness controllerHandedness,
             IMixedRealityInputSource inputSource = null,
-            MixedRealityInteractionMapping[] interactions = null,
-            WindowsMixedRealityControllerModelProvider visualizationProvider = null)
-            : this(trackingState, controllerHandedness, new WindowsMixedRealityControllerDefinition(controllerHandedness), inputSource, interactions, visualizationProvider)
+            MixedRealityInteractionMapping[] interactions = null)
+            : this(trackingState, controllerHandedness, new WindowsMixedRealityControllerDefinition(controllerHandedness), inputSource, interactions)
         { }
 
         public WindowsMixedRealityController(
@@ -47,19 +46,18 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             Handedness controllerHandedness,
             IMixedRealityInputSourceDefinition definition,
             IMixedRealityInputSource inputSource = null,
-            MixedRealityInteractionMapping[] interactions = null,
-            WindowsMixedRealityControllerModelProvider visualizationProvider = null)
+            MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions, definition)
         {
-            controllerModelProvider = visualizationProvider;
+            controllerModelProvider = new WindowsMixedRealityControllerModelProvider(controllerHandedness);
         }
 
-#if UNITY_WSA
         private bool controllerModelInitialized = false;
         private bool failedToObtainControllerModel = false;
 
         private readonly WindowsMixedRealityControllerModelProvider controllerModelProvider;
 
+#if UNITY_WSA
         #region Update data functions
 
         private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityController.UpdateController");

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -289,12 +289,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     {
                         UnityEngine.Debug.LogError("Failed to obtain a controller visualization profile");
                     }
+
+                    UnityEngine.Debug.LogWarning("Failed to create controller model from driver; defaulting to BaseController behavior.");
+                    base.TryRenderControllerModel(GetType(), InputSource.SourceType);
                 }
 
                 // If we didn't successfully set up the model and add it to the hierarchy (which returns early), destroy it.
                 UnityEngine.Object.Destroy(controllerModel);
-                UnityEngine.Debug.LogWarning("Failed to create controller model from driver; defaulting to BaseController behavior.");
-                base.TryRenderControllerModel(GetType(), InputSource.SourceType);
             }
         }
 #endif

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -293,6 +293,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
                 // If we didn't successfully set up the model and add it to the hierarchy (which returns early), destroy it.
                 UnityEngine.Object.Destroy(controllerModel);
+                UnityEngine.Debug.LogWarning("Failed to create controller model from driver; defaulting to BaseController behavior.");
+                base.TryRenderControllerModel(GetType(), InputSource.SourceType);
             }
         }
 #endif

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -3,20 +3,10 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization;
-using System;
 
 #if UNITY_WSA
-using System.Collections.Generic;
 using Unity.Profiling;
-using UnityEngine;
 using UnityEngine.XR.WSA.Input;
-#endif
-
-#if WINDOWS_UWP
-using Microsoft.MixedReality.Toolkit.Windows.Input;
-using Windows.Storage.Streams;
-using System.Threading.Tasks;
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
@@ -51,9 +41,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         {
             controllerModelProvider = new WindowsMixedRealityControllerModelProvider(controllerHandedness);
         }
-
-        private bool controllerModelInitialized = false;
-        private bool failedToObtainControllerModel = false;
 
         private readonly WindowsMixedRealityControllerModelProvider controllerModelProvider;
 
@@ -250,34 +237,36 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
 #if WINDOWS_UWP
         /// <inheritdoc />
-        protected override bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)
+        protected override bool TryRenderControllerModel(System.Type controllerType, InputSourceType inputSourceType)
         {
-            // Intercept this call if we are using the default driver provided models.
-            // Note: Obtaining models from the driver will require access to the InteractionSource.
-            // It's unclear whether the interaction source will be available during setup, so we attempt to create
-            // the controller model on an input update
-            if (controllerModelProvider.UnableToGenerateSDKModel ||
-                GetControllerVisualizationProfile() == null ||
+            if (GetControllerVisualizationProfile() == null ||
                 !GetControllerVisualizationProfile().GetUseDefaultModelsOverride(GetType(), ControllerHandedness))
             {
-                controllerModelInitialized = true;
                 return base.TryRenderControllerModel(controllerType, inputSourceType);
             }
-            else
+            else if (controllerModelProvider != null)
             {
                 TryRenderControllerModelWithModelProvider();
+                return true;
             }
 
-            return !controllerModelProvider.UnableToGenerateSDKModel;
+            return false;
         }
 
         private async void TryRenderControllerModelWithModelProvider()
         {
-            GameObject controllerModel = Task.Run(controllerModelProvider.TryGenerateControllerModelFromPlatformSDK());
+            UnityEngine.GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK();
 
             if (controllerModel != null)
             {
-                TryAddControllerModelToSceneHierarchy(controllerModel);
+                if (this != null)
+                {
+                    TryAddControllerModelToSceneHierarchy(controllerModel);
+                }
+                else
+                {
+                    UnityEngine.Object.Destroy(controllerModel);
+                }
             }
         }
 #endif

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -38,11 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             IMixedRealityInputSource inputSource = null,
             MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions, definition)
-        {
-            controllerModelProvider = new WindowsMixedRealityControllerModelProvider(controllerHandedness);
-        }
-
-        private readonly WindowsMixedRealityControllerModelProvider controllerModelProvider;
+        { }
 
 #if UNITY_WSA
         #region Update data functions
@@ -236,6 +232,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         #region Controller model functions
 
 #if WINDOWS_UWP
+        private WindowsMixedRealityControllerModelProvider controllerModelProvider;
+
         /// <inheritdoc />
         protected override bool TryRenderControllerModel(System.Type controllerType, InputSourceType inputSourceType)
         {
@@ -244,17 +242,20 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             {
                 return base.TryRenderControllerModel(controllerType, inputSourceType);
             }
-            else if (controllerModelProvider != null)
+            else
             {
                 TryRenderControllerModelWithModelProvider();
                 return true;
             }
-
-            return false;
         }
 
         private async void TryRenderControllerModelWithModelProvider()
         {
+            if (controllerModelProvider == null)
+            {
+                controllerModelProvider = new WindowsMixedRealityControllerModelProvider(ControllerHandedness);
+            }
+
             UnityEngine.GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK();
 
             if (controllerModel != null)

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -270,7 +270,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                         {
                             // Set the platform controller model to not be destroyed when the source is lost. It'll be disabled instead,
                             // and re-enabled when the same controller is re-detected.
-                            if (controllerModel.AddComponent(visualizationType.Type) is IMixedRealityControllerPoseSynchronizer visualizer)
+                            if (controllerModel.EnsureComponent(visualizationType.Type) is IMixedRealityControllerPoseSynchronizer visualizer)
                             {
                                 visualizer.DestroyOnSourceLost = false;
                             }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -37,31 +37,28 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             TrackingState trackingState,
             Handedness controllerHandedness,
             IMixedRealityInputSource inputSource = null,
-            MixedRealityInteractionMapping[] interactions = null)
-            : this(trackingState, controllerHandedness, new WindowsMixedRealityControllerDefinition(controllerHandedness), inputSource, interactions)
+            MixedRealityInteractionMapping[] interactions = null,
+            WindowsMixedRealityControllerModelProvider visualizationProvider = null)
+            : this(trackingState, controllerHandedness, new WindowsMixedRealityControllerDefinition(controllerHandedness), inputSource, interactions, visualizationProvider)
         { }
 
         public WindowsMixedRealityController(
             TrackingState trackingState,
             Handedness controllerHandedness,
-            InteractionSource interactionSource,
             IMixedRealityInputSourceDefinition definition,
             IMixedRealityInputSource inputSource = null,
-            MixedRealityInteractionMapping[] interactions = null)
+            MixedRealityInteractionMapping[] interactions = null,
+            WindowsMixedRealityControllerModelProvider visualizationProvider = null)
             : base(trackingState, controllerHandedness, inputSource, interactions, definition)
         {
-#if WINDOWS_UWP
-            controllerModelProvider = new WindowsMixedRealityControllerModelProvider(this, interactionSource.GetSpatialInteractionSource());
-#endif
+            controllerModelProvider = visualizationProvider;
         }
 
 #if UNITY_WSA
         private bool controllerModelInitialized = false;
         private bool failedToObtainControllerModel = false;
 
-#if WINDOWS_UWP
         private readonly WindowsMixedRealityControllerModelProvider controllerModelProvider;
-#endif
 
         #region Update data functions
 
@@ -288,7 +285,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 #endif
 
         #endregion Controller model functions
-
 #endif // UNITY_WSA
     }
 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/MRTK.WMR.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/MRTK.WMR.asmdef
@@ -3,7 +3,6 @@
     "references": [
         "Microsoft.MixedReality.Toolkit",
         "Microsoft.MixedReality.Toolkit.Editor.Utilities",
-        "Microsoft.MixedReality.Toolkit.Gltf",
         "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared"
     ],
     "includePlatforms": [

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -437,10 +437,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
                 if (controller != null)
                 {
-                    if (controller is WindowsMixedRealityController mrtkController)
-                    {
-                        mrtkController.EnsureControllerModel(interactionSourceState.source);
-                    }
+                    //if (controller is WindowsMixedRealityController mrtkController)
+                    //{
+                    //    mrtkController.EnsureControllerModel(interactionSourceState.source);
+                    //}
 
                     // Does the controller still exist after we loaded the controller model?
                     if (GetOrAddController(interactionSourceState.source, false) != null)
@@ -747,7 +747,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     if (isHPController)
                     {
                         // Add the controller as a HP Motion Controller
-                        HPMotionController hpController = new HPMotionController(TrackingState.NotTracked, controllingHand, inputSource);
+                        HPMotionController hpController = new HPMotionController(TrackingState.NotTracked, controllingHand, interactionSource, inputSource);
 
 #if HP_CONTROLLER_ENABLED
                         lock (trackedMotionControllerStates)
@@ -763,7 +763,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     }
                     else
                     {
-                        detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, inputSource);
+                        detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, interactionSource, inputSource);
                     }
                 }
                 else

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -744,10 +744,16 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 }
                 else if (interactionSource.kind == InteractionSourceKind.Controller)
                 {
+                    WindowsMixedRealityControllerModelProvider modelProvider = null;
+
+#if WINDOWS_UWP
+                    modelProvider = new WindowsMixedRealityControllerModelProvider(interactionSource.GetSpatialInteractionSource());
+#endif // WINDOWS_UWP
+
                     if (isHPController)
                     {
                         // Add the controller as a HP Motion Controller
-                        HPMotionController hpController = new HPMotionController(TrackingState.NotTracked, controllingHand, interactionSource, inputSource);
+                        HPMotionController hpController = new HPMotionController(TrackingState.NotTracked, controllingHand, inputSource, visualizationProvider: modelProvider);
 
 #if HP_CONTROLLER_ENABLED
                         lock (trackedMotionControllerStates)
@@ -763,7 +769,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     }
                     else
                     {
-                        detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, interactionSource, inputSource);
+                        detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, inputSource, visualizationProvider: modelProvider);
                     }
                 }
                 else

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -810,7 +810,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
             var visualizer = controller.Visualizer;
 
-            if (visualizer != null && !visualizer.Equals(null) &&
+            if (!visualizer.IsNull() &&
                 visualizer.GameObjectProxy != null)
             {
                 visualizer.GameObjectProxy.SetActive(false);

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -744,16 +744,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 }
                 else if (interactionSource.kind == InteractionSourceKind.Controller)
                 {
-                    WindowsMixedRealityControllerModelProvider modelProvider = null;
-
-#if WINDOWS_UWP
-                    modelProvider = new WindowsMixedRealityControllerModelProvider(interactionSource.GetSpatialInteractionSource());
-#endif // WINDOWS_UWP
-
                     if (isHPController)
                     {
                         // Add the controller as a HP Motion Controller
-                        HPMotionController hpController = new HPMotionController(TrackingState.NotTracked, controllingHand, inputSource, visualizationProvider: modelProvider);
+                        HPMotionController hpController = new HPMotionController(TrackingState.NotTracked, controllingHand, inputSource);
 
 #if HP_CONTROLLER_ENABLED
                         lock (trackedMotionControllerStates)
@@ -769,7 +763,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     }
                     else
                     {
-                        detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, inputSource, visualizationProvider: modelProvider);
+                        detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, inputSource);
                     }
                 }
                 else

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -437,21 +437,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
                 if (controller != null)
                 {
-                    //if (controller is WindowsMixedRealityController mrtkController)
-                    //{
-                    //    mrtkController.EnsureControllerModel(interactionSourceState.source);
-                    //}
-
-                    // Does the controller still exist after we loaded the controller model?
-                    if (GetOrAddController(interactionSourceState.source, false) != null)
+                    if (raiseSourceDetected)
                     {
-                        if (raiseSourceDetected)
-                        {
-                            Service?.RaiseSourceDetected(controller.InputSource, controller);
-                        }
-
-                        controller.UpdateController(interactionSourceState);
+                        Service?.RaiseSourceDetected(controller.InputSource, controller);
                     }
+
+                    controller.UpdateController(interactionSourceState);
                 }
             }
         }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -172,7 +172,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                         {
                             // Set the platform controller model to not be destroyed when the source is lost. It'll be disabled instead,
                             // and re-enabled when the same controller is re-detected.
-                            if (controllerModel.AddComponent(visualizationType.Type) is IMixedRealityControllerPoseSynchronizer visualizer)
+                            if (controllerModel.EnsureComponent(visualizationType.Type) is IMixedRealityControllerPoseSynchronizer visualizer)
                             {
                                 visualizer.DestroyOnSourceLost = false;
                             }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -191,12 +191,13 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                     {
                         Debug.LogError("Failed to obtain a controller visualization profile");
                     }
+
+                    Debug.LogWarning("Failed to create controller model from driver; defaulting to BaseController behavior.");
+                    base.TryRenderControllerModel(GetType(), InputSource.SourceType);
                 }
 
                 // If we didn't successfully set up the model and add it to the hierarchy (which returns early), destroy it.
                 Object.Destroy(controllerModel);
-                Debug.LogWarning("Failed to create controller model from driver; defaulting to BaseController behavior.");
-                base.TryRenderControllerModel(GetType(), InputSource.SourceType);
             }
         }
 #endif

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -196,8 +196,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                     base.TryRenderControllerModel(GetType(), InputSource.SourceType);
                 }
 
-                // If we didn't successfully set up the model and add it to the hierarchy (which returns early), destroy it.
-                Object.Destroy(controllerModel);
+                // If we didn't successfully set up the model and add it to the hierarchy (which returns early), set it inactive.
+                controllerModel.SetActive(false);
             }
         }
 #endif

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -36,7 +36,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             IMixedRealityInputSource inputSource = null,
             MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions, definition)
-        { }
+        {
+            controllerModelProvider = new WindowsMixedRealityControllerModelProvider(controllerHandedness);
+        }
+
+        private readonly WindowsMixedRealityControllerModelProvider controllerModelProvider;
 
         private static readonly ProfilerMarker UpdateButtonDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityXRSDKMotionController.UpdateButtonData");
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -158,18 +158,43 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 controllerModelProvider = new WindowsMixedRealityControllerModelProvider(ControllerHandedness);
             }
 
-            GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK(GetType());
+            GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK();
 
             if (controllerModel != null)
             {
                 if (this != null)
                 {
-                    TryAddControllerModelToSceneHierarchy(controllerModel);
+                    var visualizationProfile = GetControllerVisualizationProfile();
+                    if (visualizationProfile != null)
+                    {
+                        var visualizationType = visualizationProfile.GetControllerVisualizationTypeOverride(GetType(), ControllerHandedness);
+                        if (visualizationType != null)
+                        {
+                            // Set the platform controller model to not be destroyed when the source is lost. It'll be disabled instead,
+                            // and re-enabled when the same controller is re-detected.
+                            if (controllerModel.AddComponent(visualizationType.Type) is IMixedRealityControllerPoseSynchronizer visualizer)
+                            {
+                                visualizer.DestroyOnSourceLost = false;
+                            }
+
+                            if (TryAddControllerModelToSceneHierarchy(controllerModel))
+                            {
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            Debug.LogError("Controller visualization type not defined for controller visualization profile");
+                        }
+                    }
+                    else
+                    {
+                        Debug.LogError("Failed to obtain a controller visualization profile");
+                    }
                 }
-                else
-                {
-                    Object.Destroy(controllerModel);
-                }
+
+                // If we didn't successfully set up the model and add it to the hierarchy (which returns early), destroy it.
+                Object.Destroy(controllerModel);
             }
         }
 #endif

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -3,10 +3,13 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR;
+
+#if WINDOWS_UWP
+using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
+#endif // WINDOWS_UWP
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 {
@@ -37,11 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             IMixedRealityInputSource inputSource = null,
             MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions, definition)
-        {
-            controllerModelProvider = new WindowsMixedRealityControllerModelProvider(controllerHandedness);
-        }
-
-        private readonly WindowsMixedRealityControllerModelProvider controllerModelProvider;
+        { }
 
         private static readonly ProfilerMarker UpdateButtonDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityXRSDKMotionController.UpdateButtonData");
 
@@ -135,6 +134,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         }
 
 #if WINDOWS_UWP
+        private WindowsMixedRealityControllerModelProvider controllerModelProvider;
+
         /// <inheritdoc />
         protected override bool TryRenderControllerModel(System.Type controllerType, InputSourceType inputSourceType)
         {
@@ -143,17 +144,20 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             {
                 return base.TryRenderControllerModel(controllerType, inputSourceType);
             }
-            else if (controllerModelProvider != null)
+            else
             {
                 TryRenderControllerModelWithModelProvider();
                 return true;
             }
-
-            return false;
         }
 
         private async void TryRenderControllerModelWithModelProvider()
         {
+            if (controllerModelProvider == null)
+            {
+                controllerModelProvider = new WindowsMixedRealityControllerModelProvider(ControllerHandedness);
+            }
+
             GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK();
 
             if (controllerModel != null)

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -158,7 +158,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 controllerModelProvider = new WindowsMixedRealityControllerModelProvider(ControllerHandedness);
             }
 
-            GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK();
+            GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK(GetType());
 
             if (controllerModel != null)
             {

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -195,6 +195,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
                 // If we didn't successfully set up the model and add it to the hierarchy (which returns early), destroy it.
                 Object.Destroy(controllerModel);
+                Debug.LogWarning("Failed to create controller model from driver; defaulting to BaseController behavior.");
+                base.TryRenderControllerModel(GetType(), InputSource.SourceType);
             }
         }
 #endif

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -308,10 +308,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
             if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Controller))
             {
-                bool hasTouchpad = inputDevice.TryGetFeatureValue(CommonUsages.primary2DAxis, out _);
-                bool isHPController = !hasTouchpad;
-
-                if (isHPController)
+                // primary2DAxis represents the touchpad in Windows XR Plugin.
+                // The HP motion controller doesn't have a touchpad, so we check for its existence in the feature usages.
+                if (!inputDevice.TryGetFeatureValue(CommonUsages.primary2DAxis, out _))
                 {
                     return SupportedControllerType.HPMotionController;
                 }

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -210,7 +210,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
 
                 ActiveControllers.Add(inputDevice, detectedController);
 
-                CoreServices.InputSystem?.RaiseSourceDetected(detectedController.InputSource, detectedController);
+                Service?.RaiseSourceDetected(detectedController.InputSource, detectedController);
 
                 return detectedController;
             }
@@ -243,14 +243,16 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// </summary>
         protected void RemoveControllerFromScene(GenericXRSDKController controller)
         {
-            CoreServices.InputSystem?.RaiseSourceLost(controller.InputSource, controller);
+            Service?.RaiseSourceLost(controller.InputSource, controller);
 
             RecyclePointers(controller.InputSource);
 
-            if (controller.Visualizer != null &&
-                controller.Visualizer.GameObjectProxy != null)
+            var visualizer = controller.Visualizer;
+
+            if (!visualizer.IsNull() &&
+                visualizer.GameObjectProxy != null)
             {
-                controller.Visualizer.GameObjectProxy.SetActive(false);
+                visualizer.GameObjectProxy.SetActive(false);
             }
         }
 

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealityXRSDKControllerVisualizationProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealityXRSDKControllerVisualizationProfile.asset
@@ -29,10 +29,10 @@ MonoBehaviour:
   globalRightHandVisualizer: {fileID: 3512491064599439886, guid: 7a857af0cb85b4a47b6ec8a1babcb73c,
     type: 3}
   controllerVisualizationSettings:
-  - description: Windows Mixed Reality Controller
+  - description: Windows Mixed Reality XRSDK Motion Controller
     controllerType:
-      reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityController,
-        Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.WindowsMixedRealityXRSDKMotionController,
+        Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
     handedness: 1
     usePlatformModels: 1
     platformModelMaterial: {fileID: 0}
@@ -40,10 +40,10 @@ MonoBehaviour:
     controllerVisualizationType:
       reference: Microsoft.MixedReality.Toolkit.Input.WindowsMixedRealityControllerVisualizer,
         Microsoft.MixedReality.Toolkit.SDK
-  - description: Windows Mixed Reality Controller
+  - description: Windows Mixed Reality XRSDK Motion Controller
     controllerType:
-      reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityController,
-        Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.WindowsMixedRealityXRSDKMotionController,
+        Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
     handedness: 2
     usePlatformModels: 1
     platformModelMaterial: {fileID: 0}
@@ -73,3 +73,25 @@ MonoBehaviour:
       type: 3}
     controllerVisualizationType:
       reference: Microsoft.MixedReality.Toolkit.Input.BaseHandVisualizer, Microsoft.MixedReality.Toolkit
+  - description: HP Motion Controller
+    controllerType:
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.HPMotionController,
+        Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
+    handedness: 1
+    usePlatformModels: 1
+    platformModelMaterial: {fileID: 0}
+    overrideModel: {fileID: 0}
+    controllerVisualizationType:
+      reference: Microsoft.MixedReality.Toolkit.Input.WindowsMixedRealityControllerVisualizer,
+        Microsoft.MixedReality.Toolkit.SDK
+  - description: HP Motion Controller
+    controllerType:
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.HPMotionController,
+        Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
+    handedness: 2
+    usePlatformModels: 1
+    platformModelMaterial: {fileID: 0}
+    overrideModel: {fileID: 0}
+    controllerVisualizationType:
+      reference: Microsoft.MixedReality.Toolkit.Input.WindowsMixedRealityControllerVisualizer,
+        Microsoft.MixedReality.Toolkit.SDK


### PR DESCRIPTION
## Overview

Refactors out a WindowsMixedRealityControllerModelProvider to call into the WinRT API and load the corresponding glTF model across both legacy XR and XR SDK.

![image](https://user-images.githubusercontent.com/3580640/112519275-6fa9c400-8d57-11eb-98d7-607f31a33fa1.png)

We also probably need a follow-up to improve the materials we use when loading the models.

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8971
