### PR TITLE
Disable Teleport Gesture on Hololens

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -260,6 +260,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public void UpdateCurrentTeleportPose(MixedRealityInteractionMapping interactionMapping)
         {
+            // Disabling the teleport pose on AR devices, specifically Hololens, due to not having a good way to specify valid teleport surfaces.
+#if WINDOWS_UWP
+            if(!CoreServices.CameraSystem.IsNull() && !CoreServices.CameraSystem.IsOpaque)
+            {
+                return;
+            }
+#endif
+
             using (UpdateCurrentTeleportPosePerfMarker.Auto())
             {
                 // Check if we're focus locked or near something interactive to avoid teleporting unintentionally.


### PR DESCRIPTION
## Overview
Disabling the teleport pose on Hololens, due to not having a good way to specify valid teleport surfaces, as well as not having a great use case for teleporting on Hololens yet.

## Changes
- Fixes: #9807
