### PR TITLE
Fix profiler tag in WMRHandMeshProvider

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -107,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
             }
         }
 
-        private static readonly ProfilerMarker UpdateHandMeshPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityArticulatedHandDefinition.UpdateHandMesh");
+        private static readonly ProfilerMarker UpdateHandMeshPerfMarker = new ProfilerMarker($"[MRTK] {nameof(WindowsMixedRealityHandMeshProvider)}.UpdateHandMesh");
 
         /// <summary>
         /// Updates the current hand mesh based on the passed in state of the hand.


### PR DESCRIPTION
## Overview

The tag was referencing the previously deprecated (and where this was refactored from) `WindowsMixedRealityArticulatedHandDefinition` class. This PR updates it and uses `nameof` to help make it more robust to name changes.

Also adds a profiler marker to the OpenXRHandMeshProvider.