### PR TITLE
Add support for new OpenXR mesh settings

### DIFF
--- a/Assets/MRTK/Core/Definitions/Utilities/VolumeType.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/VolumeType.cs
@@ -4,12 +4,12 @@
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     /// <summary>
-    /// todo
+    /// The possible shapes of bounding volumes for spatial awareness of the user's surroundings.
     /// </summary>
     public enum VolumeType
     {
         /// <summary>
-        /// No Specified type.
+        /// No specified type.
         /// </summary>
         None = 0,
 

--- a/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
@@ -224,7 +224,10 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             set
             {
                 displayOption = value;
-                ApplyUpdatedMeshDisplayOption(displayOption);
+                if (Application.isPlaying)
+                {
+                    ApplyUpdatedMeshDisplayOption(displayOption);
+                }
             }
         }
 
@@ -293,7 +296,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
                 {
                     occlusionMaterial = value;
 
-                    if (DisplayOption == SpatialAwarenessMeshDisplayOptions.Occlusion)
+                    if (Application.isPlaying && DisplayOption == SpatialAwarenessMeshDisplayOptions.Occlusion)
                     {
                         ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions.Occlusion);
                     }
@@ -328,7 +331,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
                 {
                     visibleMaterial = value;
 
-                    if (DisplayOption == SpatialAwarenessMeshDisplayOptions.Visible)
+                    if (Application.isPlaying && DisplayOption == SpatialAwarenessMeshDisplayOptions.Visible)
                     {
                         ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions.Visible);
                     }

--- a/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
@@ -63,12 +63,12 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 
             // IMixedRealitySpatialAwarenessMeshObserver settings
             DisplayOption = profile.DisplayOption;
+            TrianglesPerCubicMeter = profile.TrianglesPerCubicMeter; // Set this before LevelOfDetail so it doesn't overwrite in the non-Custom case
             LevelOfDetail = profile.LevelOfDetail;
             MeshPhysicsLayer = profile.MeshPhysicsLayer;
             OcclusionMaterial = profile.OcclusionMaterial;
             PhysicsMaterial = profile.PhysicsMaterial;
             RecalculateNormals = profile.RecalculateNormals;
-            TrianglesPerCubicMeter = profile.TrianglesPerCubicMeter;
             VisibleMaterial = profile.VisibleMaterial;
 
             RuntimeSpatialMeshPrefab = profile.RuntimeSpatialMeshPrefab;

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
@@ -23,8 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         SupportedUnityXRPipelines.XRSDK)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/spatial-awareness-getting-started")]
     public class OpenXRSpatialAwarenessMeshObserver :
