### PR TITLE
Fix docs build

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         private IMixedRealityInputSource inputSource = null;
 
         /// <summary>
-        /// Sets the <see cref="IMixedRealityInputSource"/> that represents the current hand for this mesh.
+        /// Sets the <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSource"/> that represents the current hand for this mesh.
         /// </summary>
         /// <param name="inputSource">Implementation of the hand input source.</param>
         public void SetInputSource(IMixedRealityInputSource inputSource)


### PR DESCRIPTION
## Overview

The docs pipeline hasn't been running since the branch name change, so we're hitting a build failure on a type that was added after the name change.

## Changes
- Fixes: https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=18071&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=5fd232ee-0bcd-5c4f-9e6b-7e96853085e6
