### PR TITLE
Update scene content alignment and boundary system

### DIFF
--- a/Assets/MRTK/Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
@@ -152,7 +152,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         public bool IsBoundarySystemEnabled
         {
-            get { return boundarySystemType != null && boundarySystemType.Type != null && enableBoundarySystem && boundaryVisualizationProfile != null; }
+            get { return BoundarySystemSystemType != null && BoundarySystemSystemType.Type != null && enableBoundarySystem && boundaryVisualizationProfile != null; }
             internal set { enableBoundarySystem = value; }
         }
 

--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -47,6 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// <summary>
         /// Whether any XR device is present.
         /// </summary>
+        [System.Obsolete("This value is no longer used.")]
         protected virtual bool IsXRDevicePresent { get; } = true;
 
         #region IMixedRealityService Implementation
@@ -69,7 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             // after profile change reads the correct data.
             ReadProfile();
 
-            if (!Application.isPlaying || !IsXRDevicePresent) { return; }
+            if (!Application.isPlaying || !DeviceUtility.IsPresent) { return; }
 
             boundaryEventData = new BoundaryEventData(EventSystem.current);
 

--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -82,6 +82,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             RaiseBoundaryVisualizationChanged();
         }
 
+#if UNITY_EDITOR
         public override void Update()
         {
             base.Update();
@@ -92,6 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                 Initialize();
             }
         }
+#endif // UNITY_EDITOR
 
         /// <inheritdoc/>
         public override void Destroy()

--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -59,12 +59,11 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// <inheritdoc/>
         public override string Name { get; protected set; } = "Mixed Reality Boundary System";
 
-        private bool boundarySystemInitialized = false;
-
         /// <inheritdoc/>
         public override void Initialize()
         {
-            base.Initialize();
+            // Initialize this value earlier than other systems, so we can use it to block boundary events being raised too early
+            IsInitialized = false;
 
             // The profile needs to be read on initialization to ensure that re-initialization
             // after profile change reads the correct data.
@@ -77,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             SetTrackingSpace();
             CalculateBoundaryBounds();
 
-            boundarySystemInitialized = true;
+            base.Initialize();
 
             RefreshVisualization();
             RaiseBoundaryVisualizationChanged();
@@ -527,7 +526,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         {
             // If not done initializing, no need to raise the changed event or check the visualization.
             // These will both happen at the end of the initialization flow.
-            if (!boundarySystemInitialized)
+            if (!IsInitialized)
             {
                 return;
             }

--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -82,6 +82,16 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             RaiseBoundaryVisualizationChanged();
         }
 
+        public override void Update()
+        {
+            base.Update();
+
+            // If a device is attached late, initialize with the new state of the world
+            if (!IsInitialized && DeviceUtility.IsPresent)
+            {
+                Initialize();
+            }
+        }
 
         /// <inheritdoc/>
         public override void Destroy()

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -470,7 +470,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
 
             // If the Boundary system has been selected for initialization in the Active profile, enable it in the project
-            if (ActiveProfile.IsBoundarySystemEnabled && !ActiveProfile.ExperienceSettingsProfile.IsNull())
+            if (ActiveProfile.IsBoundarySystemEnabled && ActiveProfile.ExperienceSettingsProfile != null)
             {
                 DebugUtilities.LogVerbose("Begin registration of the boundary system");
                 object[] args = { ActiveProfile.BoundaryVisualizationProfile, ActiveProfile.ExperienceSettingsProfile.TargetExperienceScale };

--- a/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
+++ b/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
@@ -34,6 +34,7 @@ namespace Microsoft.MixedReality.Toolkit
         private Transform containerObject = null;
 
         private Vector3 contentPosition = Vector3.zero;
+        private const uint MaxEditorFrameWaitCount = 5;
 
         private void Awake()
         {
@@ -46,10 +47,22 @@ namespace Microsoft.MixedReality.Toolkit
             StartCoroutine(InitializeSceneContentWithDelay());
         }
 
-        // Not waiting a frame often caused the camera's position to be incorrect at this point. This seems like a Unity bug.
+        // Not waiting often caused the camera's position to be incorrect at this point. This seems like a Unity bug.
+        // Editor takes a little longer to init.
         private IEnumerator InitializeSceneContentWithDelay()
         {
-            yield return null;
+            if (Application.isEditor)
+            {
+                for (int i = 0; i < MaxEditorFrameWaitCount; i++)
+                {
+                    yield return null;
+                }
+            }
+            else
+            {
+                yield return null;
+            }
+
             InitializeSceneContent();
         }
 

--- a/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
+++ b/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// </summary>
     public class MixedRealitySceneContent : MonoBehaviour
     {
-        public enum AlignmentType
+        private enum AlignmentType
         {
             AlignWithExperienceScale,
             AlignWithHeadHeight
@@ -27,12 +27,13 @@ namespace Microsoft.MixedReality.Toolkit
 
         [SerializeField]
         [Tooltip("Select this if the container should be placed in front of the head on app launch in a room scale app.")]
-        public AlignmentType alignmentType = AlignmentType.AlignWithExperienceScale;
+        private AlignmentType alignmentType = AlignmentType.AlignWithExperienceScale;
 
-        private Vector3 contentPosition = Vector3.zero;
-
+        [SerializeField]
         [Tooltip("Optional container object reference. If null, this script will move the object it's attached to.")]
         private Transform containerObject = null;
+
+        private Vector3 contentPosition = Vector3.zero;
 
         private void Awake()
         {
@@ -77,8 +78,8 @@ namespace Microsoft.MixedReality.Toolkit
 #if UNITY_2020_1_OR_NEWER
                     XRSubsystemHelpers.InputSubsystem != null && XRSubsystemHelpers.InputSubsystem.GetTrackingOriginMode().HasFlag(TrackingOriginModeFlags.Floor);
 #elif UNITY_2019_1_OR_NEWER
-#pragma warning disable 0618
                     (XRSubsystemHelpers.InputSubsystem != null && XRSubsystemHelpers.InputSubsystem.GetTrackingOriginMode().HasFlag(TrackingOriginModeFlags.Floor)) ||
+#pragma warning disable 0618
                     (XRDevice.isPresent && XRDevice.GetTrackingSpaceType() == TrackingSpaceType.RoomScale);
 #pragma warning restore 0618
 #else

--- a/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
+++ b/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
@@ -111,11 +111,6 @@ namespace Microsoft.MixedReality.Toolkit
 
                     containerObject.position = contentPosition;
                 }
-                else
-                {
-                    contentPosition = Vector3.zero;
-                    containerObject.position = contentPosition;
-                }
             }
 
             if (alignmentType == AlignmentType.AlignWithHeadHeight)

--- a/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
+++ b/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
@@ -35,6 +35,7 @@ namespace Microsoft.MixedReality.Toolkit
 
         private Vector3 contentPosition = Vector3.zero;
         private const uint MaxEditorFrameWaitCount = 5;
+        private Coroutine initializeSceneContentWithDelay;
 
         private void Awake()
         {
@@ -44,7 +45,15 @@ namespace Microsoft.MixedReality.Toolkit
             }
 
             // Init the content height on non-XR platforms
-            StartCoroutine(InitializeSceneContentWithDelay());
+            initializeSceneContentWithDelay = StartCoroutine(InitializeSceneContentWithDelay());
+        }
+
+        private void OnDestroy()
+        {
+            if (initializeSceneContentWithDelay != null)
+            {
+                StopCoroutine(initializeSceneContentWithDelay);
+            }
         }
 
         // Not waiting often caused the camera's position to be incorrect at this point. This seems like a Unity bug.
@@ -64,6 +73,8 @@ namespace Microsoft.MixedReality.Toolkit
             }
 
             InitializeSceneContent();
+
+            initializeSceneContentWithDelay = null;
         }
 
 

