### PR TITLE
Add SupportedUnityXRPipelines enum to attributes

### DIFF
--- a/Assets/MRTK/Core/Attributes/MixedRealityControllerAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/MixedRealityControllerAttribute.cs
@@ -39,18 +39,25 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public MixedRealityControllerConfigurationFlags Flags { get; }
 
         /// <summary>
+        /// Additional flags for configuring controller capabilities.
+        /// </summary>
+        public SupportedUnityXRPipelines SupportedUnityXRPipelines { get; }
+
+        /// <summary>
         /// 
         /// </summary>
         public MixedRealityControllerAttribute(
             SupportedControllerType supportedControllerType,
             Handedness[] supportedHandedness,
             string texturePath = "",
-            MixedRealityControllerConfigurationFlags flags = 0)
+            MixedRealityControllerConfigurationFlags flags = 0,
+            SupportedUnityXRPipelines supportedUnityXRPipelines = (SupportedUnityXRPipelines)(-1))
         {
             SupportedControllerType = supportedControllerType;
             SupportedHandedness = supportedHandedness;
             TexturePath = texturePath;
             Flags = flags;
+            SupportedUnityXRPipelines = supportedUnityXRPipelines;
         }
 
         /// <summary>

--- a/Assets/MRTK/Core/Attributes/MixedRealityControllerAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/MixedRealityControllerAttribute.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public MixedRealityControllerConfigurationFlags Flags { get; }
 
         /// <summary>
-        /// Additional flags for configuring controller capabilities.
+        /// The supported Unity XR pipelines for this controller.
         /// </summary>
         public SupportedUnityXRPipelines SupportedUnityXRPipelines { get; }
 

--- a/Assets/MRTK/Core/Attributes/MixedRealityDataProviderAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/MixedRealityDataProviderAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// <summary>
     /// Attribute that defines the properties of a Mixed Reality Toolkit data provider.
     /// </summary>
-    [AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class MixedRealityDataProviderAttribute : MixedRealityExtensionServiceAttribute
     {
         /// <summary>
@@ -17,15 +17,23 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         public Type ServiceInterfaceType { get; }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        public SupportedUnityXRPipelines SupportedUnityXRPipelines { get; }
+
         public MixedRealityDataProviderAttribute(
             Type serviceInterfaceType,
             SupportedPlatforms runtimePlatforms,
             string name = "",
             string profilePath = "",
             string packageFolder = "MixedRealityToolkit",
-            bool requiresProfile = false) : base(runtimePlatforms, name, profilePath, packageFolder, requiresProfile)
+            bool requiresProfile = false,
+            SupportedUnityXRPipelines supportedUnityXRPipelines = (SupportedUnityXRPipelines)(-1))
+            : base(runtimePlatforms, name, profilePath, packageFolder, requiresProfile)
         {
             ServiceInterfaceType = serviceInterfaceType;
+            SupportedUnityXRPipelines = supportedUnityXRPipelines;
         }
     }
 }

--- a/Assets/MRTK/Core/Attributes/MixedRealityDataProviderAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/MixedRealityDataProviderAttribute.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit
         public Type ServiceInterfaceType { get; }
 
         /// <summary>
-        /// 
+        /// The supported Unity XR pipelines for this data provider.
         /// </summary>
         public SupportedUnityXRPipelines SupportedUnityXRPipelines { get; }
 

--- a/Assets/MRTK/Core/Definitions/Utilities/SupportedPlatforms.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/SupportedPlatforms.cs
@@ -23,4 +23,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         Web = 1 << 9,
         Lumin = 1 << 10
     }
+
+    [Flags]
+    public enum SupportedUnityXRPipelines
+    {
+        LegacyXR = 1 << 0,
+        XRSDK = 1 << 1,
+    }
 }

