### PR TITLE
Key off previewNumber instead of additional bool for UPM pack

### DIFF
--- a/pipelines/packageupmpublic.yaml
+++ b/pipelines/packageupmpublic.yaml
@@ -4,12 +4,9 @@ variables:
 - template: config/settings.yml
 
 parameters:
-- name: IsFinal
-  type: boolean
-  default: false
-- name: BuildNumber
+- name: PreviewNumber
   type: string
-  default: 0
+  default: ''
 
 jobs:
 - job: UPMPublicRelease
@@ -19,5 +16,4 @@ jobs:
   steps:
   - template: templates/tasks/pack-upm.yml
     parameters:
-      excludeBuildNumber: ${{ parameters.IsFinal }}
-      buildNumber: ${{ parameters.BuildNumber }}
+      previewNumber: ${{ parameters.PreviewNumber }}

--- a/pipelines/templates/tasks/pack-upm.yml
+++ b/pipelines/templates/tasks/pack-upm.yml
@@ -4,15 +4,14 @@ parameters:
   projectRoot: $(Get-Location)
   outputDirectory: $(Build.ArtifactStagingDirectory)\build\upm\output
   version: $(MRTKVersion)
-  buildNumber: $(Build.BuildNumber)
-  excludeBuildNumber: false
+  previewNumber: $(Build.BuildNumber)
 
 steps:
 - task: NodeTool@0
   inputs:
     versionSpec: '12.18.0'
 
-- ${{ if eq(parameters.excludeBuildNumber, false) }}:
+- ${{ if not(eq(parameters.previewNumber, '')) }}:
   - task: PowerShell@2
     displayName: 'Build PREVIEW UPM packages'
     inputs:
@@ -22,9 +21,9 @@ steps:
         -ProjectRoot ${{ parameters.projectRoot }}
         -OutputDirectory ${{ parameters.outputDirectory }}
         -Version ${{ parameters.version }}
-        -BuildNumber ${{ parameters.buildNumber }}
+        -PreviewNumber ${{ parameters.previewNumber }}
 
-- ${{ if eq(parameters.excludeBuildNumber, true) }}:
+- ${{ if eq(parameters.previewNumber, '') }}:
   - task: PowerShell@2
     displayName: 'Build OFFICIAL UPM packages'
     inputs:
@@ -34,8 +33,6 @@ steps:
         -ProjectRoot ${{ parameters.projectRoot }}
         -OutputDirectory ${{ parameters.outputDirectory }}
         -Version ${{ parameters.version }}
-        -BuildNumber ${{ parameters.buildNumber }}
-        -ExcludeBuildNumber
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish UPM artifacts'

--- a/scripts/packaging/createupmpackages.ps1
+++ b/scripts/packaging/createupmpackages.ps1
@@ -12,11 +12,8 @@
     Where should we place the output? Defaults to ".\artifacts"
 .PARAMETER Version
     What version of the artifacts should we build?
-.PARAMETER BuildNumber
-    The build number to append to the version. Note: This value is required when the ExcludeBuildNumber parameter is omitted.
-.PARAMETER ExcludeBuildNumber
-    Indicates that the build number should be excluded from the generated artifacts. If this parameter is specified, the version
-    of the artifacts will be formatted as "<$Version>", if omitted, the artifact version will be "<$Version>-preview.<BuildNumber>".
+.PARAMETER PreviewNumber
+    The preview number to append to the version. Note: Exclude this parameter to create non-preview packages.
 #>
 param(
     [string]$ProjectRoot,
@@ -24,9 +21,7 @@ param(
     [ValidatePattern("^\d+\.\d+\.\d+-?[a-zA-Z0-9\.]*$")]
     [string]$Version,
     [ValidatePattern("^\d+?[\.\d+]*$")]
-    [string]$BuildNumber,
-    [Parameter(Mandatory=$false)]
-    [Switch]$ExcludeBuildNumber
+    [string]$PreviewNumber
 )
 
 [string]$startPath = $(Get-Location)
@@ -40,12 +35,10 @@ if (-not $Version) {
     throw "Missing required parameter: -Version."
 }
 
-if ((-not $BuildNumber) -and (-not $ExcludeBuildNumber)) {
-    throw "Missing required parameter: -BuildNumber. This parameter is required when -ExcludeBuildNumber is not specified."
+if ($PreviewNumber) {
+    $Version = "$Version-preview.$PreviewNumber"
 }
-if (-not $ExcludeBuildNumber) {
-    $Version = "$Version-preview.$BuildNumber"
-}
+
 Write-Output "Package version: $Version"
 
 if (-not (Test-Path $OutputDirectory -PathType Container)) {


### PR DESCRIPTION
## Overview

Slightly simplifies the UPM pack pipeline and script, renaming `buildNumber` to the more descriptive `previewNumber` and removing an extra bool that represented whether to use the `previewNumber`. It now keys off whether `previewNumber` is provided or not.