-        GenericXRSDKSpatialMeshObserver,
-        IMixedRealityCapabilityCheck
+        GenericXRSDKSpatialMeshObserver
     {
         /// <summary>
         /// Constructor.

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
@@ -47,30 +47,40 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 #endif // MSFT_OPENXR_0_9_4_OR_NEWER
 
 #if MSFT_OPENXR_0_9_4_OR_NEWER
-        private static readonly ProfilerMarker ConfigureObserverVolumePerfMarker = new ProfilerMarker($"[MRTK] {nameof(OpenXRSpatialAwarenessMeshObserver)}.ConfigureObserverVolume");
+        private static readonly ProfilerMarker ApplyUpdatedMeshDisplayOptionPerfMarker = new ProfilerMarker($"[MRTK] {nameof(OpenXRSpatialAwarenessMeshObserver)}.ApplyUpdatedMeshDisplayOption");
 
         /// <inheritdoc/>
-        protected override void ConfigureObserverVolume()
+        protected override void ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions option)
         {
-            using (ConfigureObserverVolumePerfMarker.Auto())
+            using (ApplyUpdatedMeshDisplayOptionPerfMarker.Auto())
             {
-                base.ConfigureObserverVolume();
-
-                MixedRealitySpatialAwarenessMeshObserverProfile profile = ConfigurationProfile as MixedRealitySpatialAwarenessMeshObserverProfile;
-                if (profile == null)
-                {
-                    return;
-                }
-
-                MeshComputeSettings settings = new MeshComputeSettings
-                {
-                    MeshType = (profile.DisplayOption == SpatialAwarenessMeshDisplayOptions.Visible) ? MeshType.Visual : MeshType.Collider,
-                    VisualMeshLevelOfDetail = MapMRTKLevelOfDetailToOpenXR(profile.LevelOfDetail),
-                    OcclusionHint = true
-                };
-
-                MeshSettings.SetMeshComputeSettings(settings);
+                SetMeshComputeSettings(option, LevelOfDetail);
+                base.ApplyUpdatedMeshDisplayOption(option);
             }
+        }
+
+        private static readonly ProfilerMarker LookupTriangleDensityPerfMarker = new ProfilerMarker($"[MRTK] {nameof(OpenXRSpatialAwarenessMeshObserver)}.LookupTriangleDensity");
+
+        /// <inheritdoc/>
+        protected override int LookupTriangleDensity(SpatialAwarenessMeshLevelOfDetail levelOfDetail)
+        {
+            using (LookupTriangleDensityPerfMarker.Auto())
+            {
+                SetMeshComputeSettings(DisplayOption, levelOfDetail);
+                return (int)levelOfDetail;
+            }
+        }
+
+        private void SetMeshComputeSettings(SpatialAwarenessMeshDisplayOptions option, SpatialAwarenessMeshLevelOfDetail levelOfDetail)
+        {
+            MeshComputeSettings settings = new MeshComputeSettings
+            {
+                MeshType = (option == SpatialAwarenessMeshDisplayOptions.Visible) ? MeshType.Visual : MeshType.Collider,
+                VisualMeshLevelOfDetail = MapMRTKLevelOfDetailToOpenXR(levelOfDetail),
+                OcclusionHint = true
+            };
+
+            MeshSettings.SetMeshComputeSettings(settings);
         }
 
         private VisualMeshLevelOfDetail MapMRTKLevelOfDetailToOpenXR(SpatialAwarenessMeshLevelOfDetail levelOfDetail)

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.SpatialAwareness;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
+
+#if MSFT_OPENXR_0_9_4_OR_NEWER
+using Microsoft.MixedReality.OpenXR;
+using Unity.Profiling;
+using UnityEngine.XR.OpenXR;
+#endif // MSFT_OPENXR_0_9_4_OR_NEWER
+
+namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
+{
+    [MixedRealityDataProvider(
+        typeof(IMixedRealitySpatialAwarenessSystem),
+        SupportedPlatforms.WindowsUniversal,
+        "OpenXR Spatial Mesh Observer",
+        "Profiles/DefaultMixedRealitySpatialAwarenessMeshObserverProfile.asset",
+        "MixedRealityToolkit.SDK",
+        true,
+        SupportedUnityXRPipelines.XRSDK)]
+    [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/spatial-awareness-getting-started")]
+    public class OpenXRSpatialAwarenessMeshObserver :
+        GenericXRSDKSpatialMeshObserver,
+        IMixedRealityCapabilityCheck
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the service.</param>
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's configuration profile.</param>
+        public OpenXRSpatialAwarenessMeshObserver(
+            IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem,
+            string name = null,
+            uint priority = DefaultPriority,
+            BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
+        { }
+
+        protected override bool IsActiveLoader =>
+#if MSFT_OPENXR_0_9_4_OR_NEWER
+            LoaderHelpers.IsLoaderActive<OpenXRLoaderBase>();
+#else
+            false;
+#endif // MSFT_OPENXR_0_9_4_OR_NEWER
+
+#if MSFT_OPENXR_0_9_4_OR_NEWER
+        private static readonly ProfilerMarker ConfigureObserverVolumePerfMarker = new ProfilerMarker($"[MRTK] {nameof(OpenXRSpatialAwarenessMeshObserver)}.ConfigureObserverVolume");
+
+        /// <inheritdoc/>
+        protected override void ConfigureObserverVolume()
+        {
+            using (ConfigureObserverVolumePerfMarker.Auto())
+            {
+                base.ConfigureObserverVolume();
+
+                MixedRealitySpatialAwarenessMeshObserverProfile profile = ConfigurationProfile as MixedRealitySpatialAwarenessMeshObserverProfile;
+                if (profile == null)
+                {
+                    return;
+                }
+
+                MeshComputeSettings settings = new MeshComputeSettings
+                {
+                    MeshType = (profile.DisplayOption == SpatialAwarenessMeshDisplayOptions.Visible) ? MeshType.Visual : MeshType.Collider,
+                    VisualMeshLevelOfDetail = MapMRTKLevelOfDetailToOpenXR(profile.LevelOfDetail),
+                    OcclusionHint = true
+                };
+
+                MeshSettings.SetMeshComputeSettings(settings);
+            }
+        }
+
+        private VisualMeshLevelOfDetail MapMRTKLevelOfDetailToOpenXR(SpatialAwarenessMeshLevelOfDetail levelOfDetail)
+        {
+            switch (levelOfDetail)
+            {
+                case SpatialAwarenessMeshLevelOfDetail.Coarse:
+                    return VisualMeshLevelOfDetail.Coarse;
+                case SpatialAwarenessMeshLevelOfDetail.Medium:
+                    return VisualMeshLevelOfDetail.Medium;
+                case SpatialAwarenessMeshLevelOfDetail.Fine:
+                    return VisualMeshLevelOfDetail.Fine;
+                case SpatialAwarenessMeshLevelOfDetail.Unlimited:
+                    return VisualMeshLevelOfDetail.Unlimited;
+                case SpatialAwarenessMeshLevelOfDetail.Custom:
+                default:
+                    Debug.LogError($"Unsupported LevelOfDetail value {levelOfDetail}. Defaulting to {VisualMeshLevelOfDetail.Coarse}");
+                    return VisualMeshLevelOfDetail.Coarse;
+            }
+        }
+#endif // MSFT_OPENXR_0_9_4_OR_NEWER
+    }
+}

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
@@ -66,12 +66,18 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             using (LookupTriangleDensityPerfMarker.Auto())
             {
-                SetMeshComputeSettings(DisplayOption, levelOfDetail);
-                return (int)levelOfDetail;
+                if (Application.isPlaying && SetMeshComputeSettings(DisplayOption, levelOfDetail))
+                {
+                    return (int)levelOfDetail;
+                }
+                else
+                {
+                    return base.LookupTriangleDensity(levelOfDetail);
+                }
             }
         }
 
