### PR TITLE
Add support for hand mesh on OpenXR

### DIFF
--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -19,9 +19,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected readonly Dictionary<TrackedHandJoint, Transform> joints = new Dictionary<TrackedHandJoint, Transform>();
         protected MeshFilter handMeshFilter;
 
-        // This member stores the last set of hand mesh vertices, to avoid using
+        // This member stores the last count of hand mesh vertices, to avoid using
         // handMeshFilter.mesh.vertices, which does a copy of the vertices.
-        private Vector3[] lastHandMeshVertices;
+        private int lastHandMeshVerticesCount = 0;
 
         private void OnEnable()
         {
@@ -165,7 +165,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab != null)
             {
                 handMeshFilter = Instantiate(CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab).GetComponent<MeshFilter>();
-                lastHandMeshVertices = handMeshFilter.mesh.vertices;
+                lastHandMeshVerticesCount = handMeshFilter.mesh.vertices.Length;
             }
 
             if (handMeshFilter != null)
@@ -177,10 +177,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // In order to update the vertices when the array sizes change, the mesh
                 // must be cleared per instructions here:
                 // https://docs.unity3d.com/ScriptReference/Mesh.html
-                if ((lastHandMeshVertices == null && eventData.InputData.vertices != null) ||
-                    (lastHandMeshVertices != null &&
-                    lastHandMeshVertices.Length != 0 &&
-                    lastHandMeshVertices.Length != eventData.InputData.vertices?.Length))
+                if (lastHandMeshVerticesCount != eventData.InputData.vertices?.Length)
                 {
                     meshChanged = true;
                     mesh.Clear();
@@ -188,7 +185,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 mesh.vertices = eventData.InputData.vertices;
                 mesh.normals = eventData.InputData.normals;
-                lastHandMeshVertices = eventData.InputData.vertices;
+                lastHandMeshVerticesCount = eventData.InputData.vertices != null ? eventData.InputData.vertices.Length : 0;
 
                 if (newMesh || meshChanged)
                 {

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             handDefinition = Definition as ArticulatedHandDefinition;
             handMeshProvider = controllerHandedness == Handedness.Left ? OpenXRHandMeshProvider.Left : OpenXRHandMeshProvider.Right;
-            handMeshProvider.SetInputSource(inputSource);
+            handMeshProvider?.SetInputSource(inputSource);
 
 #if MSFT_OPENXR
 #if MSFT_OPENXR_0_2_0_OR_NEWER

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -47,6 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         public MicrosoftArticulatedHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions, new ArticulatedHandDefinition(inputSource, controllerHandedness))
         {
+            handDefinition = Definition as ArticulatedHandDefinition;
 #if MSFT_OPENXR
 #if MSFT_OPENXR_0_2_0_OR_NEWER
             handTracker = controllerHandedness == Handedness.Left ? HandTracker.Left : HandTracker.Right;
@@ -56,8 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 #endif // MSFT_OPENXR
         }
 
-        private ArticulatedHandDefinition handDefinition;
-        private ArticulatedHandDefinition HandDefinition => handDefinition ?? (handDefinition = Definition as ArticulatedHandDefinition);
+        private readonly ArticulatedHandDefinition handDefinition;
 
         protected readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
 
@@ -82,7 +82,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         #endregion IMixedRealityHand Implementation
 
         /// <inheritdoc/>
-        public override bool IsInPointingPose => HandDefinition.IsInPointingPose;
+        public override bool IsInPointingPose => handDefinition.IsInPointingPose;
 
         private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] MicrosoftArticulatedHand.UpdateController");
 
@@ -212,7 +212,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 switch (interactionMapping.InputType)
                 {
                     case DeviceInputType.IndexFinger:
-                        HandDefinition?.UpdateCurrentIndexPose(interactionMapping);
+                        handDefinition?.UpdateCurrentIndexPose(interactionMapping);
                         break;
                     case DeviceInputType.SpatialPointer:
                         if (inputDevice.TryGetFeatureValue(CustomUsages.PointerPosition, out currentPointerPosition))
@@ -291,7 +291,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     }
 #endif // MSFT_OPENXR
 
