### PR TITLE
Ensure XR SDK providers only run on their specified loaders

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -153,21 +153,12 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
 
         #endregion Controller Utilities
 
-        private bool? isActiveLoader = null;
-        private bool IsActiveLoader
-        {
-            get
-            {
+        private bool IsActiveLoader =>
 #if OCULUS_ENABLED
-                if (!isActiveLoader.HasValue)
-                {
-                    isActiveLoader = IsLoaderActive<OculusLoader>();
-                }
+            LoaderHelpers.IsLoaderActive<OculusLoader>();
+#else
+            false;
 #endif // OCULUS_ENABLED
-
-                return isActiveLoader ?? false;
-            }
-        }
 
         /// <inheritdoc/>
         public override void Enable()

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -33,21 +33,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(inputSystem, name, priority, profile) { }
 
-        private bool? isActiveLoader = null;
-        private bool IsActiveLoader
-        {
-            get
-            {
+        private bool IsActiveLoader =>
 #if UNITY_OPENXR
-                if (!isActiveLoader.HasValue)
-                {
-                    isActiveLoader = IsLoaderActive<OpenXRLoaderBase>();
-                }
+            LoaderHelpers.IsLoaderActive<OpenXRLoaderBase>();
+#else
+            false;
 #endif // UNITY_OPENXR
-
-                return isActiveLoader ?? false;
-            }
-        }
 
         /// <inheritdoc />
         public override void Enable()

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using UnityEngine.XR;
 
 #if UNITY_OPENXR
+using UnityEngine.XR.OpenXR;
 using UnityEngine.XR.OpenXR.Features.Interactions;
 #endif // UNITY_OPENXR
 
@@ -43,6 +44,13 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             gazeSmoother.OnSaccadeX += GazeSmoother_OnSaccadeX;
             gazeSmoother.OnSaccadeY += GazeSmoother_OnSaccadeY;
         }
+
+        private bool IsActiveLoader =>
+#if UNITY_OPENXR
+            LoaderHelpers.IsLoaderActive<OpenXRLoaderBase>();
+#else
+            false;
+#endif // UNITY_OPENXR
 
         /// <inheritdoc />
         public bool SmoothEyeTracking { get; set; } = false;
@@ -87,6 +95,18 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             base.Initialize();
         }
 
