### PR TITLE
Add Android to support Quest on OpenXR

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
@@ -10,6 +10,7 @@
         "Unity.XR.OpenXR"
     ],
     "includePlatforms": [
+        "Android",
         "Editor",
         "WSA",
         "WindowsStandalone32",


### PR DESCRIPTION
## Overview

Add Android to support Quest on OpenXR. Although [Unity currently says](https://docs.unity3d.com/Packages/com.unity.xr.openxr@1.1/manual/index.html)

> At this time, deploying directly to Oculus Quest/Quest 2 is not supported.

we don't want to block developers once that changes.

## Changes

- Part of unblocking https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9499, as Unity's support comes online
