### PR TITLE
Add "Import Examples from Package" menu item

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -560,6 +560,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             });
         }
 
+#if UNITY_2019_3_OR_NEWER
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Import Examples from Package")]
+        private static void DisplayExamplesInPackageManager()
+        {
+            UnityEditor.PackageManager.UI.Window.Open("Mixed Reality Toolkit Examples");
+        }
+#endif // UNITY_2019_3_OR_NEWER
+
         private void RenderShowUPMExamples()
         {
             if (!MRTKExamplesPackageImportedViaUPM())
@@ -579,8 +587,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 if (GUILayout.Button("Show me the examples"))
                 {
 #if UNITY_2019_3_OR_NEWER
-                    UnityEditor.PackageManager.UI.Window.Open("Mixed Reality Toolkit Examples");
-#endif
+                    DisplayExamplesInPackageManager();
+#endif // UNITY_2019_3_OR_NEWER
                 }
                 if (GUILayout.Button("Got it, next"))
                 {
@@ -660,7 +668,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             return isTMPEssentialsImported.Value;
         }
 
-        private bool MRTKExamplesPackageImportedViaUPM()
+        [MenuItem("Mixed Reality/Toolkit/Utilities/Import Examples from Package", true)]
+        private static bool MRTKExamplesPackageImportedViaUPM()
         {
 #if !UNITY_2019_3_OR_NEWER
             return false;


### PR DESCRIPTION
This change adds a new item to the Mixed Reality > Toolkit > Utilities menu to enable fast access to importing demos and examples when using the NPM packages (ex: via Mixed Reality Feature Tool).

If the examples package is not installed (or if .unitypackage files are being used), the new menu is disabled

![image](https://user-images.githubusercontent.com/13281406/118031848-d4c37400-b31b-11eb-86d3-9f5071931f7d.png)

When the examples package is present, the menu item is enabled and will display the examples package in the UPM UI

![image](https://user-images.githubusercontent.com/13281406/118031968-fa507d80-b31b-11eb-9531-3206cb371ad2.png)

![image](https://user-images.githubusercontent.com/13281406/118032034-0dfbe400-b31c-11eb-80ca-2ffc6a2972a9.png)

Fixes: #9798