### PR TITLE
Add fallback reg key in case the default one doesn't work in BuildDeployWindow

### DIFF
--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -77,6 +77,8 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private const string WINDOWS_10_KITS_PATH_REGISTRY_PATH = @"SOFTWARE\Microsoft\Windows Kits\Installed Roots";
 
+        private const string WINDOWS_10_KITS_PATH_ALTERNATE_REGISTRY_PATH = @"SOFTWARE\WOW6432Node\Microsoft\Windows Kits\Installed Roots";
+
         private const string WINDOWS_10_KITS_PATH_REGISTRY_KEY = "KitsRoot10";
 
         private const string WINDOWS_10_KITS_PATH_POSTFIX = "Lib";
@@ -1419,11 +1421,24 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             // Try to detect the installation path by checking the registry.
             try
             {
-                var registryKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(WINDOWS_10_KITS_PATH_REGISTRY_PATH);
+                var registryKey = Win32.Registry.LocalMachine.OpenSubKey(WINDOWS_10_KITS_PATH_REGISTRY_PATH);
                 var registryValue = registryKey.GetValue(WINDOWS_10_KITS_PATH_REGISTRY_KEY) as string;
                 win10KitsPath = Path.Combine(registryValue, WINDOWS_10_KITS_PATH_POSTFIX);
+
+                if (!Directory.Exists(win10KitsPath))
+                {
+                    registryKey = Win32.Registry.LocalMachine.OpenSubKey(WINDOWS_10_KITS_PATH_ALTERNATE_REGISTRY_PATH);
+                    registryValue = registryKey.GetValue(WINDOWS_10_KITS_PATH_REGISTRY_KEY) as string;
+                    win10KitsPath = Path.Combine(registryValue, WINDOWS_10_KITS_PATH_POSTFIX);
+
+                    if (!Directory.Exists(win10KitsPath))
+                    {
+                        Debug.LogWarning($"Could not find the Windows 10 SDK installation path via registry. Reverting to default path.");
+                        win10KitsPath = WINDOWS_10_KITS_DEFAULT_PATH;
+                    }
+                }
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 Debug.LogWarning($"Could not find the Windows 10 SDK installation path via registry. Reverting to default path. {e}");
                 win10KitsPath = WINDOWS_10_KITS_DEFAULT_PATH;


### PR DESCRIPTION
## Overview

Checks if the folder provided by `SOFTWARE\Microsoft\Windows Kits\Installed Roots` exists. If it doesn't, checks `SOFTWARE\WOW6432Node\Microsoft\Windows Kits\Installed Roots`. If that also doesn't exist, falls back to the default path.

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9507
