### PR TITLE
Standardize license headers

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;

--- a/Assets/MRTK/Core/Interfaces/SpatialAwareness/Observers/Experimental/IMixedRealityOnDemandObserver.cs
+++ b/Assets/MRTK/Core/Interfaces/SpatialAwareness/Observers/Experimental/IMixedRealityOnDemandObserver.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 

--- a/Assets/MRTK/Core/Interfaces/SpatialAwareness/Observers/Experimental/IMixedRealitySceneUnderstandingObserver.cs
+++ b/Assets/MRTK/Core/Interfaces/SpatialAwareness/Observers/Experimental/IMixedRealitySceneUnderstandingObserver.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using System.Collections.Generic;

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationHelpGuide.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationHelpGuide.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;

--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.license information.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;

--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfileInspector.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfileInspector.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.license information.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Editor;
 using Microsoft.MixedReality.Toolkit.Utilities;

--- a/Assets/MRTK/Examples/Demos/ScrollingObjectCollection/Scripts/ScrollablePagination.cs
+++ b/Assets/MRTK/Examples/Demos/ScrollingObjectCollection/Scripts/ScrollablePagination.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.UI;
 using UnityEngine;

--- a/Assets/MRTK/Examples/Demos/SpatialAwareness/Scripts/ShowPlaneFindingInstructions.cs
+++ b/Assets/MRTK/Examples/Demos/SpatialAwareness/Scripts/ShowPlaneFindingInstructions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Experimental.SpatialAwareness;
 using UnityEngine;

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Editor/SceneUnderstandingObserverProfileInspector.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/Editor/SceneUnderstandingObserverProfileInspector.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Editor;
 using System.Linq;

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/SceneUnderstandingObserverProfile.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/SceneUnderstandingObserverProfile.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Experimental.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Physics;

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.license information.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;

--- a/Assets/MRTK/SDK/Experimental/ColorPicker/ColorPicker.cs
+++ b/Assets/MRTK/SDK/Experimental/ColorPicker/ColorPicker.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;

--- a/Assets/MRTK/SDK/Experimental/SpatialAwareness/SurfaceMeshesToPlanes.cs
+++ b/Assets/MRTK/SDK/Experimental/SpatialAwareness/SurfaceMeshesToPlanes.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;

--- a/Assets/MRTK/Tests/EditModeTests/Core/Extensions/BoundsExtensionsTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Extensions/BoundsExtensionsTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using NUnit.Framework;
 using System;

--- a/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #if !WINDOWS_UWP
 // When the .NET scripting backend is enabled and C# projects are built

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/8102. Looks like a few more snuck in with the old style.