### PR TITLE
Fix some diagnostics panel bugs

### DIFF
--- a/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -473,9 +473,9 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             {
                 float windowDistance =
 #if WINDOWS_UWP
-                    Mathf.Max(16.0f / (appCaptureIsCapturingVideo ? previousFieldOfView : previousFieldOfView = CameraCache.Main.fieldOfView), CameraCache.Main.nearClipPlane + 0.25f);
+                    Mathf.Max(16.0f / (appCaptureIsCapturingVideo ? previousFieldOfView : previousFieldOfView = CameraCache.Main.fieldOfView), Mathf.Max(CameraCache.Main.nearClipPlane, 0.5f));
 #else
-                    Mathf.Max(16.0f / CameraCache.Main.fieldOfView, CameraCache.Main.nearClipPlane + 0.25f);
+                    Mathf.Max(16.0f / CameraCache.Main.fieldOfView, Mathf.Max(CameraCache.Main.nearClipPlane, 0.5f));
 #endif // WINDOWS_UWP
 
                 Vector3 position = cameraTransform.position + (cameraTransform.forward * windowDistance);

--- a/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -291,6 +291,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             appCapture = AppCapture.GetForCurrentView();
             if (appCapture != null)
             {
+                appCaptureIsCapturingVideo = appCapture.IsCapturingVideo;
                 appCapture.CapturingChanged += AppCapture_CapturingChanged;
             }
 #endif // WINDOWS_UWP

--- a/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
         private bool ShouldShowProfiler =>
 #if WINDOWS_UWP
-            (appCapture == null || !appCapture.IsCapturingVideo || showProfilerDuringMRC) &&
+            (!appCaptureIsCapturingVideo || showProfilerDuringMRC) &&
 #endif // WINDOWS_UWP
             isVisible;
 
@@ -217,6 +217,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
         private Mesh quadMesh;
 
 #if WINDOWS_UWP
+        private bool appCaptureIsCapturingVideo = false;
         private AppCapture appCapture;
 #endif // WINDOWS_UWP
 
@@ -289,11 +290,22 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
 #if WINDOWS_UWP
             appCapture = AppCapture.GetForCurrentView();
+            if (appCapture != null)
+            {
+                appCapture.CapturingChanged += AppCapture_CapturingChanged;
+            }
 #endif // WINDOWS_UWP
         }
 
         private void OnDestroy()
         {
+#if WINDOWS_UWP
+            if (appCapture != null)
+            {
+                appCapture.CapturingChanged -= AppCapture_CapturingChanged;
+            }
+#endif // WINDOWS_UWP
+
             if (window != null)
             {
                 Destroy(window.gameObject);
@@ -441,6 +453,10 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
                 memoryStats.gameObject.SetActive(memoryStatsVisible);
             }
         }
+
+#if WINDOWS_UWP
+        private void AppCapture_CapturingChanged(AppCapture sender, object args) => appCaptureIsCapturingVideo = sender.IsCapturingVideo;
+#endif // WINDOWS_UWP
 
         private static readonly ProfilerMarker CalculateWindowPositionPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkitVisualProfiler.CalculateWindowPosition");
 

--- a/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -22,9 +22,9 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
     /// as current, peak and max usage in a bar graph. 
     /// </summary>
     /// <remarks>
-    /// To use this profiler simply add this script as a component of any GameObject in 
+    /// <para>To use this profiler simply add this script as a component of any GameObject in 
     /// your Unity scene. The profiler is initially enabled (toggle-able via the initiallyActive 
-    /// property), but can be toggled via the enabled/disable voice commands keywords.
+    /// property), but can be toggled via the enabled/disable voice commands keywords.</para>
     /// </remarks>
     [AddComponentMenu("Scripts/MRTK/Services/MixedRealityToolkitVisualProfiler")]
     public class MixedRealityToolkitVisualProfiler : MonoBehaviour