--- a/Assets/MRTK/Core/Utilities/XRSettingsUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/XRSettingsUtilities.cs
@@ -15,9 +15,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     /// </summary>
     public static class XRSettingsUtilities
     {
-#if UNITY_2019_3_OR_NEWER
+#if UNITY_2019_3_OR_NEWER && !UNITY_2020_2_OR_NEWER
         private static bool? legacyXRAvailable = null;
-#endif // UNITY_2019_3_OR_NEWER
+#endif // UNITY_2019_3_OR_NEWER && !UNITY_2020_2_OR_NEWER
 
         /// <summary>
         /// Checks if an XR SDK plug-in is installed that disables legacy VR. Returns false if so.
@@ -26,7 +26,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             get
             {
-#if UNITY_2019_3_OR_NEWER
+#if UNITY_2020_2_OR_NEWER
+                return false;
+#elif UNITY_2019_3_OR_NEWER
                 if (!legacyXRAvailable.HasValue)
                 {
                     legacyXRAvailable = true;
@@ -47,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 return legacyXRAvailable.HasValue && legacyXRAvailable.Value;
 #else
                 return true;
-#endif // UNITY_2019_3_OR_NEWER
+#endif // UNITY_2020_2_OR_NEWER
             }
         }
     }

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -25520,7 +25520,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c65c9dd2f312b8d41b8849d58e1053fa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  alignmentType: 0
+  alignmentType: 1
+  containerObject: {fileID: 0}
 --- !u!114 &1700502666 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4448574576992466704, guid: ffbe4bef620a0a542bb77fe2f765c905,

