### PR TITLE
Fix: focus getting stuck on `Interactable` when `RequiresFocus` is `false`.

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1302,7 +1302,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             yield return new WaitForSeconds(time);
 
             HasVoiceCommand = false;
-            if (!HasFocus)
+            if (HasFocus && focusingPointers.Count == 0)
             {
                 HasFocus = false;
             }
@@ -1513,13 +1513,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (eventData.Command.Keyword == VoiceCommand && (!VoiceRequiresFocus || HasFocus) && CanInteract())
             {
-                bool hadFocus = HasFocus;
                 StartGlobalVisual(true);
                 HasVoiceCommand = true;
                 SendVoiceCommands(VoiceCommand, 0, 1);
                 TriggerOnClick();
                 eventData.Use();
-                HasFocus = hadFocus;
             }
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1513,11 +1513,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (eventData.Command.Keyword == VoiceCommand && (!VoiceRequiresFocus || HasFocus) && CanInteract())
             {
+                bool hadFocus = HasFocus;
                 StartGlobalVisual(true);
                 HasVoiceCommand = true;
                 SendVoiceCommands(VoiceCommand, 0, 1);
                 TriggerOnClick();
                 eventData.Use();
+                HasFocus = hadFocus;
             }
         }
 


### PR DESCRIPTION
## Overview
When using voice commands to trigger an `Interactable` while `RequiresFocus` is `false`, the focus of the cursor would get stuck on the triggered `Interactable`. When airtapping on another `Interactable` the previous (voice-activated) `Interactable` would still be triggered.

## Changes
- Fixes: the focus getting stuck on the voice-activated `Interactable` by resetting the focus to it's state before handling the interaction.


