### PR TITLE
Fix references to mrtk_development branch (it's now called main)

### DIFF
--- a/Documentation/Contributing/CONTRIBUTING.md
+++ b/Documentation/Contributing/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To avoid needing to rework the feature, it is generally recommended that develop
 To get started, simply follow these steps:
 
 1. Fork the repository. Click on the "Fork" button on the top right of the page and follow the flow.
-1. Create a branch in your fork (off of the [mrtk_development](https://github.com/microsoft/mixedrealitytoolkit-unity/tree/mrtk_development) branch) to make it easier for you to isolate any changes until ready for submission. For the legacy HoloToolkit use the [htk_development](https://github.com/Microsoft/MixedRealityToolkit-Unity/tree/htk_development) branch.
+1. Create a branch in your fork (off of the [main](https://github.com/microsoft/mixedrealitytoolkit-unity/tree/main) branch) to make it easier to isolate any changes until ready for submission. For bug fixes during a release stabilization period, look for the latest `prerelease/*` branch. New features should always go into `main`.
 
 If you are new to to the Git workflow, [check out this introduction from Github](https://guides.github.com/activities/hello-world/).
 

--- a/Documentation/Contributing/PullRequests.md
+++ b/Documentation/Contributing/PullRequests.md
@@ -10,7 +10,7 @@ A comment in the PR will let you know if you do.
 
 ## Creating a pull request
 
-When you are ready to submit a pull request, [create a pull request](https://github.com/microsoft/MixedRealityToolkit-Unity/compare/mrtk_development...mrtk_development?expand=1) targeting the [mrtk_development](https://github.com/microsoft/mixedrealitytoolkit-unity/tree/mrtk_development) branch.
+When you are ready to submit a pull request, [create a pull request](https://github.com/microsoft/MixedRealityToolkit-Unity/compare/main...main?expand=1) targeting the [main](https://github.com/microsoft/mixedrealitytoolkit-unity/tree/main) branch. For bug fixes during a release stabilization period, look for the latest `prerelease/*` branch. New features should always go into `main`.
 
 Read the guidelines and ensure your pull request meets the guidelines.
 

--- a/Documentation/Contributing/UnitTests.md
+++ b/Documentation/Contributing/UnitTests.md
@@ -49,7 +49,7 @@ It's also possible to run the playmode tests multiple times via the `run_repeat_
 
 MRTK's CI will build MRTK in all configurations and run all edit and play mode tests. CI can be triggered by posting a comment on the github PR `/azp run mrtk_pr` if the user has sufficient rights. CI runs can be seen in the 'checks' tab of the PR.
 
-Only after all of the tests have passed successfully can the PR be merged into mrtk_development.
+Only after all of the tests have passed successfully can the PR be merged into main.
 
 ### Stress tests / bulk tests
 

--- a/Documentation/README_Dialog.md
+++ b/Documentation/README_Dialog.md
@@ -5,7 +5,7 @@ Dialog controls are UI overlays that provide contextual app information. They of
 
 ## Example scene
 You can find examples in the **DialogExample** scene under:
-[MRTK/Examples/Demos/UX/Dialog](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/Examples/Demos/UX/Dialog)
+[MRTK/Examples/Demos/UX/Dialog](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/main/Assets/MRTK/Examples/Demos/UX/Dialog)
 
 ## How to use Dialog control
 MRTK provides three Dialog prefabs: 

--- a/Documentation/README_HandCoach.md
+++ b/Documentation/README_HandCoach.md
@@ -17,11 +17,11 @@ The current interaction model represents a wide variety of gesture controls such
 
 ## Example scene
 You can find examples in the **HandCoachExample** scene under:
-[MixedRealityToolkit.Examples/Demos/HandCoach/Scenes](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MRTK/Examples/Demos/HandCoach/Scenes)
+[MixedRealityToolkit.Examples/Demos/HandCoach/Scenes](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/main/Assets/MRTK/Examples/Demos/HandCoach/Scenes)
 
 ## Hand 3D Assets
 You can find the assets under:
-[MixedRealityToolkit.SDK/Features/UX/Meshes/HandCoach](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/SDK/Features/UX/Meshes/HandCoach)
+[MixedRealityToolkit.SDK/Features/UX/Meshes/HandCoach](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/main/Assets/MRTK/SDK/Features/UX/Meshes/HandCoach)
 
 ## Quality
 If you notice distortions on the skinned mesh, you need to make sure your project is using the proper amount of joints. 

--- a/Documentation/README_TextPrefab.md
+++ b/Documentation/README_TextPrefab.md
@@ -53,12 +53,12 @@ When adding a UI or canvas based Text element to a scene, the size disparity is 
 
 ![Font size with scaling factors](../Documentation/Images/TextPrefab/TextPrefabInstructions07.png)
 
-### [Text3DSelawik.mat](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/Core/StandardAssets/Materials)
+### [Text3DSelawik.mat](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/main/Assets/MRTK/Core/StandardAssets/Materials)
 
 Material for 3DTextPrefab with occlusion support. Requires 3DTextShader.shader
 
 ![Default Font material vs 3DTextSegoeUI material](../Documentation/Images/TextPrefab/TextPrefabInstructions06.png)
 
-### [Text3DShader.shader](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/Core/StandardAssets/Shaders)
+### [Text3DShader.shader](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/main/Assets/MRTK/Core/StandardAssets/Shaders)
 
 Shader for 3DTextPrefab with occlusion support.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you're an experienced Mixed Reality or MRTK developer, check the links in the
 
 | Branch | CI Status | Docs Status |
 |---|---|---|
-| `mrtk_development` |[![CI Status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_CI?branchName=mrtk_development)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=15)|[![Docs Status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_docs?branchName=mrtk_development)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=7)
+| `main` |[![CI Status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_CI?branchName=main)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=15)|[![Docs Status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_docs?branchName=main)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=7)
 
 # Required software
 

--- a/pipelines/ci-weekly-internal.yml
+++ b/pipelines/ci-weekly-internal.yml
@@ -6,14 +6,14 @@ schedules:
   displayName: Weekly build
   branches:
     include: 
-    - mrtk_development
+    - main
 
 variables:
 - template: config/settings.yml
 - name: 'SOMWorkspaceID'
   value: '9aee72fc-a4e1-4f86-8343-8bcb69b03955'
 - name: 'ComplianceBranch'
-  value: 'refs/heads/mrtk_development'
+  value: 'refs/heads/main'
 
 jobs:
 - job: Compliance
@@ -25,7 +25,7 @@ jobs:
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
-  # the following tasks should only be run on mrtk_development branch, otherwise we risk issue being reported multiple times on topic/release branches
+  # the following tasks should only be run on main branch, otherwise we risk issue being reported multiple times on topic/release branches
   - task: PoliCheck@1
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], variables['ComplianceBranch']))
     inputs:

--- a/scripts/ci/githubchanges.ps1
+++ b/scripts/ci/githubchanges.ps1
@@ -18,16 +18,16 @@
     in the output file.
 
     Note that this script assumes that the local git repo doesn't already contain the
-    target branch (e.g. mrtk_development). This is what happens by default on Azure DevOps
+    target branch (e.g. main). This is what happens by default on Azure DevOps
     pipeline integrations with GitHub pull requests.
 
     In particular, this will checkout (via this command:
     git fetch --force --tags --prune --progress --no-recurse-submodules origin $(System.PullRequest.TargetBranch))
 .EXAMPLE
-    .\githubchanges.ps1 -OutputFile c:\path\to\changes\file.txt -RepoRoot c:\path\to\mrtk -TargetBranch mrtk_development
+    .\githubchanges.ps1 -OutputFile c:\path\to\changes\file.txt -RepoRoot c:\path\to\mrtk -TargetBranch main
 #>
 param(
-    # The target branch that the pull request will merge into (e.g. mrtk_development)
+    # The target branch that the pull request will merge into (e.g. main)
     [string]$TargetBranch,
 
     # The output filename (e.g. c:\path\to\output.txt)

--- a/scripts/docs/docfx.json
+++ b/scripts/docs/docfx.json
@@ -60,7 +60,7 @@
 	  // remove this section if you want to restore default behavior which publishes a version of the docs that keeps the "improve this doc" link pointing to the publishing branch
       "_gitContribute": {
         "repo": "https://github.com/Microsoft/MixedRealityToolkit-Unity",
-        "branch": "mrtk_development"
+        "branch": "main"
       }
 	  // section contribute end
     },


### PR DESCRIPTION
## Overview

Fix references to mrtk_development branch (it's now called main)

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9763