--- a/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
@@ -30,17 +30,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         private static readonly List<XRInputSubsystem> XRInputSubsystems = new List<XRInputSubsystem>();
 #endif // UNITY_2019_3_OR_NEWER
 
-        /// <inheritdoc/>
-        protected override bool IsXRDevicePresent
-        {
-            get
-            {
-                List<InputDevice> devices = new List<InputDevice>();
-                InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.HeadMounted, devices);
-                return devices.Count > 0;
-            }
-        }
-
         #region IMixedRealityService Implementation
 
         /// <inheritdoc/>

--- a/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
@@ -54,11 +54,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                         xrInputSubsystem.TryGetBoundaryPoints(boundaryGeometry) &&
                         boundaryGeometry.Count > 0)
                     {
-                        return boundaryGeometry;
+                        break;
                     }
                 }
 #endif // UNITY_2019_3_OR_NEWER
-                return null;
             }
 
             return boundaryGeometry;

--- a/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
@@ -40,12 +40,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         /// <inheritdoc/>
         protected override List<Vector3> GetBoundaryGeometry()
         {
-            // Boundaries are supported for Room Scale experiences only.
-            if (XRSubsystemHelpers.InputSubsystem?.GetTrackingOriginMode() != TrackingOriginModeFlags.Floor)
-            {
-                return null;
-            }
-
             // Get the boundary geometry.
             var boundaryGeometry = new List<Vector3>(0);
 

--- a/Assets/MRTK/SDK/Profiles/HoloLens2/DefaultHoloLens2ConfigurationProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/HoloLens2/DefaultHoloLens2ConfigurationProfile.asset
@@ -25,7 +25,7 @@ MonoBehaviour:
   inputSystemProfile: {fileID: 11400000, guid: bec5ceabcd10992439d51532332137f9, type: 2}
   inputSystemType:
     reference: Microsoft.MixedReality.Toolkit.Input.MixedRealityInputSystem, Microsoft.MixedReality.Toolkit.Services.InputSystem
-  enableBoundarySystem: 0
+  enableBoundarySystem: 1
   boundarySystemType:
     reference: Microsoft.MixedReality.Toolkit.Boundary.MixedRealityBoundarySystem,
       Microsoft.MixedReality.Toolkit.Services.BoundarySystem

--- a/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
+++ b/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
@@ -24,9 +24,6 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             MixedRealityBoundaryVisualizationProfile profile,
             ExperienceScale scale) : base(profile, scale) { }
 
-        /// <inheritdoc/>
-        protected override bool IsXRDevicePresent => XRDevice.isPresent;
-
         #region IMixedRealityService Implementation
 
         /// <inheritdoc/>

--- a/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
@@ -22,7 +22,7 @@ using UnityEngine.TestTools;
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
     // Tests to verify that cursor state is updated correctly
-    public class BaseCursorTests
+    public class BaseCursorTests : BasePlayModeTests
     {
         // Keeping this low by default so the test runs fast. Increase it to be able to see hand movements in the editor.
         private const int numFramesPerMove = 1;
@@ -41,10 +41,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// for examples.
         /// See also comments at <see cref="TestUtilities.PlayspaceToArbitraryPose"/>.
         /// </remarks>
-        [UnitySetUp]
-        public IEnumerator SetUp()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
+
             TestUtilities.PlayspaceToArbitraryPose();
 
             // Target frame rate is set to 50 to match the physics
@@ -69,12 +69,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
         }
 
-        [UnityTearDown]
-        public IEnumerator TearDown()
+        public override IEnumerator TearDown()
         {
             Object.Destroy(cube);
-            TestUtilities.ShutdownMixedRealityToolkit();
-            yield return null;
+            yield return base.TearDown();
         }
 
         private void VerifyCursorStateFromPointers(IEnumerable<IMixedRealityPointer> pointers, CursorStateEnum state)

--- a/Assets/MRTK/Tests/PlayModeTests/BaseEventSystemTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseEventSystemTests.cs
@@ -31,22 +31,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// (i.e. input and diagnostics are used, but any arbitrary systems that can raise events on demand
     /// would work)
     /// </remarks>
-    class BaseEventSystemTests
+    internal class BaseEventSystemTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
-            yield return null;
-        }
-
         /// <summary>
         /// Test input system catches exception thrown in global listener responding to input event, and
         /// that the input system is still able to unregister the event listener (i.e. eventExecutionDepth

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -13,7 +13,6 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using NUnit.Framework;
 using System.Collections;
 using System.Linq;
 using UnityEngine;
