### PR TITLE
Fix some null refs when the input system is turned off

### DIFF
--- a/Assets/MRTK/Core/Providers/BaseGenericInputSource.cs
+++ b/Assets/MRTK/Core/Providers/BaseGenericInputSource.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public BaseGenericInputSource(string name, IMixedRealityPointer[] pointers = null, InputSourceType sourceType = InputSourceType.Other)
         {
-            SourceId = (CoreServices.InputSystem != null) ? CoreServices.InputSystem.GenerateNewSourceId() : 0;
+            SourceId = CoreServices.InputSystem?.GenerateNewSourceId() ?? 0;
             SourceName = name;
             if (pointers != null)
             {

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -93,15 +93,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnHandJointsUpdatedPerfMarker.Auto())
             {
-                var inputSystem = CoreServices.InputSystem;
-
                 if (eventData.InputSource.SourceId != Controller.InputSource.SourceId)
                 {
                     return;
                 }
                 Debug.Assert(eventData.Handedness == Controller.ControllerHandedness);
 
-                MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile.HandTrackingProfile;
+                IMixedRealityInputSystem inputSystem = CoreServices.InputSystem;
+                MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile != null ? inputSystem.InputSystemProfile.HandTrackingProfile : null;
                 if (handTrackingProfile != null && !handTrackingProfile.EnableHandJointVisualization)
                 {
                     // clear existing joint GameObjects / meshes
@@ -125,7 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     else
                     {
                         GameObject prefab;
-                        if (handJoint == TrackedHandJoint.None)
+                        if (handJoint == TrackedHandJoint.None || handTrackingProfile == null)
                         {
                             // No visible mesh for the "None" joint
                             prefab = null;

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -131,15 +131,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         }
                         else if (handJoint == TrackedHandJoint.Palm)
                         {
-                            prefab = inputSystem.InputSystemProfile.HandTrackingProfile.PalmJointPrefab;
+                            prefab = handTrackingProfile.PalmJointPrefab;
                         }
                         else if (handJoint == TrackedHandJoint.IndexTip)
                         {
-                            prefab = inputSystem.InputSystemProfile.HandTrackingProfile.FingerTipPrefab;
+                            prefab = handTrackingProfile.FingerTipPrefab;
                         }
                         else
                         {
-                            prefab = inputSystem.InputSystemProfile.HandTrackingProfile.JointPrefab;
+                            prefab = handTrackingProfile.JointPrefab;
                         }
 
                         GameObject jointObject;

--- a/Assets/MRTK/Core/Providers/Hands/HandJointUtils.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandJointUtils.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public static T FindHand<T>(Handedness handedness) where T : class, IMixedRealityHand
         {
-            foreach (var detectedController in CoreServices.InputSystem.DetectedControllers)
+            foreach (IMixedRealityController detectedController in CoreServices.InputSystem?.DetectedControllers)
             {
                 if (detectedController is T hand)
                 {

--- a/Assets/MRTK/Core/Providers/Hands/HandJointUtils.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandJointUtils.cs
@@ -49,7 +49,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public static T FindHand<T>(Handedness handedness) where T : class, IMixedRealityHand
         {
-            foreach (IMixedRealityController detectedController in CoreServices.InputSystem?.DetectedControllers)
+            System.Collections.Generic.HashSet<IMixedRealityController> controllers = CoreServices.InputSystem?.DetectedControllers;
+
+            if (controllers == null)
+            {
+                return null;
+            }
+
+            foreach (IMixedRealityController detectedController in controllers)
             {
                 if (detectedController is T hand)
                 {

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -24529,12 +24529,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1666569904}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1666569906 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 100004, guid: 40bb9772594a93140a43a9a4f5cf9356,
-    type: 3}
-  m_PrefabInstance: {fileID: 1666569904}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1666569907 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 100002, guid: 40bb9772594a93140a43a9a4f5cf9356,
@@ -24547,7 +24541,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1666569906}
+  m_GameObject: {fileID: 1666569907}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dac28f8bfe57b7f4182539cec9c0b40d, type: 3}
@@ -24569,46 +24563,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ShowTetherWhenManipulating: 0
   IsBoundsHandles: 0
---- !u!114 &1666569910
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1666569906}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 181cd563a8349c34ea8978b0bc8d9c7e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  hostTransform: {fileID: 1666569914}
-  manipulationType: 3
-  twoHandedManipulationType: 7
-  allowFarManipulation: 1
-  useForcesForNearManipulation: 0
-  oneHandRotationModeNear: 1
-  oneHandRotationModeFar: 1
-  releaseBehavior: -1
-  smoothingFar: 1
-  smoothingNear: 1
-  moveLerpTime: 0.000001
-  rotateLerpTime: 0.000001
-  scaleLerpTime: 0.000001
-  enableConstraints: 1
-  constraintsManager: {fileID: 1666569915}
-  elasticsManager: {fileID: 0}
-  onManipulationStarted:
-    m_PersistentCalls:
-      m_Calls: []
-  onManipulationEnded:
-    m_PersistentCalls:
-      m_Calls: []
-  onHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  onHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!82 &1666569911
 AudioSource:
   m_ObjectHideFlags: 0
@@ -24730,26 +24684,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 91cf8ec3353d87d409bfce42a1bc6d1c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1666569914 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400004, guid: 40bb9772594a93140a43a9a4f5cf9356,
-    type: 3}
-  m_PrefabInstance: {fileID: 1666569904}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1666569915
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1666569906}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a98de877dee5fc341b4eb59dfdab266c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  autoConstraintSelection: 1
-  selectedConstraints: []
 --- !u!114 &1666569917
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -24827,7 +24761,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   autoConstraintSelection: 1
-  selectedConstraints: []
+  selectedConstraints:
+  - {fileID: 1666569908}
 --- !u!1001 &1672675963
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -22202,6 +22202,7 @@ GameObject:
   - component: {fileID: 1541735672}
   - component: {fileID: 1541735671}
   - component: {fileID: 1541735673}
+  - component: {fileID: 1541735674}
   m_Layer: 0
   m_Name: Platonic
   m_TagString: Untagged
@@ -22325,7 +22326,7 @@ MonoBehaviour:
   rotateLerpTime: 0.001
   scaleLerpTime: 0.001
   enableConstraints: 1
-  constraintsManager: {fileID: 0}
+  constraintsManager: {fileID: 1541735674}
   elasticsManager: {fileID: 0}
   onManipulationStarted:
     m_PersistentCalls:
@@ -22397,6 +22398,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 91cf8ec3353d87d409bfce42a1bc6d1c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1541735674
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541735666}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a98de877dee5fc341b4eb59dfdab266c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoConstraintSelection: 1
+  selectedConstraints: []
 --- !u!1001 &1542015560
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24580,7 +24595,7 @@ MonoBehaviour:
   rotateLerpTime: 0.000001
   scaleLerpTime: 0.000001
   enableConstraints: 1
-  constraintsManager: {fileID: 0}
+  constraintsManager: {fileID: 1666569915}
   elasticsManager: {fileID: 0}
   onManipulationStarted:
     m_PersistentCalls:
@@ -24721,6 +24736,20 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1666569904}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1666569915
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1666569906}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a98de877dee5fc341b4eb59dfdab266c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoConstraintSelection: 1
+  selectedConstraints: []
 --- !u!114 &1666569917
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -24747,7 +24776,7 @@ MonoBehaviour:
   rotateLerpTime: 0.000001
   scaleLerpTime: 0.000001
   enableConstraints: 1