--- a/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -16,17 +16,16 @@ using UnityEngine.Profiling;
 namespace Microsoft.MixedReality.Toolkit.Diagnostics
 {
     /// <summary>
-    /// 
-    /// ABOUT: The VisualProfiler provides a drop in, single file, solution for viewing 
+    /// The VisualProfiler provides a drop in, single file, solution for viewing 
     /// your Windows Mixed Reality Unity application's frame rate and memory usage. Missed 
     /// frames are displayed over time to visually find problem areas. Memory is reported 
     /// as current, peak and max usage in a bar graph. 
-    /// 
-    /// USAGE: To use this profiler simply add this script as a component of any GameObject in 
+    /// </summary>
+    /// <remarks>
+    /// To use this profiler simply add this script as a component of any GameObject in 
     /// your Unity scene. The profiler is initially enabled (toggle-able via the initiallyActive 
     /// property), but can be toggled via the enabled/disable voice commands keywords.
-    /// 
-    /// </summary>
+    /// </remarks>
     [AddComponentMenu("Scripts/MRTK/Services/MixedRealityToolkitVisualProfiler")]
     public class MixedRealityToolkitVisualProfiler : MonoBehaviour
     {

--- a/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -449,8 +449,15 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
                 }
 
                 // Update visibility state.
-                window.gameObject.SetActive(ShouldShowProfiler);
-                memoryStats.gameObject.SetActive(memoryStatsVisible);
+                if (window.gameObject.activeSelf != ShouldShowProfiler)
+                {
+                    window.gameObject.SetActive(ShouldShowProfiler);
+                }
+
+                if (memoryStats.gameObject.activeSelf != memoryStatsVisible)
+                {
+                    memoryStats.gameObject.SetActive(memoryStatsVisible);
+                }
             }
         }
 
@@ -648,8 +655,15 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
                 }
             }
 
-            window.gameObject.SetActive(ShouldShowProfiler);
-            memoryStats.gameObject.SetActive(memoryStatsVisible);
+            if (window.gameObject.activeSelf != ShouldShowProfiler)
+            {
+                window.gameObject.SetActive(ShouldShowProfiler);
+            }
+
+            if (memoryStats.gameObject.activeSelf != memoryStatsVisible)
+            {
+                memoryStats.gameObject.SetActive(memoryStatsVisible);
+            }
         }
 
         private void BuildFrameRateStrings()

--- a/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MRTK/Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -462,6 +462,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
 #if WINDOWS_UWP
         private void AppCapture_CapturingChanged(AppCapture sender, object args) => appCaptureIsCapturingVideo = sender.IsCapturingVideo;
+        private float previousFieldOfView = -1.0f;
 #endif // WINDOWS_UWP
 
         private static readonly ProfilerMarker CalculateWindowPositionPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkitVisualProfiler.CalculateWindowPosition");
@@ -470,7 +471,13 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
         {
             using (CalculateWindowPositionPerfMarker.Auto())
             {
-                float windowDistance = Mathf.Max(16.0f / CameraCache.Main.fieldOfView, CameraCache.Main.nearClipPlane + 0.25f);
+                float windowDistance =
+#if WINDOWS_UWP
+                    Mathf.Max(16.0f / (appCaptureIsCapturingVideo ? previousFieldOfView : previousFieldOfView = CameraCache.Main.fieldOfView), CameraCache.Main.nearClipPlane + 0.25f);
+#else
+                    Mathf.Max(16.0f / CameraCache.Main.fieldOfView, CameraCache.Main.nearClipPlane + 0.25f);
+#endif // WINDOWS_UWP
+
                 Vector3 position = cameraTransform.position + (cameraTransform.forward * windowDistance);
                 Vector3 horizontalOffset = cameraTransform.right * windowOffset.x;
                 Vector3 verticalOffset = cameraTransform.up * windowOffset.y;


### PR DESCRIPTION
## Overview

1. `appCapture.IsCapturingVideo` can be expensive, so instead of checking it every frame we now key off the event.
2. The camera's reported FoV changes while MRC is running, so we now cache the most recent FoV and use that instead while MRC is running
3. Increased the min distance for display to 0.5 instead of "near clipping plane + 0.25" so it's more predictable

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9560, fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9596
