### PR TITLE
Addressing Scrolling Object Collection related issues

### DIFF
--- a/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
@@ -86,7 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
 
             if (autoDestroy && materialOwners.Count == 0)
             {
-                DestorySafe(this);
+                DestroySafe(this);
 
                 // OnDestroy not called on inactive objects
                 if (!gameObject.activeInHierarchy)
@@ -295,7 +295,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             {
                 for (var i = 0; i < materials.Length; ++i)
                 {
-                    DestorySafe(materials[i]);
+                    DestroySafe(materials[i]);
                 }
             }
         }
@@ -321,7 +321,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             return false;
         }
 
-        private static void DestorySafe(UnityEngine.Object toDestroy)
+        private static void DestroySafe(Object toDestroy)
         {
             if (toDestroy != null)
             {

--- a/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
@@ -160,7 +160,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
-        private void RemoveRenderer(int index)
+        private void RemoveRenderer(int index, bool autoDestroyMaterial = true)
         {
             Renderer _renderer = renderers[index];
 
@@ -181,7 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 var materialInstance = _renderer.GetComponent<MaterialInstance>();
                 if (materialInstance != null)
                 {
-                    materialInstance.ReleaseMaterial(this);
+                    materialInstance.ReleaseMaterial(this, autoDestroyMaterial);
                 }
             }
         }
@@ -189,13 +189,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// Removes all renderers in the list of objects this clipping primitive clips.
         /// </summary>
-        public void ClearRenderers()
+        public void ClearRenderers(bool autoDestroyMaterial = true)
         {
             if (renderers != null)
             {
                 while (renderers.Count != 0)
                 {
-                    RemoveRenderer(renderers.Count - 1);
+                    RemoveRenderer(renderers.Count - 1, autoDestroyMaterial);
                 }
             }
         }
@@ -314,9 +314,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             for (int i = renderers.Count - 1; i >= 0; --i)
             {
                 var _renderer = renderers[i];
-                if (Application.isPlaying && _renderer == null)
+                if (_renderer == null)
                 {
-                    RemoveRenderer(i);
+                    if (Application.isPlaying)
+                    {
+                        RemoveRenderer(i);
+                    }
                     continue;
                 }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -1183,7 +1183,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
             CoreServices.InputSystem?.UnregisterHandler<IMixedRealityTouchHandler>(this);
             CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
 
+            // Currently in editor duplicating prefab GameObject containing both TMP and non-TMP children inside the Scrolling Object Collection container causes material life cycle management issues
+            // https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9481
+            // Thus we do not automatically destroy material controlled by Material Instance if the OnDisable comes from pasting in editor
+#if UNITY_EDITOR
+            if (!Application.isPlaying)
+            {
+                bool? isCalledFromPastingGameObject = new System.Diagnostics.StackFrame(1)?.GetMethod()?.Name?.Contains("Paste");
+                RestoreContentVisibility(!isCalledFromPastingGameObject.GetValueOrDefault());
+            }
+            else
+            {
+                RestoreContentVisibility();
+            }
+#else
             RestoreContentVisibility();
+#endif
 
             if (useOnPreRender && cameraMethods != null)
             {
@@ -1643,9 +1658,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Removes all renderers currently being clipped by the clipping box
         /// </summary>
-        private void ClearClippingBox()
+        private void ClearClippingBox(bool autoDestroyMaterial = true)
         {
-            ClipBox.ClearRenderers();
+            ClipBox.ClearRenderers(autoDestroyMaterial);
         }
 
         /// <summary>
@@ -1897,9 +1912,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// All inactive content objects and colliders are reactivated and renderers are unclipped.
         /// </summary>
-        private void RestoreContentVisibility()
+        private void RestoreContentVisibility(bool autoDestroyMaterial = true)
         {
-            ClearClippingBox();
+            ClearClippingBox(autoDestroyMaterial);
             ManageVisibility(true);
         }
 


### PR DESCRIPTION
## Overview
This PR addresses the following issues:
1. When duplicating prefab GameObjects, the OnDisable function in the SOC script is called which in the end tries to destroy the instanced material managed by Material Instance. However, in the case where TextMeshPro is present in the prefab, TMP has its own material life cycle management and thus causes problems (i.e. missing material/pink and error message in the console).
2. Sometimes removing GameObjects inside the SOC container (followed by some other operations) leads to complaints about missing reference etc. from the UpdateRenderers function in the ClippingPrimitive script. This PR adds null check to guard against that case.

## Changes
- Fixes: #9481