### PR TITLE
Fixed bug where the pinch strength defaults were inverted

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -283,12 +283,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
                 if (IsPinching)
                 {
                     // If we are already pinching, we make the pinch a bit sticky
-                    IsPinching = pinchStrength > 0.85f;
+                    IsPinching = pinchStrength > 0.5f;
                 }
                 else
                 {
                     // If not yet pinching, only consider pinching if finger confidence is high
-                    IsPinching = pinchStrength > 0.5f && ovrHand.GetFingerConfidence(OVRHand.HandFinger.Index) == OVRHand.TrackingConfidence.High;
+                    IsPinching = pinchStrength > 0.85f && ovrHand.GetFingerConfidence(OVRHand.HandFinger.Index) == OVRHand.TrackingConfidence.High;
                 }
             }
 


### PR DESCRIPTION
## Overview
The pinch strength values were inverted, making the pinch bool flicker on oculus. This fixes the values so that it's harder to exit pinch once the gesture is raised

## Changes
- Fixes: #9544