--- a/Assets/MRTK/Core/Definitions/Utilities/SupportedPlatforms.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/SupportedPlatforms.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     /// <summary>
-    /// The supported platforms for Mixed Reality Toolkit Components and Features.
+    /// The supported platforms for Mixed Reality Toolkit components and features.
     /// </summary>
     [Flags]
     public enum SupportedPlatforms
@@ -24,6 +24,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         Lumin = 1 << 10
     }
 
+    /// <summary>
+    /// The supported Unity XR pipelines for Mixed Reality Toolkit components and features.
+    /// </summary>
     [Flags]
     public enum SupportedUnityXRPipelines
     {

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
@@ -17,7 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
     [MixedRealityDataProvider(
         typeof(IMixedRealityInputSystem),
         (SupportedPlatforms)(-1),  // All platforms supported by Unity
-        "Unity Joystick Manager")]
+        "Unity Joystick Manager",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class UnityJoystickManager : BaseInputDeviceManager
     {
         /// <summary>

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -18,7 +18,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
     [MixedRealityController(
         SupportedControllerType.OculusTouch,
         new[] { Handedness.Left, Handedness.Right },
-        "Textures/OculusControllersTouch")]
+        "Textures/OculusControllersTouch",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class OculusXRSDKTouchController : GenericXRSDKController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -44,7 +44,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.ArticulatedHand,
-        new[] { Handedness.Left, Handedness.Right })]
+        new[] { Handedness.Left, Handedness.Right },
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class OculusHand : BaseHand
     {
         private MixedRealityPose currentPointerPose = MixedRealityPose.ZeroIdentity;

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -27,7 +27,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         "XR SDK Oculus Device Manager",
         "Oculus/XRSDK/Profiles/DefaultOculusXRSDKDeviceManagerProfile.asset",
         "MixedRealityToolkit.Providers",
-        requiresProfile: true)]
+        true,
+        SupportedUnityXRPipelines.XRSDK)]
     public class OculusXRSDKDeviceManager : XRSDKDeviceManager
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
@@ -15,7 +15,8 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityController(
         SupportedControllerType.GenericOpenVR,
         new[] { Handedness.Left, Handedness.Right },
-        flags: MixedRealityControllerConfigurationFlags.UseCustomInteractionMappings)]
+        flags: MixedRealityControllerConfigurationFlags.UseCustomInteractionMappings,
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class GenericOpenVRController : GenericJoystickController
     {
         public GenericOpenVRController(

--- a/Assets/MRTK/Providers/OpenVR/HPMotionController.cs
+++ b/Assets/MRTK/Providers/OpenVR/HPMotionController.cs
@@ -12,7 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.HPMotionController,
-        new[] { Handedness.Left, Handedness.Right })]
+        new[] { Handedness.Left, Handedness.Right },
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class HPMotionController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/OculusRemoteController.cs
+++ b/Assets/MRTK/Providers/OpenVR/OculusRemoteController.cs
@@ -10,7 +10,8 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityController(
         SupportedControllerType.OculusRemote,
         new[] { Handedness.None },
-        "Textures/OculusRemoteController")]
+        "Textures/OculusRemoteController",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class OculusRemoteController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/OculusTouchController.cs
+++ b/Assets/MRTK/Providers/OpenVR/OculusTouchController.cs
@@ -10,7 +10,8 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityController(
         SupportedControllerType.OculusTouch,
         new[] { Handedness.Left, Handedness.Right },
-        "Textures/OculusControllersTouch")]
+        "Textures/OculusControllersTouch",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class OculusTouchController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenVR/OpenVRDeviceManager.cs
@@ -16,7 +16,8 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityDataProvider(
         typeof(IMixedRealityInputSystem),
         SupportedPlatforms.WindowsStandalone | SupportedPlatforms.MacStandalone | SupportedPlatforms.LinuxStandalone,
-        "OpenVR Device Manager")]
+        "OpenVR Device Manager",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class OpenVRDeviceManager : UnityJoystickManager, IMixedRealityCapabilityCheck
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/ViveKnucklesController.cs
+++ b/Assets/MRTK/Providers/OpenVR/ViveKnucklesController.cs
@@ -9,7 +9,8 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
 {
     [MixedRealityController(
         SupportedControllerType.ViveKnuckles,
-        new[] { Handedness.Left, Handedness.Right })]
+        new[] { Handedness.Left, Handedness.Right },
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class ViveKnucklesController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/ViveWandController.cs
+++ b/Assets/MRTK/Providers/OpenVR/ViveWandController.cs
@@ -10,7 +10,8 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityController(
         SupportedControllerType.ViveWand,
         new[] { Handedness.Left, Handedness.Right },
-        "Textures/ViveWandController")]
+        "Textures/ViveWandController",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class ViveWandController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
+++ b/Assets/MRTK/Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
@@ -13,7 +13,8 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
     [MixedRealityController(
         SupportedControllerType.WindowsMixedReality,
         new[] { Handedness.Left, Handedness.Right },
-        "Textures/MotionController")]
+        "Textures/MotionController",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class WindowsMixedRealityOpenVRMotionController : GenericOpenVRController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -17,7 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
     [MixedRealityDataProvider(
         typeof(IMixedRealityInputSystem),
         (SupportedPlatforms)(-1),
-        "OpenXR XRSDK Device Manager")]
+        "OpenXR XRSDK Device Manager",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class OpenXRDeviceManager : XRSDKDeviceManager
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
@@ -20,7 +20,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         (SupportedPlatforms)(-1),
         "OpenXR XRSDK Eye Gaze Provider",
         "Profiles/DefaultMixedRealityEyeTrackingProfile.asset", "MixedRealityToolkit.SDK",
