### PR TITLE
Object Manipulator now maintains velocity on release

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -158,11 +158,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         {
             using (UpdateVelocityPerfMarker.Auto())
             {
-                Debug.Log("updating velocity");
                 Vector3 newVelocity;
                 if (inputDevice.TryGetFeatureValue(CommonUsages.deviceVelocity, out newVelocity))
                 {
-                    Debug.Log("updating velocity2" + newVelocity);
                     Velocity = newVelocity;
                 }
                 Vector3 newAngularVelocity;

--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -86,29 +86,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
 
         protected virtual void UpdateSixDofData(InputDevice inputDevice)
         {
-            var lastState = TrackingState;
-            LastControllerPose = CurrentControllerPose;
-
-            // Check for position and rotation.
-            IsPositionAvailable = inputDevice.TryGetFeatureValue(CommonUsages.devicePosition, out CurrentControllerPosition);
-            IsPositionApproximate = false;
-
-            IsRotationAvailable = inputDevice.TryGetFeatureValue(CommonUsages.deviceRotation, out CurrentControllerRotation);
-
-            // Devices are considered tracked if we receive position OR rotation data from the sensors.
-            TrackingState = (IsPositionAvailable || IsRotationAvailable) ? TrackingState.Tracked : TrackingState.NotTracked;
-
-            CurrentControllerPosition = MixedRealityPlayspace.TransformPoint(CurrentControllerPosition);
-            CurrentControllerRotation = MixedRealityPlayspace.Rotation * CurrentControllerRotation;
-
-            CurrentControllerPose.Position = CurrentControllerPosition;
-            CurrentControllerPose.Rotation = CurrentControllerRotation;
-
-            // Raise input system events if it is enabled.
-            if (lastState != TrackingState)
-            {
-                CoreServices.InputSystem?.RaiseSourceTrackingStateChanged(InputSource, this, TrackingState);
-            }
+            UpdateSourceData(inputDevice);
+            UpdateVelocity(inputDevice);
 
             if (TrackingState == TrackingState.Tracked && LastControllerPose != CurrentControllerPose)
             {
@@ -133,6 +112,63 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                     case AxisType.SixDof:
                         UpdatePoseData(Interactions[i], inputDevice);
                         break;
+                }
+            }
+        }
+
+        private static readonly ProfilerMarker UpdateSourceDataPerfMarker = new ProfilerMarker("[MRTK] BaseWindowsMixedRealitySource.UpdateSourceData");
+
+        /// <summary>
+        /// Update the source input from the device.
+        /// </summary>
+        /// <param name="inputDevice">The InputDevice retrieved from the platform.</param>
+        public void UpdateSourceData(InputDevice inputDevice)
+        {
+            using (UpdateSourceDataPerfMarker.Auto())
+            {
+                var lastState = TrackingState;
+                LastControllerPose = CurrentControllerPose;
+
+                // Check for position and rotation.
+                IsPositionAvailable = inputDevice.TryGetFeatureValue(CommonUsages.devicePosition, out CurrentControllerPosition);
+                IsPositionApproximate = false;
+
+                IsRotationAvailable = inputDevice.TryGetFeatureValue(CommonUsages.deviceRotation, out CurrentControllerRotation);
+
+                // Devices are considered tracked if we receive position OR rotation data from the sensors.
+                TrackingState = (IsPositionAvailable || IsRotationAvailable) ? TrackingState.Tracked : TrackingState.NotTracked;
+
+                CurrentControllerPosition = MixedRealityPlayspace.TransformPoint(CurrentControllerPosition);
+                CurrentControllerRotation = MixedRealityPlayspace.Rotation * CurrentControllerRotation;
+
+                CurrentControllerPose.Position = CurrentControllerPosition;
+                CurrentControllerPose.Rotation = CurrentControllerRotation;
+
+                // Raise input system events if it is enabled.
+                if (lastState != TrackingState)
+                {
+                    CoreServices.InputSystem?.RaiseSourceTrackingStateChanged(InputSource, this, TrackingState);
+                }
+            }
+        }
+
+        private static readonly ProfilerMarker UpdateVelocityPerfMarker = new ProfilerMarker("[MRTK] GenericXRSDKController.UpdateVelocity");
+
+        public void UpdateVelocity(InputDevice inputDevice)
+        {
+            using (UpdateVelocityPerfMarker.Auto())
+            {
+                Debug.Log("updating velocity");
+                Vector3 newVelocity;
+                if (inputDevice.TryGetFeatureValue(CommonUsages.deviceVelocity, out newVelocity))
+                {
+                    Debug.Log("updating velocity2" + newVelocity);
+                    Velocity = newVelocity;
+                }
+                Vector3 newAngularVelocity;
+                if (inputDevice.TryGetFeatureValue(CommonUsages.deviceAngularVelocity, out newAngularVelocity))
+                {
+                    AngularVelocity = newAngularVelocity;
                 }
             }
         }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -973,20 +973,20 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 rigidBody.useGravity = wasGravity;
                 rigidBody.isKinematic = wasKinematic;
-            }
 
-            // Match the object's velocity to the controller for near interactions
-            // Otherwise keep the objects current velocity so that it's not dampened unnaturally
-            if(isNearManipulation)
-            {
-                if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepVelocity))
+                // Match the object's velocity to the controller for near interactions
+                // Otherwise keep the objects current velocity so that it's not dampened unnaturally
+                if (isNearManipulation)
                 {
-                    rigidBody.velocity = velocity;
-                }
+                    if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepVelocity))
+                    {
+                        rigidBody.velocity = velocity;
+                    }
 
