### PR TITLE
Refactored Controller visualization code, Oculus Touch uses their own standalone visualizer

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
@@ -166,11 +166,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return null;
         }
 
-        public bool ControllerVisualizationDefinitionExists(Type controllerType, Handedness hand)
-        {
-            return GetControllerVisualizationDefinition(controllerType, hand).HasValue;
-        }
-
         /// <summary>
         /// Gets the override model for a specific controller type and hand
         /// </summary>

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
@@ -154,6 +154,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public MixedRealityControllerVisualizationSetting[] ControllerVisualizationSettings => controllerVisualizationSettings;
 
+        private MixedRealityControllerVisualizationSetting? GetControllerVisualizationDefinition(Type controllerType, Handedness hand)
+        {
+            for (int i = 0; i < controllerVisualizationSettings.Length; i++)
+            {
+                if (SettingContainsParameters(controllerVisualizationSettings[i], controllerType, hand))
+                {
+                    return controllerVisualizationSettings[i];
+                }
+            }
+            return null;
+        }
+
+        public bool ControllerVisualizationDefinitionExists(Type controllerType, Handedness hand)
+        {
+            return GetControllerVisualizationDefinition(controllerType, hand).HasValue;
+        }
+
         /// <summary>
         /// Gets the override model for a specific controller type and hand
         /// </summary>
@@ -161,15 +178,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="hand">The specific hand assigned to the controller</param>
         public GameObject GetControllerModelOverride(Type controllerType, Handedness hand)
         {
-            for (int i = 0; i < controllerVisualizationSettings.Length; i++)
-            {
-                if (SettingContainsParameters(controllerVisualizationSettings[i], controllerType, hand))
-                {
-                    return controllerVisualizationSettings[i].OverrideControllerModel;
-                }
-            }
-
-            return null;
+            return GetControllerVisualizationDefinition(controllerType, hand).HasValue ? GetControllerVisualizationDefinition(controllerType, hand).Value.OverrideControllerModel : null;
         }
 
         /// <summary>
@@ -180,53 +189,59 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="hand">The specific hand assigned to the controller</param>
         public SystemType GetControllerVisualizationTypeOverride(Type controllerType, Handedness hand)
         {
-            for (int i = 0; i < controllerVisualizationSettings.Length; i++)
-            {
-                if (SettingContainsParameters(controllerVisualizationSettings[i], controllerType, hand))
-                {
-                    return controllerVisualizationSettings[i].ControllerVisualizationType;
-                }
-            }
-
-            return defaultControllerVisualizationType;
+            return GetControllerVisualizationDefinition(controllerType, hand).HasValue ? GetControllerVisualizationDefinition(controllerType, hand).Value.ControllerVisualizationType : defaultControllerVisualizationType;
         }
 
         /// <summary>
-        /// Gets the UseDefaultModels value defined for the specified controller definition.
-        /// If the requested controller type is not defined, the default UseDefaultModels is returned.
+        /// Gets the UsePlatformModels value defined for the specified controller definition.
+        /// If the requested controller type is not defined, the default UsePlatformModels is returned.
         /// </summary>
         /// <param name="controllerType">The type of controller to query for</param>
         /// <param name="hand">The specific hand assigned to the controller</param>
+        /// <remarks>
+        /// GetUseDefaultModelsOverride is obsolete and will be removed in a future Mixed Reality Toolkit release. Please use GetUsePlatformModelsOverride.
+        /// </remarks>
+        [Obsolete("GetUseDefaultModelsOverride is obsolete and will be removed in a future Mixed Reality Toolkit release. Please use GetUsePlatformModelsOverride.")]
         public bool GetUseDefaultModelsOverride(Type controllerType, Handedness hand)
         {
-            for (int i = 0; i < controllerVisualizationSettings.Length; i++)
-            {
-                if (SettingContainsParameters(controllerVisualizationSettings[i], controllerType, hand))
-                {
-                    return controllerVisualizationSettings[i].UsePlatformModels;
-                }
-            }
+            return GetUsePlatformModelsOverride(controllerType, hand);
+        }
 
-            return usePlatformModels;
+        /// <summary>
+        /// Gets the UsePlatformModels value defined for the specified controller definition.
+        /// If the requested controller type is not defined, the default UsePlatformModels is returned.
+        /// </summary>
+        /// <param name="controllerType">The type of controller to query for</param>
+        /// <param name="hand">The specific hand assigned to the controller</param>
+        public bool GetUsePlatformModelsOverride(Type controllerType, Handedness hand)
+        {
+            return GetControllerVisualizationDefinition(controllerType, hand).HasValue ? GetControllerVisualizationDefinition(controllerType, hand).Value.UsePlatformModels : usePlatformModels;
         }
 
         /// <summary>
         /// Gets the DefaultModelMaterial value defined for the specified controller definition.