-        true)]
+        true,
+        SupportedUnityXRPipelines.XRSDK)]
     public class OpenXREyeGazeDataProvider : BaseInputDeviceManager, IMixedRealityEyeGazeDataProvider, IMixedRealityEyeSaccadeProvider, IMixedRealityCapabilityCheck
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
@@ -9,12 +9,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
     /// <summary>
     /// Camera settings provider for use with Windows Mixed Reality.
     /// </summary>
-    [MixedRealityDataProvider(
-        typeof(IMixedRealityCameraSystem),
-        SupportedPlatforms.WindowsUniversal,
-        "Windows Mixed Reality Camera Settings",
-        "WindowsMixedReality/Shared/Profiles/DefaultWindowsMixedRealityCameraSettingsProfile.asset",
-        "MixedRealityToolkit.Providers")]
     public abstract class BaseWindowsMixedRealityCameraSettings : BaseCameraSettingsProvider, IMixedRealityCameraProjectionOverrideProvider
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/HPMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/HPMotionController.cs
@@ -19,7 +19,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.HPMotionController,
-        new[] { Handedness.Left, Handedness.Right })]
+        new[] { Handedness.Left, Handedness.Right },
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class HPMotionController : WindowsMixedRealityController
     {
 #if HP_CONTROLLER_ENABLED

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
@@ -29,7 +29,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.ArticulatedHand,
-        new[] { Handedness.Left, Handedness.Right })]
+        new[] { Handedness.Left, Handedness.Right },
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class WindowsMixedRealityArticulatedHand : BaseWindowsMixedRealitySource, IMixedRealityHand
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -17,7 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
     [MixedRealityController(
         SupportedControllerType.WindowsMixedReality,
         new[] { Handedness.Left, Handedness.Right },
-        "Textures/MotionController")]
+        "Textures/MotionController",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class WindowsMixedRealityController : BaseWindowsMixedRealitySource
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityGGVHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityGGVHand.cs
@@ -11,7 +11,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.GGVHand,
-        new[] { Handedness.Left, Handedness.Right, Handedness.None })]
+        new[] { Handedness.Left, Handedness.Right, Handedness.None },
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class WindowsMixedRealityGGVHand : BaseWindowsMixedRealitySource
     {
         public WindowsMixedRealityGGVHand(

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityCameraSettings.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.CameraSystem;
+using Microsoft.MixedReality.Toolkit.Utilities;
 
 #if UNITY_WSA
 using UnityEngine.XR.WSA;
@@ -12,6 +13,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
     /// <summary>
     /// Camera settings provider for use with Windows Mixed Reality.
     /// </summary>
+    [MixedRealityDataProvider(
+        typeof(IMixedRealityCameraSystem),
+        SupportedPlatforms.WindowsUniversal,
+        "Windows Mixed Reality Camera Settings",
+        "WindowsMixedReality/Shared/Profiles/DefaultWindowsMixedRealityCameraSettingsProfile.asset",
+        "MixedRealityToolkit.Providers",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class WindowsMixedRealityCameraSettings : BaseWindowsMixedRealityCameraSettings
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -37,7 +37,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
     [MixedRealityDataProvider(
         typeof(IMixedRealityInputSystem),
         SupportedPlatforms.WindowsUniversal,
-        "Windows Mixed Reality Device Manager")]
+        "Windows Mixed Reality Device Manager",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
     public class WindowsMixedRealityDeviceManager : BaseInputDeviceManager, IMixedRealityCapabilityCheck
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -25,7 +25,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         SupportedPlatforms.WindowsUniversal,
         "Windows Mixed Reality Eye Gaze Provider",
         "Profiles/DefaultMixedRealityEyeTrackingProfile.asset", "MixedRealityToolkit.SDK",
-        true)]
+        true,
+        SupportedUnityXRPipelines.LegacyXR)]
     public class WindowsMixedRealityEyeGazeDataProvider : BaseInputDeviceManager, IMixedRealityEyeGazeDataProvider, IMixedRealityEyeSaccadeProvider, IMixedRealityCapabilityCheck
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -25,7 +25,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         "Windows Mixed Reality Spatial Mesh Observer",
         "Profiles/DefaultMixedRealitySpatialAwarenessMeshObserverProfile.asset",
         "MixedRealityToolkit.SDK",
