### PR TITLE
Wrap namespace in #if MSFT_OPENXR_0_2_0_OR_NEWER

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#if MSFT_OPENXR_0_2_0_OR_NEWER
 using Microsoft.MixedReality.OpenXR;
+#endif // MSFT_OPENXR_0_2_0_OR_NEWER
+
 using Microsoft.MixedReality.Toolkit.Input;
 using System.Collections.Generic;
 using UnityEngine;


### PR DESCRIPTION
## Overview
Wrap namespace in #if MSFT_OPENXR_0_2_0_OR_NEWER

## Changes
- Fixes: build break in 2020 without OpenXR installed

