### PR TITLE
Update MRTK keyboard based on Unity 2019.4.25/2020.3.2 fixes

### DIFF
--- a/Assets/MRTK/Examples/Demos/HandTracking/Scripts/SystemKeyboardExample.cs
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scripts/SystemKeyboardExample.cs
@@ -12,8 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
     /// (MixedRealityKeyboard) or Unity's TouchScreenKeyboard API depending on the platform.
     /// </summary>
     /// <remarks>
-    /// <para>Note that like Unity's TouchScreenKeyboard API, this script only supports WSA, iOS,
-    /// and Android.</para>
+    /// <para>Note that like Unity's TouchScreenKeyboard API, this script only supports WSA, iOS, and Android.</para>
+    /// <para>If using Unity 2019 or 2020, make sure the version >= 2019.4.25 or 2020.3.2 to ensure the latest fixes for Unity keyboard bugs are present.</para>
     /// </remarks>
     [AddComponentMenu("Scripts/MRTK/Examples/SystemKeyboardExample")]
     public class SystemKeyboardExample : MonoBehaviour

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKTMPInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKTMPInputField.cs
@@ -8,9 +8,12 @@ using TMPro;
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     /// <summary>
-    /// A derived class of TMP's InputField to workaround with some issues of typing on HoloLens 2
-    /// No longer used in Unity 2019.3 and later versions.
+    /// A derived class of TMP's InputField to workaround with some issues of typing on HoloLens 2 specific to Unity 2018.4
     /// </summary>
+    /// <remarks>
+    /// <para>If using Unity 2019 or 2020, make sure the version >= 2019.4.25 or 2020.3.2 to ensure the latest fixes for Unity keyboard bugs are present.</para>
+    /// <para>There is a known Unity/TMP issue preventing the caret from showing up. Please see https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9056 for updates.</para>
+    /// </remarks>
     public class MRTKTMPInputField : TMP_InputField
     {
 #if !UNITY_2019_3_OR_NEWER

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MRTKUGUIInputField.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using UnityEngine;
 using UnityEngine.UI;
 
 #if !UNITY_2019_3_OR_NEWER
@@ -11,38 +10,20 @@ using UnityEngine.EventSystems;
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     /// <summary>
-    /// A derived class of UGUI's InputField to workaround with some issues of typing on HoloLens 2
+    /// A derived class of UGUI's InputField to workaround with some issues of typing on HoloLens 2 specific to Unity 2018.4
     /// </summary>
+    /// <remarks>
+    /// <para>If using Unity 2019 or 2020, make sure the version >= 2019.4.25 or 2020.3.2 to ensure the latest fixes for Unity keyboard bugs are present.</para>
+    /// </remarks>
     public class MRTKUGUIInputField : InputField
     {
-#if UNITY_2019_3_OR_NEWER
-        [SerializeField]
-        private bool disableUGUIWorkaround = false;
-
-        /// <summary>
-        /// Currently there is a Unity bug that needs a workaround. Please keep this setting to be false until an announcement of the version of Unity/UGUI that resolves the issue is made.
-        /// </summary>
-        public bool DisableUGUIWorkaround
-        {
-            get => disableUGUIWorkaround;
-            set => disableUGUIWorkaround = value;
-        }
-
-        protected override void LateUpdate()
-        {
-            if (!DisableUGUIWorkaround && isFocused && m_Keyboard != null && (UnityEngine.Input.GetKeyDown(KeyCode.Backspace)))
-            {
-                m_Keyboard.text = m_Text;
-            }
-            base.LateUpdate();
-        }
-#else
+#if !UNITY_2019_3_OR_NEWER
         public int SelectionPosition
         {
             get => caretSelectPositionInternal;
             set => caretSelectPositionInternal = value;
         }
         public override void OnUpdateSelected(BaseEventData eventData) { }
-#endif // UNITY_2019_3_OR_NEWER
+#endif // !UNITY_2019_3_OR_NEWER
     }
 }

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/TMP_KeyboardInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/TMP_KeyboardInputField.cs
@@ -11,9 +11,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     /// <summary>
     /// A component that can be added to InputField to make it work with Windows Mixed Reality's system keyboard.
-    /// Required when using Unity 2018.4.
+    /// Only used in Unity 2018.4.
     /// No longer used in Unity 2019.3 and later versions (becomes an empty MonoBehaviour and is only around for compatibility) and you can safely remove it if you wish
     /// </summary>
+    /// <remarks>
+    /// <para>If using Unity 2019 or 2020, make sure the version >= 2019.4.25 or 2020.3.2 to ensure the latest fixes for Unity keyboard bugs are present.</para>
+    /// <para>There is a known Unity/TMP issue preventing the caret from showing up. Please see https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9056 for updates.</para>
+    /// </remarks>
 #if !UNITY_2019_3_OR_NEWER
     [RequireComponent(typeof(MRTKTMPInputField))]
     [AddComponentMenu("Scripts/MRTK/Experimental/Keyboard/TMP_KeyboardInputField")]

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
@@ -11,8 +11,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     /// <summary>
     /// A component that can be added to InputField to make it work with Windows Mixed Reality's system keyboard.
-    /// Will no longer be necessary in Unity 2019.3 and later versions after a Unity/UGUI bug is fixed (see disableUGUIWorkaround).
+    /// Only used in Unity 2018.4.
+    /// No longer used in Unity 2019.3 and later versions (becomes an empty MonoBehaviour and is only around for compatibility) and you can safely remove it if you wish
     /// </summary>
+    /// <remarks>
+    /// <para>If using Unity 2019 or 2020, make sure the version >= 2019.4.25 or 2020.3.2 to ensure the latest fixes for Unity keyboard bugs are present.</para>
+    /// </remarks>
     [RequireComponent(typeof(MRTKUGUIInputField))]
     [AddComponentMenu("Scripts/MRTK/Experimental/Keyboard/UI_KeyboardInputField")]
     public class UI_KeyboardInputField :
@@ -30,20 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             inputField.caretPosition = CaretIndex;
             inputField.SelectionPosition = CaretIndex;
-        }
-#else
-        [SerializeField, Tooltip("Currently there is a Unity bug that needs a workaround. Please keep this setting to be false until an announcement of the version of Unity/UGUI that resolves the issue is made.")]
-        private bool disableUGUIWorkaround = false;
-
-        private MRTKUGUIInputField inputField;
-
-        private void OnValidate()
-        {
-            if (inputField == null)
-            {
-                inputField = GetComponent<MRTKUGUIInputField>();
-            }
-            inputField.DisableUGUIWorkaround = disableUGUIWorkaround;
         }
 #endif
     }


### PR DESCRIPTION
## Overview
This PR updates the MRTK keyboard implementations/workarounds to align with Unity's keyboard behavior after its recent fixes in 2019.4.25 and 2020.3.2. Note Unity 2019 and 2020 customers need to update to those two versions or later to get the expected experience.