-  constraintsManager: {fileID: 0}
+  constraintsManager: {fileID: 1666569918}
   elasticsManager: {fileID: 0}
   onManipulationStarted:
     m_PersistentCalls:
@@ -24785,6 +24814,20 @@ MonoBehaviour:
   onHoverExited:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1666569918
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1666569907}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a98de877dee5fc341b4eb59dfdab266c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoConstraintSelection: 1
+  selectedConstraints: []
 --- !u!1001 &1672675963
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1158,11 +1158,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public static MixedRealityInputAction ResolveInputAction(int index)
         {
-            MixedRealityInputAction[] actions = CoreServices.InputSystem.InputSystemProfile.InputActionsProfile.InputActions;
-            if (actions?.Length > 0)
+            if (CoreServices.InputSystem?.InputSystemProfile != null
+                && CoreServices.InputSystem.InputSystemProfile.InputActionsProfile != null)
             {
-                index = Mathf.Clamp(index, 0, actions.Length - 1);
-                return actions[index];
+                MixedRealityInputAction[] actions = CoreServices.InputSystem.InputSystemProfile.InputActionsProfile.InputActions;
+                if (actions?.Length > 0)
+                {
+                    index = Mathf.Clamp(index, 0, actions.Length - 1);
+                    return actions[index];
+                }
             }
 
             return default;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -850,6 +850,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             TargetBounds.EnsureComponent<NearInteractionGrabbable>();
         }
 
