### PR TITLE
Hand mesh and scene updates

### DIFF
--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -14501,7 +14501,7 @@ PrefabInstance:
     - target: {fileID: 4943773361295851263, guid: c0931c4da6d91ea429abedb10290dd16,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6325538427078370090, guid: c0931c4da6d91ea429abedb10290dd16,
         type: 3}

--- a/Assets/MRTK/Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubSceneSystemProfile.asset
+++ b/Assets/MRTK/Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubSceneSystemProfile.asset
@@ -33,116 +33,116 @@ MonoBehaviour:
   contentScenes:
   - Name: MRTKExamplesHubMainMenu
     Path: Assets/MRTK/Examples/Experimental/ExamplesHub/Scenes/MRTKExamplesHubMainMenu.unity
-    Included: 1
-    BuildIndex: 1
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 63a00118e809c754f9c7911bb85d635f, type: 3}
   - Name: HandInteractionExamples
     Path: Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
     Included: 1
-    BuildIndex: 2
+    BuildIndex: 0
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 3dd4a396b5225f8469b9a1eb608bfa57, type: 3}
   - Name: ClippingExamples
     Path: Assets/MRTK/Examples/Demos/StandardShader/Scenes/ClippingExamples.unity
-    Included: 1
-    BuildIndex: 3
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: e532091edada3e04aa706112e8d5f310, type: 3}
   - Name: TooltipExamples
     Path: Assets/MRTK/Examples/Demos/UX/Tooltips/Scenes/TooltipExamples.unity
-    Included: 1
-    BuildIndex: 4
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: de90a43947eced441b4c426e11f35f28, type: 3}
   - Name: MaterialGallery
     Path: Assets/MRTK/Examples/Demos/StandardShader/Scenes/MaterialGallery.unity
-    Included: 1
-    BuildIndex: 5
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: c6b1477d31864dff836e9738518eae60, type: 3}
   - Name: BoundingBoxExamples
     Path: Assets/MRTK/Examples/Demos/UX/BoundingBox/Scenes/BoundingBoxExamples.unity
-    Included: 1
-    BuildIndex: 6
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 9da574c0affd04d42a6b1e5db09e82b4, type: 3}
   - Name: PressableButtonExample
     Path: Assets/MRTK/Examples/Demos/UX/PressableButton/Scenes/PressableButtonExample.unity
-    Included: 1
-    BuildIndex: 7
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: b2d06bb8d7f107d4783a56c796c5c120, type: 3}
   - Name: HandMenuExamples
     Path: Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandMenuExamples.unity
-    Included: 1
-    BuildIndex: 8
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 2792ec9767804e644906ab978f2eed23, type: 3}
   - Name: SlateExample
     Path: Assets/MRTK/Examples/Demos/UX/Slate/SlateExample.unity
-    Included: 1
-    BuildIndex: 9
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 86e8b0c6246dbb74aa04ecd40a57d89c, type: 3}
   - Name: SliderExample
     Path: Assets/MRTK/Examples/Demos/UX/Slider/Scenes/SliderExample.unity
-    Included: 1
-    BuildIndex: 10
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 086aad2912678d04e968264b2398004b, type: 3}
   - Name: EyeTrackingDemo-02-TargetSelection
     Path: Assets/MRTK/Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-02-TargetSelection.unity
-    Included: 1
-    BuildIndex: 11
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 55643f7e4eceb734784192b162f565e0, type: 3}
   - Name: EyeTrackingDemo-03-Navigation
     Path: Assets/MRTK/Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation.unity
-    Included: 1
-    BuildIndex: 12
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 5df475f0bf57b1f488d59e0e16040d9a, type: 3}
   - Name: EyeTrackingDemo-04-TargetPositioning
     Path: Assets/MRTK/Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-04-TargetPositioning.unity
-    Included: 1
-    BuildIndex: 13
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 91ded1f5ef2ae854ba4ac94eca7a2494, type: 3}
   - Name: EyeTrackingDemo-05-Visualizer
     Path: Assets/MRTK/Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-05-Visualizer.unity
-    Included: 1
-    BuildIndex: 14
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 2d6c43a82f3a88c4dbdc3b5e99a68d8a, type: 3}
   - Name: NearMenuExamples
     Path: Assets/MRTK/Examples/Demos/HandTracking/Scenes/NearMenuExamples.unity
-    Included: 1
-    BuildIndex: 15
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: bf3eb3415bffceb41810526380c2c71c, type: 3}
   - Name: ScrollingObjectCollection
     Path: Assets/MRTK/Examples/Demos/ScrollingObjectCollection/Scenes/ScrollingObjectCollection.unity
-    Included: 1
-    BuildIndex: 17
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 79a0bb4c0426b7a4099c35eeced52ee4, type: 3}
   - Name: HandCoachExample
     Path: Assets/MRTK/Examples/Demos/HandCoach/Scenes/HandCoachExample.unity