-        true)]
+        true,
+        SupportedUnityXRPipelines.LegacyXR)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/spatial-awareness-getting-started")]
     public class WindowsMixedRealitySpatialMeshObserver :
         BaseSpatialMeshObserver,

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/HPMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/HPMotionController.cs
@@ -17,7 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.HPMotionController,
-        new[] { Handedness.Left, Handedness.Right })]
+        new[] { Handedness.Left, Handedness.Right },
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class HPMotionController : WindowsMixedRealityXRSDKMotionController
     {
 #if HP_CONTROLLER_ENABLED

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -24,7 +24,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.ArticulatedHand,
-        new[] { Handedness.Left, Handedness.Right })]
+        new[] { Handedness.Left, Handedness.Right },
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class WindowsMixedRealityXRSDKArticulatedHand : BaseWindowsMixedRealityXRSDKSource, IMixedRealityHand
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKGGVHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKGGVHand.cs
@@ -11,7 +11,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.GGVHand,
-        new[] { Handedness.Left, Handedness.Right, Handedness.None })]
+        new[] { Handedness.Left, Handedness.Right, Handedness.None },
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class WindowsMixedRealityXRSDKGGVHand : BaseWindowsMixedRealityXRSDKSource
     {
         public WindowsMixedRealityXRSDKGGVHand(

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -19,7 +19,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
     [MixedRealityController(
         SupportedControllerType.WindowsMixedReality,
         new[] { Handedness.Left, Handedness.Right },
-        "Textures/MotionController")]
+        "Textures/MotionController",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class WindowsMixedRealityXRSDKMotionController : BaseWindowsMixedRealityXRSDKSource
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
@@ -15,7 +15,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         SupportedPlatforms.WindowsUniversal | SupportedPlatforms.WindowsStandalone,
         "XR SDK Windows Mixed Reality Camera Settings",
         "WindowsMixedReality/Shared/Profiles/DefaultWindowsMixedRealityCameraSettingsProfile.asset",
-        "MixedRealityToolkit.Providers")]
+        "MixedRealityToolkit.Providers",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class WindowsMixedRealityCameraSettings : BaseWindowsMixedRealityCameraSettings
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -34,7 +34,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
     [MixedRealityDataProvider(
         typeof(IMixedRealityInputSystem),
         SupportedPlatforms.WindowsStandalone | SupportedPlatforms.WindowsUniversal,
-        "XR SDK Windows Mixed Reality Device Manager")]
+        "XR SDK Windows Mixed Reality Device Manager",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class WindowsMixedRealityDeviceManager : XRSDKDeviceManager
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -21,7 +21,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         SupportedPlatforms.WindowsUniversal,
         "XRSDK Windows Mixed Reality Eye Gaze Provider",
         "Profiles/DefaultMixedRealityEyeTrackingProfile.asset", "MixedRealityToolkit.SDK",