-        /// If the requested controller type is not defined, the global DefaultControllerModelMaterial is returned.
+        /// If the requested controller type is not defined, the global platformModelMaterial is returned.
         /// </summary>
         /// <param name="controllerType">The type of controller to query for</param>
         /// <param name="hand">The specific hand assigned to the controller</param>
+        /// <remarks>
+        /// GetDefaultControllerModelMaterialOverride is obsolete and will be removed in a future Mixed Reality Toolkit release. Please use GetPlatformModelMaterialOverride.
+        /// </remarks>
+        [Obsolete("GetDefaultControllerModelMaterialOverride is obsolete and will be removed in a future Mixed Reality Toolkit release. Please use GetPlatformModelMaterial.")]
         public Material GetDefaultControllerModelMaterialOverride(Type controllerType, Handedness hand)
         {
-            for (int i = 0; i < controllerVisualizationSettings.Length; i++)
-            {
-                if (SettingContainsParameters(controllerVisualizationSettings[i], controllerType, hand))
-                {
-                    return controllerVisualizationSettings[i].PlatformModelMaterial;
-                }
-            }
+            return GetPlatformModelMaterialOverride(controllerType, hand);
+        }
 
-            return platformModelMaterial;
+        /// <summary>
+        /// Gets the PlatformModelMaterial value defined for the specified controller definition.
+        /// If the requested controller type is not defined, the global platformModelMaterial is returned.
+        /// </summary>
+        /// <param name="controllerType">The type of controller to query for</param>
+        /// <param name="hand">The specific hand assigned to the controller</param>
+        public Material GetPlatformModelMaterialOverride(Type controllerType, Handedness hand)
+        {
+            return GetControllerVisualizationDefinition(controllerType, hand).HasValue ? GetControllerVisualizationDefinition(controllerType, hand).Value.PlatformModelMaterial : platformModelMaterial;
         }
 
         private bool SettingContainsParameters(MixedRealityControllerVisualizationSetting setting, Type controllerType, Handedness hand)

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
@@ -173,7 +173,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="hand">The specific hand assigned to the controller</param>
         public GameObject GetControllerModelOverride(Type controllerType, Handedness hand)
         {
-            return GetControllerVisualizationDefinition(controllerType, hand).HasValue ? GetControllerVisualizationDefinition(controllerType, hand).Value.OverrideControllerModel : null;
+            MixedRealityControllerVisualizationSetting? setting = GetControllerVisualizationDefinition(controllerType, hand);
+            return setting.HasValue ? setting.Value.OverrideControllerModel : null;
         }
 
         /// <summary>
@@ -184,7 +185,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="hand">The specific hand assigned to the controller</param>
         public SystemType GetControllerVisualizationTypeOverride(Type controllerType, Handedness hand)
         {
-            return GetControllerVisualizationDefinition(controllerType, hand).HasValue ? GetControllerVisualizationDefinition(controllerType, hand).Value.ControllerVisualizationType : defaultControllerVisualizationType;
+            MixedRealityControllerVisualizationSetting? setting = GetControllerVisualizationDefinition(controllerType, hand);
+            return setting.HasValue ? setting.Value.ControllerVisualizationType : null;
         }
 
         /// <summary>
@@ -210,7 +212,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="hand">The specific hand assigned to the controller</param>
         public bool GetUsePlatformModelsOverride(Type controllerType, Handedness hand)
         {
-            return GetControllerVisualizationDefinition(controllerType, hand).HasValue ? GetControllerVisualizationDefinition(controllerType, hand).Value.UsePlatformModels : usePlatformModels;
+            MixedRealityControllerVisualizationSetting? setting = GetControllerVisualizationDefinition(controllerType, hand);
+            return setting.HasValue ? setting.Value.UsePlatformModels : usePlatformModels;
         }
 
         /// <summary>
