### PR TITLE
Update pr.yaml and add Unity 2020 Pipeline 

### DIFF
--- a/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
@@ -138,6 +138,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Move back so the cursor is no longer on the object
             yield return hand.MoveTo(offObjectPos, numFramesPerMove);
             VerifyCursorStateFromPointers(inputSystem.FocusProvider.GetPointers<ShellHandRayPointer>(), CursorStateEnum.Interact);
+
+            yield return null;
         }
 
         [UnityTest]

--- a/pipelines/config/settings.yml
+++ b/pipelines/config/settings.yml
@@ -2,6 +2,7 @@ variables:
   # Unity version on AIPMR build agents
   Unity2018Version: Unity2018.4.26f1
   Unity2019Version: Unity2019.4.8f1
+  Unity2020Version: Unity2020.3.5f1
   # Unity version on internal build agents (release builds)
   Unity2018VersionInternal: Unity2018.4.23f1
   Unity2019VersionInternal: Unity2019.4.17f1

--- a/pipelines/pr-2020.yaml
+++ b/pipelines/pr-2020.yaml
@@ -1,15 +1,26 @@
-# Build for PR validation.
+# Build for PR validation via Unity 2020.
 
 variables:
 - template: config/settings.yml
 
 jobs:
-- job: PRValidation
+- job: CodeValidation
+  pool:
+    vmImage: windows-2019
+  steps:
+  - template: templates/validation.yml
+    parameters:
+      # For mrtk_pr builds, validation scripts (code and docs) should be scoped to only
+      # the set of changed files, so that we can save some time. There's no need to
+      # check unchanged files for code style/doc style violations.
+      scopedValidation: true
+
+- job: Unity2020Validation
   timeoutInMinutes: 90
   pool:
     name: On-Prem Unity
     demands:
-    - ${{ variables.Unity2019Version }}
+    - ${{ variables.Unity2020Version }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
     - VS2019 -equals TRUE
@@ -27,6 +38,6 @@ jobs:
       buildUWPX86: false
       buildUWPArm: false
       buildUWPDotNet: false
-      UnityVersion: $(Unity2019Version)
+      UnityVersion: $(Unity2020Version)
 
   - template: templates/end.yml

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -1,4 +1,4 @@
-# Build for PR validation.
+# Build for PR validation via Unity 2018 + Unity 2019.
 
 variables:
 - template: config/settings.yml
@@ -15,7 +15,7 @@ jobs:
       # check unchanged files for code style/doc style violations.
       scopedValidation: true
 
-- job: UnityValidation
+- job: Unity2018Validation
   timeoutInMinutes: 90
   pool:
     name: On-Prem Unity
@@ -38,4 +38,21 @@ jobs:
       buildUWPArm: false
       buildUWPDotNet: false
       UnityVersion: $(Unity2018Version)
+  
+- job: Unity2019Validation
+  timeoutInMinutes: 90
+  pool:
+    name: On-Prem Unity
+    demands:
+    - ${{ variables.Unity2019Version }}
+    - COG-UnityCache-WUS2-01
+    - SDK_18362 -equals TRUE
+    - VS2019 -equals TRUE
+  steps:
+  - template: templates/common.yml
+    parameters:
+      buildUWPX86: false
+      buildUWPArm: false
+      buildUWPDotNet: false
+      UnityVersion: $(Unity2019Version)
   - template: templates/end.yml

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -56,7 +56,7 @@ jobs:
       buildUWPDotNet: false
       UnityVersion: $(Unity2019Version)
 
-  - job: Unity2020Validation
+- job: Unity2020Validation
   timeoutInMinutes: 90
   pool:
     name: On-Prem Unity

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -1,4 +1,4 @@
-# Build for PR validation via Unity 2018 + Unity 2019.
+# Build for PR validation via Unity 2018, 2019 and 2020.
 
 variables:
 - template: config/settings.yml
@@ -55,4 +55,21 @@ jobs:
       buildUWPArm: false
       buildUWPDotNet: false
       UnityVersion: $(Unity2019Version)
+
+  - job: Unity2020Validation
+  timeoutInMinutes: 90
+  pool:
+    name: On-Prem Unity
+    demands:
+    - ${{ variables.Unity2020Version }}
+    - COG-UnityCache-WUS2-01
+    - SDK_18362 -equals TRUE
+    - VS2019 -equals TRUE
+  steps:
+  - template: templates/common.yml
+    parameters:
+      buildUWPX86: false
+      buildUWPArm: false
+      buildUWPDotNet: false
+      UnityVersion: $(Unity2020Version)
   - template: templates/end.yml

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -1,4 +1,4 @@
-# Build for PR validation via Unity 2018, 2019 and 2020.
+# Build for PR validation via Unity 2018 and 2019
 
 variables:
 - template: config/settings.yml
@@ -55,21 +55,4 @@ jobs:
       buildUWPArm: false
       buildUWPDotNet: false
       UnityVersion: $(Unity2019Version)
-
-- job: Unity2020Validation
-  timeoutInMinutes: 90
-  pool:
-    name: On-Prem Unity
-    demands:
-    - ${{ variables.Unity2020Version }}
-    - COG-UnityCache-WUS2-01
-    - SDK_18362 -equals TRUE
-    - VS2019 -equals TRUE
-  steps:
-  - template: templates/common.yml
-    parameters:
-      buildUWPX86: false
-      buildUWPArm: false
-      buildUWPDotNet: false
-      UnityVersion: $(Unity2020Version)
   - template: templates/end.yml


### PR DESCRIPTION
## Overview

- Modified the pr.yaml file to include Unity 2018, 2019 ~~and 2020 validation~~ 
  - Removed 2020 validation from pr.yaml due to the failing Base Cursor Test for now 
- Renamed the pr-2019.yaml file to pr-2020.yaml and added 2020 variables 