-    Included: 1
-    BuildIndex: 19
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 58e887502677eb649950ada695c4ad38, type: 3}
   - Name: SceneUnderstandingExample
     Path: Assets/MRTK/Examples/Experimental/SceneUnderstanding/Scenes/SceneUnderstandingExample.unity
-    Included: 1
-    BuildIndex: 20
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: d42a352dc9a8c4d4990a924687759199, type: 3}
   - Name: SurfaceMagnetismSpatialAwarenessExample
     Path: Assets/MRTK/Examples/Demos/Solvers/Scenes/SurfaceMagnetismSpatialAwarenessExample.unity
-    Included: 1
-    BuildIndex: 18
+    Included: 0
+    BuildIndex: -1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 8feae87497f549c4e8dc08a6e4b7b15c, type: 3}
   permittedLightingSceneComponentTypes:

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -33,7 +33,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         private WindowsMixedRealityHandMeshProvider(Handedness handedness) => this.handedness = handedness;
 
         [Obsolete("WindowsMixedRealityHandMeshProvider(IMixedRealityController) is obsolete. Please use either the static Left or Right members and call SetInputSource()")]
-        public WindowsMixedRealityHandMeshProvider(IMixedRealityController controller) => inputSource = controller.InputSource;
+        public WindowsMixedRealityHandMeshProvider(IMixedRealityController controller) : this(controller.ControllerHandedness)
+        {
+            SetInputSource(controller.InputSource);
+        }
 
         private readonly Handedness handedness;
         private IMixedRealityInputSource inputSource = null;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PulseShader/PulseShaderHandMeshHandler.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PulseShader/PulseShaderHandMeshHandler.cs
@@ -188,20 +188,14 @@ namespace Microsoft.MixedReality.Toolkit.UI.PulseShader
         // Check if the palm is facing the camera
         private bool IsAPalmFacingCamera()
         {
-            foreach (IMixedRealityController c in CoreServices.InputSystem.DetectedControllers)
+            foreach (IMixedRealityController controller in CoreServices.InputSystem.DetectedControllers)
             {
-                if (c.ControllerHandedness.IsMatch(Handedness.Both))
+                if (controller.ControllerHandedness.IsMatch(Handedness.Both)
+                    && controller is IMixedRealityHand jointedHand
+                    && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out MixedRealityPose palmPose)
+                    && Vector3.Dot(palmPose.Up, CameraCache.Main.transform.forward) > 0.0f)
                 {
-                    MixedRealityPose palmPose;
-                    var jointedHand = c as IMixedRealityHand;
-
-                    if ((jointedHand != null) && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
-                    {
-                        if (Vector3.Dot(palmPose.Up, CameraCache.Main.transform.forward) > 0.0f)
-                        {
-                            return true;
-                        }
-                    }
+                    return true;
                 }
             }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/FeaturesPanelVisuals.cs
@@ -21,8 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         private Interactable handJointsButton = null;
 
-        // Start is called before the first frame update
-        void Start()
+        private void Start()
         {
             profilerButton.IsToggled = (CoreServices.DiagnosticsSystem?.ShowProfiler).GetValueOrDefault(false);
             handRayButton.IsToggled = PointerUtils.GetPointerBehavior<ShellHandRayPointer>(Handedness.Any, InputSourceType.Hand) != PointerBehavior.AlwaysOff;
@@ -32,8 +31,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 handProfile = CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile;
             }
-            handMeshButton.IsToggled = (handProfile != null) ? handProfile.EnableHandMeshVisualization : false;
-            handJointsButton.IsToggled = (handProfile != null) ? handProfile.EnableHandJointVisualization : false;
+            handMeshButton.IsToggled = handProfile != null && handProfile.EnableHandMeshVisualization;
+            handJointsButton.IsToggled = handProfile != null && handProfile.EnableHandJointVisualization;
         }
     }
 }

--- a/Assets/MRTK/SDK/StandardAssets/Prefabs/ArticulatedHandMesh.prefab
+++ b/Assets/MRTK/SDK/StandardAssets/Prefabs/ArticulatedHandMesh.prefab
@@ -57,7 +57,7 @@ MeshRenderer:
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 8898ca407d928454d876a616ba1be32e, type: 2}
+  - {fileID: 2100000, guid: 45082b98567b3d44ca3bdbe39f46041a, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0


### PR DESCRIPTION
## Overview

* Reverts a couple changes in #9613 which made the hand mesh impossible to trigger in the HandInteractionExamples scene
    * Reverts the material change on the hand mesh prefab back to the "always visible" material vs the pulse material
    * Re-enables the hand feature toggle panel in the scene
    * Update the scene system profile, which Unity keeps reserializing, to the checked-in state of the repo
* Fixes the obsolete `WindowsMixedRealityHandMeshProvider` to still function properly
* Minor syntax updates in `FeaturesPanelVisuals` and `PulseShaderHandMeshHandler` for clarity