### PR TITLE
Another perf pass on HandInteractionExamples

### DIFF
--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationHelpGuide.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationHelpGuide.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -31,6 +32,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void Start()
         {
+            if (DeviceUtility.IsPresent)
+            {
+                gameObject.SetActive(false);
+                return;
+            }
+
             string HelpGuideShortcutString = "";
             for (int i = 0; i < helpGuideShortcutKeys.Count; i++)
             {

--- a/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationHelpGuide.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/InputSimulationHelpGuide.cs
@@ -1,64 +1,63 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.MixedReality.Toolkit.Utilities;
-using UnityEngine;
 using System.Collections.Generic;
-using Microsoft.MixedReality.Toolkit.Input;
 using TMPro;
+using UnityEngine;
+using UnityEngine.Serialization;
 
-namespace Microsoft.MixedReality.Toolkit.Examples
+namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// Class which handles displaying and hiding the input simulation help guide
     /// </summary>
-    public class InputSimulationHelpGuide : MonoBehaviour
+    internal class InputSimulationHelpGuide : MonoBehaviour
     {
-        [SerializeField]
+        [SerializeField, FormerlySerializedAs("HelpGuideShortcutKeys")]
         [Tooltip("Keys required to bring up the input display tips")]
-        public List<KeyCode> HelpGuideShortcutKeys;
+        private List<KeyCode> helpGuideShortcutKeys = new List<KeyCode>(0);
 
-        [SerializeField]
-        [Tooltip("The gameobject that displays the shortcut for bringing up the input simulation help guide")]
-        public GameObject HelpGuideShortcutTip = null;
+        [SerializeField, FormerlySerializedAs("HelpGuideShortcutTip")]
+        [Tooltip("The GameObject that displays the shortcut for bringing up the input simulation help guide")]
+        private GameObject helpGuideShortcutTip = null;
 
-        [SerializeField]
+        [SerializeField, FormerlySerializedAs("DisplayHelpGuideShortcutTipOnStart")]
         [Tooltip("Whether or not to show the help guide shortcut on startup")]
-        public bool DisplayHelpGuideShortcutTipOnStart = true;
+        private bool displayHelpGuideShortcutTipOnStart = true;
 
-        [SerializeField]
-        [Tooltip("The game object containing the input simulation help guide")]
-        public GameObject HelpGuideVisual = null;
+        [SerializeField, FormerlySerializedAs("HelpGuideVisual")]
+        [Tooltip("The GameObject containing the input simulation help guide")]
+        private GameObject helpGuideVisual = null;
 
-        // Start is called before the first frame update
-        void Start()
+        private void Start()
         {
             string HelpGuideShortcutString = "";
-            for (int i = 0; i < HelpGuideShortcutKeys.Count; i++)
+            for (int i = 0; i < helpGuideShortcutKeys.Count; i++)
             {
-                string key = HelpGuideShortcutKeys[i].ToString();
+                string key = helpGuideShortcutKeys[i].ToString();
                 if (i > 0)
+                {
                     HelpGuideShortcutString += " + ";
+                }
                 HelpGuideShortcutString += key;
             }
 
-            HelpGuideShortcutTip.GetComponentInChildren<TextMeshProUGUI>().text = "Press " + HelpGuideShortcutString + " to open up the input simulation guide";
-            if (DisplayHelpGuideShortcutTipOnStart)
+            helpGuideShortcutTip.GetComponentInChildren<TextMeshProUGUI>().text = "Press " + HelpGuideShortcutString + " to open up the input simulation guide";
+            if (displayHelpGuideShortcutTipOnStart)
             {
-                HelpGuideShortcutTip.SetActive(true);
+                helpGuideShortcutTip.SetActive(true);
             }
-            HelpGuideVisual.SetActive(false);
+            helpGuideVisual.SetActive(false);
         }
 
-        // Update is called once per frame
-        void Update()
+        private void Update()
         {
             bool shortcutPressed = true;
             bool shortcutDown = false;
 
             // Checks to make sure that all keys are pressed and that one of the required shortcut keys was pressed on this frame
             // before bringing up the shortcut
-            foreach (KeyCode key in HelpGuideShortcutKeys)
+            foreach (KeyCode key in helpGuideShortcutKeys)
             {
                 shortcutPressed &= KeyInputSystem.GetKey(KeyBinding.FromKey(key));
                 shortcutDown |= KeyInputSystem.GetKeyDown(KeyBinding.FromKey(key));
@@ -66,8 +65,8 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 
             if (shortcutPressed && shortcutDown)
             {
-                HelpGuideVisual.SetActive(!HelpGuideVisual.activeSelf);
-                HelpGuideShortcutTip.SetActive(false);
+                helpGuideVisual.SetActive(!helpGuideVisual.activeSelf);
+                helpGuideShortcutTip.SetActive(false);
             }
         }
     }

--- a/Assets/MRTK/Examples/Common/Prefabs/Help_Panel_Viewer.prefab
+++ b/Assets/MRTK/Examples/Common/Prefabs/Help_Panel_Viewer.prefab
@@ -560,7 +560,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b468aa5b7f931c140adaa4a3e66d718e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  HelpGuideShortcutKeys: 3201000068000000
-  HelpGuideShortcutTip: {fileID: 2003569881887503376}
-  DisplayHelpGuideShortcutTipOnStart: 1
-  HelpGuideVisual: {fileID: 3884521507736125813}
+  helpGuideShortcutKeys: 3201000068000000
+  helpGuideShortcutTip: {fileID: 2003569881887503376}
+  displayHelpGuideShortcutTipOnStart: 1
+  helpGuideVisual: {fileID: 3884521507736125813}

--- a/Assets/MRTK/Examples/Common/Prefabs/Help_Panel_Viewer.prefab
+++ b/Assets/MRTK/Examples/Common/Prefabs/Help_Panel_Viewer.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 7679070037079963644}
   - component: {fileID: 1025555136919324373}
   - component: {fileID: 5160033305772425515}
-  - component: {fileID: 661491026927839371}
   m_Layer: 5
   m_Name: Canvas_Tip
   m_TagString: Untagged
@@ -82,23 +81,6 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
---- !u!114 &661491026927839371
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2003569881887503376}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!1 &2039166811144635796
 GameObject:
   m_ObjectHideFlags: 0
@@ -272,7 +254,6 @@ GameObject:
   - component: {fileID: 1664423664642718425}
   - component: {fileID: 6335558611449888476}
   - component: {fileID: 4008448074863834326}
-  - component: {fileID: 7378147382707451450}
   m_Layer: 5
   m_Name: Canvas_Details
   m_TagString: Untagged
@@ -343,23 +324,6 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
---- !u!114 &7378147382707451450
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3884521507736125813}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!1 &4854470455832798453
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/Examples/Common/Prefabs/Help_Panel_Viewer.prefab
+++ b/Assets/MRTK/Examples/Common/Prefabs/Help_Panel_Viewer.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7679070037079963644
 RectTransform:
   m_ObjectHideFlags: 0