-                if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepAngularVelocity))
-                {
-                    rigidBody.angularVelocity = angularVelocity;
+                    if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepAngularVelocity))
+                    {
+                        rigidBody.angularVelocity = angularVelocity;
+                    }
                 }
             }
         }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -973,16 +973,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 rigidBody.useGravity = wasGravity;
                 rigidBody.isKinematic = wasKinematic;
-
-                if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepVelocity))
-                {
-                    rigidBody.velocity = velocity;
-                }
-
-                if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepAngularVelocity))
-                {
-                    rigidBody.angularVelocity = angularVelocity;
-                }
             }
         }
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -975,7 +975,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 rigidBody.isKinematic = wasKinematic;
             }
 
-            // Match the object't velocity to the controller for near interactions
+            // Match the object's velocity to the controller for near interactions
             // Otherwise keep the objects current velocity so that it's not dampened unnaturally
             if(isNearManipulation)
             {

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -974,6 +974,21 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 rigidBody.useGravity = wasGravity;
                 rigidBody.isKinematic = wasKinematic;
             }
+
+            // Match the object't velocity to the controller for near interactions
+            // Otherwise keep the objects current velocity so that it's not dampened unnaturally
+            if(isNearManipulation)
+            {
+                if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepVelocity))
+                {
+                    rigidBody.velocity = velocity;
+                }
+
+                if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepAngularVelocity))
+                {
+                    rigidBody.angularVelocity = angularVelocity;
+                }
+            }
         }
 
         private PointerData GetFirstPointer()

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// certain distance when being released from grab during hand movement
         /// </summary>
         [UnityTest]
-        public IEnumerator ObjectManipulatorThrow()
+        public IEnumerator ObjectManipulatorNearThrow()
         {
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -179,7 +179,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         /// <summary>
         /// Test validates throw behavior on manipulation handler. Box with disabled gravity should travel a
-        /// certain distance when being released from grab during hand movement
+        /// certain distance when being released from grab during hand movement. Specifically for near interactions, 
+        /// where we expect the thrown object to match the controllers velocities.
         /// </summary>
         [UnityTest]
         public IEnumerator ObjectManipulatorNearThrow()
@@ -232,6 +233,59 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
         }
 
+
+        /// <summary>
+        /// Test validates throw behavior on manipulation handler. Box with disabled gravity should travel a
+        /// certain distance when being released from grab during hand movement. Specifically for far interactions, 
+        /// where we expect the thrown object to maintain it's velocities after being thrown
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ObjectManipulatorFarThrow()
+        {
+            // set up cube with manipulation handler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.transform.localScale = Vector3.one * 0.2f;
+            Vector3 initialObjectPosition = new Vector3(-0.637f, -0.679f, 1.13f);
+            testObject.transform.position = initialObjectPosition;
+
+            var rigidBody = testObject.AddComponent<Rigidbody>();
+            rigidBody.useGravity = false;
+
+            var manipHandler = testObject.AddComponent<ObjectManipulator>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingFar = false;
+            manipHandler.SmoothingNear = false;
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            TestHand hand = new TestHand(Handedness.Right);
+
+            // grab the cube - move it to the right
+            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
+
+            Vector3 handOffset = new Vector3(0, 0, 0.1f);
+            Vector3 initialHandPosition = Vector3.zero;
+            Vector3 rightPosition = new Vector3(1f, 0f, 1f);
+
+            yield return hand.Show(initialHandPosition);
+
+            // Note: don't wait for a physics update after releasing, because it would recompute
+            // the velocity of the hand and make it deviate from the rigid body velocity!
+            yield return hand.GrabAndThrowAt(rightPosition, false);
+
+            // With simulated hand angular velocity would not be equal to 0, because of how simulation
+            // moves hand when releasing the Pitch. Even though it doesn't directly follow from hand movement, there will always be some rotation.
+            Assert.Zero(rigidBody.angularVelocity.magnitude, "Object should have maintained its angular velocity of zero being released.");
+            Assert.IsTrue(rigidBody.velocity != hand.GetVelocity() && rigidBody.velocity.magnitude > 0.0f, "ObjectManipulator should not dampen it's velocity to match the hand's upon release.");
+
+            // This is just for debugging purposes, so object's movement after release can be seen.
+            yield return hand.MoveTo(initialHandPosition);
+            yield return hand.Hide();
+
+            GameObject.Destroy(testObject);
+            yield return null;
+        }
 
         /// <summary>
         /// This tests the one hand near movement while camera (character) is moving around.


### PR DESCRIPTION
## Overview
Fixed Object Manipulator behavior to maintain velocity on release

This fix also entailed fixing the GenericXRSDKController to properly read Velocity and Angular Velocity Data from the input devices. However, this also required a fix from the XRSDK side of things, so this PR combined with the to be completed update to the Windows XRSDK plugin will solve this issue completely

Additionally, I found that objects that are thrown with the controller's velocity feel a bit dampened and unnaturally stiff compared to letting them maintain their velocity. I have included examples of both behavior in the video clips below, which looks the best/most natural?

Old Behavior:
https://user-images.githubusercontent.com/39840334/116744273-f3864a00-a9ae-11eb-90d8-4e99e120f932.mp4


Controller dampened velocity:
https://user-images.githubusercontent.com/39840334/116744492-37794f00-a9af-11eb-9016-6989f4e23834.mp4


Maintaining original velocity:
https://user-images.githubusercontent.com/39840334/116744514-3e07c680-a9af-11eb-93b4-6cea3eacb7dc.mp4



## Changes
- Fixes: #9690

