### PR TITLE
Use hashset instead of list to get better perf in SOC

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -1691,7 +1691,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Bounds clippingThresholdBounds = ClippingBoundsCollider.bounds;
 
             Renderer[] contentRenderers = ScrollContainer.GetComponentsInChildren<Renderer>(true);
-            List<Renderer> clippedRenderers = ClipBox.GetRenderersCopy().ToList();
+            HashSet<Renderer> clippedRenderers = new HashSet<Renderer>(ClipBox.GetRenderersCopy());
 
             // Remove all renderers from clipping primitive that are not part of scroll content
             foreach (var clippedRenderer in clippedRenderers)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -722,6 +722,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool oldIsTargetPositionLockedOnFocusLock;
 
+        private readonly HashSet<Renderer> clippedRenderers = new HashSet<Renderer>();
+
         #region scroll state variables
 
         /// <summary>
@@ -1691,7 +1693,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Bounds clippingThresholdBounds = ClippingBoundsCollider.bounds;
 
             Renderer[] contentRenderers = ScrollContainer.GetComponentsInChildren<Renderer>(true);
-            HashSet<Renderer> clippedRenderers = new HashSet<Renderer>(ClipBox.GetRenderersCopy());
+            clippedRenderers.Clear();
+            clippedRenderers.UnionWith(ClipBox.GetRenderersCopy());
 
             // Remove all renderers from clipping primitive that are not part of scroll content
             foreach (var clippedRenderer in clippedRenderers)


### PR DESCRIPTION
## Overview
Store the renderers in a HashSet instead of a List as there could be many calls to Contains() per frame. Thanks @nuernber for bringing this up!

## Changes
- Fixes: #9553