@@ -260,7 +260,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1664423664642718425
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -22889,11 +22889,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 914966060}
     m_Modifications:
-    - target: {fileID: 1025555136919324373, guid: af7def2dd5079e044b0e1cf4a927cfc8,
-        type: 3}
-      propertyPath: m_AdditionalShaderChannelsFlag
-      value: 25
-      objectReference: {fileID: 0}
     - target: {fileID: 5629718995931189460, guid: af7def2dd5079e044b0e1cf4a927cfc8,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -22953,11 +22948,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Help Panel Viewer
-      objectReference: {fileID: 0}
-    - target: {fileID: 6335558611449888476, guid: af7def2dd5079e044b0e1cf4a927cfc8,
-        type: 3}
-      propertyPath: m_AdditionalShaderChannelsFlag
-      value: 25
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: af7def2dd5079e044b0e1cf4a927cfc8, type: 3}

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Slate/SlateUGUI.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Slate/SlateUGUI.prefab
@@ -1456,7 +1456,6 @@ GameObject:
   m_Component:
   - component: {fileID: 6896587427799967441}
   - component: {fileID: 5967205054349935234}
-  - component: {fileID: 7924849509645966436}
   - component: {fileID: 2065027785916651345}
   - component: {fileID: 3915916941640423525}
   m_Layer: 5
@@ -1518,28 +1517,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &7924849509645966436
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1978128616940766997}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
 --- !u!114 &2065027785916651345
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3459,7 +3436,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8207401073449336098}
   - component: {fileID: 897212547853413281}
-  - component: {fileID: 5165075626778922832}
   - component: {fileID: 2638062821548204409}
   - component: {fileID: 359438915768081255}
   m_Layer: 5
@@ -3515,28 +3491,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &5165075626778922832
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5024941865655156334}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
 --- !u!114 &2638062821548204409
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/SDK/StandardAssets/Prefabs/SceneDescriptionPanelRev.prefab
+++ b/Assets/MRTK/SDK/StandardAssets/Prefabs/SceneDescriptionPanelRev.prefab
@@ -1640,6 +1640,166 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 7614231225550487853}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: OnHandPressCompleted
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 7614231225550487858}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: PlayOneShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 8300000, guid: 40ae713ddf420714bbc1a3b5c3f2eac1, type: 3}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.AudioClip, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 7614231225550487853}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: OnHandPressCompleted
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 7614231225550487853}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: OnHandPressTriggered
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 7614231225550487858}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: PlayOneShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 8300000, guid: 291bf9326e517b0489c2ee53d0a6a63f, type: 3}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.AudioClip, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 7614231225550487853}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: OnHandPressTriggered
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 156863744684443484, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: ButtonPressed.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 2406973081839446391, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
         type: 3}
       propertyPath: m_Mesh
