### PR TITLE
Teleport pointer controls the layers masks it raycasts against

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -278,6 +278,9 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 
                 // Re-enable gravity if we're looking at a hotspot
                 GravityDistorter.enabled = (TeleportSurfaceResult == TeleportSurfaceResult.HotSpot);
+
+                // Set the have the teleport pointer control which layer masks it raycasts against
+                PrioritizedLayerMasksOverride = PrioritizedLayerMasksOverride ?? new LayerMask[] { ValidLayers | InvalidLayers };
             }
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
@@ -11,6 +11,7 @@
 // play mode tests in this check.
 
 using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Teleport;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using System;
@@ -279,6 +280,50 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // We should have teleported in the forward direction after the teleport
             Assert.IsTrue(MixedRealityPlayspace.Position.z > initialForwardPosition);
             leftHand.Hide();
+        }
+
+
+        /// <summary>
+        /// Tests that the teleport pointer functions as expected
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTeleportLayers()
+        {
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+
+            // Create a floor and make sure it's below the camera
+            var floor = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            floor.transform.position = -0.5f * Vector3.up;
+
+            // Bring out the right hand and set it to the teleport gesture
+            TestUtilities.PlayspaceToOriginLookingForward();
+            float initialForwardPosition = MixedRealityPlayspace.Position.z;
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+
+            // Make sure the hand is in front of the camera
+            yield return rightHand.Show(Vector3.forward * 0.6f);
+            rightHand.SetRotation(Quaternion.identity);
+
+            yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.TeleportStart);
+            // Wait for the hand to animate
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            yield return new WaitForSeconds(1.0f / iss.InputSimulationProfile.HandGestureAnimationSpeed + 0.1f);
+
+            TeleportPointer teleportPointer = rightHand.GetPointer<TeleportPointer>();
+
+            floor.layer = LayerMask.NameToLayer("Default");
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            Assert.AreEqual(teleportPointer.TeleportSurfaceResult, Physics.TeleportSurfaceResult.Valid);
+
+            floor.layer = LayerMask.NameToLayer("Ignore Raycast");
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            Assert.AreEqual(rightHand.GetPointer<TeleportPointer>().TeleportSurfaceResult, Physics.TeleportSurfaceResult.Invalid);
+
+            floor.layer = LayerMask.NameToLayer("UI");
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            Assert.AreEqual(rightHand.GetPointer<TeleportPointer>().TeleportSurfaceResult, Physics.TeleportSurfaceResult.None);
+
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

Previously, the teleport pointer's raycast layer mask targets were the global defaults. Now, Valid and Invalid Layers will be raycast against, and all other layers will be ignored.

![TeleportLayerMasks](https://user-images.githubusercontent.com/39840334/112908145-d73b7880-90a3-11eb-9619-79c9b2ccd246.gif)


## Changes
- Fixes: #9552 

