### PR TITLE
Add configurable UI filter for null providers

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
@@ -49,6 +49,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static readonly GUIContent ComponentTypeLabel = new GUIContent("Type");
         private static readonly GUIContent SupportedPlatformsLabel = new GUIContent("Supported Platform(s)");
 
+        private const string NewDataProvider = "New data provider";
+
         /// <inheritdoc/>
         protected override void OnEnable()
         {
@@ -72,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             SerializedProperty provider = providerConfigurations.GetArrayElementAtIndex(providerConfigurations.arraySize - 1);
 
             ServiceConfigurationProperties providerProperties = GetDataProviderConfigurationProperties(provider);
-            providerProperties.componentName.stringValue = $"New data provider {providerConfigurations.arraySize - 1}";
+            providerProperties.componentName.stringValue = $"{NewDataProvider} {providerConfigurations.arraySize - 1}";
             providerProperties.runtimePlatform.intValue = -1;
             providerProperties.providerProfile.objectReferenceValue = null;
 
@@ -162,7 +164,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             var serviceType = GetDataProviderConfiguration(index).ComponentType;
 
-            if (serviceType?.Type == null && !MixedRealityProjectPreferences.ShowNullDataProviders)
+            // Don't hide new data providers added via the UI, otherwise there's no easy way to change their type
+            if (serviceType?.Type == null && !MixedRealityProjectPreferences.ShowNullDataProviders && !providerProperties.componentName.stringValue.StartsWith(NewDataProvider))
             {
                 return false;
             }

--- a/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
@@ -162,9 +162,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             var serviceType = GetDataProviderConfiguration(index).ComponentType;
 
-
-            SerializedProperty typeProperty = providerProperties.componentType.FindPropertyRelative("reference");
-            if (!string.IsNullOrEmpty(typeProperty.stringValue) && Type.GetType(typeProperty.stringValue) == null && !MixedRealityProjectPreferences.ShowNullDataProviders)
+            if (serviceType?.Type == null && !MixedRealityProjectPreferences.ShowNullDataProviders)
             {
                 return false;
             }

--- a/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/DataProviderAccessServiceInspector.cs
@@ -162,6 +162,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             var serviceType = GetDataProviderConfiguration(index).ComponentType;
 
+
+            SerializedProperty typeProperty = providerProperties.componentType.FindPropertyRelative("reference");
+            if (!string.IsNullOrEmpty(typeProperty.stringValue) && Type.GetType(typeProperty.stringValue) == null && !MixedRealityProjectPreferences.ShowNullDataProviders)
+            {
+                return false;
+            }
+
             using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
             {
                 using (new EditorGUILayout.HorizontalScope())

--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
@@ -122,6 +122,34 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #endregion Run optimal configuration analysis on Play
 
+        #region Display null data providers
+
+        private static readonly GUIContent NullDataProviderContent = new GUIContent("Show null data providers in the input profile", "Mainly used for debugging unexpected behavior. Will render null data providers in red in the inspector.");
+        private const string NULL_DATA_PROVIDER_KEY = "MixedRealityToolkit_Editor_NullDataProviders";
+        private static bool nullDataProviderPrefLoaded;
+        private static bool nullDataProvider;
+
+        /// <summary>
+        /// Whether to show null data providers in the profile UI.
+        /// </summary>
+        /// <remarks>Mainly used for debugging unexpected behavior. Data providers may be null due to a namespace change or while using an incompatible Unity version.</remarks>
+        public static bool ShowNullDataProviders
+        {
+            get
+            {
+                if (!nullDataProviderPrefLoaded)
+                {
+                    nullDataProvider = ProjectPreferences.Get(NULL_DATA_PROVIDER_KEY, false);
+                    nullDataProviderPrefLoaded = true;
+                }
+
+                return nullDataProvider;
+            }
+            set => ProjectPreferences.Set(NULL_DATA_PROVIDER_KEY, nullDataProvider = value);
+        }
+
+        #endregion Display null data providers
+
         #region Project configuration cache
 
         // This section contains data that gets cached for future reference to help detect configuration
@@ -210,6 +238,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 if (EditorGUI.EndChangeCheck())
                 {
                     RunOptimalConfiguration = runOptimalConfig;
+                }
+
+                bool nullProviders = EditorGUILayout.Toggle(NullDataProviderContent, ShowNullDataProviders);
+                if (ShowNullDataProviders != nullProviders)
+                {
+                    ShowNullDataProviders = nullProviders;
                 }
 
                 EditorGUIUtility.labelWidth = prevLabelWidth;


### PR DESCRIPTION
## Overview

Makes showing null data providers in the UI optional (doesn't apply to newly added providers which haven't yet been assigned a type).

This becomes important for filtering provider types in the UI, since filtering happens via the attribute (incoming in #9670). If the type isn't loadable, the attribute isn't loadable, and the type is unfiltered in the UI and can be confusing.

For debugging purposes, the checkbox in settings can be enabled to make all providers visible.

## Changes
- Part of #9419
