### PR TITLE
Update to use non-obsolete method in WMR controller

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -140,7 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         protected override bool TryRenderControllerModel(System.Type controllerType, InputSourceType inputSourceType)
         {
             if (GetControllerVisualizationProfile() == null ||
-                !GetControllerVisualizationProfile().GetUseDefaultModelsOverride(GetType(), ControllerHandedness))
+                !GetControllerVisualizationProfile().GetUsePlatformModelsOverride(GetType(), ControllerHandedness))
             {
                 return base.TryRenderControllerModel(controllerType, inputSourceType);
             }


### PR DESCRIPTION
## Overview

https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9589 deprecated `GetUseDefaultModelsOverride`, but one of the classes is still calling it. Updated to the new `GetUsePlatformModelsOverride` instead.

This was preventing building in Unity 2019+