### PR TITLE
Renamed parts of the handtracking profile inspector to improve clarity

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityHandTrackingProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityHandTrackingProfileInspector.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
         private SerializedProperty handMeshVisualizationModes;
         private SerializedProperty handJointVisualizationModes;
 
-        private const string ProfileTitle = "Hand Tracking Settings";
+        private const string ProfileTitle = "Articulated Hand Tracking Settings";
         private const string ProfileDescription = "Use this for hand tracking settings.";
 
         protected override void OnEnable()
@@ -48,6 +48,8 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                 EditorGUILayout.PropertyField(palmPrefab);
                 EditorGUILayout.PropertyField(fingertipPrefab);
                 EditorGUILayout.PropertyField(handMeshPrefab);
+
+                EditorGUILayout.LabelField("Visualization settings", EditorStyles.boldLabel);
                 EditorGUILayout.PropertyField(handMeshVisualizationModes);
                 EditorGUILayout.PropertyField(handJointVisualizationModes);
 

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -160,7 +160,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     }
                 }, ShowInputSystem_Speech_PreferenceKey);
 
-                RenderFoldout(ref showHandTrackingProperties, "Hand Tracking", () =>
+                RenderFoldout(ref showHandTrackingProperties, "Articulated Hand Tracking", () =>
                 {
                     using (new EditorGUI.IndentLevelScope())
                     {


### PR DESCRIPTION
## Overview
The hand tracking profile is not super clear that it refers mainly to full articulated hand visualization settings, this PR helps address this issue

## Changes
Helps with #9823