-        private void SetMeshComputeSettings(SpatialAwarenessMeshDisplayOptions option, SpatialAwarenessMeshLevelOfDetail levelOfDetail)
+        private bool SetMeshComputeSettings(SpatialAwarenessMeshDisplayOptions option, SpatialAwarenessMeshLevelOfDetail levelOfDetail)
         {
             MeshComputeSettings settings = new MeshComputeSettings
             {
@@ -80,7 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 OcclusionHint = true
             };
 
-            MeshSettings.SetMeshComputeSettings(settings);
+            return MeshSettings.TrySetMeshComputeSettings(settings);
         }
 
         private VisualMeshLevelOfDetail MapMRTKLevelOfDetailToOpenXR(SpatialAwarenessMeshLevelOfDetail levelOfDetail)

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs.meta
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a089829172b56141bae656dc55e1862
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
@@ -22,8 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         SupportedUnityXRPipelines.XRSDK)]
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/spatial-awareness/spatial-awareness-getting-started")]
     public class WindowsMixedRealitySpatialMeshObserver :
-        GenericXRSDKSpatialMeshObserver,
-        IMixedRealityCapabilityCheck
+        GenericXRSDKSpatialMeshObserver
     {
         /// <summary>
         /// Constructor.

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -133,7 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             var descriptors = new List<XRMeshSubsystemDescriptor>();
             SubsystemManager.GetSubsystemDescriptors(descriptors);
 
-            return descriptors.Count > 0;
+            return descriptors.Count > 0 && IsActiveLoader;
         }
 
         #endregion IMixedRealityCapabilityCheck Implementation

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
 {
     [MixedRealityDataProvider(
         typeof(IMixedRealitySpatialAwarenessSystem),
-        (SupportedPlatforms)(-1), // All platforms supported by Unity
+        (SupportedPlatforms)(-1) ^ SupportedPlatforms.WindowsUniversal, // All platforms supported by Unity except UWP
         "XR SDK Spatial Mesh Observer",
         "Profiles/DefaultMixedRealitySpatialAwarenessMeshObserverProfile.asset",
         "MixedRealityToolkit.SDK",
@@ -41,9 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         { }
 
-        // Don't run this one on Windows MR, since that has its own observer
-        // There's probably a better way to manage these two...
-        protected virtual bool IsActiveLoader => !LoaderHelpers.IsLoaderActive("Windows MR Loader");
+        protected virtual bool IsActiveLoader => true;
 
         /// <inheritdoc />
         public override void Enable()

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealitySpatialAwarenessSystemProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealitySpatialAwarenessSystemProfile.asset
@@ -33,5 +33,12 @@ MonoBehaviour:
         Microsoft.MixedReality.Toolkit.Providers.XRSDK
     componentName: XR SDK Spatial Mesh Observer
     priority: 0
-    runtimePlatform: -1
+    runtimePlatform: -9
+    observerProfile: {fileID: 11400000, guid: 8be0bcd2117dd214da41ed98f0def2e3, type: 2}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.XRSDK.OpenXR.OpenXRSpatialAwarenessMeshObserver,
+        Microsoft.MixedReality.Toolkit.Providers.OpenXR
+    componentName: OpenXR Spatial Mesh Observer
+    priority: 0
+    runtimePlatform: 8
     observerProfile: {fileID: 11400000, guid: 8be0bcd2117dd214da41ed98f0def2e3, type: 2}


### PR DESCRIPTION
## Overview

The 0.9.4 release of Mixed Reality OpenXR plugin is going to expose a new `MeshComputeSettings` struct for setting specific settings. This aligns with the scene understanding capabilities going forward and will ensure we have forward compatibility as the OpenXR plugin comes online.

There's a fairly straight forward mapping from MRTK settings to these new OpenXR settings.