### PR TITLE
Deprecate `DeviceManagerProfile` in favor of inherited property

### DIFF
--- a/Assets/MRTK/Core/Definitions/MixedRealityInputDataProviderConfiguration.cs
+++ b/Assets/MRTK/Core/Definitions/MixedRealityInputDataProviderConfiguration.cs
@@ -45,6 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Device manager specific configuration profile.
         /// </summary>
+        [Obsolete("Use the Profile property instead.")]
         public BaseMixedRealityProfile DeviceManagerProfile => deviceManagerProfile;
 
         /// <summary>

--- a/Assets/MRTK/Core/Definitions/MixedRealityServiceConfiguration.cs
+++ b/Assets/MRTK/Core/Definitions/MixedRealityServiceConfiguration.cs
@@ -70,7 +70,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <summary>
         /// The configuration profile for the service.
         /// </summary>
-        [Obsolete("Use Profile property instead")]
+        [Obsolete("Use the Profile property instead.")]
         public BaseMixedRealityProfile ConfigurationProfile => configurationProfile;
     }
 }

--- a/Assets/MRTK/Core/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor.Search;
 using System.Reflection;

--- a/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             providerConfigurations.InsertArrayElementAtIndex(providerConfigurations.arraySize);
             SerializedProperty provider = providerConfigurations.GetArrayElementAtIndex(providerConfigurations.arraySize - 1);
 
-            var providerProperties = GetDataProviderConfigurationProperties(provider);
+            ServiceConfigurationProperties providerProperties = GetDataProviderConfigurationProperties(provider);
             providerProperties.componentName.stringValue = $"New data provider {providerConfigurations.arraySize - 1}";
             providerProperties.runtimePlatform.intValue = -1;
             providerProperties.providerProfile.objectReferenceValue = null;

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityEyeTrackingProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityEyeTrackingProfileInspector.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                 MixedRealityToolkit.Instance.HasActiveProfile &&
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile != null &&
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.DataProviderConfigurations != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.DataProviderConfigurations.Any(s => profile == s.DeviceManagerProfile);
+                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.DataProviderConfigurations.Any(s => profile == s.Profile);
         }
     }
 }

--- a/Assets/MRTK/Core/Providers/InputSimulation/Editor/MixedRealityInputSimulationProfileInspector.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/Editor/MixedRealityInputSimulationProfileInspector.cs
@@ -223,7 +223,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return MixedRealityToolkit.IsInitialized && profile != null &&
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile != null &&
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.DataProviderConfigurations != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.DataProviderConfigurations.Any(s => profile == s.DeviceManagerProfile);
+                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.DataProviderConfigurations.Any(s => profile == s.Profile);
         }
     }
 }

--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionDeviceManagerProfileInspector.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionDeviceManagerProfileInspector.cs
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Inspectors
             return MixedRealityToolkit.IsInitialized && profile != null &&
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile != null &&
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.DataProviderConfigurations != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.DataProviderConfigurations.Any(s => profile == s.DeviceManagerProfile);
+                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.DataProviderConfigurations.Any(s => profile == s.Profile);
         }
     }
 }

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -288,7 +288,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 for (int i = 0; i < profile.DataProviderConfigurations.Length; i++)
                 {
                     MixedRealityInputDataProviderConfiguration configuration = profile.DataProviderConfigurations[i];
-                    object[] args = { this, configuration.ComponentName, configuration.Priority, configuration.DeviceManagerProfile };
+                    object[] args = { this, configuration.ComponentName, configuration.Priority, configuration.Profile };
 
                     DebugUtilities.LogVerboseFormat(
                         "Attempting to register input system data provider {0}, {1}, {2}",


### PR DESCRIPTION
`DeviceManagerProfile` has the exact same type as the `Profile` a couple lines higher, so it can be safely deprecated in favor of the inherited property.

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/4f7a007c7dfadb725613667cef34470db8c7d038/Assets/MRTK/Core/Definitions/MixedRealityInputDataProviderConfiguration.cs#L42-L43