### PR TITLE
Rename Mixed Reality Toolkit menus to Mixed Reality

### DIFF
--- a/Assets/MRTK/Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
     /// <summary>
     /// Configuration profile settings for setting up boundary visualizations.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Boundary Visualization Profile", fileName = "MixedRealityBoundaryVisualizationProfile", order = (int)CreateProfileMenuItemIndices.BoundaryVisualization)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Boundary Visualization Profile", fileName = "MixedRealityBoundaryVisualizationProfile", order = (int)CreateProfileMenuItemIndices.BoundaryVisualization)]
     [MixedRealityServiceProfile(typeof(IMixedRealityBoundarySystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/boundary/boundary-system-getting-started")]
     public class MixedRealityBoundaryVisualizationProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
     /// <summary>
     /// Configuration profile settings for setting up boundary visualizations.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Boundary Visualization Profile", fileName = "MixedRealityBoundaryVisualizationProfile", order = (int)CreateProfileMenuItemIndices.BoundaryVisualization)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Boundary Visualization Profile", fileName = "MixedRealityBoundaryVisualizationProfile", order = (int)CreateProfileMenuItemIndices.BoundaryVisualization)]
     [MixedRealityServiceProfile(typeof(IMixedRealityBoundarySystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/boundary/boundary-system-getting-started")]
     public class MixedRealityBoundaryVisualizationProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
+++ b/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT License.``
 
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// is a transparent device or an occluded device.
     /// Based on those values, you can customize your camera and quality settings.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Camera Profile", fileName = "MixedRealityCameraProfile", order = (int)CreateProfileMenuItemIndices.Camera)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Camera Profile", fileName = "MixedRealityCameraProfile", order = (int)CreateProfileMenuItemIndices.Camera)]
     [MixedRealityServiceProfile(typeof(IMixedRealityCameraSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/configuration/mixed-reality-configuration-guide#camera")]
     public class MixedRealityCameraProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
+++ b/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// is a transparent device or an occluded device.
     /// Based on those values, you can customize your camera and quality settings.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Camera Profile", fileName = "MixedRealityCameraProfile", order = (int)CreateProfileMenuItemIndices.Camera)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Camera Profile", fileName = "MixedRealityCameraProfile", order = (int)CreateProfileMenuItemIndices.Camera)]
     [MixedRealityServiceProfile(typeof(IMixedRealityCameraSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/configuration/mixed-reality-configuration-guide#camera")]
     public class MixedRealityCameraProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
+++ b/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.``
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Utilities;

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// New controller types can be registered by adding the MixedRealityControllerAttribute to
     /// the controller class.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Controller Mapping Profile", fileName = "MixedRealityControllerMappingProfile", order = (int)CreateProfileMenuItemIndices.ControllerMapping)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Controller Mapping Profile", fileName = "MixedRealityControllerMappingProfile", order = (int)CreateProfileMenuItemIndices.ControllerMapping)]
     public class MixedRealityControllerMappingProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public MixedRealityControllerMapping[] MixedRealityControllerMappingProfiles => mixedRealityControllerMappings;
 
 #if UNITY_EDITOR
-        [MenuItem("Mixed Reality Toolkit/Utilities/Update/Controller Mapping Profiles")]
+        [MenuItem("Mixed Reality/Utilities/Update/Controller Mapping Profiles")]
         private static void UpdateAllControllerMappingProfiles()
         {
             string[] guids = AssetDatabase.FindAssets("t:MixedRealityControllerMappingProfile");

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// New controller types can be registered by adding the MixedRealityControllerAttribute to
     /// the controller class.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Controller Mapping Profile", fileName = "MixedRealityControllerMappingProfile", order = (int)CreateProfileMenuItemIndices.ControllerMapping)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Controller Mapping Profile", fileName = "MixedRealityControllerMappingProfile", order = (int)CreateProfileMenuItemIndices.ControllerMapping)]
     public class MixedRealityControllerMappingProfile : BaseMixedRealityProfile
     {
         [SerializeField]
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public MixedRealityControllerMapping[] MixedRealityControllerMappingProfiles => mixedRealityControllerMappings;
 
 #if UNITY_EDITOR
-        [MenuItem("Mixed Reality/Utilities/Update/Controller Mapping Profiles")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Update/Controller Mapping Profiles")]
         private static void UpdateAllControllerMappingProfiles()
         {
             string[] guids = AssetDatabase.FindAssets("t:MixedRealityControllerMappingProfile");

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Profile that determines relevant overrides and properties for controller visualization
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Controller Visualization Profile", fileName = "MixedRealityControllerVisualizationProfile", order = (int)CreateProfileMenuItemIndices.ControllerVisualization)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Controller Visualization Profile", fileName = "MixedRealityControllerVisualizationProfile", order = (int)CreateProfileMenuItemIndices.ControllerVisualization)]
     [MixedRealityServiceProfile(typeof(IMixedRealityControllerVisualizer))]
     public class MixedRealityControllerVisualizationProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Profile that determines relevant overrides and properties for controller visualization
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Controller Visualization Profile", fileName = "MixedRealityControllerVisualizationProfile", order = (int)CreateProfileMenuItemIndices.ControllerVisualization)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Controller Visualization Profile", fileName = "MixedRealityControllerVisualizationProfile", order = (int)CreateProfileMenuItemIndices.ControllerVisualization)]
     [MixedRealityServiceProfile(typeof(IMixedRealityControllerVisualizer))]
     public class MixedRealityControllerVisualizationProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityEyeTrackingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityEyeTrackingProfile.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Eye Tracking Profile", fileName = "MixedRealityEyeTrackingProfile", order = (int)CreateProfileMenuItemIndices.EyeTracking)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Eye Tracking Profile", fileName = "MixedRealityEyeTrackingProfile", order = (int)CreateProfileMenuItemIndices.EyeTracking)]
     [MixedRealityServiceProfile(requiredTypes: new Type[] { typeof(IMixedRealityEyeGazeDataProvider), typeof(IMixedRealityEyeSaccadeProvider) })]
     public class MixedRealityEyeTrackingProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityEyeTrackingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityEyeTrackingProfile.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Eye Tracking Profile", fileName = "MixedRealityEyeTrackingProfile", order = (int)CreateProfileMenuItemIndices.EyeTracking)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Eye Tracking Profile", fileName = "MixedRealityEyeTrackingProfile", order = (int)CreateProfileMenuItemIndices.EyeTracking)]
     [MixedRealityServiceProfile(requiredTypes: new Type[] { typeof(IMixedRealityEyeGazeDataProvider), typeof(IMixedRealityEyeSaccadeProvider) })]
     public class MixedRealityEyeTrackingProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityHandTrackingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityHandTrackingProfile.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Hand Tracking Profile", fileName = "MixedRealityHandTrackingProfile", order = (int)CreateProfileMenuItemIndices.HandTracking)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Hand Tracking Profile", fileName = "MixedRealityHandTrackingProfile", order = (int)CreateProfileMenuItemIndices.HandTracking)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/hand-tracking")]
     public class MixedRealityHandTrackingProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityHandTrackingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityHandTrackingProfile.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Hand Tracking Profile", fileName = "MixedRealityHandTrackingProfile", order = (int)CreateProfileMenuItemIndices.HandTracking)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Hand Tracking Profile", fileName = "MixedRealityHandTrackingProfile", order = (int)CreateProfileMenuItemIndices.HandTracking)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/hand-tracking")]
     public class MixedRealityHandTrackingProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
     /// <summary>
     /// Configuration profile settings for setting up diagnostics.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Diagnostics Profile", fileName = "MixedRealityDiagnosticsProfile", order = (int)CreateProfileMenuItemIndices.Diagnostics)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Diagnostics Profile", fileName = "MixedRealityDiagnosticsProfile", order = (int)CreateProfileMenuItemIndices.Diagnostics)]
     [MixedRealityServiceProfile(typeof(IMixedRealityDiagnosticsSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/diagnostics/diagnostics-system-getting-started")]
     public class MixedRealityDiagnosticsProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
     /// <summary>
     /// Configuration profile settings for setting up diagnostics.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Diagnostics Profile", fileName = "MixedRealityDiagnosticsProfile", order = (int)CreateProfileMenuItemIndices.Diagnostics)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Diagnostics Profile", fileName = "MixedRealityDiagnosticsProfile", order = (int)CreateProfileMenuItemIndices.Diagnostics)]
     [MixedRealityServiceProfile(typeof(IMixedRealityDiagnosticsSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/diagnostics/diagnostics-system-getting-started")]
     public class MixedRealityDiagnosticsProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityGesturesProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityGesturesProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up and consuming Input Actions.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Gestures Profile", fileName = "MixedRealityGesturesProfile", order = (int)CreateProfileMenuItemIndices.Gestures)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Gestures Profile", fileName = "MixedRealityGesturesProfile", order = (int)CreateProfileMenuItemIndices.Gestures)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/gestures")]
     public class MixedRealityGesturesProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityGesturesProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityGesturesProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up and consuming Input Actions.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Gestures Profile", fileName = "MixedRealityGesturesProfile", order = (int)CreateProfileMenuItemIndices.Gestures)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Gestures Profile", fileName = "MixedRealityGesturesProfile", order = (int)CreateProfileMenuItemIndices.Gestures)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/gestures")]
     public class MixedRealityGesturesProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputActionRulesProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputActionRulesProfile.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Input Action Rules Profile", fileName = "MixedRealityInputActionRulesProfile", order = (int)CreateProfileMenuItemIndices.InputActionRules)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Input Action Rules Profile", fileName = "MixedRealityInputActionRulesProfile", order = (int)CreateProfileMenuItemIndices.InputActionRules)]
     public class MixedRealityInputActionRulesProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputActionRulesProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputActionRulesProfile.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Input Action Rules Profile", fileName = "MixedRealityInputActionRulesProfile", order = (int)CreateProfileMenuItemIndices.InputActionRules)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Input Action Rules Profile", fileName = "MixedRealityInputActionRulesProfile", order = (int)CreateProfileMenuItemIndices.InputActionRules)]
     public class MixedRealityInputActionRulesProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up and consuming Input Actions.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Input Actions Profile", fileName = "MixedRealityInputActionsProfile", order = (int)CreateProfileMenuItemIndices.InputActions)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Input Actions Profile", fileName = "MixedRealityInputActionsProfile", order = (int)CreateProfileMenuItemIndices.InputActions)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/input-actions")]
     public class MixedRealityInputActionsProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up and consuming Input Actions.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Input Actions Profile", fileName = "MixedRealityInputActionsProfile", order = (int)CreateProfileMenuItemIndices.InputActions)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Input Actions Profile", fileName = "MixedRealityInputActionsProfile", order = (int)CreateProfileMenuItemIndices.InputActions)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/input-actions")]
     public class MixedRealityInputActionsProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up controller pointers.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Input System Profile", fileName = "MixedRealityInputSystemProfile", order = (int)CreateProfileMenuItemIndices.Input)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Input System Profile", fileName = "MixedRealityInputSystemProfile", order = (int)CreateProfileMenuItemIndices.Input)]
     [MixedRealityServiceProfile(typeof(IMixedRealityInputSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/overview")]
     public class MixedRealityInputSystemProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up controller pointers.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Input System Profile", fileName = "MixedRealityInputSystemProfile", order = (int)CreateProfileMenuItemIndices.Input)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Input System Profile", fileName = "MixedRealityInputSystemProfile", order = (int)CreateProfileMenuItemIndices.Input)]
     [MixedRealityServiceProfile(typeof(IMixedRealityInputSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/overview")]
     public class MixedRealityInputSystemProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up controller pointers.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Pointer Profile", fileName = "MixedRealityInputPointerProfile", order = (int)CreateProfileMenuItemIndices.Pointer)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Pointer Profile", fileName = "MixedRealityInputPointerProfile", order = (int)CreateProfileMenuItemIndices.Pointer)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/pointers")]
     public class MixedRealityPointerProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up controller pointers.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Pointer Profile", fileName = "MixedRealityInputPointerProfile", order = (int)CreateProfileMenuItemIndices.Pointer)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Pointer Profile", fileName = "MixedRealityInputPointerProfile", order = (int)CreateProfileMenuItemIndices.Pointer)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/pointers")]
     public class MixedRealityPointerProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up and consuming Speech Commands.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Speech Commands Profile", fileName = "MixedRealitySpeechCommandsProfile", order = (int)CreateProfileMenuItemIndices.Speech)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Speech Commands Profile", fileName = "MixedRealitySpeechCommandsProfile", order = (int)CreateProfileMenuItemIndices.Speech)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/speech")]
     public class MixedRealitySpeechCommandsProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Configuration profile settings for setting up and consuming Speech Commands.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Speech Commands Profile", fileName = "MixedRealitySpeechCommandsProfile", order = (int)CreateProfileMenuItemIndices.Speech)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Speech Commands Profile", fileName = "MixedRealitySpeechCommandsProfile", order = (int)CreateProfileMenuItemIndices.Speech)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/speech")]
     public class MixedRealitySpeechCommandsProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/MixedRealityRegisteredServiceProvidersProfile.cs
+++ b/Assets/MRTK/Core/Definitions/MixedRealityRegisteredServiceProvidersProfile.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit
 {
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Registered Service Providers Profile", fileName = "MixedRealityRegisteredServiceProvidersProfile", order = (int)CreateProfileMenuItemIndices.RegisteredServiceProviders)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Registered Service Providers Profile", fileName = "MixedRealityRegisteredServiceProvidersProfile", order = (int)CreateProfileMenuItemIndices.RegisteredServiceProviders)]
     public class MixedRealityRegisteredServiceProvidersProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MRTK/Core/Definitions/MixedRealityRegisteredServiceProvidersProfile.cs
+++ b/Assets/MRTK/Core/Definitions/MixedRealityRegisteredServiceProvidersProfile.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit
 {
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Registered Service Providers Profile", fileName = "MixedRealityRegisteredServiceProvidersProfile", order = (int)CreateProfileMenuItemIndices.RegisteredServiceProviders)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Registered Service Providers Profile", fileName = "MixedRealityRegisteredServiceProvidersProfile", order = (int)CreateProfileMenuItemIndices.RegisteredServiceProviders)]
     public class MixedRealityRegisteredServiceProvidersProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MRTK/Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// <summary>
     /// Configuration profile settings for the Mixed Reality Toolkit.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Toolkit Configuration Profile", fileName = "MixedRealityToolkitConfigurationProfile", order = (int)CreateProfileMenuItemIndices.Configuration)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Toolkit Configuration Profile", fileName = "MixedRealityToolkitConfigurationProfile", order = (int)CreateProfileMenuItemIndices.Configuration)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/configuration/mixed-reality-configuration-guide")]
     public class MixedRealityToolkitConfigurationProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// <summary>
     /// Configuration profile settings for the Mixed Reality Toolkit.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Toolkit Configuration Profile", fileName = "MixedRealityToolkitConfigurationProfile", order = (int)CreateProfileMenuItemIndices.Configuration)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Toolkit Configuration Profile", fileName = "MixedRealityToolkitConfigurationProfile", order = (int)CreateProfileMenuItemIndices.Configuration)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/configuration/mixed-reality-configuration-guide")]
     public class MixedRealityToolkitConfigurationProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Definitions/SceneSystem/MixedRealitySceneSystemProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SceneSystem/MixedRealitySceneSystemProfile.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
     /// <summary>
     /// Configuration profile settings for setting up scene system.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Scene System Profile", fileName = "MixedRealitySceneSystemProfile", order = (int)CreateProfileMenuItemIndices.SceneSystem)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Scene System Profile", fileName = "MixedRealitySceneSystemProfile", order = (int)CreateProfileMenuItemIndices.SceneSystem)]
     [MixedRealityServiceProfile(typeof(IMixedRealitySceneSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/scene-system/scene-system-getting-started")]
     public class MixedRealitySceneSystemProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/SceneSystem/MixedRealitySceneSystemProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SceneSystem/MixedRealitySceneSystemProfile.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
     /// <summary>
     /// Configuration profile settings for setting up scene system.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Scene System Profile", fileName = "MixedRealitySceneSystemProfile", order = (int)CreateProfileMenuItemIndices.SceneSystem)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Scene System Profile", fileName = "MixedRealitySceneSystemProfile", order = (int)CreateProfileMenuItemIndices.SceneSystem)]
     [MixedRealityServiceProfile(typeof(IMixedRealitySceneSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/scene-system/scene-system-getting-started")]
     public class MixedRealitySceneSystemProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     /// <summary>
     /// Configuration profile settings for spatial awareness mesh observers.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Spatial Awareness Mesh Observer Profile", fileName = "MixedRealitySpatialAwarenessMeshObserverProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwarenessMeshObserver)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Spatial Awareness Mesh Observer Profile", fileName = "MixedRealitySpatialAwarenessMeshObserverProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwarenessMeshObserver)]
     [MixedRealityServiceProfile(typeof(IMixedRealitySpatialAwarenessMeshObserver))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/configuring-spatial-awareness-mesh-observer")]
     public class MixedRealitySpatialAwarenessMeshObserverProfile : BaseSpatialAwarenessObserverProfile

--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     /// <summary>
     /// Configuration profile settings for spatial awareness mesh observers.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Spatial Awareness Mesh Observer Profile", fileName = "MixedRealitySpatialAwarenessMeshObserverProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwarenessMeshObserver)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Spatial Awareness Mesh Observer Profile", fileName = "MixedRealitySpatialAwarenessMeshObserverProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwarenessMeshObserver)]
     [MixedRealityServiceProfile(typeof(IMixedRealitySpatialAwarenessMeshObserver))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/configuring-spatial-awareness-mesh-observer")]
     public class MixedRealitySpatialAwarenessMeshObserverProfile : BaseSpatialAwarenessObserverProfile

--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessSystemProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessSystemProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     /// <summary>
     /// Configuration profile settings for spatial awareness mesh observers.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Spatial Awareness System Profile", fileName = "MixedRealitySpatialAwarenessSystemProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwareness)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Spatial Awareness System Profile", fileName = "MixedRealitySpatialAwarenessSystemProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwareness)]
     [MixedRealityServiceProfile(typeof(IMixedRealitySpatialAwarenessSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/spatial-awareness-getting-started")]
     public class MixedRealitySpatialAwarenessSystemProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessSystemProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessSystemProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     /// <summary>
     /// Configuration profile settings for spatial awareness mesh observers.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Spatial Awareness System Profile", fileName = "MixedRealitySpatialAwarenessSystemProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwareness)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Spatial Awareness System Profile", fileName = "MixedRealitySpatialAwarenessSystemProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwareness)]
     [MixedRealityServiceProfile(typeof(IMixedRealitySpatialAwarenessSystem))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/spatial-awareness-getting-started")]
     public class MixedRealitySpatialAwarenessSystemProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -781,9 +781,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         }
 
 #if UNITY_2019_1_OR_NEWER
-        [MenuItem("Mixed Reality/Utilities/Upgrade MRTK Standard Shader for Universal Render Pipeline")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Upgrade MRTK Standard Shader for Universal Render Pipeline")]
 #else
-        [MenuItem("Mixed Reality/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline")]
 #endif
         protected static void UpgradeShaderForUniversalRenderPipeline()
         {
@@ -840,9 +840,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         }
 
 #if UNITY_2019_1_OR_NEWER
-        [MenuItem("Mixed Reality/Utilities/Upgrade MRTK Standard Shader for Universal Render Pipeline", true)]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Upgrade MRTK Standard Shader for Universal Render Pipeline", true)]
 #else
-        [MenuItem("Mixed Reality/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline", true)]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline", true)]
 #endif
         protected static bool UpgradeShaderForUniversalRenderPipelineValidate()
         {

--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -781,9 +781,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         }
 
 #if UNITY_2019_1_OR_NEWER
-        [MenuItem("Mixed Reality Toolkit/Utilities/Upgrade MRTK Standard Shader for Universal Render Pipeline")]
+        [MenuItem("Mixed Reality/Utilities/Upgrade MRTK Standard Shader for Universal Render Pipeline")]
 #else
-        [MenuItem("Mixed Reality Toolkit/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline")]
+        [MenuItem("Mixed Reality/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline")]
 #endif
         protected static void UpgradeShaderForUniversalRenderPipeline()
         {
@@ -840,9 +840,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         }
 
 #if UNITY_2019_1_OR_NEWER
-        [MenuItem("Mixed Reality Toolkit/Utilities/Upgrade MRTK Standard Shader for Universal Render Pipeline", true)]
+        [MenuItem("Mixed Reality/Utilities/Upgrade MRTK Standard Shader for Universal Render Pipeline", true)]
 #else
-        [MenuItem("Mixed Reality Toolkit/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline", true)]
+        [MenuItem("Mixed Reality/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline", true)]
 #endif
         protected static bool UpgradeShaderForUniversalRenderPipelineValidate()
         {

--- a/Assets/MRTK/Core/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityToolkitInspector.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
-        [MenuItem("Mixed Reality/Add to Scene and Configure...")]
+        [MenuItem("Mixed Reality/Toolkit/Add to Scene and Configure...")]
         public static void CreateMixedRealityToolkitGameObject()
         {
             MixedRealityInspectorUtility.AddMixedRealityToolkitToScene();

--- a/Assets/MRTK/Core/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityToolkitInspector.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
-        [MenuItem("Mixed Reality Toolkit/Add to Scene and Configure...")]
+        [MenuItem("Mixed Reality/Add to Scene and Configure...")]
         public static void CreateMixedRealityToolkitGameObject()
         {
             MixedRealityInspectorUtility.AddMixedRealityToolkitToScene();

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Show the MRTK Project Configurator utility window or focus if already opened
         /// </summary>
-        [MenuItem("Mixed Realityt/Utilities/Configure Unity Project", false, 499)]
+        [MenuItem("Mixed Reality/Utilities/Configure Unity Project", false, 499)]
         public static void ShowWindow()
         {
             // There should be only one configurator window open as a "pop-up". If already open, then just force focus on our instance

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Show the MRTK Project Configurator utility window or focus if already opened
         /// </summary>
-        [MenuItem("Mixed Reality/Utilities/Configure Unity Project", false, 499)]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Configure Unity Project", false, 499)]
         public static void ShowWindow()
         {
             // There should be only one configurator window open as a "pop-up". If already open, then just force focus on our instance

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Show the MRTK Project Configurator utility window or focus if already opened
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Configure Unity Project", false, 499)]
+        [MenuItem("Mixed Realityt/Utilities/Configure Unity Project", false, 499)]
         public static void ShowWindow()
         {
             // There should be only one configurator window open as a "pop-up". If already open, then just force focus on our instance

--- a/Assets/MRTK/Core/Providers/InputAnimation/MixedRealityInputRecordingProfile.cs
+++ b/Assets/MRTK/Core/Providers/InputAnimation/MixedRealityInputRecordingProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Settings for recording input animation assets.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Input Recording Profile", fileName = "MixedRealityInputRecordingProfile", order = (int)CreateProfileMenuItemIndices.Input)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Input Recording Profile", fileName = "MixedRealityInputRecordingProfile", order = (int)CreateProfileMenuItemIndices.Input)]
     [MixedRealityServiceProfile(typeof(IMixedRealityInputRecordingService))]
     public class MixedRealityInputRecordingProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Providers/InputAnimation/MixedRealityInputRecordingProfile.cs
+++ b/Assets/MRTK/Core/Providers/InputAnimation/MixedRealityInputRecordingProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Settings for recording input animation assets.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Input Recording Profile", fileName = "MixedRealityInputRecordingProfile", order = (int)CreateProfileMenuItemIndices.Input)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Input Recording Profile", fileName = "MixedRealityInputRecordingProfile", order = (int)CreateProfileMenuItemIndices.Input)]
     [MixedRealityServiceProfile(typeof(IMixedRealityInputRecordingService))]
     public class MixedRealityInputRecordingProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Core/Providers/InputSimulation/Editor/InputSimulationWindow.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/Editor/InputSimulationWindow.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private Texture2D iconJumpBack = null;
         private Texture2D iconJumpFwd = null;
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Input Simulation")]
+        [MenuItem("Mixed Reality/Utilities/Input Simulation")]
         private static void ShowWindow()
         {
             InputSimulationWindow window = GetWindow<InputSimulationWindow>();

--- a/Assets/MRTK/Core/Providers/InputSimulation/Editor/InputSimulationWindow.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/Editor/InputSimulationWindow.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private Texture2D iconJumpBack = null;
         private Texture2D iconJumpFwd = null;
 
-        [MenuItem("Mixed Reality/Utilities/Input Simulation")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Input Simulation")]
         private static void ShowWindow()
         {
             InputSimulationWindow window = GetWindow<InputSimulationWindow>();

--- a/Assets/MRTK/Core/Providers/InputSimulation/MixedRealityInputSimulationProfile.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/MixedRealityInputSimulationProfile.cs
@@ -8,7 +8,7 @@ using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Simulated Input Profile", fileName = "MixedRealityInputSimulationProfile", order = (int)CreateProfileMenuItemIndices.InputSimulation)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Simulated Input Profile", fileName = "MixedRealityInputSimulationProfile", order = (int)CreateProfileMenuItemIndices.InputSimulation)]
     [MixedRealityServiceProfile(typeof(IInputSimulationService))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input-simulation/input-simulation-service")]
     public class MixedRealityInputSimulationProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Providers/InputSimulation/MixedRealityInputSimulationProfile.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/MixedRealityInputSimulationProfile.cs
@@ -8,7 +8,7 @@ using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Simulated Input Profile", fileName = "MixedRealityInputSimulationProfile", order = (int)CreateProfileMenuItemIndices.InputSimulation)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Simulated Input Profile", fileName = "MixedRealityInputSimulationProfile", order = (int)CreateProfileMenuItemIndices.InputSimulation)]
     [MixedRealityServiceProfile(typeof(IInputSimulationService))]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input-simulation/input-simulation-service")]
     public class MixedRealityInputSimulationProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfile.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
     /// <summary>
     /// Configuration profile for the spatial object mesh observer.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Spatial Object Mesh Observer Profile", fileName = "SpatialObjectMeshObserverProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Spatial Object Mesh Observer Profile", fileName = "SpatialObjectMeshObserverProfile", order = 100)]
     public class SpatialObjectMeshObserverProfile : MixedRealitySpatialAwarenessMeshObserverProfile
     {
         [SerializeField]

--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfile.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
     /// <summary>
     /// Configuration profile for the spatial object mesh observer.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Spatial Object Mesh Observer Profile", fileName = "SpatialObjectMeshObserverProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Spatial Object Mesh Observer Profile", fileName = "SpatialObjectMeshObserverProfile", order = 100)]
     public class SpatialObjectMeshObserverProfile : MixedRealitySpatialAwarenessMeshObserverProfile
     {
         [SerializeField]

--- a/Assets/MRTK/Core/Providers/UnityInput/MixedRealityMouseInputProfile.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/MixedRealityMouseInputProfile.cs
@@ -9,7 +9,7 @@ using UnityEngine.Serialization;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     [CreateAssetMenu(
-        menuName = "Mixed Reality/Profiles/Mixed Reality Mouse Input Profile",
+        menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Mouse Input Profile",
         fileName = "MixedRealityMouseInputProfile",
         order = (int)CreateProfileMenuItemIndices.MouseInput)]
     [MixedRealityServiceProfile(typeof(MouseDeviceManager))]

--- a/Assets/MRTK/Core/Providers/UnityInput/MixedRealityMouseInputProfile.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/MixedRealityMouseInputProfile.cs
@@ -9,7 +9,7 @@ using UnityEngine.Serialization;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     [CreateAssetMenu(
-        menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Mouse Input Profile",
+        menuName = "Mixed Reality/Profiles/Mixed Reality Mouse Input Profile",
         fileName = "MixedRealityMouseInputProfile",
         order = (int)CreateProfileMenuItemIndices.MouseInput)]
     [MixedRealityServiceProfile(typeof(MouseDeviceManager))]

--- a/Assets/MRTK/Examples/Common/Scripts/DwellProfileWithDecay.cs
+++ b/Assets/MRTK/Examples/Common/Scripts/DwellProfileWithDecay.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Dwell
     /// Custom profile for CustomDwellHandler to show the dwell with decay behavior
     /// </summary>
     [MixedRealityServiceProfile(typeof(DwellProfileWithDecay))]
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Dwell Profile With Decay", fileName = "DwellProfileWithDecay", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Dwell Profile With Decay", fileName = "DwellProfileWithDecay", order = 100)]
     [Serializable]
     public class DwellProfileWithDecay : DwellProfile
     {

--- a/Assets/MRTK/Examples/Common/Scripts/DwellProfileWithDecay.cs
+++ b/Assets/MRTK/Examples/Common/Scripts/DwellProfileWithDecay.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Dwell
     /// Custom profile for CustomDwellHandler to show the dwell with decay behavior
     /// </summary>
     [MixedRealityServiceProfile(typeof(DwellProfileWithDecay))]
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Dwell Profile With Decay", fileName = "DwellProfileWithDecay", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Dwell Profile With Decay", fileName = "DwellProfileWithDecay", order = 100)]
     [Serializable]
     public class DwellProfileWithDecay : DwellProfile
     {

--- a/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs
+++ b/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
     /// Configuration profile for <see cref="HandPhysicsService"/> extension service.
     /// </summary>
 	[MixedRealityServiceProfile(typeof(IHandPhysicsService))]
-    [CreateAssetMenu(fileName = "HandPhysicsServiceProfile", menuName = "Mixed Reality/Extensions/Hand Physics Service/Hand Physics Service Configuration Profile")]
+    [CreateAssetMenu(fileName = "HandPhysicsServiceProfile", menuName = "Mixed Reality/Toolkit/Extensions/Hand Physics Service/Hand Physics Service Configuration Profile")]
     public class HandPhysicsServiceProfile : BaseMixedRealityProfile
     {
         /// <summary>

--- a/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs
+++ b/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
     /// Configuration profile for <see cref="HandPhysicsService"/> extension service.
     /// </summary>
 	[MixedRealityServiceProfile(typeof(IHandPhysicsService))]
-    [CreateAssetMenu(fileName = "HandPhysicsServiceProfile", menuName = "Mixed Reality Toolkit/Extensions/Hand Physics Service/Hand Physics Service Configuration Profile")]
+    [CreateAssetMenu(fileName = "HandPhysicsServiceProfile", menuName = "Mixed Reality/Extensions/Hand Physics Service/Hand Physics Service Configuration Profile")]
     public class HandPhysicsServiceProfile : BaseMixedRealityProfile
     {
         /// <summary>

--- a/Assets/MRTK/Extensions/LostTrackingService/LostTrackingServiceProfile.cs
+++ b/Assets/MRTK/Extensions/LostTrackingService/LostTrackingServiceProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
     /// The profile definition for an <see cref="ILostTrackingService"/>.
     /// </summary>
     [MixedRealityServiceProfile(typeof(ILostTrackingService))]
-    [CreateAssetMenu(fileName = "LostTrackingServiceProfile", menuName = "Mixed Reality/Extensions/Lost Tracking Service/Mixed Reality Lost Tracking Service Profile")]
+    [CreateAssetMenu(fileName = "LostTrackingServiceProfile", menuName = "Mixed Reality/Toolkit/Extensions/Lost Tracking Service/Mixed Reality Lost Tracking Service Profile")]
     public class LostTrackingServiceProfile : BaseMixedRealityProfile
     {
         /// <summary>

--- a/Assets/MRTK/Extensions/LostTrackingService/LostTrackingServiceProfile.cs
+++ b/Assets/MRTK/Extensions/LostTrackingService/LostTrackingServiceProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
     /// The profile definition for an <see cref="ILostTrackingService"/>.
     /// </summary>
     [MixedRealityServiceProfile(typeof(ILostTrackingService))]
-    [CreateAssetMenu(fileName = "LostTrackingServiceProfile", menuName = "Mixed Reality Toolkit/Extensions/Lost Tracking Service/Mixed Reality Lost Tracking Service Profile")]
+    [CreateAssetMenu(fileName = "LostTrackingServiceProfile", menuName = "Mixed Reality/Extensions/Lost Tracking Service/Mixed Reality Lost Tracking Service Profile")]
     public class LostTrackingServiceProfile : BaseMixedRealityProfile
     {
         /// <summary>

--- a/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
+++ b/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
 {
     [MixedRealityServiceProfile(typeof(ISceneTransitionService))]
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Extensions/Scene Transition Service/Scene Transition Service Profile", fileName = "SceneTransitionServiceProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Extensions/Scene Transition Service/Scene Transition Service Profile", fileName = "SceneTransitionServiceProfile", order = 100)]
     public class SceneTransitionServiceProfile : BaseMixedRealityProfile
     {
         public bool UseDefaultProgressIndicator => useDefaultProgressIndicator;

--- a/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
+++ b/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
 {
     [MixedRealityServiceProfile(typeof(ISceneTransitionService))]
-    [CreateAssetMenu(menuName = "Mixed Reality/Extensions/Scene Transition Service/Scene Transition Service Profile", fileName = "SceneTransitionServiceProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Extensions/Scene Transition Service/Scene Transition Service Profile", fileName = "SceneTransitionServiceProfile", order = 100)]
     public class SceneTransitionServiceProfile : BaseMixedRealityProfile
     {
         public bool UseDefaultProgressIndicator => useDefaultProgressIndicator;

--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -398,7 +398,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         /// <summary>
         /// Integrate MRTK and the Leap Motion Unity Modules if the Leap Motion Unity Modules are in the project. If they are not in the project, display a pop up window.
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Leap Motion/Integrate Leap Motion Unity Modules")]
+        [MenuItem("Mixed Reality/Utilities/Leap Motion/Integrate Leap Motion Unity Modules")]
         public static void IntegrateLeapMotionWithMRTK()
         {
             // Check if leap unity modules are in the project
@@ -419,7 +419,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         /// <summary>
         /// Separate MRTK and the Leap Motion Unity Modules and display a prompt for the user to close unity and delete the assets.
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Leap Motion/Separate Leap Motion Unity Modules")]
+        [MenuItem("Mixed Reality/Utilities/Leap Motion/Separate Leap Motion Unity Modules")]
         public static void SeparateLeapMotion()
         {
 
@@ -441,7 +441,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         /// <summary>
         /// Check the integration status of the Leap Motion Assets and display a message to the user.
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Leap Motion/Check Integration Status")]
+        [MenuItem("Mixed Reality/Utilities/Leap Motion/Check Integration Status")]
         public static void CheckIntegrationStatus()
         {
             if (isLeapRecognizedByMRTK)

--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -398,7 +398,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         /// <summary>
         /// Integrate MRTK and the Leap Motion Unity Modules if the Leap Motion Unity Modules are in the project. If they are not in the project, display a pop up window.
         /// </summary>
-        [MenuItem("Mixed Reality/Utilities/Leap Motion/Integrate Leap Motion Unity Modules")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Leap Motion/Integrate Leap Motion Unity Modules")]
         public static void IntegrateLeapMotionWithMRTK()
         {
             // Check if leap unity modules are in the project
@@ -419,7 +419,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         /// <summary>
         /// Separate MRTK and the Leap Motion Unity Modules and display a prompt for the user to close unity and delete the assets.
         /// </summary>
-        [MenuItem("Mixed Reality/Utilities/Leap Motion/Separate Leap Motion Unity Modules")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Leap Motion/Separate Leap Motion Unity Modules")]
         public static void SeparateLeapMotion()
         {
 
@@ -441,7 +441,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         /// <summary>
         /// Check the integration status of the Leap Motion Assets and display a message to the user.
         /// </summary>
-        [MenuItem("Mixed Reality/Utilities/Leap Motion/Check Integration Status")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Leap Motion/Check Integration Status")]
         public static void CheckIntegrationStatus()
         {
             if (isLeapRecognizedByMRTK)

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
     /// The profile for the Leap Motion Device Manager. The settings for this profile can be viewed if the Leap Motion Device Manager input data provider is 
     /// added to the MRTK input configuration profile.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Leap Motion Profile", fileName = "LeapMotionDeviceManagerProfile", order = 4)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Mixed Reality Leap Motion Profile", fileName = "LeapMotionDeviceManagerProfile", order = 4)]
     [MixedRealityServiceProfile(typeof(LeapMotionDeviceManager))]
     public class LeapMotionDeviceManagerProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
     /// The profile for the Leap Motion Device Manager. The settings for this profile can be viewed if the Leap Motion Device Manager input data provider is 
     /// added to the MRTK input configuration profile.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Leap Motion Profile", fileName = "LeapMotionDeviceManagerProfile", order = 4)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Mixed Reality Leap Motion Profile", fileName = "LeapMotionDeviceManagerProfile", order = 4)]
     [MixedRealityServiceProfile(typeof(LeapMotionDeviceManager))]
     public class LeapMotionDeviceManagerProfile : BaseMixedRealityProfile
     {

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
         /// <summary>
         /// Integrate MRTK and the Oculus Integration Unity Modules if the Oculus Integration Unity Modules is in the project. If it is not in the project, display a pop up window.
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Oculus/Integrate Oculus Integration Unity Modules")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Oculus/Integrate Oculus Integration Unity Modules")]
         internal static void IntegrateOculusWithMRTK()
         {
             // Check if Oculus Integration package is present
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
         /// <summary>
         /// Separate MRTK and the Oculus Integration Unity Modules and display a prompt for the user to close unity and delete the assets.
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Oculus/Separate Oculus Integration Unity Modules")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Oculus/Separate Oculus Integration Unity Modules")]
         internal static void SeparateOculusFromMRTK()
         {
             bool oculusIntegrationPresent = DetectOculusIntegrationAsset();
@@ -114,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
         /// <summary>
         /// Initialize the Oculus Project Config with the appropriate settings to enable handtracking and keyboard support.
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Oculus/Initialize Oculus Project Config")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Oculus/Initialize Oculus Project Config")]
         internal static void InitializeOculusProjectConfig()
         {
 #if OCULUSINTEGRATION_PRESENT
@@ -132,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
 #endif
         }
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Oculus/Initialize Oculus Project Config", true)]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Oculus/Initialize Oculus Project Config", true)]
         private static bool CheckScriptingDefinePresent()
         {
 #if OCULUSINTEGRATION_PRESENT

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         {
             base.Initialize();
             UnityEngine.Debug.Log(@"Detected a potential deployment issue for the Oculus Quest. In order to use hand tracking with the Oculus Quest, download the Oculus Integration Package from the Unity Asset Store and run the Integration tool before deploying.
-The tool can be found under <i>Mixed Reality Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules</i>");
+The tool can be found under <i>Mixed Reality > Utilities > Oculus > Integrate Oculus Integration Unity Modules</i>");
         }
 #endif
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         {
             base.Initialize();
             UnityEngine.Debug.Log(@"Detected a potential deployment issue for the Oculus Quest. In order to use hand tracking with the Oculus Quest, download the Oculus Integration Package from the Unity Asset Store and run the Integration tool before deploying.
-The tool can be found under <i>Mixed Reality > Utilities > Oculus > Integrate Oculus Integration Unity Modules</i>");
+The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules</i>");
         }
 #endif
 

--- a/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         /// Ensures that the appropriate symbolic constant is defined based on the presence of the AR Foundation package.
         /// </summary>
         /// <returns>True if the define was added, false otherwise.</returns>
-        [MenuItem("Mixed Reality/Utilities/UnityAR/Update Scripting Defines")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/UnityAR/Update Scripting Defines")]
         private static bool ReconcileArFoundationDefine()
         {
             FileInfo[] files = FileUtilities.FindFilesInPackageCache(FileName);

--- a/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/UnityAR/Editor/UnityARConfigurationChecker.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         /// Ensures that the appropriate symbolic constant is defined based on the presence of the AR Foundation package.
         /// </summary>
         /// <returns>True if the define was added, false otherwise.</returns>
-        [MenuItem("Mixed Reality Toolkit/Utilities/UnityAR/Update Scripting Defines")]
+        [MenuItem("Mixed Reality/Utilities/UnityAR/Update Scripting Defines")]
         private static bool ReconcileArFoundationDefine()
         {
             FileInfo[] files = FileUtilities.FindFilesInPackageCache(FileName);

--- a/Assets/MRTK/Providers/UnityAR/UnityARCameraSettingsProfile.cs
+++ b/Assets/MRTK/Providers/UnityAR/UnityARCameraSettingsProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
     /// <summary>
     /// Configuration profile for the XR camera settings provider.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Providers/Unity AR/Unity AR Foundation Camera Settings Profile", fileName = "DefaultUnityARCameraSettingsProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Providers/Unity AR/Unity AR Foundation Camera Settings Profile", fileName = "DefaultUnityARCameraSettingsProfile", order = 100)]
     [MixedRealityServiceProfile(typeof(UnityARCameraSettings))]
     public class UnityARCameraSettingsProfile : BaseCameraSettingsProfile
     {

--- a/Assets/MRTK/Providers/UnityAR/UnityARCameraSettingsProfile.cs
+++ b/Assets/MRTK/Providers/UnityAR/UnityARCameraSettingsProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
     /// <summary>
     /// Configuration profile for the XR camera settings provider.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Providers/Unity AR/Unity AR Foundation Camera Settings Profile", fileName = "DefaultUnityARCameraSettingsProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Providers/Unity AR/Unity AR Foundation Camera Settings Profile", fileName = "DefaultUnityARCameraSettingsProfile", order = 100)]
     [MixedRealityServiceProfile(typeof(UnityARCameraSettings))]
     public class UnityARCameraSettingsProfile : BaseCameraSettingsProfile
     {

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         /// <summary>
         /// Ensures that the appropriate symbolic constant is defined based on the presence of the DotNetWinRT binary.
         /// </summary>
-        [MenuItem("Mixed Reality/Utilities/Windows Mixed Reality/Check Configuration")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Windows Mixed Reality/Check Configuration")]
         private static void ReconcileDotNetWinRTDefine()
         {
             FileInfo[] files = FileUtilities.FindFilesInAssets(FileName);

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/WindowsMixedRealityConfigurationChecker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         /// <summary>
         /// Ensures that the appropriate symbolic constant is defined based on the presence of the DotNetWinRT binary.
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Windows Mixed Reality/Check Configuration")]
+        [MenuItem("Mixed Reality/Utilities/Windows Mixed Reality/Check Configuration")]
         private static void ReconcileDotNetWinRTDefine()
         {
             FileInfo[] files = FileUtilities.FindFilesInAssets(FileName);

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityCameraSettingsProfile.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityCameraSettingsProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
     /// <summary>
     /// Configuration profile for the Windows Mixed Reality camera settings provider.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Providers/Windows Mixed Reality/Windows Mixed Reality Camera Settings Profile", fileName = "WindowsMixedRealityCameraSettingsProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Providers/Windows Mixed Reality/Windows Mixed Reality Camera Settings Profile", fileName = "WindowsMixedRealityCameraSettingsProfile", order = 100)]
     [MixedRealityServiceProfile(typeof(BaseWindowsMixedRealityCameraSettings))]
     public class WindowsMixedRealityCameraSettingsProfile : BaseCameraSettingsProfile
     {

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityCameraSettingsProfile.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityCameraSettingsProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
     /// <summary>
     /// Configuration profile for the Windows Mixed Reality camera settings provider.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality/Providers/Windows Mixed Reality/Windows Mixed Reality Camera Settings Profile", fileName = "WindowsMixedRealityCameraSettingsProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Providers/Windows Mixed Reality/Windows Mixed Reality Camera Settings Profile", fileName = "WindowsMixedRealityCameraSettingsProfile", order = 100)]
     [MixedRealityServiceProfile(typeof(BaseWindowsMixedRealityCameraSettings))]
     public class WindowsMixedRealityCameraSettingsProfile : BaseCameraSettingsProfile
     {

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -90,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                     {
                         if (GUILayout.Button("Use migration tool to upgrade buttons"))
                         {
-                            if (!EditorApplication.ExecuteMenuItem("Mixed Reality Toolkit/Utilities/Migration Window"))
+                            if (!EditorApplication.ExecuteMenuItem("Mixed Reality/Utilities/Migration Window"))
                             {
                                 EditorUtility.DisplayDialog("Package Required", "You need to install the MRTK tools (Microsoft.MixedRealityToolkit.Unity.Tools) package to use the Migration Tool", "OK");
                             }

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -90,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                     {
                         if (GUILayout.Button("Use migration tool to upgrade buttons"))
                         {
-                            if (!EditorApplication.ExecuteMenuItem("Mixed Reality/Utilities/Migration Window"))
+                            if (!EditorApplication.ExecuteMenuItem("Mixed Reality/Toolkit/Utilities/Migration Window"))
                             {
                                 EditorUtility.DisplayDialog("Package Required", "You need to install the MRTK tools (Microsoft.MixedRealityToolkit.Unity.Tools) package to use the Migration Tool", "OK");
                             }

--- a/Assets/MRTK/SDK/Experimental/Elastic/Scripts/ElasticConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Elastic/Scripts/ElasticConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Physics
     /// <summary>
     /// Scriptable object that wraps the <see cref="ElasticProperties"/> struct, allowing for easily reusable spring configs.
     /// </summary>
-    [CreateAssetMenu(fileName = "ElasticConfiguration", menuName = "Mixed Reality/Experimental/Elastic/Elastic Configuration")]
+    [CreateAssetMenu(fileName = "ElasticConfiguration", menuName = "Mixed Reality/Toolkit/Experimental/Elastic/Elastic Configuration")]
     public class ElasticConfiguration : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MRTK/SDK/Experimental/Elastic/Scripts/ElasticConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Elastic/Scripts/ElasticConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Physics
     /// <summary>
     /// Scriptable object that wraps the <see cref="ElasticProperties"/> struct, allowing for easily reusable spring configs.
     /// </summary>
-    [CreateAssetMenu(fileName = "ElasticConfiguration", menuName = "Mixed Reality Toolkit/Experimental/Elastic/Elastic Configuration")]
+    [CreateAssetMenu(fileName = "ElasticConfiguration", menuName = "Mixed Reality/Experimental/Elastic/Elastic Configuration")]
     public class ElasticConfiguration : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/BoxDisplayConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/BoxDisplayConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Shareable configuration for the <see cref="BoxDisplay" /> of <see cref="BoundsControl"/>
     /// This class provides all data members needed to create a solid box display for bounds control
     /// </summary>
-    [CreateAssetMenu(fileName = "BoxDisplayConfiguration", menuName = "Mixed Reality/Bounds Control/Box Display Configuration")]
+    [CreateAssetMenu(fileName = "BoxDisplayConfiguration", menuName = "Mixed Reality/Toolkit/Bounds Control/Box Display Configuration")]
     public class BoxDisplayConfiguration : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/BoxDisplayConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/BoxDisplayConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Shareable configuration for the <see cref="BoxDisplay" /> of <see cref="BoundsControl"/>
     /// This class provides all data members needed to create a solid box display for bounds control
     /// </summary>
-    [CreateAssetMenu(fileName = "BoxDisplayConfiguration", menuName = "Mixed Reality Toolkit/Bounds Control/Box Display Configuration")]
+    [CreateAssetMenu(fileName = "BoxDisplayConfiguration", menuName = "Mixed Reality/Bounds Control/Box Display Configuration")]
     public class BoxDisplayConfiguration : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Configuration for <see cref="Links"/> used in <see cref="BoundsControl"/>
     /// This class provides all data members needed to create a link of a bounds control
     /// </summary>
-    [CreateAssetMenu(fileName = "LinksConfiguration", menuName = "Mixed Reality Toolkit/Bounds Control/Links Configuration")]
+    [CreateAssetMenu(fileName = "LinksConfiguration", menuName = "Mixed Reality/Bounds Control/Links Configuration")]
     public class LinksConfiguration : ScriptableObject
     {
         #region Serialized Properties

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Configuration for <see cref="Links"/> used in <see cref="BoundsControl"/>
     /// This class provides all data members needed to create a link of a bounds control
     /// </summary>
-    [CreateAssetMenu(fileName = "LinksConfiguration", menuName = "Mixed Reality/Bounds Control/Links Configuration")]
+    [CreateAssetMenu(fileName = "LinksConfiguration", menuName = "Mixed Reality/Toolkit/Bounds Control/Links Configuration")]
     public class LinksConfiguration : ScriptableObject
     {
         #region Serialized Properties

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Configuration for <see cref="RotationHandles"/> used in <see cref="BoundsControl"/>
     /// This class provides all data members needed to create rotation handles for <see cref="BoundsControl"/>
     /// </summary>
-    [CreateAssetMenu(fileName = "RotationHandlesConfiguration", menuName = "Mixed Reality/Bounds Control/Rotation Handles Configuration")]
+    [CreateAssetMenu(fileName = "RotationHandlesConfiguration", menuName = "Mixed Reality/Toolkit/Bounds Control/Rotation Handles Configuration")]
     public class RotationHandlesConfiguration : PerAxisHandlesConfiguration
     {
         /// <summary>

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Configuration for <see cref="RotationHandles"/> used in <see cref="BoundsControl"/>
     /// This class provides all data members needed to create rotation handles for <see cref="BoundsControl"/>
     /// </summary>
-    [CreateAssetMenu(fileName = "RotationHandlesConfiguration", menuName = "Mixed Reality Toolkit/Bounds Control/Rotation Handles Configuration")]
+    [CreateAssetMenu(fileName = "RotationHandlesConfiguration", menuName = "Mixed Reality/Bounds Control/Rotation Handles Configuration")]
     public class RotationHandlesConfiguration : PerAxisHandlesConfiguration
     {
         /// <summary>

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Configuration for <see cref="ScaleHandles"/> used in <see cref="BoundsControl"/>
     /// This class provides all data members needed to create scale handles for <see cref="BoundsControl"/>
     /// </summary>
-    [CreateAssetMenu(fileName = "ScaleHandlesConfiguration", menuName = "Mixed Reality Toolkit/Bounds Control/Scale Handles Configuration")]
+    [CreateAssetMenu(fileName = "ScaleHandlesConfiguration", menuName = "Mixed Reality/Bounds Control/Scale Handles Configuration")]
     public class ScaleHandlesConfiguration : HandlesBaseConfiguration
     {
         #region serialized fields

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Configuration for <see cref="ScaleHandles"/> used in <see cref="BoundsControl"/>
     /// This class provides all data members needed to create scale handles for <see cref="BoundsControl"/>
     /// </summary>
-    [CreateAssetMenu(fileName = "ScaleHandlesConfiguration", menuName = "Mixed Reality/Bounds Control/Scale Handles Configuration")]
+    [CreateAssetMenu(fileName = "ScaleHandlesConfiguration", menuName = "Mixed Reality/Toolkit/Bounds Control/Scale Handles Configuration")]
     public class ScaleHandlesConfiguration : HandlesBaseConfiguration
     {
         #region serialized fields

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/TranslationHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/TranslationHandlesConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Configuration for <see cref="TranslationHandles"/> used in <see cref="BoundsControl"/>
     /// This class provides all data members needed to create translation handles for <see cref="BoundsControl"/>
     /// </summary>
-    [CreateAssetMenu(fileName = "TranslationHandlesConfiguration", menuName = "Mixed Reality/Bounds Control/Translation Handles Configuration")]
+    [CreateAssetMenu(fileName = "TranslationHandlesConfiguration", menuName = "Mixed Reality/Toolkit/Bounds Control/Translation Handles Configuration")]
     public class TranslationHandlesConfiguration : PerAxisHandlesConfiguration
     {
         TranslationHandlesConfiguration()

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/TranslationHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/Configuration/TranslationHandlesConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Configuration for <see cref="TranslationHandles"/> used in <see cref="BoundsControl"/>
     /// This class provides all data members needed to create translation handles for <see cref="BoundsControl"/>
     /// </summary>
-    [CreateAssetMenu(fileName = "TranslationHandlesConfiguration", menuName = "Mixed Reality Toolkit/Bounds Control/Translation Handles Configuration")]
+    [CreateAssetMenu(fileName = "TranslationHandlesConfiguration", menuName = "Mixed Reality/Bounds Control/Translation Handles Configuration")]
     public class TranslationHandlesConfiguration : PerAxisHandlesConfiguration
     {
         TranslationHandlesConfiguration()

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffectConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffectConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Scaling is done on three different stages: far / medium and close proximity whereas material switching 
     /// will only be done on close proximity.
     /// </summary>
-    [CreateAssetMenu(fileName = "ProximityEffect", menuName = "Mixed Reality Toolkit/Bounds Control/Proximity Effect")]
+    [CreateAssetMenu(fileName = "ProximityEffect", menuName = "Mixed Reality/Bounds Control/Proximity Effect")]
     public class ProximityEffectConfiguration : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffectConfiguration.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffectConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
     /// Scaling is done on three different stages: far / medium and close proximity whereas material switching 
     /// will only be done on close proximity.
     /// </summary>
-    [CreateAssetMenu(fileName = "ProximityEffect", menuName = "Mixed Reality/Bounds Control/Proximity Effect")]
+    [CreateAssetMenu(fileName = "ProximityEffect", menuName = "Mixed Reality/Toolkit/Bounds Control/Proximity Effect")]
     public class ProximityEffectConfiguration : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// An asset for storing textures, sprites and character icons for use with MRTK buttons. Used by ButtonConfigHelper script.
     /// </summary>
-    [CreateAssetMenu(fileName = "IconSet", menuName = "Mixed Reality Toolkit/IconSet")]
+    [CreateAssetMenu(fileName = "IconSet", menuName = "Mixed Reality/IconSet")]
     public class ButtonIconSet : ScriptableObject
     {
         // Struct used to pair a font icon with a searchable name.

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// An asset for storing textures, sprites and character icons for use with MRTK buttons. Used by ButtonConfigHelper script.
     /// </summary>
-    [CreateAssetMenu(fileName = "IconSet", menuName = "Mixed Reality/IconSet")]
+    [CreateAssetMenu(fileName = "IconSet", menuName = "Mixed Reality/Toolkit/IconSet")]
     public class ButtonIconSet : ScriptableObject
     {
         // Struct used to pair a font icon with a searchable name.

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Dwell/DwellProfile.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Dwell/DwellProfile.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Dwell
     /// Profile used by dwell handler to configure the various thresholds.
     /// </summary>
     [MixedRealityServiceProfile(typeof(DwellProfile))]
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Dwell Profile", fileName = "DwellProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Dwell Profile", fileName = "DwellProfile", order = 100)]
     [Serializable]
     public class DwellProfile : ScriptableObject
     {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Dwell/DwellProfile.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Dwell/DwellProfile.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Dwell
     /// Profile used by dwell handler to configure the various thresholds.
     /// </summary>
     [MixedRealityServiceProfile(typeof(DwellProfile))]
-    [CreateAssetMenu(menuName = "Mixed Reality/Profiles/Dwell Profile", fileName = "DwellProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality/Toolkit/Profiles/Dwell Profile", fileName = "DwellProfile", order = 100)]
     [Serializable]
     public class DwellProfile : ScriptableObject
     {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/Theme.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/Theme.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// Theme scriptableObject for loading theme settings
     /// </summary>
-    [CreateAssetMenu(fileName = "Theme", menuName = "Mixed Reality Toolkit/Theme", order = 1)]
+    [CreateAssetMenu(fileName = "Theme", menuName = "Mixed Reality/Theme", order = 1)]
     public class Theme : ScriptableObject
     {
         [FormerlySerializedAs("Settings")]

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/Theme.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/Theme.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// Theme scriptableObject for loading theme settings
     /// </summary>
-    [CreateAssetMenu(fileName = "Theme", menuName = "Mixed Reality/Theme", order = 1)]
+    [CreateAssetMenu(fileName = "Theme", menuName = "Mixed Reality/Toolkit/Theme", order = 1)]
     public class Theme : ScriptableObject
     {
         [FormerlySerializedAs("Settings")]

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/States.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/States.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// States scriptableObject for storing available states and related state model
     /// </summary>
-    [CreateAssetMenu(fileName = "States", menuName = "Mixed Reality Toolkit/State", order = 1)]
+    [CreateAssetMenu(fileName = "States", menuName = "Mixed Reality/State", order = 1)]
     public class States : ScriptableObject
     {
         [FormerlySerializedAs("StateList")]

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/States.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/States.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// States scriptableObject for storing available states and related state model
     /// </summary>
-    [CreateAssetMenu(fileName = "States", menuName = "Mixed Reality/State", order = 1)]
+    [CreateAssetMenu(fileName = "States", menuName = "Mixed Reality/Toolkit/State", order = 1)]
     public class States : ScriptableObject
     {
         [FormerlySerializedAs("StateList")]

--- a/Assets/MRTK/StandardAssets/EditorUtilities/OnLoadUtilities.cs
+++ b/Assets/MRTK/StandardAssets/EditorUtilities/OnLoadUtilities.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Checks for updated shaders and bypasses the ignore update check.
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Check for Shader Updates")]
+        [MenuItem("Mixed Reality/Utilities/Check for Shader Updates")]
         private static void CheckForShaderUpdates()
         {
             EnsureShaders(true);

--- a/Assets/MRTK/StandardAssets/EditorUtilities/OnLoadUtilities.cs
+++ b/Assets/MRTK/StandardAssets/EditorUtilities/OnLoadUtilities.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Checks for updated shaders and bypasses the ignore update check.
         /// </summary>
-        [MenuItem("Mixed Reality/Utilities/Check for Shader Updates")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Check for Shader Updates")]
         private static void CheckForShaderUpdates()
         {
             EnsureShaders(true);

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -415,7 +415,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
 #if UNITY_EDITOR
-        [MenuItem("Mixed Reality/Utilities/Update/Icons/Tests")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Update/Icons/Tests")]
         private static void UpdateTestScriptIcons()
         {
             Texture2D icon = null;

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -415,7 +415,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
 #if UNITY_EDITOR
-        [MenuItem("Mixed Reality Toolkit/Utilities/Update/Icons/Tests")]
+        [MenuItem("Mixed Reality/Utilities/Update/Icons/Tests")]
         private static void UpdateTestScriptIcons()
         {
             Texture2D icon = null;

--- a/Assets/MRTK/Tools/AssetSwapUtility/AssetSwapUtility.cs
+++ b/Assets/MRTK/Tools/AssetSwapUtility/AssetSwapUtility.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private SelectionMode selectionMode;
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Create Asset Swap Collection")]
+        [MenuItem("Mixed Reality/Utilities/Create Asset Swap Collection")]
         public static void CreateAssetSwapCollection()
         {
             AssetSwapUtility utility = CreateInstance<AssetSwapUtility>();

--- a/Assets/MRTK/Tools/AssetSwapUtility/AssetSwapUtility.cs
+++ b/Assets/MRTK/Tools/AssetSwapUtility/AssetSwapUtility.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// <summary>
     /// A scriptable object which contains data and UI functionality to swap object (asset) references within a scene.
     /// </summary>
-    [CreateAssetMenu(fileName = "AssetSwapCollection", menuName = "Mixed Reality Toolkit/AssetSwapCollection")]
+    [CreateAssetMenu(fileName = "AssetSwapCollection", menuName = "Mixed Reality/AssetSwapCollection")]
     public class AssetSwapUtility : ScriptableObject
     {
         [System.Serializable]

--- a/Assets/MRTK/Tools/AssetSwapUtility/AssetSwapUtility.cs
+++ b/Assets/MRTK/Tools/AssetSwapUtility/AssetSwapUtility.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// <summary>
     /// A scriptable object which contains data and UI functionality to swap object (asset) references within a scene.
     /// </summary>
-    [CreateAssetMenu(fileName = "AssetSwapCollection", menuName = "Mixed Reality/AssetSwapCollection")]
+    [CreateAssetMenu(fileName = "AssetSwapCollection", menuName = "Mixed Reality/Toolkit/AssetSwapCollection")]
     public class AssetSwapUtility : ScriptableObject
     {
         [System.Serializable]
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private SelectionMode selectionMode;
 
-        [MenuItem("Mixed Reality/Utilities/Create Asset Swap Collection")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Create Asset Swap Collection")]
         public static void CreateAssetSwapCollection()
         {
             AssetSwapUtility utility = CreateInstance<AssetSwapUtility>();

--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -273,7 +273,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         #region Methods
 
-        [MenuItem("Mixed Reality/Utilities/Build Window", false, 0)]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Build Window", false, 0)]
         public static void OpenWindow()
         {
             // Dock it next to the Scene View.

--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -273,7 +273,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         #region Methods
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Build Window", false, 0)]
+        [MenuItem("Mixed Reality/Utilities/Build Window", false, 0)]
         public static void OpenWindow()
         {
             // Dock it next to the Scene View.

--- a/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
+++ b/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private const string DependencyWindow_URL = "https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/tools/dependency-window";
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Dependency Window", false, 3)]
+        [MenuItem("Mixed Reality/Utilities/Dependency Window", false, 3)]
         private static void ShowWindow()
         {
             var window = GetWindow<DependencyWindow>(typeof(SceneView));

--- a/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
+++ b/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private const string DependencyWindow_URL = "https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/tools/dependency-window";
 
-        [MenuItem("Mixed Reality/Utilities/Dependency Window", false, 3)]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Dependency Window", false, 3)]
         private static void ShowWindow()
         {
             var window = GetWindow<DependencyWindow>(typeof(SceneView));

--- a/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private Vector2 outputFoldersScrollPos;
         private bool useUniversalFolder = true;
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Create Extension Service", false, 500)]
+        [MenuItem("Mixed Reality/Utilities/Create Extension Service", false, 500)]
         private static void CreateExtensionServiceMenuItem()
         {
             if (window != null)

--- a/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private Vector2 outputFoldersScrollPos;
         private bool useUniversalFolder = true;
 
-        [MenuItem("Mixed Reality/Utilities/Create Extension Service", false, 500)]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Create Extension Service", false, 500)]
         private static void CreateExtensionServiceMenuItem()
         {
             if (window != null)

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             }
         }
 
-        [MenuItem("Mixed Reality Toolkit/MSBuild/Retarget assets to scripts")]
+        [MenuItem("Mixed Reality/MSBuild/Retarget assets to scripts")]
         public static void RetargetAssetsToScript() => RunRetargetToScript();
 
         private static void RunRetargetToDLL()

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             }
         }
 
-        [MenuItem("Mixed Reality/MSBuild/Retarget assets to scripts")]
+        [MenuItem("Mixed Reality/Toolkit/MSBuild/Retarget assets to scripts")]
         public static void RetargetAssetsToScript() => RunRetargetToScript();
 
         private static void RunRetargetToDLL()

--- a/Assets/MRTK/Tools/MSBuild/Scripts/MSBuildTools.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/MSBuildTools.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         private static readonly string uwpMinPlatformVersion = EditorUserBuildSettings.wsaMinUWPSDK;
         private static readonly string uwpTargetPlatformVersion = EditorUserBuildSettings.wsaUWPSDK;
 
-        [MenuItem("Mixed Reality Toolkit/MSBuild/Generate C# SDK Projects")]
+        [MenuItem("Mixed Reality/MSBuild/Generate C# SDK Projects")]
         public static void GenerateSDKProjects()
         {
             try

--- a/Assets/MRTK/Tools/MSBuild/Scripts/MSBuildTools.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/MSBuildTools.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         private static readonly string uwpMinPlatformVersion = EditorUserBuildSettings.wsaMinUWPSDK;
         private static readonly string uwpTargetPlatformVersion = EditorUserBuildSettings.wsaUWPSDK;
 
-        [MenuItem("Mixed Reality/MSBuild/Generate C# SDK Projects")]
+        [MenuItem("Mixed Reality/Toolkit/MSBuild/Generate C# SDK Projects")]
         public static void GenerateSDKProjects()
         {
             try

--- a/Assets/MRTK/Tools/MigrationWindow/MigrationWindow.cs
+++ b/Assets/MRTK/Tools/MigrationWindow/MigrationWindow.cs
@@ -63,7 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private readonly MigrationTool migrationTool = new MigrationTool();
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Migration Window", false, 4)]
+        [MenuItem("Mixed Reality/Utilities/Migration Window", false, 4)]
         private static void ShowWindow()
         {
             var window = GetWindow<MigrationWindow>(typeof(SceneView));

--- a/Assets/MRTK/Tools/MigrationWindow/MigrationWindow.cs
+++ b/Assets/MRTK/Tools/MigrationWindow/MigrationWindow.cs
@@ -63,7 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private readonly MigrationTool migrationTool = new MigrationTool();
 
-        [MenuItem("Mixed Reality/Utilities/Migration Window", false, 4)]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Migration Window", false, 4)]
         private static void ShowWindow()
         {
             var window = GetWindow<MigrationWindow>(typeof(SceneView));

--- a/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
+++ b/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
@@ -109,7 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [SerializeField]
         private PerformanceTarget PerfTarget = PerformanceTarget.AR_Headsets;
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Optimize Window", false, 0)]
+        [MenuItem("Mixed Reality/Utilities/Optimize Window", false, 0)]
         public static void OpenWindow()
         {
             // Dock it next to the Scene View.

--- a/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
+++ b/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
@@ -109,7 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [SerializeField]
         private PerformanceTarget PerfTarget = PerformanceTarget.AR_Headsets;
 
-        [MenuItem("Mixed Reality/Utilities/Optimize Window", false, 0)]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Optimize Window", false, 0)]
         public static void OpenWindow()
         {
             // Dock it next to the Scene View.

--- a/Assets/MRTK/Tools/ReserializeAssetsUtility/ReserializeAssetsUtility.cs
+++ b/Assets/MRTK/Tools/ReserializeAssetsUtility/ReserializeAssetsUtility.cs
@@ -16,21 +16,21 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// </remarks>
     public class ReserializeUtility
     {
-        [MenuItem("Mixed Reality/Utilities/Reserialize/Prefabs, Scenes, and ScriptableObjects")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Reserialize/Prefabs, Scenes, and ScriptableObjects")]
         private static void ReserializePrefabsAndScenes()
         {
             var array = GetAssets("t:Prefab t:Scene t:ScriptableObject");
             AssetDatabase.ForceReserializeAssets(array);
         }
 
-        [MenuItem("Mixed Reality/Utilities/Reserialize/Materials and Textures")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Reserialize/Materials and Textures")]
         private static void ReserializeMaterials()
         {
             var array = GetAssets("t:Material t:Texture");
             AssetDatabase.ForceReserializeAssets(array);
         }
 
-        [MenuItem("Mixed Reality/Utilities/Reserialize/Reserialize Selection")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Reserialize/Reserialize Selection")]
         [MenuItem("Assets/Mixed Reality/Reserialize Selection")]
         public static void ReserializeSelection()
         {

--- a/Assets/MRTK/Tools/ReserializeAssetsUtility/ReserializeAssetsUtility.cs
+++ b/Assets/MRTK/Tools/ReserializeAssetsUtility/ReserializeAssetsUtility.cs
@@ -16,22 +16,22 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// </remarks>
     public class ReserializeUtility
     {
-        [MenuItem("Mixed Reality Toolkit/Utilities/Reserialize/Prefabs, Scenes, and ScriptableObjects")]
+        [MenuItem("Mixed Reality/Utilities/Reserialize/Prefabs, Scenes, and ScriptableObjects")]
         private static void ReserializePrefabsAndScenes()
         {
             var array = GetAssets("t:Prefab t:Scene t:ScriptableObject");
             AssetDatabase.ForceReserializeAssets(array);
         }
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Reserialize/Materials and Textures")]
+        [MenuItem("Mixed Reality/Utilities/Reserialize/Materials and Textures")]
         private static void ReserializeMaterials()
         {
             var array = GetAssets("t:Material t:Texture");
             AssetDatabase.ForceReserializeAssets(array);
         }
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Reserialize/Reserialize Selection")]
-        [MenuItem("Assets/Mixed Reality Toolkit/Reserialize Selection")]
+        [MenuItem("Mixed Reality/Utilities/Reserialize/Reserialize Selection")]
+        [MenuItem("Assets/Mixed Reality/Reserialize Selection")]
         public static void ReserializeSelection()
         {
             Object[] selectedAssets = Selection.GetFiltered(typeof(Object), SelectionMode.DeepAssets);

--- a/Assets/MRTK/Tools/ScreenshotUtility/ScreenshotUtility.cs
+++ b/Assets/MRTK/Tools/ScreenshotUtility/ScreenshotUtility.cs
@@ -15,42 +15,42 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// </summary>
     public class ScreenshotUtility
     {
-        [MenuItem("Mixed Reality Toolkit/Utilities/Take Screenshot/Native Resolution")]
+        [MenuItem("Mixed Reality/Utilities/Take Screenshot/Native Resolution")]
         private static void CaptureScreenshot1x()
         {
             CaptureScreenshot(GetScreenshotPath(), 1);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Take Screenshot/Native Resolution (Transparent Background)")]
+        [MenuItem("Mixed Reality/Utilities/Take Screenshot/Native Resolution (Transparent Background)")]
         private static void CaptureScreenshot1xAlphaComposite()
         {
             CaptureScreenshot(GetScreenshotPath(), 1, true);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Take Screenshot/2x Resolution")]
+        [MenuItem("Mixed Reality/Utilities/Take Screenshot/2x Resolution")]
         private static void CaptureScreenshot2x()
         {
             CaptureScreenshot(GetScreenshotPath(), 2);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Take Screenshot/2x Resolution (Transparent Background)")]
+        [MenuItem("Mixed Reality/Utilities/Take Screenshot/2x Resolution (Transparent Background)")]
         private static void CaptureScreenshot2xAlphaComposite()
         {
             CaptureScreenshot(GetScreenshotPath(), 2, true);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Take Screenshot/4x Resolution")]
+        [MenuItem("Mixed Reality/Utilities/Take Screenshot/4x Resolution")]
         private static void CaptureScreenshot4x()
         {
             CaptureScreenshot(GetScreenshotPath(), 4);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Take Screenshot/4x Resolution (Transparent Background)")]
+        [MenuItem("Mixed Reality/Utilities/Take Screenshot/4x Resolution (Transparent Background)")]
         private static void CaptureScreenshot4xAlphaComposite()
         {
             CaptureScreenshot(GetScreenshotPath(), 4, true);

--- a/Assets/MRTK/Tools/ScreenshotUtility/ScreenshotUtility.cs
+++ b/Assets/MRTK/Tools/ScreenshotUtility/ScreenshotUtility.cs
@@ -15,42 +15,42 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// </summary>
     public class ScreenshotUtility
     {
-        [MenuItem("Mixed Reality/Utilities/Take Screenshot/Native Resolution")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Take Screenshot/Native Resolution")]
         private static void CaptureScreenshot1x()
         {
             CaptureScreenshot(GetScreenshotPath(), 1);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality/Utilities/Take Screenshot/Native Resolution (Transparent Background)")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Take Screenshot/Native Resolution (Transparent Background)")]
         private static void CaptureScreenshot1xAlphaComposite()
         {
             CaptureScreenshot(GetScreenshotPath(), 1, true);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality/Utilities/Take Screenshot/2x Resolution")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Take Screenshot/2x Resolution")]
         private static void CaptureScreenshot2x()
         {
             CaptureScreenshot(GetScreenshotPath(), 2);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality/Utilities/Take Screenshot/2x Resolution (Transparent Background)")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Take Screenshot/2x Resolution (Transparent Background)")]
         private static void CaptureScreenshot2xAlphaComposite()
         {
             CaptureScreenshot(GetScreenshotPath(), 2, true);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality/Utilities/Take Screenshot/4x Resolution")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Take Screenshot/4x Resolution")]
         private static void CaptureScreenshot4x()
         {
             CaptureScreenshot(GetScreenshotPath(), 4);
             EditorUtility.RevealInFinder(GetScreenshotDirectory());
         }
 
-        [MenuItem("Mixed Reality/Utilities/Take Screenshot/4x Resolution (Transparent Background)")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Take Screenshot/4x Resolution (Transparent Background)")]
         private static void CaptureScreenshot4xAlphaComposite()
         {
             CaptureScreenshot(GetScreenshotPath(), 4, true);

--- a/Assets/MRTK/Tools/TextureCombinerWindow/TextureCombinerWindow.cs
+++ b/Assets/MRTK/Tools/TextureCombinerWindow/TextureCombinerWindow.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private const string StandardRoughnessShaderName = "Standard (Roughness setup)";
         private const string StandardSpecularShaderName = "Standard (Specular setup)";
 
-        [MenuItem("Mixed Reality/Utilities/Texture Combiner")]
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Texture Combiner")]
         private static void ShowWindow()
         {
             TextureCombinerWindow window = GetWindow<TextureCombinerWindow>();

--- a/Assets/MRTK/Tools/TextureCombinerWindow/TextureCombinerWindow.cs
+++ b/Assets/MRTK/Tools/TextureCombinerWindow/TextureCombinerWindow.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private const string StandardRoughnessShaderName = "Standard (Roughness setup)";
         private const string StandardSpecularShaderName = "Standard (Specular setup)";
 
-        [MenuItem("Mixed Reality Toolkit/Utilities/Texture Combiner")]
+        [MenuItem("Mixed Reality/Utilities/Texture Combiner")]
         private static void ShowWindow()
         {
             TextureCombinerWindow window = GetWindow<TextureCombinerWindow>();

--- a/Assets/MRTK/Tools/Toolbox/MixedRealityToolboxWindow.cs
+++ b/Assets/MRTK/Tools/Toolbox/MixedRealityToolboxWindow.cs
@@ -162,7 +162,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private GUIStyle centeredStyle;
 
-        [MenuItem("Mixed Reality Toolkit/Toolbox", false, 3)]
+        [MenuItem("Mixed Reality/Toolbox", false, 3)]
         internal static void ShowWindow()
         {
             var window = GetWindow<MixedRealityToolboxWindow>(typeof(SceneView));

--- a/Assets/MRTK/Tools/Toolbox/MixedRealityToolboxWindow.cs
+++ b/Assets/MRTK/Tools/Toolbox/MixedRealityToolboxWindow.cs
@@ -162,7 +162,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private GUIStyle centeredStyle;
 
-        [MenuItem("Mixed Reality/Toolbox", false, 3)]
+        [MenuItem("Mixed Reality/Toolkit/Toolbox", false, 3)]
         internal static void ShowWindow()
         {
             var window = GetWindow<MixedRealityToolboxWindow>(typeof(SceneView));


### PR DESCRIPTION
This change renames the "Mixed Reality Toolkit" menus with "Mixed Reality" to unify with other packages (ex: OpenXR extensions)

Top level:
![image](https://user-images.githubusercontent.com/13281406/114442768-c568d380-9b81-11eb-9227-c460f6518b72.png)

Assets menu:
![image](https://user-images.githubusercontent.com/13281406/114443941-25ac4500-9b83-11eb-805e-dbba66b6426d.png)
