### PR TITLE
Wrap glTF scripted importers with !MRTK_GLTF_IMPORTER_OFF

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/ScriptUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/ScriptUtilities.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <param name="symbols">Array of symbols to define.</param>
         public static void AppendScriptingDefinitions(
             BuildTargetGroup targetGroup,
-            string[] symbols)
+            params string[] symbols)
         {
             if (symbols == null || symbols.Length == 0) { return; }
 
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <param name="symbols">Array of symbols to remove.</param>
         public static void RemoveScriptingDefinitions(
             BuildTargetGroup targetGroup,
-            string[] symbols)
+            params string[] symbols)
         {
             if (symbols == null || symbols.Length == 0) { return; }
 

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GlbAssetImporter.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GlbAssetImporter.cs
@@ -9,7 +9,9 @@ using UnityEditor.Experimental.AssetImporters;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization.Editor
 {
+#if !MRTK_GLTF_IMPORTER_OFF
     [ScriptedImporter(1, "glb")]
+#endif // !MRTK_GLTF_IMPORTER_OFF
     public class GlbAssetImporter : ScriptedImporter
     {
         public override void OnImportAsset(AssetImportContext context)

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GltfAssetImporter.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GltfAssetImporter.cs
@@ -9,7 +9,9 @@ using UnityEditor.Experimental.AssetImporters;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization.Editor
 {
+#if !MRTK_GLTF_IMPORTER_OFF
     [ScriptedImporter(1, "gltf")]
+#endif // !MRTK_GLTF_IMPORTER_OFF
     public class GltfAssetImporter : ScriptedImporter
     {
         public override void OnImportAsset(AssetImportContext context)

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GltfEditorImporter.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/GltfEditorImporter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema;
 using System.IO;
 using UnityEditor;
@@ -16,6 +17,22 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization.Editor
 {
     public static class GltfEditorImporter
     {
+#if MRTK_GLTF_IMPORTER_OFF
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Enable MRTK glTF asset importer")]
+#else
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Disable MRTK glTF asset importer")]
+#endif
+        private static void ReconcileGltfImporterDefine()
+        {
+            BuildTargetGroup group = BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget);
+
+#if MRTK_GLTF_IMPORTER_OFF
+            ScriptUtilities.RemoveScriptingDefinitions(group, "MRTK_GLTF_IMPORTER_OFF");
+#else
+            ScriptUtilities.AppendScriptingDefinitions(group, "MRTK_GLTF_IMPORTER_OFF");
+#endif
+        }
+
         public static async void OnImportGltfAsset(AssetImportContext context)
         {
             var importedObject = await GltfUtility.ImportGltfObjectFromPathAsync(context.assetPath);


### PR DESCRIPTION
## Overview

This enables them to be turned off if they collide with other importers like TriLib.

![image](https://user-images.githubusercontent.com/3580640/114602187-2c05f400-9c4b-11eb-8cf5-102ff20f5ad5.png)


## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9653