-                    HandDefinition?.UpdateHandJoints(unityJointPoses);
+                    handDefinition?.UpdateHandJoints(unityJointPoses);
                 }
             }
         }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -48,6 +48,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             : base(trackingState, controllerHandedness, inputSource, interactions, new ArticulatedHandDefinition(inputSource, controllerHandedness))
         {
             handDefinition = Definition as ArticulatedHandDefinition;
+            handMeshProvider = controllerHandedness == Handedness.Left ? OpenXRHandMeshProvider.Left : OpenXRHandMeshProvider.Right;
+            handMeshProvider.SetInputSource(inputSource);
+
 #if MSFT_OPENXR
 #if MSFT_OPENXR_0_2_0_OR_NEWER
             handTracker = controllerHandedness == Handedness.Left ? HandTracker.Left : HandTracker.Right;
@@ -58,6 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         }
 
         private readonly ArticulatedHandDefinition handDefinition;
+        private readonly OpenXRHandMeshProvider handMeshProvider;
 
         protected readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
 
@@ -251,6 +255,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             using (UpdateHandDataPerfMarker.Auto())
             {
+                handMeshProvider?.UpdateHandMesh();
+
 #if MSFT_OPENXR
                 if (handTracker != null && handTracker.TryLocateHandJoints(FrameTime.OnUpdate, locations))
                 {

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.OpenXR;
+using Microsoft.MixedReality.Toolkit.Input;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
+{
+    /// <summary>
+    /// Provides the ability to load a hand mesh from OpenXR for the corresponding hand.
+    /// </summary>
+    internal class OpenXRHandMeshProvider
+    {
+        /// <summary>
+        /// The user's left hand.
+        /// </summary>
+        public static OpenXRHandMeshProvider Left { get; } =
+#if MSFT_OPENXR_0_2_0_OR_NEWER
+            new OpenXRHandMeshProvider(HandMeshTracker.Left, Utilities.Handedness.Left);
+#else
+            null;
+#endif // MSFT_OPENXR_0_2_0_OR_NEWER
+
+        /// <summary>
+        /// The user's right hand.
+        /// </summary>
+        public static OpenXRHandMeshProvider Right { get; } =
+#if MSFT_OPENXR_0_2_0_OR_NEWER
+            new OpenXRHandMeshProvider(HandMeshTracker.Right, Utilities.Handedness.Right);
+#else
+            null;
+#endif // MSFT_OPENXR_0_2_0_OR_NEWER
+
+#if MSFT_OPENXR_0_2_0_OR_NEWER
+        private OpenXRHandMeshProvider(HandMeshTracker handMeshTracker, Utilities.Handedness handedness)
+        {
+            this.handMeshTracker = handMeshTracker;
+            this.handedness = handedness;
+
+            mesh = new Mesh();
+            neutralPoseMesh = new Mesh();
+        }
+
+        private readonly HandMeshTracker handMeshTracker;
+        private readonly Utilities.Handedness handedness;
+        private readonly Mesh mesh;
+        private readonly Mesh neutralPoseMesh;
+
+        private readonly List<Vector3> vertices = new List<Vector3>();
+        private readonly List<Vector3> normals = new List<Vector3>();
+        private readonly List<int> triangles = new List<int>();
+
+        private Vector2[] handMeshUVs = null;
+#endif // MSFT_OPENXR_0_2_0_OR_NEWER
+
+        private IMixedRealityInputSource inputSource = null;
+
+        /// <summary>
+        /// Sets the <see cref="IMixedRealityInputSource"/> that represents the current hand for this mesh.
+        /// </summary>
+        /// <param name="inputSource">Implementation of the hand input source.</param>
+        public void SetInputSource(IMixedRealityInputSource inputSource) => this.inputSource = inputSource;
+
+        /// <summary>
+        /// Updates the hand mesh based on the current state of the hand.
+        /// </summary>
+        public void UpdateHandMesh()
+        {
+#if MSFT_OPENXR_0_2_0_OR_NEWER
+            if (handMeshUVs == null && handMeshTracker.TryGetHandMesh(FrameTime.OnUpdate, neutralPoseMesh, HandPoseType.ReferenceOpenPalm))
+            {
+                handMeshUVs = InitializeUVs(neutralPoseMesh.vertices);
+            }
+
+            if (handMeshTracker.TryGetHandMesh(FrameTime.OnUpdate, mesh) && handMeshTracker.TryLocateHandMesh(FrameTime.OnUpdate, out Pose pose))
+            {
+                mesh.GetVertices(vertices);
+                mesh.GetNormals(normals);
+                mesh.GetTriangles(triangles, 0);
+
+                HandMeshInfo handMeshInfo = new HandMeshInfo
+                {
+                    vertices = vertices.ToArray(),
+                    normals = normals.ToArray(),
+                    triangles = triangles.ToArray(),
+                    uvs = handMeshUVs,
+                    position = pose.position,
+                    rotation = pose.rotation
+                };
+
+                CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+            }
+        }
+
+        private Vector2[] InitializeUVs(Vector3[] neutralPoseVertices)
+        {
+            if (neutralPoseVertices.Length == 0)
+            {
+                Debug.LogError("Loaded 0 verts for neutralPoseVertices");
+            }
+
+            float minY = neutralPoseVertices[0].y;
+            float maxY = minY;
+
+            for (int ix = 1; ix < neutralPoseVertices.Length; ix++)
+            {
+                Vector3 p = neutralPoseVertices[ix];
+
+                if (p.y < minY)
+                {
+                    minY = p.y;
+                }
+                else if (p.y > maxY)
+                {
+                    maxY = p.y;
+                }
+            }
+
+            float scale = 1.0f / (maxY - minY);
+
+            Vector2[] uvs = new Vector2[neutralPoseVertices.Length];
+
+            for (int ix = 0; ix < neutralPoseVertices.Length; ix++)
+            {
+                Vector3 p = neutralPoseVertices[ix];
+
+                uvs[ix] = new Vector2(p.x * scale + 0.5f, (p.y - minY) * scale);
+            }
+
+            return uvs;
+#endif // MSFT_OPENXR_0_2_0_OR_NEWER
+        }
+    }
+}

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
@@ -69,6 +69,21 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         public void UpdateHandMesh()
         {
 #if MSFT_OPENXR_0_2_0_OR_NEWER
+            MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
+            MixedRealityHandTrackingProfile handTrackingProfile = inputSystemProfile != null ? inputSystemProfile.HandTrackingProfile : null;
+
+            if (handTrackingProfile == null || !handTrackingProfile.EnableHandMeshVisualization)
+            {
+                // If hand mesh visualization is disabled make sure to clean up if we've already initialized
+                if (handMeshUVs != null)
+                {
+                    // Notify that hand mesh has been updated (cleared)
+                    CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, new HandMeshInfo());
+                    handMeshUVs = null;
+                }
+                return;
+            }
+
             if (handMeshUVs == null && handMeshTracker.TryGetHandMesh(FrameTime.OnUpdate, neutralPoseMesh, HandPoseType.ReferenceOpenPalm))
             {
                 handMeshUVs = InitializeUVs(neutralPoseMesh.vertices);

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs.meta
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cc852bb8ba84e44d938b5775b96bb89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -90,12 +90,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         {
             using (UpdateHandMeshPerfMarker.Auto())
             {
-                MixedRealityHandTrackingProfile handTrackingProfile = null;
                 MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
-                if (inputSystemProfile != null)
-                {
-                    handTrackingProfile = inputSystemProfile.HandTrackingProfile;
-                }
+                MixedRealityHandTrackingProfile handTrackingProfile = inputSystemProfile != null ? inputSystemProfile.HandTrackingProfile : null;
 
                 if (handTrackingProfile == null || !handTrackingProfile.EnableHandMeshVisualization)
                 {


### PR DESCRIPTION
## Overview

Using the `HandMeshTracker` class added in the 0.2.0 Mixed Reality OpenXR package release, this PR adds support via the MRTK's APIs.

Also does some minor rework of what's stored in the hand visualizer between events to try to help perf (no need to store the full array when we only need the count).

![image](https://user-images.githubusercontent.com/3580640/112909923-32bb3580-90a7-11eb-925d-464b135edc61.png)
