### PR TITLE
Only use scenes specified in command line when flags are present

### DIFF
--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
@@ -224,13 +224,13 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                         buildInfo.AutoIncrement = true;
                         break;
                     case "-sceneList":
-                        buildInfo.Scenes = buildInfo.Scenes.Union(SplitSceneList(arguments[++i]));
+                        buildInfo.Scenes = SplitSceneList(arguments[++i]);
                         break;
                     case "-sceneListFile":
                         string path = arguments[++i];
                         if (File.Exists(path))
                         {
-                            buildInfo.Scenes = buildInfo.Scenes.Union(SplitSceneList(File.ReadAllText(path)));
+                            buildInfo.Scenes = SplitSceneList(File.ReadAllText(path));
                         }
                         else
                         {

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
@@ -215,6 +215,10 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         public static void ParseBuildCommandLine(ref IBuildInfo buildInfo)
         {
             string[] arguments = Environment.GetCommandLineArgs();
+            
+            // Boolean used to track whether builfInfo contains scenes that are not specified by command line arguments.
+            // These non command line arugment scenes should be overwritten by those specified in the command line.
+            bool buildInfoContainsNonCommandLineScene = buildInfo.Scenes.Count() > 0;
 
             for (int i = 0; i < arguments.Length; ++i)
             {
@@ -224,13 +228,29 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                         buildInfo.AutoIncrement = true;
                         break;
                     case "-sceneList":
-                        buildInfo.Scenes = SplitSceneList(arguments[++i]);
+                        if (buildInfoContainsNonCommandLineScene)
+                        {
+                            buildInfo.Scenes = SplitSceneList(arguments[++i]);
+                            buildInfoContainsNonCommandLineScene = false;
+                        }
+                        else
+                        {
+                            buildInfo.Scenes = buildInfo.Scenes.Union(SplitSceneList(arguments[++i]));
+                        }
                         break;
                     case "-sceneListFile":
                         string path = arguments[++i];
                         if (File.Exists(path))
                         {
-                            buildInfo.Scenes = SplitSceneList(File.ReadAllText(path));
+                            if (buildInfoContainsNonCommandLineScene)
+                            {
+                                buildInfo.Scenes = SplitSceneList(File.ReadAllText(path));
+                                buildInfoContainsNonCommandLineScene = false;
+                            }
+                            else
+                            {
+                                buildInfo.Scenes = buildInfo.Scenes.Union(SplitSceneList(File.ReadAllText(path)));
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
## Overview
This PR makes the build tool only use scenes specified by the sceneList or sceneListFile flags when the flags are present.

## Changes
- Fixes #9677