### PR TITLE
Add support for controller haptics across legacy, Windows XR Plugin, and OpenXR

### DIFF
--- a/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHapticFeedback.cs
+++ b/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHapticFeedback.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    /// <summary>
+    /// Provides access to the haptic capabilities of a device.
+    /// </summary>
+    public interface IMixedRealityHapticFeedback
+    {
+        /// <summary>
+        /// Start haptic feedback by the input device.
+        /// </summary>
+        /// <param name="intensity">The 0.0 to 1.0 strength of the haptic feedback based on the capability of the input device.</param>
+        /// <param name="durationInSeconds">The duration in seconds or float.MaxValue for indefinite duration.</param>
+        /// <returns>True if haptic feedback was successfully started.</returns>
+        bool StartHapticImpulse(float intensity, float durationInSeconds = float.MaxValue);
+
+        /// <summary>
+        /// Terminates haptic feedback by the input device.
+        /// </summary>
+        void StopHapticFeedback();
+    }
+}

--- a/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHapticFeedback.cs
+++ b/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHapticFeedback.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Start haptic feedback by the input device.
         /// </summary>
         /// <param name="intensity">The 0.0 to 1.0 strength of the haptic feedback based on the capability of the input device.</param>
-        /// <param name="durationInSeconds">The duration in seconds or float.MaxValue for indefinite duration.</param>
+        /// <param name="durationInSeconds">The duration in seconds or float.MaxValue for indefinite duration (if supported by the platform).</param>
         /// <returns>True if haptic feedback was successfully started.</returns>
         bool StartHapticImpulse(float intensity, float durationInSeconds = float.MaxValue);
 

--- a/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHapticFeedback.cs.meta
+++ b/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHapticFeedback.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8b096bc9a37cfa4cb18b2a3dc758178
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Windows.Input;
 
 #if UNITY_WSA
 using Unity.Profiling;
@@ -19,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         new[] { Handedness.Left, Handedness.Right },
         "Textures/MotionController",
         supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
-    public class WindowsMixedRealityController : BaseWindowsMixedRealitySource
+    public class WindowsMixedRealityController : BaseWindowsMixedRealitySource, IMixedRealityHapticFeedback
     {
         /// <summary>
         /// Constructor.
@@ -283,5 +284,23 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         #endregion Controller model functions
 #endif // UNITY_WSA
+
+        #region Haptic feedback functions
+
+        public bool StartHapticImpulse(float intensity, float durationInSeconds = float.MaxValue) =>
+#if UNITY_WSA
+            LastSourceStateReading.source.StartHaptics(intensity, durationInSeconds);
+#else
+            false;
+#endif // UNITY_WSA
+
+        public void StopHapticFeedback()
+        {
+#if UNITY_WSA
+            LastSourceStateReading.source.StopHaptics();
+#endif // UNITY_WSA
+        }
+
+        #endregion Haptic feedback functions
     }
 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             {
                 if (hapticsFeedback.Waveform.Equals(ContinuousBuzzWaveform))
                 {
-                    if (durationInSeconds.Equals(float.MaxValue))
+                    if (UnityEngine.Mathf.Approximately(durationInSeconds, float.MaxValue))
                     {
                         simpleHapticsController.SendHapticFeedback(hapticsFeedback, intensity);
                     }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// </summary>
         /// <param name="interactionSource">The source to start haptics on.</param>
         /// <param name="intensity">The strength of the haptic feedback from 0.0 (no haptics) to 1.0 (maximum strength).</param>
-        public static void StartHaptics(this InteractionSource interactionSource, float intensity) => interactionSource.StartHaptics(intensity, float.MaxValue);
+        public static bool StartHaptics(this InteractionSource interactionSource, float intensity) => interactionSource.StartHaptics(intensity, float.MaxValue);
 
         /// <summary>
         /// Start haptic feedback on the interaction source with the specified intensity and continue for the specified amount of time.
@@ -85,11 +85,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <param name="interactionSource">The source to start haptics on.</param>
         /// <param name="intensity">The strength of the haptic feedback from 0.0 (no haptics) to 1.0 (maximum strength).</param>
         /// <param name="durationInSeconds">The time period expressed in seconds.</param>
-        public static void StartHaptics(this InteractionSource interactionSource, float intensity, float durationInSeconds)
+        public static bool StartHaptics(this InteractionSource interactionSource, float intensity, float durationInSeconds)
         {
             if (!IsHapticsAvailable)
             {
-                return;
+                return false;
             }
 
 #if WINDOWS_UWP || DOTNETWINRT_PRESENT
@@ -106,10 +106,12 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                     {
                         simpleHapticsController.SendHapticFeedbackForDuration(hapticsFeedback, intensity, TimeSpan.FromSeconds(durationInSeconds));
                     }
-                    return;
+                    return true;
                 }
             }
 #endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

Add support for controller haptics across legacy, Windows XR Plugin, and OpenXR (might work for Oculus too). It can be accessed by querying an object (likely an `IMixedRealityController` if it supports `IMixedRealityHapticFeedback`.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9734
