### PR TITLE
Correct parenting of spatial mesh to preserve local transform.

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -495,8 +495,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                         }
                         meshes.Add(meshObject.Id, meshObject);
 
-                        meshObject.GameObject.transform.parent = (ObservedObjectParent.transform != null) ?
-                            ObservedObjectParent.transform : null;
+                        // This is important. We need to preserve the mesh's local transform here, not its global pose.
+                        // Think of it like this. If we set the camera's coordinates 3 meters to the left, the physical camera
+                        // hasn't moved, only its coordinates have changed. Likewise, the physical room hasn't moved (relative to
+                        // the physical camera), so we also want to set its coordinates 3 meters to the left.
+                        Transform meshObjectParent = (ObservedObjectParent.transform != null) ? ObservedObjectParent.transform : null;
+                        meshObject.GameObject.transform.SetParent(meshObjectParent, false);
 
                         meshEventData.Initialize(this, meshObject.Id, meshObject);
                         if (isMeshUpdate)


### PR DESCRIPTION
## Overview
When the spatial mesh's transform was getting attached to the ObservedObjectParent using the parent property, the default behavior of preserving world space position was kicking in. 

This _sounds_ right, but isn't. It meant that the current ObservedObjectParent's transform (which ultimately resolves to the MRTK Playspace transform) was getting discarded (or more specifically, absorbed into the mesh's local transform).

This led to the observed behavior, that when the MRTK Playspace transform changed, existing spatial meshes remained in correct position (because they were attached to the MRTK Playspace). But new spatial meshes, because they essentially discarded the playspace transform, would appear offset from their physical counterparts.

## Changes
- Fixes: #9810  .


## Verification

The issue was most easily seen by clearing the hololens spatial map via WDP before running.
Only XRSDK was affected. WSA worked fine, OpenXR doesn't seem to have spatial meshes yet.

> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
