### PR TITLE
Marked instances of IsNearObject virtual

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -127,7 +127,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <inheritdoc />
-        public bool IsNearObject
+        public virtual bool IsNearObject
         {
             get => closestProximityTouchable != null;
         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -168,7 +168,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Ignores bounds handlers for the IsNearObject check.
         /// </summary>
         /// <returns>True if the pointer is near any collider that's both on a grabbable layer mask, and has a NearInteractionGrabbable.</returns>
-        public bool IsNearObject => queryBufferNearObjectRadius.ContainsGrabbable || queryBufferInteractionRadius.NearObjectDetected;
+        public virtual bool IsNearObject => queryBufferNearObjectRadius.ContainsGrabbable || queryBufferInteractionRadius.NearObjectDetected;
 
         /// <summary>
         /// Test if the pointer is within the grabbable radius of collider that's both on a grabbable layer mask, and has a NearInteractionGrabbable.


### PR DESCRIPTION
## Overview
Marked IsNearObject as virtual so users can extend off sphere and poke pointer

## Changes
- Fixes: #9794
