### PR TITLE
Update to use non-obsolete method in WMR controller

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -238,7 +238,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         protected override bool TryRenderControllerModel(System.Type controllerType, InputSourceType inputSourceType)
         {
             if (GetControllerVisualizationProfile() == null ||
-                !GetControllerVisualizationProfile().GetUseDefaultModelsOverride(GetType(), ControllerHandedness))
+                !GetControllerVisualizationProfile().GetUsePlatformModelsOverride(GetType(), ControllerHandedness))
             {
                 return base.TryRenderControllerModel(controllerType, inputSourceType);
             }


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9633

>https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9589 deprecated `GetUseDefaultModelsOverride`, but one of the classes is still calling it. Updated to the new `GetUsePlatformModelsOverride` instead.