+        /// <inheritdoc />
+        public override void Enable()
+        {
+            if (!IsActiveLoader)
+            {
+                IsEnabled = false;
+                return;
+            }
+
+            base.Enable();
+        }
+
         private void ReadProfile()
         {
             if (ConfigurationProfile == null)
@@ -116,6 +136,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             using (UpdatePerfMarker.Auto())
             {
+                if (!IsEnabled)
+                {
+                    return;
+                }
+
                 if (!eyeTrackingDevice.isValid)
                 {
                     InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.EyeTracking, InputDeviceList);

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -50,21 +50,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(inputSystem, name, priority, profile) { }
 
-        private bool? isActiveLoader = null;
-        private bool IsActiveLoader
-        {
-            get
-            {
+        private bool IsActiveLoader =>
 #if WMR_ENABLED
-                if (!isActiveLoader.HasValue)
-                {
-                    isActiveLoader = IsLoaderActive("Windows MR Loader");
-                }
+            LoaderHelpers.IsLoaderActive("Windows MR Loader");
+#else
+            false;
 #endif // WMR_ENABLED
-
-                return isActiveLoader ?? false;
-            }
-        }
 
         #region IMixedRealityDeviceManager Interface
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -45,6 +45,13 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             gazeSmoother.OnSaccadeY += GazeSmoother_OnSaccadeY;
         }
 
+        private bool IsActiveLoader =>
+#if WMR_ENABLED
+            LoaderHelpers.IsLoaderActive("Windows MR Loader");
+#else
+            false;
+#endif // WMR_ENABLED
+
         /// <inheritdoc />
         public bool SmoothEyeTracking { get; set; } = false;
 
@@ -66,6 +73,18 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         [Obsolete("Register for this provider's SaccadeProvider's actions instead")]
         public event Action OnSaccadeY;
         private void GazeSmoother_OnSaccadeY() => OnSaccadeY?.Invoke();
+
+        /// <inheritdoc />
+        public override void Enable()
+        {
+            if (!IsActiveLoader)
+            {
+                IsEnabled = false;
+                return;
+            }
+
+            base.Enable();
+        }
 
         #region IMixedRealityCapabilityCheck Implementation
 
@@ -126,6 +145,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         {
             using (UpdatePerfMarker.Auto())
             {
+                if (!IsEnabled)
+                {
+                    return;
+                }
+
                 if (!centerEye.isValid)
                 {
                     centerEye = InputDevices.GetDeviceAtXRNode(XRNode.CenterEye);

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
@@ -37,6 +37,13 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         { }
 
+        protected override bool IsActiveLoader =>
+#if WMR_ENABLED
+            LoaderHelpers.IsLoaderActive("Windows MR Loader");
+#else
+            false;
+#endif // WMR_ENABLED
+
         private static readonly ProfilerMarker ConfigureObserverVolumePerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealitySpatialMeshObserver.ConfigureObserverVolume");
 
         private Vector3 oldObserverOrigin = Vector3.zero;

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -39,6 +39,22 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         { }
 
+        // Don't run this one on Windows MR, since that has its own observer
+        // There's probably a better way to manage these two...
+        protected virtual bool IsActiveLoader => !LoaderHelpers.IsLoaderActive("Windows MR Loader");
+
+        /// <inheritdoc />
+        public override void Enable()
+        {
+            if (!IsActiveLoader)
+            {
+                IsEnabled = false;
+                return;
+            }
+
+            base.Enable();
+        }
+
         #region BaseSpatialObserver Implementation
 
         private XRMeshSubsystem meshSubsystem;
@@ -131,6 +147,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             using (UpdatePerfMarker.Auto())
             {
+                if (!IsEnabled)
+                {
+                    return;
+                }
+
                 base.Update();
                 UpdateObserver();
             }

--- a/Assets/MRTK/Providers/XRSDK/LoaderHelpers.cs
+++ b/Assets/MRTK/Providers/XRSDK/LoaderHelpers.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if XR_MANAGEMENT_ENABLED
+using UnityEngine.XR.Management;
+#endif
+
+namespace Microsoft.MixedReality.Toolkit.XRSDK
+{
+    public static class LoaderHelpers
+    {
+        /// <summary>
+        /// Checks if the active loader has a specific name. Used in cases where the loader class is internal, like WindowsMRLoader.
+        /// </summary>
+        /// <param name="loaderName">The string name to compare against the active loader.</param>
+        /// <returns>True if the active loader has the same name as the parameter.</returns>
+        public static bool IsLoaderActive(string loaderName) =>
+#if XR_MANAGEMENT_ENABLED
+            XRGeneralSettings.Instance != null
+            && XRGeneralSettings.Instance.Manager != null
+            && XRGeneralSettings.Instance.Manager.activeLoader != null
+            && XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
+#else
+            false;
+#endif
+
+#if XR_MANAGEMENT_ENABLED
+        /// <summary>
+        /// Checks if the active loader is of a specific type. Used in cases where the loader class is accessible, like OculusLoader.
+        /// </summary>
+        /// <typeparam name="T">The loader class type to check against the active loader.</typeparam>
+        /// <returns>True if the active loader is of the specified type.</returns>
+        public static bool IsLoaderActive<T>() where T : XRLoader =>
+            XRGeneralSettings.Instance != null
+            && XRGeneralSettings.Instance.Manager != null
+            && XRGeneralSettings.Instance.Manager.activeLoader is T;
+#endif
+    }
+}

--- a/Assets/MRTK/Providers/XRSDK/LoaderHelpers.cs.meta
+++ b/Assets/MRTK/Providers/XRSDK/LoaderHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d5accc365a0a584ab4330f2ce52d821
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -62,15 +62,16 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// </summary>
         /// <param name="loaderName">The string name to compare against the active loader.</param>
         /// <returns>True if the active loader has the same name as the parameter.</returns>
-        protected virtual bool IsLoaderActive(string loaderName) => XRGeneralSettings.Instance != null && XRGeneralSettings.Instance.Manager != null &&
-            XRGeneralSettings.Instance.Manager.activeLoader != null && XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
+        [Obsolete("Use XRSDKLoaderHelpers instead.")]
+        protected virtual bool IsLoaderActive(string loaderName) => LoaderHelpers.IsLoaderActive(loaderName);
 
         /// <summary>
         /// Checks if the active loader is of a specific type. Used in cases where the loader class is accessible, like OculusLoader.
         /// </summary>
         /// <typeparam name="T">The loader class type to check against the active loader.</typeparam>
         /// <returns>True if the active loader is of the specified type.</returns>
-        protected virtual bool IsLoaderActive<T>() where T : XRLoader => XRGeneralSettings.Instance != null && XRGeneralSettings.Instance.Manager != null && XRGeneralSettings.Instance.Manager.activeLoader is T;
+        [Obsolete("Use XRSDKLoaderHelpers instead.")]
+        protected virtual bool IsLoaderActive<T>() where T : XRLoader => LoaderHelpers.IsLoaderActive<T>();
 #endif // XR_MANAGEMENT_ENABLED
 
         private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] XRSDKDeviceManager.Update");


### PR DESCRIPTION
## Overview

Slightly updates the existing pattern, refactors the methods out so other non-input providers can use them, and ensures all XR SDK providers across spatial and input check their loader before enabling.

## Changes
- Part of #9419, follow-up to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9338