### PR TITLE
Don't constantly recreate the base profile editor

### DIFF
--- a/Assets/MRTK/Core/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityToolkitInspector.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     public class MixedRealityToolkitInspector : UnityEditor.Editor
     {
         private SerializedProperty activeProfile;
+        private UnityEditor.Editor activeProfileEditor;
 
         private void OnEnable()
         {
@@ -33,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 {
                     if (GUILayout.Button("Select Active Instance"))
                     {
-                        UnityEditor.Selection.activeGameObject = MixedRealityToolkit.Instance.gameObject;
+                        Selection.activeGameObject = MixedRealityToolkit.Instance.gameObject;
                     }
 
                     if (GUILayout.Button("Make this the Active Instance"))
@@ -46,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             serializedObject.Update();
 
-            // If not profile is assigned, then warn user
+            // If no profile is assigned, then warn user
             if (activeProfile.objectReferenceValue == null)
             {
                 EditorGUILayout.HelpBox("MixedRealityToolkit cannot initialize unless an Active Profile is assigned!", MessageType.Error);
@@ -59,12 +60,17 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (changed)
             {
                 MixedRealityToolkit.Instance.ResetConfiguration((MixedRealityToolkitConfigurationProfile)activeProfile.objectReferenceValue);
+                activeProfileEditor = null;
             }
 
-            if (activeProfile.objectReferenceValue != null)
+            if (activeProfile.objectReferenceValue != null && activeProfileEditor == null)
             {
-                // For configure, show the default inspector GUI
-                UnityEditor.Editor activeProfileEditor = CreateEditor(activeProfile.objectReferenceValue);
+                // For the configuration profile, show the default inspector GUI
+                activeProfileEditor = CreateEditor(activeProfile.objectReferenceValue);
+            }
+
+            if (activeProfileEditor != null)
+            {
                 activeProfileEditor.OnInspectorGUI();
             }
         }


### PR DESCRIPTION
## Overview

`MixedRealityToolkitInspector` was recreating the configuration profile's inspector in `OnInspectorGUI`, which happens...a lot. This lead to unexpected behavior in `OnEnable` for things that weren't expected to happen often.

This change makes it so we reuse the most recent editor unless the editor has gone null, or the profile is changed

## Changes
- Part of #9419