@@ -1718,3 +1878,21 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 7614231225850281981}
   m_PrefabAsset: {fileID: 0}
+--- !u!82 &7614231225550487858 stripped
+AudioSource:
+  m_CorrespondingSourceObject: {fileID: 316800719, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+    type: 3}
+  m_PrefabInstance: {fileID: 7614231225850281981}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7614231225550487853 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 316800720, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+    type: 3}
+  m_PrefabInstance: {fileID: 7614231225850281981}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 881d1ff8f009f5148b9f192e6ba31223, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/MRTK/SDK/StandardAssets/Prefabs/SceneDescriptionPanelRev.prefab
+++ b/Assets/MRTK/SDK/StandardAssets/Prefabs/SceneDescriptionPanelRev.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 8163735710819725799}
   - component: {fileID: 6889657447556473283}
   - component: {fileID: 4253669631570318577}
-  - component: {fileID: 967908720142479309}
   m_Layer: 0
   m_Name: Quad
   m_TagString: Untagged
@@ -78,20 +77,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!64 &967908720142479309
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 49146335930689594}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &535320291758134886
 GameObject:
   m_ObjectHideFlags: 0
@@ -259,6 +244,7 @@ GameObject:
   - component: {fileID: 2652140712778390387}
   - component: {fileID: 5715629545189034945}
   - component: {fileID: 7177841727496788269}
+  - component: {fileID: 2894974111286814447}
   m_Layer: 0
   m_Name: ContentBackPlate(Please adjust for content size)
   m_TagString: Untagged
@@ -325,6 +311,19 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!65 &2894974111286814447
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1149787733619785606}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 6.123233e-17}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1600130203466990489
 GameObject:
   m_ObjectHideFlags: 0
@@ -442,11 +441,6 @@ GameObject:
   m_Component:
   - component: {fileID: 3377769224622482396}
   - component: {fileID: 3379072703660761358}
-  - component: {fileID: 3200604930101035326}
-  - component: {fileID: 3199535566851361816}
-  - component: {fileID: 3200475335149234636}
-  - component: {fileID: 815356209963854706}
-  - component: {fileID: 3314476758001819302}
   m_Layer: 5
   m_Name: Content
   m_TagString: Untagged
@@ -496,167 +490,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &3200604930101035326
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3313749612546052192}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
---- !u!114 &3199535566851361816
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3313749612546052192}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &3200475335149234636
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3313749612546052192}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff4e3b9019304b5aaec5664de0778d21, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &815356209963854706
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3313749612546052192}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2fcaf896491074042b7ed7684454a412, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  eventsToReceive: 1
-  debounceThreshold: 0.01
---- !u!82 &3314476758001819302
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3313749612546052192}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!1 &4806417826881736189
 GameObject:
   m_ObjectHideFlags: 0
@@ -728,8 +561,6 @@ GameObject:
   m_Component:
   - component: {fileID: 6636591464266677543}
   - component: {fileID: 2417563302873344932}
-  - component: {fileID: 7661023078183718741}
-  - component: {fileID: 676431804241142140}
   - component: {fileID: 2955373760948247394}
   m_Layer: 5
   m_Name: Column
@@ -780,45 +611,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &7661023078183718741
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7512933317390859883}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
---- !u!114 &676431804241142140
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7512933317390859883}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!114 &2955373760948247394
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1804,10 +1596,6 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 1911902820, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 115e8a36a794d414d96ca3ae31a090fe, type: 2}
     - target: {fileID: 1944713263, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.0165
@@ -1870,7 +1658,7 @@ PrefabInstance:
     - target: {fileID: 7440800412470431853, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
         type: 3}
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: 
+      value: SetActive
       objectReference: {fileID: 0}
     - target: {fileID: 7440800412470431853, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
         type: 3}


### PR DESCRIPTION
## Overview

* Cleans up some extra graphic raycasters, as extra graphic raycasters lead to a longer time spent raycasting in the scene.
* Also disables the input simulation help guide when a device is attached, as overlay canvases in VR have a rendering hit without being visible
* Updates InputSimulationHelpGuide to be `internal` and have the correct namespace
   * This is a **BREAKING CHANGE**, but I don't expect anybody to be talking to this component directly (and I'm not convinced they should, hence the change to `internal`)
* Updates the "close" button to play the audio before setting the GameObject inactive, as currently the audio is logging an issue with trying to play a disabled audio source

> Can not play a disabled audio source
> UnityEngine.AudioSource:PlayOneShot(AudioClip, Single)