### PR TITLE
Remove unused dependency from shared WMR.Editor

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/MRTK.WMR.Editor.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/Editor/MRTK.WMR.Editor.asmdef
@@ -2,9 +2,8 @@
     "name": "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Editor",
     "references": [
         "Microsoft.MixedReality.Toolkit",
-        "Microsoft.MixedReality.Toolkit.Editor.Inspectors",
-        "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality",
         "Microsoft.MixedReality.Toolkit.Editor.Utilities",
+        "Microsoft.MixedReality.Toolkit.Editor.Inspectors",
         "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared"
     ],
     "optionalUnityReferences": [],


### PR DESCRIPTION
## Overview

Removes an almost-circular `Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality` dependency, since there should be no dependencies from the shared folder into the XR2018/XRSDK folders (just the other way around).