### PR TITLE
Delist github.io docs from search results

### DIFF
--- a/scripts/docs/templates/mrtk/partials/head.tmpl.partial
+++ b/scripts/docs/templates/mrtk/partials/head.tmpl.partial
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width">
   <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
   <meta name="generator" content="docfx {{_docfxVersion}}">
+  <meta name="robots" content="noindex">
   {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
   <link rel="shortcut icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
   <link rel="stylesheet" href="{{_rel}}styles/docfx.vendor.css">


### PR DESCRIPTION
Add a meta tag to the github.io docs site to prevent the obsolete docs from showing up in search results.