+        private readonly List<Transform> childTransforms = new List<Transform>();
+
         private Bounds GetTargetBounds()
         {
             TotalBoundsCorners.Clear();
@@ -859,7 +861,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             // Since those have the gizmo structure childed, be need to omit them completely in the calculation of the bounds
             // This can only happen by name unless there is a better idea of tracking the rigRoot that needs destruction
 
-            List<Transform> childTransforms = new List<Transform>();
+            childTransforms.Clear();
             if (Target != gameObject)
             {
                 childTransforms.Add(Target.transform);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
@@ -146,8 +146,15 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             proximityPointers.Clear();
             proximityPoints.Clear();
 
+            HashSet<IMixedRealityInputSource> inputSources = CoreServices.InputSystem?.DetectedInputSources;
+
+            if (inputSources == null)
+            {
+                return;
+            }
+
             // Find all valid pointers
-            foreach (IMixedRealityInputSource inputSource in CoreServices.InputSystem?.DetectedInputSources)
+            foreach (IMixedRealityInputSource inputSource in inputSources)
             {
                 foreach (IMixedRealityPointer pointer in inputSource.Pointers)
                 {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
@@ -147,7 +147,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             proximityPoints.Clear();
 
             // Find all valid pointers
-            foreach (var inputSource in CoreServices.InputSystem.DetectedInputSources)
+            foreach (IMixedRealityInputSource inputSource in CoreServices.InputSystem?.DetectedInputSources)
             {
                 foreach (var pointer in inputSource.Pointers)
                 {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
@@ -149,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             // Find all valid pointers
             foreach (IMixedRealityInputSource inputSource in CoreServices.InputSystem?.DetectedInputSources)
             {
-                foreach (var pointer in inputSource.Pointers)
+                foreach (IMixedRealityPointer pointer in inputSource.Pointers)
                 {
                     // don't use IsInteractionEnabled for near pointers as the pointers might have a different radius when deciding
                     // if they can interact with a near-by object - we might still want to show proximity scaling even if
@@ -187,10 +187,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             float closestDistanceSqr = float.MaxValue;
             foreach (var point in proximityPoints)
             {
-
                 foreach (var keyValuePair in registeredObjects)
                 {
-
                     foreach (var item in keyValuePair.Value)
                     {
                         // If object can't be visible, skip calculations

--- a/Assets/MRTK/SDK/Features/Utilities/InputRayUtils.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/InputRayUtils.cs
@@ -110,7 +110,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             controller = null;
 
-            foreach (IMixedRealityController c in CoreServices.InputSystem.DetectedControllers)
+            System.Collections.Generic.HashSet<IMixedRealityController> controllers = CoreServices.InputSystem?.DetectedControllers;
+
+            if (controllers == null)
+            {
+                return false;
+            }
+
+            foreach (IMixedRealityController c in controllers)
             {
                 if ((c.InputSource?.SourceType == sourceType) &&
                     (c.ControllerHandedness == hand))

--- a/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
@@ -153,7 +153,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <returns><seealso cref="Microsoft.MixedReality.Toolkit.Input.PointerBehavior"/> for the given pointer type and handedness</returns>
         public static PointerBehavior GetPointerBehavior<T>(Handedness handedness, InputSourceType inputSourceType) where T : class, IMixedRealityPointer
         {
-            if (CoreServices.InputSystem.FocusProvider is IPointerPreferences preferences)
+            if (CoreServices.InputSystem?.FocusProvider is IPointerPreferences preferences)
             {
                 if (typeof(T) == typeof(GGVPointer))
                 {

--- a/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
@@ -138,7 +138,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             foreach (var inputSource in CoreServices.InputSystem.DetectedInputSources)
             {
-                foreach (var pointer in inputSource.Pointers)
+                foreach (IMixedRealityPointer pointer in inputSource.Pointers)
                 {
                     yield return pointer;
                 }

--- a/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
@@ -136,7 +136,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public static IEnumerable<IMixedRealityPointer> GetPointers()
         {
-            foreach (var inputSource in CoreServices.InputSystem.DetectedInputSources)
+            HashSet<IMixedRealityInputSource> inputSources = CoreServices.InputSystem?.DetectedInputSources;
+
+            if (inputSources == null)
+            {
+                yield break;
+            }
+
+            foreach (IMixedRealityInputSource inputSource in inputSources)
             {
                 foreach (IMixedRealityPointer pointer in inputSource.Pointers)
                 {

--- a/Assets/MRTK/Tests/PlayModeTests/ProfileTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ProfileTests.cs
@@ -92,10 +92,17 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private List<IMixedRealityPointer> GetAllPointers()
         {
             var allPointers = new List<IMixedRealityPointer>();
-            foreach (var i in CoreServices.InputSystem.DetectedInputSources)
+
+            HashSet<IMixedRealityInputSource> inputSources = CoreServices.InputSystem?.DetectedInputSources;
+
+            if (inputSources != null)
             {
-                allPointers.AddRange(i.Pointers);
+                foreach (var inputSource in inputSources)
+                {
+                    allPointers.AddRange(inputSource.Pointers);
+                }
             }
+
             return allPointers;
         }
 


### PR DESCRIPTION
## Overview

While testing MRTK perf with various systems turned off, I hit several null reference exceptions where scripts weren't properly checking for the input system's existence.

Also added some missing `ConstraintManager`s to some objects and fixed up a misconfigured constraint in HandInteractionExamples to reduce logging noise.