@@ -236,7 +239,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="hand">The specific hand assigned to the controller</param>
         public Material GetPlatformModelMaterialOverride(Type controllerType, Handedness hand)
         {
-            return GetControllerVisualizationDefinition(controllerType, hand).HasValue ? GetControllerVisualizationDefinition(controllerType, hand).Value.PlatformModelMaterial : platformModelMaterial;
+
+            MixedRealityControllerVisualizationSetting? setting = GetControllerVisualizationDefinition(controllerType, hand);
+            return setting.HasValue ? setting.Value.PlatformModelMaterial : platformModelMaterial;
         }
 
         private bool SettingContainsParameters(MixedRealityControllerVisualizationSetting setting, Type controllerType, Handedness hand)

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
@@ -102,7 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
                     if (usePlatformControllerModels.boolValue && (leftHandModelPrefab != null || rightHandModelPrefab != null))
                     {
-                        EditorGUILayout.HelpBox("When default models are used, an attempt is made to obtain controller models from the platform SDK. The global left and right models are only shown if no model can be obtained.", MessageType.Warning);
+                        EditorGUILayout.HelpBox("When platform models are used, an attempt is made to obtain controller models from the platform SDK. The global left and right models are only shown if no model can be obtained.", MessageType.Warning);
                     }
 
                     EditorGUI.BeginChangeCheck();
@@ -208,6 +208,12 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     EditorGUILayout.HelpBox("A controller type must be defined!", MessageType.Error);
                 }
 
+                bool isOculusType = thisProfile.ControllerVisualizationSettings[i].ControllerType.Type.FullName.Contains("OculusXRSDKTouchController");
+                if (isOculusType)
+                {
+                    EditorGUILayout.HelpBox("Oculus Touch controller model visualization is not managed by MRTK, refer to the Oculus XRSDK Device Manager to configure controller visualization settings", MessageType.Error);
+                }
+
                 var handednessValue = mixedRealityControllerHandedness.intValue - 1;
 
                 // Reset in case it was set to something other than left or right.
@@ -233,11 +239,15 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
                 if (controllerUsePlatformModelOverride.boolValue && overrideModelPrefab != null)
                 {
-                    EditorGUILayout.HelpBox("When default model is used, the override model will only be used if the default model cannot be loaded from the driver.", MessageType.Warning);
+                    EditorGUILayout.HelpBox("When platform model is used, the override model will only be used if the default model cannot be loaded from the driver.", MessageType.Warning);
                 }
 
                 EditorGUI.BeginChangeCheck();
                 overrideModelPrefab = EditorGUILayout.ObjectField(new GUIContent(overrideModel.displayName, "If no override model is set, the global model is used."), overrideModelPrefab, typeof(GameObject), false) as GameObject;
+                if(overrideModelPrefab == null && !controllerUsePlatformModelOverride.boolValue)
+                {
+                    EditorGUILayout.HelpBox("No override model was assigned and this controller will not attempt to use the platform's model, the global model will be used instead", MessageType.Warning);
+                }
 
                 if (EditorGUI.EndChangeCheck() && CheckVisualizer(overrideModelPrefab))
                 {

--- a/Assets/MRTK/Core/Providers/BaseController.cs
+++ b/Assets/MRTK/Core/Providers/BaseController.cs
@@ -234,50 +234,50 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <returns>True if a model was successfully loaded or model rendering is disabled. False if a model tried to load but failed.</returns>
         protected virtual bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)
         {
-            if (GetControllerVisualizationProfile() == null ||
-                !GetControllerVisualizationProfile().RenderMotionControllers)
+            MixedRealityControllerVisualizationProfile controllerVisualizationProfile = GetControllerVisualizationProfile();
+            bool controllerVisualizationProfilePresent = GetControllerVisualizationProfile() != null;
+           
+            if (!controllerVisualizationProfilePresent || !controllerVisualizationProfile.RenderMotionControllers)
             {
                 return true;
             }
 
             GameObject controllerModel = null;
+            bool usePlatformModels = !controllerVisualizationProfile.GetUsePlatformModelsOverride(controllerType, ControllerHandedness);
 
-            // If a specific controller template wants to override the global model, assign that instead.
-            if (IsControllerMappingEnabled() &&
-                GetControllerVisualizationProfile() != null &&
-                !(GetControllerVisualizationProfile().GetUseDefaultModelsOverride(controllerType, ControllerHandedness)))
+            // If a specific controller template wants to override the global model, assign it
+            if (!usePlatformModels)
             {
-                controllerModel = GetControllerVisualizationProfile().GetControllerModelOverride(controllerType, ControllerHandedness);
+                controllerModel = controllerVisualizationProfile.GetControllerModelOverride(controllerType, ControllerHandedness);
             }
 
-            // Get the global controller model for each hand.
-            if (controllerModel == null &&
-                GetControllerVisualizationProfile() != null)
+            // If the Controller model is still null in the end, use the global defaults.
+            if (controllerModel == null)
             {
                 if (inputSourceType == InputSourceType.Controller)
                 {
                     if (ControllerHandedness == Handedness.Left &&
-                        GetControllerVisualizationProfile().GlobalLeftHandModel != null)
+                        controllerVisualizationProfile.GlobalLeftHandModel != null)
                     {
-                        controllerModel = GetControllerVisualizationProfile().GlobalLeftHandModel;
+                        controllerModel = controllerVisualizationProfile.GlobalLeftHandModel;
                     }
                     else if (ControllerHandedness == Handedness.Right &&
                         GetControllerVisualizationProfile().GlobalRightHandModel != null)
                     {
-                        controllerModel = GetControllerVisualizationProfile().GlobalRightHandModel;
+                        controllerModel = controllerVisualizationProfile.GlobalRightHandModel;
                     }
                 }
                 else if (inputSourceType == InputSourceType.Hand)
                 {
                     if (ControllerHandedness == Handedness.Left &&
-                        GetControllerVisualizationProfile().GlobalLeftHandVisualizer != null)
+                        controllerVisualizationProfile.GlobalLeftHandVisualizer != null)
                     {
-                        controllerModel = GetControllerVisualizationProfile().GlobalLeftHandVisualizer;
+                        controllerModel = controllerVisualizationProfile.GlobalLeftHandVisualizer;
                     }
                     else if (ControllerHandedness == Handedness.Right &&
-                        GetControllerVisualizationProfile().GlobalRightHandVisualizer != null)
+                        controllerVisualizationProfile.GlobalRightHandVisualizer != null)
                     {
-                        controllerModel = GetControllerVisualizationProfile().GlobalRightHandVisualizer;
+                        controllerModel = controllerVisualizationProfile.GlobalRightHandVisualizer;
                     }
                 }
             }

