### PR TITLE
Remove orphaned properties from TapToPlaceInspector

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs
@@ -29,6 +29,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
 
         // Advanced properties
         private SerializedProperty magneticSurfaces;
+        private SerializedProperty updateLinkedTransformProperty;
+        private SerializedProperty moveLerpTimeProperty;
+        private SerializedProperty rotateLerpTimeProperty;
+        private SerializedProperty scaleLerpTimeProperty;
+        private SerializedProperty maintainScaleOnInitializationProperty;
+        private SerializedProperty smoothingProperty;
+        private SerializedProperty lifetimeProperty;
 
         private const string AdvancedPropertiesFoldoutKey = "TapToPlaceAdvancedProperties";
 
@@ -49,6 +56,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
             onPlacingStarted = serializedObject.FindProperty("onPlacingStarted");
 
             // Advanced Properties
+            updateLinkedTransformProperty = serializedObject.FindProperty("updateLinkedTransform");
+            moveLerpTimeProperty = serializedObject.FindProperty("moveLerpTime");
+            rotateLerpTimeProperty = serializedObject.FindProperty("rotateLerpTime");
+            scaleLerpTimeProperty = serializedObject.FindProperty("scaleLerpTime");
+            maintainScaleOnInitializationProperty = serializedObject.FindProperty("maintainScaleOnInitialization");
+            smoothingProperty = serializedObject.FindProperty("smoothing");
+            lifetimeProperty = serializedObject.FindProperty("lifetime");
             magneticSurfaces = serializedObject.FindProperty("magneticSurfaces");
         }
 
@@ -96,6 +110,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
                 using (new EditorGUI.IndentLevelScope())
                 {
                     EditorGUILayout.Space();
+                    EditorGUILayout.PropertyField(updateLinkedTransformProperty);
+                    EditorGUILayout.PropertyField(moveLerpTimeProperty);
+                    EditorGUILayout.PropertyField(rotateLerpTimeProperty);
+                    EditorGUILayout.PropertyField(scaleLerpTimeProperty);
+                    EditorGUILayout.PropertyField(maintainScaleOnInitializationProperty);
+                    EditorGUILayout.PropertyField(smoothingProperty);
+                    EditorGUILayout.PropertyField(lifetimeProperty);
                     EditorGUILayout.PropertyField(magneticSurfaces, true);
                 }
             }

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs
@@ -28,20 +28,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
         private SerializedProperty onPlacingStopped;
 
         // Advanced properties
-        private SerializedProperty updateLinkedTransformProperty;
-        private SerializedProperty moveLerpTimeProperty;
-        private SerializedProperty rotateLerpTimeProperty;
-        private SerializedProperty scaleLerpTimeProperty;
-        private SerializedProperty maintainScaleProperty;
-        private SerializedProperty smoothingProperty;
-        private SerializedProperty lifetimeProperty;
         private SerializedProperty magneticSurfaces;
 
         private const string AdvancedPropertiesFoldoutKey = "TapToPlaceAdvancedProperties";
 
         protected virtual void OnEnable()
         {
-            instance = (TapToPlace)target;
+            instance = (TapToPlace) target;
 
             // Main Tap to Place Properties
             autoStart = serializedObject.FindProperty("autoStart");
@@ -56,13 +49,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
             onPlacingStarted = serializedObject.FindProperty("onPlacingStarted");
 
             // Advanced Properties
-            updateLinkedTransformProperty = serializedObject.FindProperty("updateLinkedTransform");
-            moveLerpTimeProperty = serializedObject.FindProperty("moveLerpTime");
-            rotateLerpTimeProperty = serializedObject.FindProperty("rotateLerpTime");
-            scaleLerpTimeProperty = serializedObject.FindProperty("scaleLerpTime");
-            maintainScaleProperty = serializedObject.FindProperty("maintainScale");
-            smoothingProperty = serializedObject.FindProperty("smoothing");
-            lifetimeProperty = serializedObject.FindProperty("lifetime");
             magneticSurfaces = serializedObject.FindProperty("magneticSurfaces");
         }
 
@@ -104,19 +90,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
         private void RenderAdvancedProperties()
         {
             // Render Advanced Settings
-            if (InspectorUIUtility.DrawSectionFoldoutWithKey("Advanced Properties", AdvancedPropertiesFoldoutKey, MixedRealityStylesUtility.TitleFoldoutStyle, false))
+            if (InspectorUIUtility.DrawSectionFoldoutWithKey("Advanced Properties", AdvancedPropertiesFoldoutKey,
+                MixedRealityStylesUtility.TitleFoldoutStyle, false))
             {
                 using (new EditorGUI.IndentLevelScope())
                 {
                     EditorGUILayout.Space();
-
-                    EditorGUILayout.PropertyField(updateLinkedTransformProperty);
-                    EditorGUILayout.PropertyField(moveLerpTimeProperty);
-                    EditorGUILayout.PropertyField(rotateLerpTimeProperty);
-                    EditorGUILayout.PropertyField(scaleLerpTimeProperty);
-                    EditorGUILayout.PropertyField(maintainScaleProperty);
-                    EditorGUILayout.PropertyField(smoothingProperty);
-                    EditorGUILayout.PropertyField(lifetimeProperty);
                     EditorGUILayout.PropertyField(magneticSurfaces, true);
                 }
             }


### PR DESCRIPTION
Fix issue #9645

## Overview
TopToPlaceInspector references properties which don't exists in TapToPlace. This causes an error in the console and the Magnetic Surface inspector settings will not be rendered as described in #9645.

## Changes
- Fixes: Orphaned properties in TapToPlaceInspector
