### PR TITLE
Better format the handler type in the BaseEventSystem log

### DIFF
--- a/Assets/MRTK/Core/Services/BaseEventSystem.cs
+++ b/Assets/MRTK/Core/Services/BaseEventSystem.cs
@@ -174,7 +174,7 @@ namespace Microsoft.MixedReality.Toolkit
 #endif
             Debug.Assert(typeof(T).IsAssignableFrom(handler.GetType()), "Handler passed to RegisterHandler doesn't implement a type given as generic parameter.");
 
-            DebugUtilities.LogVerboseFormat("Registering handler {0} against system {1}", handler, this);
+            DebugUtilities.LogVerboseFormat("Registering handler {0} against system {1}", handler.ToString().Trim(), this);
 
             TraverseEventSystemHandlerHierarchy<T>(handler, RegisterHandler);
         }


### PR DESCRIPTION
## Overview

When I was running verbose logging for some testing, I noticed that some handler `ToString()` representations (mostly the input module) ended with some newlines for some reason. This change trims those out for better formatting.