--- a/Assets/MRTK/Core/Providers/BaseController.cs
+++ b/Assets/MRTK/Core/Providers/BaseController.cs
@@ -243,7 +243,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             GameObject controllerModel = null;
-            bool usePlatformModels = !controllerVisualizationProfile.GetUsePlatformModelsOverride(controllerType, ControllerHandedness);
+            bool usePlatformModels = controllerVisualizationProfile.GetUsePlatformModelsOverride(controllerType, ControllerHandedness);
 
             // If a specific controller template wants to override the global model, assign it
             if (!usePlatformModels)

--- a/Assets/MRTK/Core/Providers/BaseController.cs
+++ b/Assets/MRTK/Core/Providers/BaseController.cs
@@ -235,7 +235,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected virtual bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)
         {
             MixedRealityControllerVisualizationProfile controllerVisualizationProfile = GetControllerVisualizationProfile();
-            bool controllerVisualizationProfilePresent = GetControllerVisualizationProfile() != null;
+            bool controllerVisualizationProfilePresent = controllerVisualizationProfile != null;
            
             if (!controllerVisualizationProfilePresent || !controllerVisualizationProfile.RenderMotionControllers)
             {

--- a/Assets/MRTK/Core/Providers/BaseController.cs
+++ b/Assets/MRTK/Core/Providers/BaseController.cs
@@ -262,7 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         controllerModel = controllerVisualizationProfile.GlobalLeftHandModel;
                     }
                     else if (ControllerHandedness == Handedness.Right &&
-                        GetControllerVisualizationProfile().GlobalRightHandModel != null)
+                        controllerVisualizationProfile.GlobalRightHandModel != null)
                     {
                         controllerModel = controllerVisualizationProfile.GlobalRightHandModel;
                     }

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -97,7 +97,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
 
         /// <inheritdoc/>
         /// <remarks>
-        /// If UseMRTKControllerVisualization is fals, Oculus Touch controller model visualization will not be managed by MRTK
+        /// If UseMRTKControllerVisualization is false, Oculus Touch controller model visualization will not be managed by MRTK
         /// Ensure that the Oculus Integration Package is installed and the Ovr Camera Rig is set correctly in the Oculus XRSDK Device Manager
         /// </remarks>
         protected override bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -7,6 +7,7 @@ using Microsoft.MixedReality.Toolkit.XRSDK.Input;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR;
+using System;
 
 #if OCULUS_ENABLED
 using Unity.XR.Oculus;