@@ -22,22 +21,9 @@ using Assert = UnityEngine.Assertions.Assert;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class BoundingBoxTests
+    public class BoundingBoxTests : BasePlayModeTests
     {
         #region Utilities
-        [UnitySetUp]
-        public IEnumerator SetUp()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
-            yield return null;
-        }
 
         private readonly Vector3 boundingBoxStartCenter = Vector3.forward * 1.5f;
         private readonly Vector3 boundingBoxStartScale = Vector3.one * 0.5f;

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -27,17 +27,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// <summary>
     /// Tests for runtime behavior of bounds control
     /// </summary>
-    public class BoundsControlTests
+    public class BoundsControlTests : BasePlayModeTests
     {
         private Material testMaterial;
         private Material testMaterialGrabbed;
 
         #region Utilities
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
 
+        public override IEnumerator Setup()
+        {
             // create shared test materials
             var shader = StandardShaderUtility.MrtkStandardShader;
             testMaterial = new Material(shader);
@@ -45,14 +43,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             testMaterialGrabbed = new Material(shader);
             testMaterialGrabbed.color = Color.green;
-            yield return null;
-        }
 
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
-            yield return null;
+            yield return base.Setup();
         }
 
         private readonly Vector3 boundsControlStartCenter = Vector3.forward * 1.5f;

--- a/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
@@ -12,7 +12,6 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using NUnit.Framework;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -20,7 +19,7 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class BaseHandVisualizerTests
+    public class BaseHandVisualizerTests : BasePlayModeTests
     {
         /// <summary>
         /// A mock IMixedRealityInputSource, used to test BaseHandVisualizer::OnHandMeshUpdated.
@@ -69,20 +68,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             public Vector3 Velocity => throw new System.NotImplementedException();
 
             public bool IsInPointingPose => throw new System.NotImplementedException();
-        }
-
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            TestUtilities.ShutdownMixedRealityToolkit();
-            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/ElasticTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/ElasticTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
     /// <summary>
     /// Tests for runtime behavior of the ElasticSystem.
     /// </summary>
-    public class ElasticSystemTests
+    public class ElasticSystemTests : BasePlayModeTests
     {
         #region Utilities
 
@@ -61,19 +61,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Drag = 0.2f
         };
 
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            TestUtilities.ShutdownMixedRealityToolkit();
-            yield return null;
-        }
         #endregion
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/SpatialObserverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpatialObserverTests.cs
@@ -15,7 +15,6 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using System.Collections;
 using UnityEditor;
-using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
@@ -117,9 +116,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator TestDisableSpatialAwarenessSystem()
         {
             var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath);
-            
+
             mrtkProfile.IsSpatialAwarenessSystemEnabled = false;
-            
+
             TestUtilities.InitializeMixedRealityToolkit(mrtkProfile);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
@@ -129,11 +128,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private static MixedRealityToolkitConfigurationProfile CreateMRTKTestProfile(string spatialAwarenessSystemPath)
         {
             var mrtkProfile = TestUtilities.GetDefaultMixedRealityProfile<MixedRealityToolkitConfigurationProfile>();
-            
+
             mrtkProfile.SpatialAwarenessSystemSystemType = new SystemType(typeof(MixedRealitySpatialAwarenessSystem));
             mrtkProfile.IsSpatialAwarenessSystemEnabled = true;
             mrtkProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(spatialAwarenessSystemPath);
-            
+
             return mrtkProfile;
         }
     }

--- a/scripts/test/run_playmode_tests.ps1
+++ b/scripts/test/run_playmode_tests.ps1
@@ -36,7 +36,7 @@ $timer = [System.Diagnostics.Stopwatch]::StartNew()
 Write-Host "Starting test run"
 Write-Host "Writing test output to $logPath...`n"
 
-$args = @(
+$unityArgs = @(
     "-runTests",
     "-testPlatform playmode"
     "-batchmode",
@@ -46,8 +46,8 @@ $args = @(
     "-editorTestsFilter $editorTestsFilter"
     )
 Write-Host "Running command:"
-Write-Host $unityExePath ($args -Join " ")
-$handle = Start-Process -FilePath $unityExePath -PassThru -ArgumentList $args
+Write-Host $unityExePath ($unityArgs -Join " ")
+$handle = Start-Process -FilePath $unityExePath -PassThru -ArgumentList $unityArgs
 
 Start-Process powershell -ArgumentList @(
     "-command", 


### PR DESCRIPTION
## Overview

There were some quirks on legacy vs Windows XR Plugin vs OpenXR.

1. Non-legacy in the editor seemed to need to wait ~4 frames instead of 1 to align scene content. Defaulting to 5 to be safe
2. Boundary was broken in 2020, since it was looking specifically at the legacy type which is null in 2020 and returning that boundary was always disabled
3. Reworked BaseBoundarySystem a bit to use a built-in MRTK utility for detecting device presence, as well as allowing it to late-init in the editor since there were a few frames of the device not being "present" in OpenXR
4. Minor formatting (made some unshipped things private that didn't need to be public)