-        true)]
+        true,
+        SupportedUnityXRPipelines.XRSDK)]
     public class WindowsMixedRealityEyeGazeDataProvider : BaseInputDeviceManager, IMixedRealityEyeGazeDataProvider, IMixedRealityEyeSaccadeProvider, IMixedRealityCapabilityCheck
     {
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
@@ -17,7 +17,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         SupportedPlatforms.WindowsUniversal,
         "XR SDK Windows Mixed Reality Spatial Mesh Observer",
         "Profiles/DefaultMixedRealitySpatialAwarenessMeshObserverProfile.asset",
-        "MixedRealityToolkit.SDK")]
+        "MixedRealityToolkit.SDK",
+        true,
+        SupportedUnityXRPipelines.XRSDK)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/spatial-awareness-getting-started")]
     public class WindowsMixedRealitySpatialMeshObserver :
         GenericXRSDKSpatialMeshObserver,

--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -12,7 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
     [MixedRealityController(
         SupportedControllerType.GenericUnity,
         new[] { Handedness.Left, Handedness.Right },
-        flags: MixedRealityControllerConfigurationFlags.UseCustomInteractionMappings)]
+        flags: MixedRealityControllerConfigurationFlags.UseCustomInteractionMappings,
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class GenericXRSDKController : BaseController
     {
         public GenericXRSDKController(

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
@@ -17,7 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
     [MixedRealityDataProvider(
         typeof(IMixedRealityCameraSystem),
         (SupportedPlatforms)(-1),
-        "XR SDK Camera Settings")]
+        "XR SDK Camera Settings",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class GenericXRSDKCameraSettings : BaseCameraSettingsProvider
     {
         /// <summary>

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -19,7 +19,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         (SupportedPlatforms)(-1), // All platforms supported by Unity
         "XR SDK Spatial Mesh Observer",
         "Profiles/DefaultMixedRealitySpatialAwarenessMeshObserverProfile.asset",
-        "MixedRealityToolkit.SDK")]
+        "MixedRealityToolkit.SDK",
+        true,
+        SupportedUnityXRPipelines.XRSDK)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/spatial-awareness-getting-started")]
     public class GenericXRSDKSpatialMeshObserver :
         BaseSpatialMeshObserver,

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -21,7 +21,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
     [MixedRealityDataProvider(
         typeof(IMixedRealityInputSystem),
         SupportedPlatforms.WindowsStandalone | SupportedPlatforms.MacStandalone | SupportedPlatforms.LinuxStandalone | SupportedPlatforms.WindowsUniversal,
-        "XR SDK Device Manager")]
+        "XR SDK Device Manager",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class XRSDKDeviceManager : BaseInputDeviceManager, IMixedRealityCapabilityCheck
     {
         /// <summary>


### PR DESCRIPTION
## Overview

Adds `SupportedUnityXRPipelines` to define which Unity XR pipelines specific controllers and data providers are valid for. This will allow (incoming in a follow-up PR) filtering in the profile UI.

## Changes
- Part of #9419
