### PR TITLE
Assorted perf improvements

### DIFF
--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -59,15 +59,24 @@ namespace Microsoft.MixedReality.Toolkit.Input
             internal set { raycastProviderType = value; }
         }
 
+        [SerializeField]
+        [Range(1, 2048)]
+        [Tooltip("Maximum number of colliders that can be detected in a SphereOverlap scene query.")]
+        private int focusQueryBufferSize = 128;
+
         /// <summary>
         /// Maximum number of colliders that can be detected in a SphereOverlap scene query.
         /// </summary>
         public int FocusQueryBufferSize => focusQueryBufferSize;
 
         [SerializeField]
-        [Range(1, 2048)]
-        [Tooltip("Maximum number of colliders that can be detected in a SphereOverlap scene query.")]
-        private int focusQueryBufferSize = 128;
+        [Tooltip("Whether or not MRTK should try to raycast against Unity UI.")]
+        private bool shouldUseGraphicsRaycast = true;
+
+        /// <summary>
+        /// Whether or not MRTK should try to raycast against Unity UI.
+        /// </summary>
+        public bool ShouldUseGraphicsRaycast => shouldUseGraphicsRaycast;
 
         [SerializeField]
         [Tooltip("In case of a compound collider, does the individual collider receive focus")]

--- a/Assets/MRTK/Core/Definitions/Utilities/ArticulatedHandPose.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/ArticulatedHandPose.cs
@@ -18,7 +18,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     public class ArticulatedHandPose
     {
         private static readonly TrackedHandJoint[] Joints = Enum.GetValues(typeof(TrackedHandJoint)) as TrackedHandJoint[];
-        private static readonly int JointCount = Joints.Length;
+
+        /// <summary>
+        /// Represents the maximum number of tracked hand joints.
+        /// </summary>
+        public static int JointCount { get; } = Joints.Length;
 
         /// <summary>
         /// Joint poses are stored as right-hand poses in camera space.
@@ -302,14 +306,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         [Serializable]
         internal class ArticulatedHandPoseDictionary
         {
-            private static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
-
             public ArticulatedHandPoseItem[] items = null;
 
             public void FromJointPoses(MixedRealityPose[] jointPoses)
             {
-                items = new ArticulatedHandPoseItem[jointCount];
-                for (int i = 0; i < jointCount; ++i)
+                items = new ArticulatedHandPoseItem[JointCount];
+                for (int i = 0; i < JointCount; ++i)
                 {
                     items[i].JointIndex = (TrackedHandJoint)i;
                     items[i].pose = jointPoses[i];
@@ -318,7 +320,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             public void ToJointPoses(MixedRealityPose[] jointPoses)
             {
-                for (int i = 0; i < jointCount; ++i)
+                for (int i = 0; i < JointCount; ++i)
                 {
                     jointPoses[i] = MixedRealityPose.ZeroIdentity;
                 }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -24,6 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private SerializedProperty focusQueryBufferSize;
         private SerializedProperty raycastProviderType;
         private SerializedProperty focusIndividualCompoundCollider;
+        private SerializedProperty shouldUseGraphicsRaycast;
 
         private static bool showPointerProperties = false;
         private const string ShowInputSystem_Pointers_PreferenceKey = "ShowInputSystem_Pointers_PreferenceKey";
@@ -64,6 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             focusQueryBufferSize = serializedObject.FindProperty("focusQueryBufferSize");
             raycastProviderType = serializedObject.FindProperty("raycastProviderType");
             focusIndividualCompoundCollider = serializedObject.FindProperty("focusIndividualCompoundCollider");
+            shouldUseGraphicsRaycast = serializedObject.FindProperty("shouldUseGraphicsRaycast");
             inputActionsProfile = serializedObject.FindProperty("inputActionsProfile");
             inputActionRulesProfile = serializedObject.FindProperty("inputActionRulesProfile");
             pointerProfile = serializedObject.FindProperty("pointerProfile");
@@ -93,6 +95,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 EditorGUILayout.PropertyField(focusQueryBufferSize);
                 EditorGUILayout.PropertyField(raycastProviderType);
                 EditorGUILayout.PropertyField(focusIndividualCompoundCollider);
+                EditorGUILayout.PropertyField(shouldUseGraphicsRaycast);
                 changed |= EditorGUI.EndChangeCheck();
 
                 EditorGUILayout.Space();

--- a/Assets/MRTK/Core/Providers/InputAnimation/InputAnimation.cs
+++ b/Assets/MRTK/Core/Providers/InputAnimation/InputAnimation.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Contains a set of animation curves that describe motion of camera and hands.
     /// </summary>
-    [System.Serializable]
+    [Serializable]
     public class InputAnimation
     {
         /// <summary>

--- a/Assets/MRTK/Core/Providers/InputAnimation/InputAnimation.cs
+++ b/Assets/MRTK/Core/Providers/InputAnimation/InputAnimation.cs
@@ -33,8 +33,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [System.Serializable]
     public class InputAnimation
     {
-        protected static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
-
         /// <summary>
         /// Arbitrarily large weight for representing a boolean value in float curves.
         /// </summary>
@@ -340,7 +338,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 InputAnimationSerializationUtils.WriteBoolCurve(writer, handPinchCurveLeft, startTime);
                 InputAnimationSerializationUtils.WriteBoolCurve(writer, handPinchCurveRight, startTime);
 
-                for (int i = 0; i < jointCount; ++i)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; ++i)
                 {
                     if (!handJointCurvesLeft.TryGetValue((TrackedHandJoint)i, out var curves))
                     {
@@ -348,7 +346,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                     PoseCurvesToStream(writer, curves, startTime);
                 }
-                for (int i = 0; i < jointCount; ++i)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; ++i)
                 {
                     if (!handJointCurvesRight.TryGetValue((TrackedHandJoint)i, out var curves))
                     {
@@ -612,7 +610,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 InputAnimationSerializationUtils.ReadBoolCurve(reader, animation.handPinchCurveLeft);
                 InputAnimationSerializationUtils.ReadBoolCurve(reader, animation.handPinchCurveRight);
 
-                for (int i = 0; i < jointCount; ++i)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; ++i)
                 {
                     if (!animation.handJointCurvesLeft.TryGetValue((TrackedHandJoint)i, out var curves))
                     {
@@ -623,7 +621,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     PoseCurvesFromStream(reader, curves, useNewFormat);
                 }
 
-                for (int i = 0; i < jointCount; ++i)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; ++i)
                 {
                     if (!animation.handJointCurvesRight.TryGetValue(key: (TrackedHandJoint)i, out var curves))
                     {

--- a/Assets/MRTK/Core/Providers/InputAnimation/InputAnimationSerializationUtils.cs
+++ b/Assets/MRTK/Core/Providers/InputAnimation/InputAnimationSerializationUtils.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -14,8 +13,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     public static class InputAnimationSerializationUtils
     {
-        private static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
-
         public const string Extension = "bin";
 
         const long Magic = 0x6a8faf6e0f9e42c6;

--- a/Assets/MRTK/Core/Providers/InputAnimation/InputAnimationSerializationUtils.cs
+++ b/Assets/MRTK/Core/Providers/InputAnimation/InputAnimationSerializationUtils.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             string filename;
             if (appendTimestamp)
             {
-                filename = String.Format("{0}-{1}.{2}", baseName, DateTime.UtcNow.ToString("yyyyMMdd-HHmmss"), InputAnimationSerializationUtils.Extension);
+                filename = string.Format("{0}-{1}.{2}", baseName, DateTime.UtcNow.ToString("yyyyMMdd-HHmmss"), Extension);
             }
             else
             {

--- a/Assets/MRTK/Core/Providers/InputAnimation/InputRecordingService.cs
+++ b/Assets/MRTK/Core/Providers/InputAnimation/InputRecordingService.cs
@@ -23,8 +23,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         BaseInputDeviceManager,
         IMixedRealityInputRecordingService
     {
-        private static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
-
         /// <summary>
         /// Invoked when recording begins
         /// </summary>
@@ -392,7 +390,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             if (isTracked)
             {
-                for (int i = 0; i < jointCount; ++i)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; ++i)
                 {
                     if (hand.TryGetJoint((TrackedHandJoint)i, out MixedRealityPose jointPose))
                     {

--- a/Assets/MRTK/Core/Providers/InputSimulation/BaseInputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/BaseInputSimulationService.cs
@@ -22,13 +22,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Active controllers
         /// </summary>
-        private IMixedRealityController[] activeControllers = System.Array.Empty<IMixedRealityController>();
+        private IMixedRealityController[] activeControllers = Array.Empty<IMixedRealityController>();
 
         /// <inheritdoc />
-        public override IMixedRealityController[] GetActiveControllers()
-        {
-            return activeControllers;
-        }
+        public override IMixedRealityController[] GetActiveControllers() => activeControllers;
 
         #region BaseInputDeviceManager Implementation
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputPlaybackService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputPlaybackService.cs
@@ -21,8 +21,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         IMixedRealityInputPlaybackService,
         IMixedRealityEyeGazeDataProvider
     {
-        private static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
-
         /// <summary>
         /// Invoked when playback begins or resumes
         /// </summary>
@@ -276,7 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (handData.Update(isTracked, isPinching,
                 (MixedRealityPose[] joints) =>
                 {
-                    for (int i = 0; i < jointCount; ++i)
+                    for (int i = 0; i < ArticulatedHandPose.JointCount; ++i)
                     {
                         joints[i] = animation.EvaluateHandJoint(localTime, handedness, (TrackedHandJoint)i);
                     }

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationService.cs
@@ -262,7 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             if (indicators)
             {
-                GameObject.Destroy(indicators);
+                UnityEngine.Object.Destroy(indicators);
             }
 
             DisableCameraControl();

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedArticulatedHand.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedArticulatedHand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         protected override void UpdateHandJoints(SimulatedHandData handData)
         {
-            for (int i = 0; i < jointCount; i++)
+            for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
             {
                 TrackedHandJoint handJoint = (TrackedHandJoint)i;
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedGestureHand.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedGestureHand.cs
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         protected override void UpdateHandJoints(SimulatedHandData handData)
         {
-            for (int i = 0; i < jointCount; i++)
+            for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
             {
                 TrackedHandJoint handJoint = (TrackedHandJoint)i;
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
@@ -14,8 +14,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [Serializable]
     public class SimulatedHandData
     {
-        private static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
-
         [SerializeField]
         private bool isTracked = false;
 
@@ -24,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool IsTracked => isTracked;
         [SerializeField]
-        private MixedRealityPose[] joints = new MixedRealityPose[jointCount];
+        private MixedRealityPose[] joints = new MixedRealityPose[ArticulatedHandPose.JointCount];
 
         /// <summary>
         /// Array storing the joints of the hand
@@ -47,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             isTracked = other.isTracked;
             isPinching = other.isPinching;
-            for (int i = 0; i < jointCount; ++i)
+            for (int i = 0; i < ArticulatedHandPose.JointCount; ++i)
             {
                 joints[i] = other.joints[i];
             }
@@ -85,8 +83,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public abstract class SimulatedHand : BaseHand
     {
         public abstract ControllerSimulationMode SimulationMode { get; }
-
-        protected static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
 
         protected readonly Dictionary<TrackedHandJoint, MixedRealityPose> jointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
@@ -21,6 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Whether the hand is currently being tracked
         /// </summary>
         public bool IsTracked => isTracked;
+
         [SerializeField]
         private MixedRealityPose[] joints = new MixedRealityPose[ArticulatedHandPose.JointCount];
 
@@ -28,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Array storing the joints of the hand
         /// </summary>
         public MixedRealityPose[] Joints => joints;
+
         [SerializeField]
         private bool isPinching = false;
 

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandUtils.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHandUtils.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
-using System;
 using System.Linq;
 using UnityEngine;
 
@@ -10,8 +9,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     public class SimulatedHandUtils
     {
-        private static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
-
         /// <summary>
         /// Compute the rotation of each joint, with the forward vector of the rotation pointing along the joint bone, 
         /// and the up vector pointing up.

--- a/Assets/MRTK/Core/Utilities/MaintainBorderLightWidth.cs
+++ b/Assets/MRTK/Core/Utilities/MaintainBorderLightWidth.cs
@@ -6,8 +6,8 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     /// <summary>
-    /// Utility component to keep the border light width a constant size no mater the 
-    /// object scale. This component should be used in conjunction with the 
+    /// Utility component to keep the border light width a constant size no matter the
+    /// object scale. This component should be used in conjunction with the
     /// "MixedRealityToolkit/Standard" shader "_BorderLight" feature.
     /// </summary>
     [RequireComponent(typeof(Renderer))]
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     {
         private Renderer targetRenderer = null;
         private MaterialPropertyBlock properties = null;
-        private static int borderWidthID = Shader.PropertyToID("_BorderWidth");
+        private static readonly int BorderWidthID = Shader.PropertyToID("_BorderWidth");
         private float initialBorderWidth = 1.0f;
         private Vector3 initialScale = Vector3.one;
         private Vector3 prevScale;
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             targetRenderer = GetComponent<Renderer>();
             properties = new MaterialPropertyBlock();
 
-            initialBorderWidth = targetRenderer.sharedMaterial.GetFloat(borderWidthID);
+            initialBorderWidth = targetRenderer.sharedMaterial.GetFloat(BorderWidthID);
             initialScale = transform.lossyScale;
             prevScale = initialScale;
 
@@ -70,7 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 }
 
                 targetRenderer.GetPropertyBlock(properties);
-                properties.SetFloat(borderWidthID, initialBorderWidth / scalePercentage);
+                properties.SetFloat(BorderWidthID, initialBorderWidth / scalePercentage);
                 targetRenderer.SetPropertyBlock(properties);
             }
         }

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandRecorder.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandRecorder.cs
@@ -17,8 +17,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [AddComponentMenu("Scripts/MRTK/Providers/WindowsMixedRealityHandRecorder")]
     public class WindowsMixedRealityHandRecorder : MonoBehaviour
     {
-        private static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
-
         /// <summary>
         /// The joint positioned at the origin at the start of the recording.
         /// </summary>
@@ -56,8 +54,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public void RecordHandStop()
         {
-            MixedRealityPose[] jointPoses = new MixedRealityPose[jointCount];
-            for (int i = 0; i < jointCount; ++i)
+            MixedRealityPose[] jointPoses = new MixedRealityPose[ArticulatedHandPose.JointCount];
+            for (int i = 0; i < ArticulatedHandPose.JointCount; ++i)
             {
                 HandJointUtils.TryGetJointPose((TrackedHandJoint)i, recordingHand, out jointPoses[i]);
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
@@ -128,7 +128,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set { state = value; }
         }
 
-
         [Header("Default Button Options")]
 
         [Tooltip("Should the AppBar have a remove button")]
@@ -462,14 +461,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (!(Target is IBoundsTargetProvider boundsProvider) || boundsProvider.IsNull() || boundsProvider.Target == null)
             {
-                if (DisplayType == AppBarDisplayTypeEnum.Manipulation)
+                bool isDisplayTypeNotManipulation = DisplayType != AppBarDisplayTypeEnum.Manipulation;
+                if (BaseRenderer.activeSelf != isDisplayTypeNotManipulation)
                 {
-                    // Hide our buttons
-                    BaseRenderer.SetActive(false);
-                }
-                else
-                {
-                    BaseRenderer.SetActive(true);
+                    BaseRenderer.SetActive(isDisplayTypeNotManipulation);
                 }
                 return;
             }
@@ -562,10 +557,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     {
                         // Show hide, adjust, remove buttons
                         // The rest are hidden
-                        case AppBar.ButtonTypeEnum.Hide:
-                        case AppBar.ButtonTypeEnum.Remove:
-                        case AppBar.ButtonTypeEnum.Adjust:
-                        case AppBar.ButtonTypeEnum.Custom:
+                        case ButtonTypeEnum.Hide:
+                        case ButtonTypeEnum.Remove:
+                        case ButtonTypeEnum.Adjust:
+                        case ButtonTypeEnum.Custom:
                             return true;
 
                         default:
@@ -589,7 +584,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     {
                         // Show done button
                         // The rest are hidden
-                        case AppBar.ButtonTypeEnum.Done:
+                        case ButtonTypeEnum.Done:
                             return true;
 
                         default:

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -109,22 +109,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [Tooltip("Current scale value. 1 is the original 100%.")]
         private float currentScale;
+
         /// <summary>
         /// Current scale value. 1 is the original 100%.
         /// </summary>
-        public float CurrentScale
-        {
-            get { return currentScale; }
-        }
+        public float CurrentScale => currentScale;
 
         /// <summary>
         /// Returns the current pan delta (pan value - previous pan value)
-        /// in UV coordinates (0 being no pan, 1, being pan of the entire ) 
+        /// in UV coordinates (0 being no pan, 1 being pan of the entire slate)
         /// </summary>
-        public Vector2 CurrentPanDelta
-        {
-            get { return totalUVOffset; }
-        }
+        public Vector2 CurrentPanDelta => totalUVOffset;
 
         [Header("Events")]
         public PanUnityEvent PanStarted = new PanUnityEvent();
@@ -144,7 +139,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private float previousContactRatio = 1.0f;
         private float initialTouchDistance = 0.0f;
-        private float lastTouchDistance = 0.0f;
         private Vector2 totalUVOffset = Vector2.zero;
         private Vector2 totalUVScale = Vector2.one;
         private bool affordancesVisible = false;
@@ -157,6 +151,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private Dictionary<uint, HandPanData> handDataMap = new Dictionary<uint, HandPanData>();
         private List<Vector2> uvs = new List<Vector2>();
         private List<Vector2> uvsOrig = new List<Vector2>();
+        private List<Vector2> uvDeltas = new List<Vector2>();
         private bool oldIsTargetPositionLockedOnFocusLock;
 
 #if UNITY_2019_3_OR_NEWER
@@ -398,13 +393,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 // Test for scale limits
                 if (currentScale > minScale && currentScale < maxScale)
                 {
-                    var scaleAndScrollUVDeltas = new List<Vector2>();
+                    uvDeltas.Clear();
                     for (int i = 0; i < uvs.Count; i++)
                     {
                         Vector2 adjustedScaleUVDelta = ((uvs[i] - scaleUVCentroid) / scaleUVDelta) + scaleUVCentroid - uvs[i];
-                        scaleAndScrollUVDeltas.Add(adjustedScaleUVDelta + offsetUVDelta);
+                        uvDeltas.Add(adjustedScaleUVDelta + offsetUVDelta);
                     }
-                    UpdateUV(uvs, scaleAndScrollUVDeltas);
+                    UpdateUV(uvs, uvDeltas);
 
                     Vector2 upperLeft = uvs[UpperLeftQuadIndex];
                     Vector2 upperRight = uvs[UpperRightQuadIndex];
@@ -424,12 +419,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void UpdateUVWithScroll(List<Vector2> uvs, Vector2 uvDelta)
         {
-            var uvDeltas = new List<Vector2>();
+            uvDeltas.Clear();
             for (int i = 0; i < uvs.Count; i++)
             {
                 uvDeltas.Add(uvDelta);
             }
-
             UpdateUV(uvs, uvDeltas, true);
         }
 
@@ -763,7 +757,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             data.touchingUVOffset = data.touchingUVTotalOffset;
             handDataMap.Add(data.touchingSource.SourceId, data);
             initialTouchDistance = GetContactDistance();
-            lastTouchDistance = initialTouchDistance;
             totalUVOffset = Vector2.zero;
 
             if (handDataMap.Keys.Count > 1)

--- a/Assets/MRTK/SDK/Profiles/HoloLens2/DefaultHoloLens2InputSystemProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/HoloLens2/DefaultHoloLens2InputSystemProfile.asset
@@ -133,6 +133,7 @@ MonoBehaviour:
   raycastProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultRaycastProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
   focusQueryBufferSize: 128
+  shouldUseGraphicsRaycast: 1
   focusIndividualCompoundCollider: 0
   inputActionsProfile: {fileID: 11400000, guid: 723eb97b02944311b92861f473eee53e,
     type: 2}

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -43,6 +43,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             maxQuerySceneResults = profile.FocusQueryBufferSize;
             focusIndividualCompoundCollider = profile.FocusIndividualCompoundCollider;
+            inputSystemProfile = profile;
+            shouldUseGraphicsRaycast = inputSystemProfile == null || inputSystemProfile.ShouldUseGraphicsRaycast;
         }
 
         private readonly Dictionary<uint, PointerData> pointers = new Dictionary<uint, PointerData>();
@@ -52,8 +54,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private readonly Dictionary<uint, IMixedRealityPointerMediator> pointerMediators = new Dictionary<uint, IMixedRealityPointerMediator>();
         private readonly PointerHitResult hitResult3d = new PointerHitResult();
         private readonly PointerHitResult hitResultUi = new PointerHitResult();
+        private readonly MixedRealityInputSystemProfile inputSystemProfile;
 
         private readonly int maxQuerySceneResults = 128;
+        private readonly bool shouldUseGraphicsRaycast = true;
         private bool focusIndividualCompoundCollider = false;
 
         public IReadOnlyDictionary<uint, IMixedRealityPointerMediator> PointerMediators => pointerMediators;
@@ -98,11 +102,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             get
             {
-                MixedRealityInputSystemProfile profile = ConfigurationProfile as MixedRealityInputSystemProfile;
-
-                if (profile != null && profile.PointerProfile != null)
+                if (inputSystemProfile != null && inputSystemProfile.PointerProfile != null)
                 {
-                    return profile.PointerProfile.PointingExtent;
+                    return inputSystemProfile.PointerProfile.PointingExtent;
                 }
 
                 return 10f;
@@ -118,11 +120,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 if (focusLayerMasks == null)
                 {
-                    MixedRealityInputSystemProfile profile = ConfigurationProfile as MixedRealityInputSystemProfile;
-
-                    if (profile != null && profile.PointerProfile != null)
+                    if (inputSystemProfile != null && inputSystemProfile.PointerProfile != null)
                     {
-                        return focusLayerMasks = profile.PointerProfile.PointingRaycastLayerMasks;
+                        return focusLayerMasks = inputSystemProfile.PointerProfile.PointingRaycastLayerMasks;
                     }
 
                     return focusLayerMasks = new LayerMask[] { UnityPhysics.DefaultRaycastLayers };
@@ -153,15 +153,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     return false;
                 }
 
-                MixedRealityInputSystemProfile profile = ConfigurationProfile as MixedRealityInputSystemProfile;
-
-                if (profile == null)
+                if (inputSystemProfile == null)
                 {
                     Debug.LogError($"Unable to start {Name}. An Input System Profile is required for this feature.");
                     return false;
                 }
 
-                if (profile.PointerProfile == null)
+                if (inputSystemProfile.PointerProfile == null)
                 {
                     Debug.LogError($"Unable to start {Name}. An Pointer Profile is required for this feature.");
                     return false;
@@ -591,9 +589,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         QueryScene(gazeProviderPointingData.Pointer, raycastProvider, prioritizedLayerMasks,
                             hitResult3d, maxQuerySceneResults, focusIndividualCompoundCollider);
 
-                        // get ui hit
-                        hitResultUi.Clear();
-                        RaycastGraphics(gazeProviderPointingData.Pointer, gazeProviderPointingData.GraphicEventData, prioritizedLayerMasks, hitResultUi);
+                        if (shouldUseGraphicsRaycast)
+                        {
+                            // get ui hit
+                            hitResultUi.Clear();
+                            RaycastGraphics(gazeProviderPointingData.Pointer, gazeProviderPointingData.GraphicEventData, prioritizedLayerMasks, hitResultUi);
+                        }
 
                         // set gaze hit according to distance and prioritization layer mask
                         gazeHitResult = GetPrioritizedHitResult(hitResult3d, hitResultUi, prioritizedLayerMasks);
@@ -834,7 +835,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     RegisterPointer(inputSource.Pointers[i]);
 
                     // Special Registration for Gaze
-                    if (!CoreServices.InputSystem.GazeProvider.IsNull() && inputSource.SourceId == CoreServices.InputSystem.GazeProvider.GazeInputSource.SourceId && gazeProviderPointingData == null)
+                    if (!CoreServices.InputSystem.GazeProvider.IsNull()
+                        && inputSource.SourceId == CoreServices.InputSystem.GazeProvider.GazeInputSource.SourceId
+                        && gazeProviderPointingData == null)
                     {
                         gazeProviderPointingData = new PointerData(inputSource.Pointers[i]);
                     }
@@ -950,8 +953,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (UpdatePointersPerfMarker.Auto())
             {
-                MixedRealityInputSystemProfile profile = ConfigurationProfile as MixedRealityInputSystemProfile;
-                if (profile == null) { return; }
+                if (inputSystemProfile == null) { return; }
 
                 ReconcilePointers();
 
@@ -968,7 +970,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     UpdatePointer(pointerData);
 
 #if UNITY_EDITOR
-                    var pointerProfile = profile.PointerProfile;
+                    var pointerProfile = inputSystemProfile.PointerProfile;
                     if (pointerProfile != null && pointerProfile.DebugDrawPointingRays)
                     {
                         MixedRealityRaycaster.DebugEnabled = pointerProfile.DebugDrawPointingRays;
@@ -1032,7 +1034,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         pointerData.UpdateFocusLockedHit();
 
                         // If we have a unity event system, perform graphics raycasts as well to support Unity UI interactions
-                        if (EventSystem.current != null)
+                        if (shouldUseGraphicsRaycast && EventSystem.current != null)
                         {
                             // NOTE: We need to do this AFTER RaycastPhysics so we use the current hit point to perform the correct 2D UI Raycast.
                             hitResultUi.Clear();
@@ -1057,7 +1059,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                         PointerHitResult hit = hitResult3d;
                         // If we have a unity event system, perform graphics raycasts as well to support Unity UI interactions
-                        if (EventSystem.current != null)
+                        if (shouldUseGraphicsRaycast && EventSystem.current != null)
                         {
                             // NOTE: We need to do this AFTER RaycastPhysics so we use the current hit point to perform the correct 2D UI Raycast.
                             hitResultUi.Clear();
@@ -1270,7 +1272,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                             }
                             else if (colliders.Length != maxQuerySceneResults)
                             {
-                                Array.Resize<Collider>(ref colliders, maxQuerySceneResults);
+                                Array.Resize(ref colliders, maxQuerySceneResults);
                             }
 
                             Vector3 testPoint = pointer.Rays[i].Origin;
@@ -1282,7 +1284,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                             // Since this is usually done when a pointer passes a IsInteractionEnabled, maybe we can cache the selected colliders inside the pointer?
                             foreach (LayerMask layerMask in prioritizedLayerMasks)
                             {
-                                int numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(pointer.Rays[i].Origin, pointer.SphereCastRadius, colliders, layerMask);
+                                int numColliders = UnityPhysics.OverlapSphereNonAlloc(pointer.Rays[i].Origin, pointer.SphereCastRadius, colliders, layerMask);
                                 if (numColliders > 0)
                                 {
                                     if (numColliders >= maxQuerySceneResults)

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -557,7 +557,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (UpdatePerfMarker.Auto())
             {
-                if (!IsSetupValid) { return; }
+                if (!IsInitialized) { return; }
 
                 base.Update();
 


### PR DESCRIPTION
## Overview

1. Makes the graphics raycast optional for apps who don't use Unity UI
    1. Defaults to true. Is controlled in the input profile via `shouldUseGraphicsRaycast`
2. Updates to use one central definition for `JointCount`
3. Removes an every-frame list allocation in `HandInteractionPanZoom`
4. Remove some frequent `ConfigurationProfile as MixedRealityInputSystemProfile` casts in FocusProvider