### PR TITLE
Update more play mode test scripts to inherit BasePlayModeTests for consistent setup / teardown

### DIFF
--- a/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
@@ -22,22 +22,8 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class ConstraintTests
+    public class ConstraintTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator SetUp()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
-            yield return null;
-        }
-
         /// <summary>
         /// Tests that the MoveAxisConstraint works for various axes.
         /// This test uses world space axes.

--- a/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/RiggedHandVisualizerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/RiggedHandVisualizerTests.cs
@@ -21,25 +21,17 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class RiggedHandVisualizerTests
+    public class RiggedHandVisualizerTests : BasePlayModeTests
     {
         private const string RiggedHandProfileName = "TestRiggedHandVisualizationConfigurationProfile";
 
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-
             var riggedHandProfile = ScriptableObjectExtensions.GetAllInstances<MixedRealityToolkitConfigurationProfile>()
                            .FirstOrDefault(x => x.name.Equals(RiggedHandProfileName));
             PlayModeTestUtilities.Setup(riggedHandProfile);
 
             yield return null;
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
         }
 
 #if UNITY_2019_3_OR_NEWER

--- a/Assets/MRTK/Tests/PlayModeTests/DialogTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/DialogTests.cs
@@ -21,7 +21,7 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class DialogTests
+    public class DialogTests : BasePlayModeTests
     {
         // SDK/Features/UX/Prefabs/Slate/Slate.prefab
         private const string smallDialogPrefabAssetGuid = "8e686c90124b8e14cbf8093893109e9a";
@@ -33,21 +33,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         private const float DialogStabilizationTime = 1.5f;
 
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
             yield return null;
         }
 
-        [UnityTearDown]
-        public IEnumerator TearDown()
+        public override IEnumerator TearDown()
         {
-            GameObject.Destroy(dialogGameObject);
-            GameObject.Destroy(dialogComponent);
-            PlayModeTestUtilities.TearDown();
-            yield return null;
+            Object.Destroy(dialogGameObject);
+            Object.Destroy(dialogComponent);
+            yield return base.TearDown();
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/FocusProviderRaycastTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/FocusProviderRaycastTests.cs
@@ -9,7 +9,6 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using NUnit.Framework;
 using System.Collections;
-using System.IO;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -19,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// <summary>
     /// This class is used to test that <see cref="Toolkit.Input.FocusProvider"/> raycasts are selecting the correct focus object.
     /// </summary>
-    public class FocusProviderRaycastTests
+    public class FocusProviderRaycastTests : BasePlayModeTests
     {
         private GameObject raycastTestPrefabInstance = null;
         private TestPointer pointer = null;
@@ -47,10 +46,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
         }
 
-        [UnitySetUp]
-        public IEnumerator SetupFocusProviderRaycastTests()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
 
             focusProvider = PlayModeTestUtilities.GetInputSystem().FocusProvider;
 
@@ -62,8 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
         }
 
-        [UnityTearDown]
-        public IEnumerator ShutdownFocusProviderRaycastTests()
+        public override IEnumerator TearDown()
         {
             if (raycastTestPrefabInstance)
             {
@@ -75,8 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             focusProvider = null;
             pointer = null;
 
-            PlayModeTestUtilities.TearDown();
-            yield return null;
+            yield return base.TearDown();
         }
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/FocusProviderTests.cs
@@ -22,22 +22,8 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class FocusProviderTests
+    public class FocusProviderTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
-            yield return null;
-        }
-
         /// <summary>
         /// Test that the gaze cursor behaves properly with articulated hand pointers.
         /// </summary>
