### PR TITLE
Reverting change which disabled the teleport gesture #9814

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -260,14 +260,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public void UpdateCurrentTeleportPose(MixedRealityInteractionMapping interactionMapping)
         {
-            // Disabling the teleport pose on AR devices, specifically Hololens, due to not having a good way to specify valid teleport surfaces.
-#if WINDOWS_UWP
-            if(!CoreServices.CameraSystem.IsNull() && !CoreServices.CameraSystem.IsOpaque)
-            {
-                return;
-            }
-#endif
-
             using (UpdateCurrentTeleportPosePerfMarker.Auto())
             {
                 // Check if we're focus locked or near something interactive to avoid teleporting unintentionally.


### PR DESCRIPTION
## Overview
Reverts changes made to make teleport not be raised on Hololens 2. For users who do not wish to have the teleport gesture raise the teleport pointer, we currently allow them to disable the teleport system.