@@ -87,6 +88,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
                     }
                 }
             }
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Oculus Touch controller model visualization is not managed by MRTK, refer to the Oculus XRSDK Device Manager to configure controller visualization settings
+        /// </remarks>
+        protected override bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)
+        {
+            return false;
         }
     }
 }

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -90,13 +90,26 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             }
         }
 
+        /// <summary>
+        /// Determines whether or not this controller uses MRTK for controller visualization or not
+        /// </summary>
+        public bool UseMRTKControllerVisualization = false;
+
         /// <inheritdoc/>
         /// <remarks>
-        /// Oculus Touch controller model visualization is not managed by MRTK, refer to the Oculus XRSDK Device Manager to configure controller visualization settings
+        /// If UseMRTKControllerVisualization is fals, Oculus Touch controller model visualization will not be managed by MRTK
+        /// Ensure that the Oculus Integration Package is installed and the Ovr Camera Rig is set correctly in the Oculus XRSDK Device Manager
         /// </remarks>
         protected override bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)
         {
-            return false;
+            if (UseMRTKControllerVisualization)
+            {
+                return base.TryRenderControllerModel(controllerType, inputSourceType);
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -93,7 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         /// <summary>
         /// Determines whether or not this controller uses MRTK for controller visualization or not
         /// </summary>
-        public bool UseMRTKControllerVisualization = false;
+        internal bool UseMRTKControllerVisualization { get; set; } = false;
 
         /// <inheritdoc/>
         /// <remarks>

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
@@ -125,6 +125,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
                 defaultOculusProjectConfig.handTrackingSupport = OVRProjectConfig.HandTrackingSupport.ControllersAndHands;
                 defaultOculusProjectConfig.requiresSystemKeyboard = true;
 
+                OVRProjectConfig.CommitProjectConfig(defaultOculusProjectConfig);
+
                 Debug.Log("Enabled Oculus Quest Keyboard and Handtracking in the Oculus Project Config");
             }
 #endif

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -88,6 +88,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
 
         #region Controller Utilities
 
+#if OCULUSINTEGRATION_PRESENT
         /// <inheritdoc />
         protected override GenericXRSDKController GetOrAddController(InputDevice inputDevice)
         {
@@ -101,6 +102,7 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
 
             return oculusTouchController;
         }
+#endif
 
         /// <inheritdoc />
         protected override Type GetControllerType(SupportedControllerType supportedControllerType)

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -89,6 +89,20 @@ The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Inte
         #region Controller Utilities
 
         /// <inheritdoc />
+        protected override GenericXRSDKController GetOrAddController(InputDevice inputDevice)
+        {
+            GenericXRSDKController controller = base.GetOrAddController(inputDevice);
+            OculusXRSDKTouchController oculusTouchController = controller as OculusXRSDKTouchController;
+
+            if(!oculusTouchController.IsNull())
+            {
+                oculusTouchController.UseMRTKControllerVisualization = cameraRig.IsNull();
+            }
+
+            return oculusTouchController;
+        }
+
+        /// <inheritdoc />
         protected override Type GetControllerType(SupportedControllerType supportedControllerType)
         {
             switch (supportedControllerType)

--- a/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
@@ -282,7 +282,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
                 }
 
                 OpenVRRenderModel openVRRenderModel = controllerModelGameObject.AddComponent<OpenVRRenderModel>();
-                Material overrideMaterial = visualizationProfile.GetDefaultControllerModelMaterialOverride(GetType(), ControllerHandedness);
+                Material overrideMaterial = visualizationProfile.GetPlatformModelMaterialOverride(GetType(), ControllerHandedness);
                 if (overrideMaterial != null)
                 {
                     openVRRenderModel.shader = overrideMaterial.shader;

--- a/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
@@ -254,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
 
             // Intercept this call if we are using the default driver provided models.
             if (visualizationProfile == null ||
-                !visualizationProfile.GetUseDefaultModelsOverride(GetType(), ControllerHandedness))
+                !visualizationProfile.GetUsePlatformModelsOverride(GetType(), ControllerHandedness))
             {
                 return base.TryRenderControllerModel(controllerType, inputSourceType);
             }


### PR DESCRIPTION
## Overview
Cleaned up some of the confusing controller visualization code and added QoL improvements to feedback given by the profile.

Oculus XRSDK Touch controllers can now opt to not use MRTK for controller visualization, since the oculus integration package has their own standalone visualization (some of our users were confused and complaining that they could not get rid of the default gizmos)

## Changes
Fixes #9590