@@ -176,7 +162,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestGazeProviderDestroyed()
         {
-            PlayModeTestUtilities.Setup();
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
             // remove the gaze provider and it's components from the scene
@@ -201,8 +186,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestOverrideFocusDetails()
         {
-            PlayModeTestUtilities.Setup();
-
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             yield return null;
 

--- a/Assets/MRTK/Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/FocusProviderTests.cs
@@ -168,7 +168,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             GazeProvider gazeProvider = CoreServices.InputSystem.GazeProvider.GameObjectReference.GetComponent<GazeProvider>();
             gazeProvider.GazePointer.BaseCursor.Destroy();
             DebugUtilities.LogVerbose("Application was playing, destroyed the gaze pointer's BaseCursor");
-            UnityObjectExtensions.DestroyObject(gazeProvider as Component);
+            UnityObjectExtensions.DestroyObject(gazeProvider);
             gazeProvider = null;
 
             // Ensure that the input system and it's related input sources are able to be reinitialized without issue.
@@ -201,10 +201,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsTrue(focusProvider.TryGetFocusDetails(pointer, out focusDetails));
             Assert.IsNull(focusDetails.Object);
 
-            var newFocusDetails = new Physics.FocusDetails();
-            newFocusDetails.Object = cube;
-            newFocusDetails.RayDistance = 10;
-            newFocusDetails.Point = new Vector3(1, 2, 3);
+            var newFocusDetails = new Physics.FocusDetails
+            {
+                Object = cube,
+                RayDistance = 10,
+                Point = new Vector3(1, 2, 3)
+            };
             Assert.IsTrue(focusProvider.TryOverrideFocusDetails(pointer, newFocusDetails));
 
             Assert.IsTrue(focusProvider.TryGetFocusDetails(pointer, out focusDetails));

--- a/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
@@ -22,26 +22,24 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class GltfTests
+    public class GltfTests : BasePlayModeTests
     {
         private const string AvocadoCustomAttrGuid = "fea29429b97dbb14b97820f56c74060a";
         private const string CubeCustomAttrGuid = "f0bb9fb635c69be4e8526b0fb6b48f39";
 
         private AsyncCoroutineRunner asyncCoroutineRunner;
-        [UnitySetUp]
-        public IEnumerator Setup()
+
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             asyncCoroutineRunner = new GameObject("AsyncCoroutineRunner").AddComponent<AsyncCoroutineRunner>();
             yield return null;
         }
 
-        [UnityTearDown]
-        public IEnumerator TearDown()
+        public override IEnumerator TearDown()
         {
-            PlayModeTestUtilities.TearDown();
-            GameObject.Destroy(asyncCoroutineRunner.gameObject);
-            yield return null;
+            Object.Destroy(asyncCoroutineRunner.gameObject);
+            yield return base.TearDown();
         }
 
         private IEnumerator WaitForTask(Task task)

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -31,20 +31,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// You can use GridObjectLayoutControl.cs in the examples package to
     /// quickly generate the expected positions used in these tests.
     /// </summary>
-    internal class GridObjectCollectionTests
+    internal class GridObjectCollectionTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/HandCoachTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/HandCoachTests.cs
@@ -21,23 +21,15 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    class HandCoachTests
+    class HandCoachTests : BasePlayModeTests
     {
         private const string handCoachRightGuid = "2225b28a6968ba04594a7564e934a679";
         private static readonly string handCoachRightPath = AssetDatabase.GUIDToAssetPath(handCoachRightGuid);
 
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/InputEventSystemTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputEventSystemTests.cs
@@ -26,22 +26,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     using Handle = BaseEventSystem.EventHandlerEntry;
     using HandleList = List<BaseEventSystem.EventHandlerEntry>;
 
-    class InputEventSystemTests
+    class InputEventSystemTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
-            yield return null;
-        }
-
         /// <summary>
         /// </summary>
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/InputRayUtilsTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputRayUtilsTests.cs
@@ -14,27 +14,18 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using System.Collections;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
     // Tests to verify that the ray utilities methods are functioning correctly
-    public class InputRayUtilsTests
+    public class InputRayUtilsTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/DefaultRaycastProviderTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/DefaultRaycastProviderTest.cs
@@ -11,7 +11,7 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.Input
 {
-    class DefaultRaycastProviderTest
+    class DefaultRaycastProviderTest : BasePlayModeTests
     {
         private DefaultRaycastProvider defaultRaycastProvider;
 
@@ -32,18 +32,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             yield return null;
         }
 
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             defaultRaycastProvider = new DefaultRaycastProvider(null);
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
     }

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs
@@ -18,22 +18,8 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.Input
 {
-    class DisableEnableInputSystemTest
+    class DisableEnableInputSystemTest : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
-            yield return null;
-        }
-
         [UnityTest]
         public IEnumerator DisableEnableInputSystem()
         {

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/EyeTrackingTargetTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/EyeTrackingTargetTest.cs
@@ -20,7 +20,7 @@ using UnityEngine.TestTools;
 namespace Microsoft.MixedReality.Toolkit.Tests.Input
 {
     // tests for eyetracking
-    public class EyeTrackingTargetTest
+    public class EyeTrackingTargetTest : BasePlayModeTests
     {
         // Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoConfigurationProfile.asset
         private const string eyeTrackingConfigurationProfileGuid = "6615cacb3eaaa044f99b917186093aeb";
@@ -31,18 +31,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
         // This method is called once before we enter play mode and execute any of the tests
         // do any kind of setup here that can't be done in playmode
-        [SetUp]
-        public void Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-        }
-
-        // Destroy the scene - this method is called after each test listed below has completed
-        [TearDown]
-        public void TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
+            yield return null;
         }
 
         #region Tests

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableEventTests.cs
@@ -20,15 +20,14 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    class InteractableEventTests
+    class InteractableEventTests : BasePlayModeTests
     {
         GameObject cube;
         Interactable interactable;
 
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
 
             cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -39,12 +38,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
         }
 
-        [UnityTearDown]
-        public IEnumerator TearDown()
+        public override IEnumerator TearDown()
         {
-            GameObject.Destroy(cube);
-            PlayModeTestUtilities.TearDown();
-            yield return null;
+            Object.Destroy(cube);
+            yield return base.TearDown();
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/JoystickTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/JoystickTests.cs
@@ -20,22 +20,8 @@ using Assert = UnityEngine.Assertions.Assert;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class JoystickTests
+    public class JoystickTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
-            yield return null;
-        }
-
         #region Tests
         [UnityTest]
         public IEnumerator TestJoystickTranslation()

--- a/Assets/MRTK/Tests/PlayModeTests/JoystickTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/JoystickTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     public class JoystickTests : BasePlayModeTests
     {
         #region Tests
+
         [UnityTest]
         public IEnumerator TestJoystickTranslation()
         {
@@ -133,9 +134,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(startScale != endScale);
         }
+
         #endregion Tests
 
         #region Utilities
+
         public readonly string JoystickPrefabAssetPath = AssetDatabase.GUIDToAssetPath(JoystickPrefabGuid);
 
         // Examples/Experimental/Joystick/JoystickPrefab.prefab
@@ -168,6 +171,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNotNull(joystick);
             return joystick;
         }
+
         #endregion Utilities
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -22,24 +22,14 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class ManipulationHandlerTests
+    public class ManipulationHandlerTests : BasePlayModeTests
     {
         private readonly List<Action> cleanupAction = new List<Action>();
 
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
+        public override IEnumerator TearDown()
         {
             cleanupAction.ForEach(f => f?.Invoke());
-
-            PlayModeTestUtilities.TearDown();
-            yield return null;
+            yield return base.TearDown();
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/NearInteractionGrabbableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/NearInteractionGrabbableTests.cs
@@ -18,20 +18,12 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class NearInteractionGrabbableTests
+    public class NearInteractionGrabbableTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             PlayModeTestUtilities.EnsureInputModule();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/NearInteractionTouchableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/NearInteractionTouchableTests.cs
@@ -19,12 +19,11 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class NearInteractionTouchableTests
+    public class NearInteractionTouchableTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             PlayModeTestUtilities.EnsureInputModule();
 
             inputSim = PlayModeTestUtilities.GetInputSimulationService();
@@ -44,13 +43,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             pokeMaterial = new Material(shader);
             pokeMaterial.color = Color.green;
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -22,24 +22,14 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class ObjectManipulatorTests
+    public class ObjectManipulatorTests : BasePlayModeTests
     {
         private readonly List<Action> cleanupAction = new List<Action>();
 
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
+        public override IEnumerator TearDown()
         {
             cleanupAction.ForEach(f => f?.Invoke());
-
-            PlayModeTestUtilities.TearDown();
-            yield return null;
+            yield return base.TearDown();
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PinchSliderTests.cs
@@ -21,24 +21,16 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    class PinchSliderTests
+    class PinchSliderTests : BasePlayModeTests
     {
         // SDK/Features/UX/Prefabs/Sliders/PinchSlider.prefab
         private const string defaultPinchSliderPrefabGuid = "1093263a89abe47499cccf7dcb08effb";
         private static readonly string defaultPinchSliderPrefabPath = AssetDatabase.GUIDToAssetPath(defaultPinchSliderPrefabGuid);
 
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/PointerEventsTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerEventsTests.cs
@@ -14,14 +14,13 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using System.Collections;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
     // Tests to verify that pointer events are being raised correctly
-    public class PointerEventsTests
+    public class PointerEventsTests : BasePlayModeTests
     {
 
         // Helper script used to keep track of the number of pointer events raised
@@ -127,10 +126,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const int numFramesPerMove = 1;
 
         // Initializes MRTK, instantiates the test content prefab and adds a pointer handler to the test collider
-        [UnitySetUp]
-        public IEnumerator SetUp()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
 
             // Target frame rate is set to 50 to match the physics
@@ -147,13 +145,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNotNull(collider);
 
             handler = collider.gameObject.AddComponent<PointerHandler>();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            TestUtilities.ShutdownMixedRealityToolkit();
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/PointerProfileTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerProfileTests.cs
@@ -9,25 +9,17 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    class PointerProfileTests
+    class PointerProfileTests : BasePlayModeTests
     {
         // Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoConfigurationProfile.asset
         private const string eyeTrackingConfigurationProfileGuid = "6615cacb3eaaa044f99b917186093aeb";
 
         private static readonly string eyeTrackingConfigurationProfilePath = AssetDatabase.GUIDToAssetPath(eyeTrackingConfigurationProfileGuid);
 
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// <summary>
     /// Tests to verify pointer state and pointer direction
     /// </summary>
-    public class PointerTests
+    public class PointerTests : BasePlayModeTests
     {
         // SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab
         private const string LinePointerGuid = "d5b94136462644c9873bb3347169ae7e";
@@ -52,18 +52,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// See usage of these helpers throughout the tests within this file, e.g. <see cref="TestSpherePointerInsideGrabbable"/>.
         /// See also comments at <see cref="TestUtilities.PlayspaceToArbitraryPose"/>.
         /// </remarks>
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToArbitraryPose();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
@@ -23,7 +23,7 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class SlateTests
+    public class SlateTests : BasePlayModeTests
     {
         // SDK/Features/UX/Prefabs/Slate/Slate.prefab
         private const string slatePrefabAssetGuid = "937ce507dd7ee334ba569554e24adbdd";
@@ -34,21 +34,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private MeshFilter meshFilter;
         private Material material;
 
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
             yield return null;
         }
 
-        [UnityTearDown]
-        public IEnumerator TearDown()
+        public override IEnumerator TearDown()
         {
-            GameObject.Destroy(panObject);
-            GameObject.Destroy(panZoom);
-            PlayModeTestUtilities.TearDown();
-            yield return null;
+            Object.Destroy(panObject);
+            Object.Destroy(panZoom);
+            yield return base.TearDown();
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/SpeechTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpeechTests.cs
@@ -21,22 +21,8 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class SpeechTests
+    public class SpeechTests : BasePlayModeTests
     {
-        [UnitySetUp]
-        public IEnumerator Setup()
-        {
-            PlayModeTestUtilities.Setup();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
-            yield return null;
-        }
-
         [UnityTest]
         public IEnumerator TestToggleProfilerCommand()
         {

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -20,15 +20,14 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.Input
 {
-    class UserInputSimulationTest
+    class UserInputSimulationTest : BasePlayModeTests
     {
         GameObject cube;
         Interactable interactable;
 
-        [UnitySetUp]
-        public IEnumerator SetUp()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
 
             // Explicitly enable user input to test in editor behavior.
             InputSimulationService iss = PlayModeTestUtilities.GetInputSimulationService();
@@ -45,12 +44,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             yield return null;
         }
 
-        [UnityTearDown]
-        public IEnumerator TearDown()
+        public override IEnumerator TearDown()
         {
             KeyInputSystem.StopKeyInputSimulation();
-            PlayModeTestUtilities.TearDown();
-            yield return null;
+            yield return base.TearDown();
         }
 
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
@@ -23,22 +23,14 @@ using UnityEngine.UI;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    class VisualThemeTests
+    class VisualThemeTests : BasePlayModeTests
     {
         private const string DefaultColorProperty = "_Color";
 
-        [UnitySetUp]
-        public IEnumerator Setup()
+        public override IEnumerator Setup()
         {
-            PlayModeTestUtilities.Setup();
+            yield return base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-            yield return null;
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDown()
-        {
-            PlayModeTestUtilities.TearDown();
             yield return null;
         }
 


### PR DESCRIPTION
## Overview

Follow-up to #9714, which exposed some of the inconsistencies in our play mode test set up and tear down. I fixed up the min set for that PR to succeed, but this is a follow-up to fill out much of the rest of the test classes.