### PR TITLE
Only publish docs binaries if checkout and generation succeed

### DIFF
--- a/pipelines/docs-binaries.yml
+++ b/pipelines/docs-binaries.yml
@@ -30,7 +30,6 @@ jobs:
 
   - task: PublishPipelineArtifact@1
     displayName: Publish docs binaries
-    condition: always()
     inputs:
       targetPath: $(Build.ArtifactStagingDirectory)
       artifactName: DocsBinariesForUnity2020
@@ -59,7 +58,6 @@ jobs:
 
   - task: PublishPipelineArtifact@1
     displayName: Publish docs binaries
-    condition: always()
     inputs:
       targetPath: $(Build.ArtifactStagingDirectory)
       artifactName: DocsBinariesForUnity2019


### PR DESCRIPTION
## Overview

Currently, the 2019 and 2020 docs binary generation steps `always()` try to publish artifacts, even if previous steps failed. This can get into a state like the linked pipeline below, where the checkout step failed initially, succeeded on a re-run, but can't publish binaries because the failed run published an empty artifact.

## Changes

- Fixes: https://microsoft.visualstudio.com/Analog/_build/results?buildId=33400250&view=artifacts&pathAsName=false&type=publishedArtifacts
