### PR TITLE
Fix hand meshes popping in and out quickly as hand tracking is regained

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -175,6 +175,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void Start()
         {
+            // Ensure hand is not visible until we can update position first time.
+            HandRenderer.enabled = false;
+
             // Initialize joint dictionary with their corresponding joint transforms
             joints[TrackedHandJoint.Wrist] = Wrist;
             joints[TrackedHandJoint.Palm] = Palm;


### PR DESCRIPTION
## Overview
`RiggedHandVisualizer` is instantiated when hand tracking is regained. At that point, the `HandRenderer` is enabled and actually rendering, making the hand mesh visible - even if hand mesh visualization is disabled in MRTK scene settings.

Afterwards, `OnHandJointsUpdated` is called in a subsequent frame, which will evaluate if the profile has hand mesh visualisation enabled, and disable it if not. This results in a bug where, if you had hand mesh visualization enabled, you see the hand mesh popping in at its original location, and then see it disappear again because it is being hidden. If you had hand mesh visualization enabled, you would also see this popping, because the location of the mesh wasn't updated until later.

Disabling the hand mesh rendering on start (until we've been able to update its position, and evaluate if it needs to render at all) seems to fix this.

I'm using an unstable version of the MRTK on `main` with other bugfixes I need, but I verified this also occurs on stable MRTK 2.6.1. An example of the problem:

https://user-images.githubusercontent.com/73220431/116879801-6b5bab00-ac21-11eb-8fb5-721cb1561b5b.mp4

## Changes
This is not related to the hand meshes "getting stuck" as described in #7896 and others, but appears to be a different issue.
