### PR TITLE
Don't load legacy OpenVR assembly on Unity 2020

### DIFF
--- a/Assets/MRTK/Providers/OpenVR/MRTK.OpenVR.asmdef
+++ b/Assets/MRTK/Providers/OpenVR/MRTK.OpenVR.asmdef
@@ -3,7 +3,6 @@
     "references": [
         "Microsoft.MixedReality.Toolkit"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor",
         "LinuxStandalone64",
@@ -16,5 +15,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [
+        "!UNITY_2020_1_OR_NEWER"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/MRTK/Tests/EditModeTests/Core/Definitions/Devices/MixedRealityControllerMappingProfileTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Definitions/Devices/MixedRealityControllerMappingProfileTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.OpenVR.Input;
 using NUnit.Framework;
 using UnityEditor;
 
@@ -18,8 +17,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         {
             MixedRealityControllerMapping[] testMappingsChanged = new MixedRealityControllerMapping[]
             {
-                new MixedRealityControllerMapping(typeof(ViveWandController), Utilities.Handedness.Left),
-                new MixedRealityControllerMapping(typeof(ViveWandController), Utilities.Handedness.Right)
+#if UNITY_2020_1_OR_NEWER
+                new MixedRealityControllerMapping(typeof(XRSDK.OpenXR.HPReverbG2Controller), Utilities.Handedness.Left),
+                new MixedRealityControllerMapping(typeof(XRSDK.OpenXR.HPReverbG2Controller), Utilities.Handedness.Right)
+#else
+                new MixedRealityControllerMapping(typeof(OpenVR.Input.ViveWandController), Utilities.Handedness.Left),
+                new MixedRealityControllerMapping(typeof(OpenVR.Input.ViveWandController), Utilities.Handedness.Right)
+#endif
             };
 
             testMappingsChanged[0].SetDefaultInteractionMapping();

--- a/Assets/MRTK/Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Input.UnityInput;
-using Microsoft.MixedReality.Toolkit.OpenVR.Input;
 using NUnit.Framework;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
@@ -39,11 +38,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
             TestGenericJoystickControllerUpdate(controller);
         }
 
+#if !UNITY_2020_1_OR_NEWER
         [Test]
         public void GenericOpenVRControllerUpdateTest()
         {
-            GenericOpenVRController leftController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            GenericOpenVRController rightController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            OpenVR.Input.GenericOpenVRController leftController = new OpenVR.Input.GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            OpenVR.Input.GenericOpenVRController rightController = new OpenVR.Input.GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void OculusRemoteControllerUpdateTest()
         {
-            OculusRemoteController controller = new OculusRemoteController(TrackingState.NotTracked, Utilities.Handedness.None);
+            OpenVR.Input.OculusRemoteController controller = new OpenVR.Input.OculusRemoteController(TrackingState.NotTracked, Utilities.Handedness.None);
 
             TestGenericJoystickControllerUpdate(controller);
         }
@@ -60,8 +60,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void OculusTouchControllerUpdateTest()
         {
-            OculusTouchController leftController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            OculusTouchController rightController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            OpenVR.Input.OculusTouchController leftController = new OpenVR.Input.OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            OpenVR.Input.OculusTouchController rightController = new OpenVR.Input.OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -70,8 +70,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void ViveKnucklesControllerUpdateTest()
         {
-            ViveKnucklesController leftController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            ViveKnucklesController rightController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            OpenVR.Input.ViveKnucklesController leftController = new OpenVR.Input.ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            OpenVR.Input.ViveKnucklesController rightController = new OpenVR.Input.ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -80,8 +80,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void ViveWandControllerUpdateTest()
         {
-            ViveWandController leftController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            ViveWandController rightController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            OpenVR.Input.ViveWandController leftController = new OpenVR.Input.ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            OpenVR.Input.ViveWandController rightController = new OpenVR.Input.ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -90,12 +90,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void WindowsMixedRealityOpenVRMotionControllerUpdateTest()
         {
-            WindowsMixedRealityOpenVRMotionController leftController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            WindowsMixedRealityOpenVRMotionController rightController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            OpenVR.Input.WindowsMixedRealityOpenVRMotionController leftController = new OpenVR.Input.WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            OpenVR.Input.WindowsMixedRealityOpenVRMotionController rightController = new OpenVR.Input.WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
         }
+#endif // !UNITY_2020_1_OR_NEWER
 
         private void TestGenericJoystickControllerUpdate(GenericJoystickController controller)
         {

--- a/Assets/MRTK/Tests/EditModeTests/MRTK.EditModeTests.asmdef
+++ b/Assets/MRTK/Tests/EditModeTests/MRTK.EditModeTests.asmdef
@@ -7,6 +7,7 @@
         "Microsoft.MixedReality.Toolkit.Editor.Utilities",
         "Microsoft.MixedReality.Toolkit.Examples",
         "Microsoft.MixedReality.Toolkit.Providers.OpenVR",
+        "Microsoft.MixedReality.Toolkit.Providers.OpenXR",
         "Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus.Handtracking.Editor",
         "Microsoft.MixedReality.Toolkit.SDK",
         "Microsoft.MixedReality.Toolkit.SDK.Editor",


### PR DESCRIPTION
## Overview

Similar to how we've handled the legacy WMR assembly, we shouldn't try loading the legacy OpenVR assembly to make it clear that those types aren't compatible here.

Also updates the tests to account for these types missing in Unity 2020+.

## Changes

- Part of #9419 