### PR TITLE
Adding the option to use nuget.exe for restore in build tools

### DIFF
--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -90,13 +90,27 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             string storagePath = Path.GetFullPath(Path.Combine(Path.Combine(Application.dataPath, ".."), buildInfo.OutputDirectory));
             string solutionProjectPath = Path.GetFullPath(Path.Combine(storagePath, $@"{PlayerSettings.productName}.sln"));
 
+            int exitCode;
+
             // Building the solution requires first restoring NuGet packages - when built through
             // Visual Studio, VS does this automatically - when building via msbuild like we're doing here,
             // we have to do that step manually.
-            int exitCode = await Run(msBuildPath,
+            // We use msbuild for nuget restore by default, but if a path to nuget.exe is supplied then we use that executable
+            if (string.IsNullOrEmpty(buildInfo.NugetExecutablePath))
+            {
+                exitCode = await Run(msBuildPath,
                 $"\"{solutionProjectPath}\" /t:restore {GetMSBuildLoggingCommand(buildInfo.LogDirectory, "nugetRestore.log")}",
                 !Application.isBatchMode,
                 cancellationToken);
+            }
+            else
+            {
+                exitCode = await Run(buildInfo.NugetExecutablePath,
+                $"restore \"{solutionProjectPath}\"",
+                !Application.isBatchMode,
+                cancellationToken);
+            }
+            
             if (exitCode != 0)
             {
                 IsBuilding = false;

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -46,6 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         private const string EDITOR_PREF_MULTICORE_APPX_BUILD_ENABLED = "BuildDeployWindow_MulticoreAppxBuildEnabled";
         private const string EDITOR_PREF_RESEARCH_MODE_CAPABILITY_ENABLED = "BuildDeployWindow_ResearchModeCapabilityEnabled";
         private const string EDITOR_PREF_ALLOW_UNSAFE_CODE = "BuildDeployWindow_AllowUnsafeCode";
+        private const string EDITOR_PREF_NUGET_EXECUTABLE_PATH = "BuildDeployWindow_NugetExecutablePath";
 
         /// <summary>
         /// The current Build Configuration. (Debug, Release, or Master)
@@ -193,6 +194,15 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         {
             get => EditorPreferences.Get(EDITOR_PREF_ALLOW_UNSAFE_CODE, false);
             set => EditorPreferences.Set(EDITOR_PREF_ALLOW_UNSAFE_CODE, value);
+        }
+
+        /// <summary>
+        /// Current value of the optional path to nuget.exe.
+        /// </summary>
+        public static string NugetExecutablePath
+        {
+            get => EditorPreferences.Get(EDITOR_PREF_NUGET_EXECUTABLE_PATH, string.Empty);
+            set => EditorPreferences.Set(EDITOR_PREF_NUGET_EXECUTABLE_PATH, value);
         }
     }
 }

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpBuildInfo.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpBuildInfo.cs
@@ -58,5 +58,10 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// in the list to the manifest
         /// </summary>
         public List<string> DeviceCapabilities { get; set; } = null;
+
+        /// <summary>
+        /// Optional path to nuget.exe. Used when performing package restore with nuget.exe (instead of msbuild) is desired.
+        /// </summary>
+        public string NugetExecutablePath { get; set; }
     }
 }

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
@@ -38,6 +38,9 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                         // Note: the min sdk target cannot be changed.
                         EditorUserBuildSettings.wsaUWPSDK = arguments[++i];
                         break;
+                    case "-nugetPath":
+                        buildInfo.NugetExecutablePath = arguments[++i];
+                        break;
                 }
             }
         }

--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -139,6 +139,8 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private readonly GUIContent ViewPlayerLogLabel = new GUIContent("View Player Log", "Launch notepad with more recent player log for listed AppX on either currently selected device or from all devices.");
 
+        private readonly GUIContent NugetPathLabel = new GUIContent("Nuget Executable Path", "Only set this when restoring packages with nuget.exe (instead of msbuild) is desired.");
+
         #endregion Labels
 
         #region Properties
@@ -563,6 +565,22 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     // since there's a null texture issue when Unity reloads the assets during a build
                     MixedRealityBuildPreferences.DrawAppLauncherModelField(appxCancellationTokenSource == null);
 
+                    // Draw the section for nuget path
+                    EditorGUILayout.LabelField("Nuget Path (Optional)", EditorStyles.boldLabel);
+
+                    string nugetExecutablePath = EditorGUILayout.TextField(NugetPathLabel, UwpBuildDeployPreferences.NugetExecutablePath);
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        if (GUILayout.Button("Select Nuget Executable Path"))
+                        {
+                            nugetExecutablePath = EditorUtility.OpenFilePanel(
+                                "Select Nuget Executable Path", "", "exe");
+                        }
+                        if (GUILayout.Button("Use msbuild for Restore & Clear Path"))
+                        {
+                            nugetExecutablePath = "";
+                        }
+                    }
                     if (c.changed)
                     {
                         UwpBuildDeployPreferences.PlatformToolset = PLATFORM_TOOLSET_VALUES[newPlatformToolsetIndex];
@@ -571,6 +589,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                         UwpBuildDeployPreferences.ResearchModeCapabilityEnabled = researchModeEnabled;
                         UwpBuildDeployPreferences.ForceRebuild = forceRebuildAppx;
                         UwpBuildDeployPreferences.MulticoreAppxBuildEnabled = multicoreAppxBuildEnabled;
+                        UwpBuildDeployPreferences.NugetExecutablePath = nugetExecutablePath;
                     }
                 }
             }

--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -565,7 +565,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     // since there's a null texture issue when Unity reloads the assets during a build
                     MixedRealityBuildPreferences.DrawAppLauncherModelField(appxCancellationTokenSource == null);
 
-                    // Draw the section for nuget path
+                    // Draw the section for nuget executable path
                     EditorGUILayout.LabelField("Nuget Path (Optional)", EditorStyles.boldLabel);
 
                     string nugetExecutablePath = EditorGUILayout.TextField(NugetPathLabel, UwpBuildDeployPreferences.NugetExecutablePath);


### PR DESCRIPTION
## Overview

This PR adds the option to specify a path to nuget.exe and use that to perform package restore instead of using msbuild (the default option).

![image](https://user-images.githubusercontent.com/68253937/112571478-59c2f000-8da5-11eb-849e-0e1ca96d8ed8.png)