### PR TITLE
Adding Bounds Control's Configuration files to SharedAssets

### DIFF
--- a/Assets/MRTK/SDK/StandardAssets/Profiles.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b3d7956ebccade469f7ed3f28a3da9b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 341bed195033b7e46bee016737dcbff3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63b5e08377683a44583a9737b6790948
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/BoxDisplayConfiguration_HoloLens2_Slate.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/BoxDisplayConfiguration_HoloLens2_Slate.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 240d9483db94993408ff1d02335ea212, type: 3}
+  m_Name: BoxDisplayConfiguration_HoloLens2_Slate
+  m_EditorClassIdentifier: 
+  boxMaterial: {fileID: 2100000, guid: 6f044b5d95469d64ea8feb1225b1d5fa, type: 2}
+  boxGrabbedMaterial: {fileID: 2100000, guid: f671b04930fdad54c8b50a4c6d7d9b02, type: 2}
+  flattenAxisDisplayScale: 0

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/BoxDisplayConfiguration_HoloLens2_Slate.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/BoxDisplayConfiguration_HoloLens2_Slate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dda36b069f5139e44998995a0e25fbe3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/LinksConfiguration_HoloLens2_Slate.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/LinksConfiguration_HoloLens2_Slate.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b80d41f9007c4b948b0808690195e77c, type: 3}
+  m_Name: LinksConfiguration_HoloLens2_Slate
+  m_EditorClassIdentifier: 
+  wireframeMaterial: {fileID: 0}
+  wireframeEdgeRadius: 0.005
+  wireframeShape: 0
+  showWireframe: 0

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/LinksConfiguration_HoloLens2_Slate.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/LinksConfiguration_HoloLens2_Slate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 671e2126e50a8794aa0347227ad916d0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/ProximityEffectConfiguration_HoloLens2_Slate.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/ProximityEffectConfiguration_HoloLens2_Slate.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ae6b815054539c4cbce3013daf8f276, type: 3}
+  m_Name: ProximityEffectConfiguration_HoloLens2_Slate
+  m_EditorClassIdentifier: 
+  proximityEffectActive: 1
+  objectMediumProximity: 0.08
+  objectCloseProximity: 0.05
+  farScale: 0
+  mediumScale: 1
+  closeScale: 1.5
+  farGrowRate: 0.3
+  mediumGrowRate: 0.2
+  closeGrowRate: 0.3

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/ProximityEffectConfiguration_HoloLens2_Slate.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/ProximityEffectConfiguration_HoloLens2_Slate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f8b72cca266dcd040a60c85305eae504
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/RotationHandlesConfiguration_HoloLens2_Slate.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/RotationHandlesConfiguration_HoloLens2_Slate.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36981d974b5546a4cbfa0b4bfa0c0ecb, type: 3}
+  m_Name: RotationHandlesConfiguration_HoloLens2_Slate
+  m_EditorClassIdentifier: 
+  handleMaterial: {fileID: 2100000, guid: 986558eab447a9847bbe138149edc1b4, type: 2}
+  handleGrabbedMaterial: {fileID: 2100000, guid: bf37b5eab60b288498d02fd524325d10,
+    type: 2}
+  handlePrefab: {fileID: 3868891704370700786, guid: 969c9b04d1b1848489de0d6efe6250fc,
+    type: 3}
+  handleSize: 0.032
+  colliderPadding: {x: 0.032, y: 0.016, z: 0.016}
+  drawTetherWhenManipulating: 1
+  handlesIgnoreCollider: {fileID: 0}
+  handlePrefabColliderType: 1
+  showHandleForX: 1
+  showHandleForY: 1
+  showHandleForZ: 0

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/RotationHandlesConfiguration_HoloLens2_Slate.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/RotationHandlesConfiguration_HoloLens2_Slate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4f94bad23b0d244d9fdd7635c8e8a14
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/ScaleHandlesConfiguration_HoloLens2_Slate.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/ScaleHandlesConfiguration_HoloLens2_Slate.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0d3e2fcd636d0243820f1bebf6e167b, type: 3}
+  m_Name: ScaleHandlesConfiguration_HoloLens2_Slate
+  m_EditorClassIdentifier: 
+  handleMaterial: {fileID: 2100000, guid: 986558eab447a9847bbe138149edc1b4, type: 2}
+  handleGrabbedMaterial: {fileID: 2100000, guid: bf37b5eab60b288498d02fd524325d10,
+    type: 2}
+  handlePrefab: {fileID: 1361136173122186969, guid: ba9083550f965e545a628b53bfa80c9e,
+    type: 3}
+  handleSize: 0.016
+  colliderPadding: {x: 0.016, y: 0.016, z: 0.016}
+  drawTetherWhenManipulating: 1
+  handlesIgnoreCollider: {fileID: 0}
+  handleSlatePrefab: {fileID: 1134031327877807717, guid: c45e552a6d92491468c421c35c5dd63d,
+    type: 3}
+  showScaleHandles: 1
+  scaleBehavior: 0

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/ScaleHandlesConfiguration_HoloLens2_Slate.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Slate/ScaleHandlesConfiguration_HoloLens2_Slate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 901ed6b94a657664492ab0dd5c7c56f2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e76fc3f0c163f541a5252de0124c57d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/BoxDisplayConfiguration_HoloLens2_Volumetric.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/BoxDisplayConfiguration_HoloLens2_Volumetric.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 240d9483db94993408ff1d02335ea212, type: 3}
+  m_Name: BoxDisplayConfiguration_HoloLens2_Volumetric
+  m_EditorClassIdentifier: 
+  boxMaterial: {fileID: 2100000, guid: 4a9aae3094118f44593e7f8000e24c31, type: 2}
+  boxGrabbedMaterial: {fileID: 2100000, guid: 7e4095c5609075846b657c8917aae797, type: 2}
+  flattenAxisDisplayScale: 0

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/BoxDisplayConfiguration_HoloLens2_Volumetric.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/BoxDisplayConfiguration_HoloLens2_Volumetric.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2b8a0ee1166d2f43a8acffd135b182c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/LinksConfiguration_HoloLens2_Volumetric.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/LinksConfiguration_HoloLens2_Volumetric.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b80d41f9007c4b948b0808690195e77c, type: 3}
+  m_Name: LinksConfiguration_HoloLens2_Volumetric
+  m_EditorClassIdentifier: 
+  wireframeMaterial: {fileID: 0}
+  wireframeEdgeRadius: 0.001
+  wireframeShape: 0
+  showWireframe: 0

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/LinksConfiguration_HoloLens2_Volumetric.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/LinksConfiguration_HoloLens2_Volumetric.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2a31d826856fe2e46985907117da99d3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/ProximityEffectConfiguration_HoloLens2_Volumetric.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/ProximityEffectConfiguration_HoloLens2_Volumetric.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ae6b815054539c4cbce3013daf8f276, type: 3}
+  m_Name: ProximityEffectConfiguration_HoloLens2_Volumetric
+  m_EditorClassIdentifier: 
+  proximityEffectActive: 1
+  objectMediumProximity: 0.1
+  objectCloseProximity: 0.016
+  farScale: 0
+  mediumScale: 1
+  closeScale: 1.5
+  farGrowRate: 0.3
+  mediumGrowRate: 0.2
+  closeGrowRate: 0.3

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/ProximityEffectConfiguration_HoloLens2_Volumetric.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/ProximityEffectConfiguration_HoloLens2_Volumetric.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9607516de9549d6468834d73e183e029
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/RotationHandlesConfiguration_HoloLens2_Volumetric.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/RotationHandlesConfiguration_HoloLens2_Volumetric.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36981d974b5546a4cbfa0b4bfa0c0ecb, type: 3}
+  m_Name: RotationHandlesConfiguration_HoloLens2_Volumetric
+  m_EditorClassIdentifier: 
+  handleMaterial: {fileID: 2100000, guid: 986558eab447a9847bbe138149edc1b4, type: 2}
+  handleGrabbedMaterial: {fileID: 2100000, guid: bf37b5eab60b288498d02fd524325d10,
+    type: 2}
+  handlePrefab: {fileID: 100000, guid: 57c53da2552a8114ab6d68e0cd31b1eb, type: 3}
+  handleSize: 0.016
+  colliderPadding: {x: 0.016, y: 0.016, z: 0.016}
+  drawTetherWhenManipulating: 1
+  handlesIgnoreCollider: {fileID: 0}
+  handlePrefabColliderType: 0
+  showHandleForX: 0
+  showHandleForY: 1
+  showHandleForZ: 0

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/RotationHandlesConfiguration_HoloLens2_Volumetric.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/RotationHandlesConfiguration_HoloLens2_Volumetric.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f34c3b9bc270d0e44bbc851fa6541b3a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/ScaleHandlesConfiguration_HoloLens2_Volumetric.asset
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/ScaleHandlesConfiguration_HoloLens2_Volumetric.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0d3e2fcd636d0243820f1bebf6e167b, type: 3}
+  m_Name: ScaleHandlesConfiguration_HoloLens2_Volumetric
+  m_EditorClassIdentifier: 
+  handleMaterial: {fileID: 2100000, guid: 986558eab447a9847bbe138149edc1b4, type: 2}
+  handleGrabbedMaterial: {fileID: 2100000, guid: bf37b5eab60b288498d02fd524325d10,
+    type: 2}
+  handlePrefab: {fileID: 1361136173122186969, guid: ba9083550f965e545a628b53bfa80c9e,
+    type: 3}
+  handleSize: 0.016
+  colliderPadding: {x: 0.016, y: 0.016, z: 0.016}
+  drawTetherWhenManipulating: 1
+  handlesIgnoreCollider: {fileID: 0}
+  handleSlatePrefab: {fileID: 1134031327877807717, guid: c45e552a6d92491468c421c35c5dd63d,
+    type: 3}
+  showScaleHandles: 1
+  scaleBehavior: 0

--- a/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/ScaleHandlesConfiguration_HoloLens2_Volumetric.asset.meta
+++ b/Assets/MRTK/SDK/StandardAssets/Profiles/BoundsControl/HoloLens2Style_Volumetric/ScaleHandlesConfiguration_HoloLens2_Volumetric.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ecd649e5a31d9734d82dc2e41d2dd34d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
BoundsControl.cs provides the capability for customizing visuals through Configuration (profile) files. However, currently, there are no configuration files in the assets. Users have to use configuration files under specific example (Cheese.prefab) which can cause problems when those prefabs are deleted or removed from the project.
![BoundsControlConfig_LI](https://user-images.githubusercontent.com/13754172/118593700-fded6580-b75c-11eb-8de3-896f648a8f97.jpg)



## Changes
- Fixes: #9829

## Screenshots
Added two types of configuration files - volumetric and slate. These config files were extracted from Cheese.prefab and Slate.prefab. 

<img width="450" alt="2021-05-17 21_32_17-MRTK - Untitled - Universal Windows Platform - Unity 2019 4 22f1  PREVIEW PACKAG" src="https://user-images.githubusercontent.com/13754172/118593276-46f0ea00-b75c-11eb-91e4-4f56f3c128f6.png">

<img width="469" alt="2021-05-17 21_32_31-" src="https://user-images.githubusercontent.com/13754172/118593297-4e17f800-b75c-11eb-82d7-83a87a26ac34.png">
<img width="470" alt="2021-05-17 21_32_49-" src="https://user-images.githubusercontent.com/13754172/118593304-507a5200-b75c-11eb-8824-1f2b557bba56.png">
<img width="470" alt="2021-05-17 21_33_22-" src="https://user-images.githubusercontent.com/13754172/118593308-51ab7f00-b75c-11eb-905e-042b6927bb0e.png">
<img width="486" alt="2021-05-17 21_45_52-MRTK - BB - Universal Windows Platform - Unity 2019 4 22f1  PREVIEW PACKAGES IN " src="https://user-images.githubusercontent.com/13754172/118593319-56703300-b75c-11eb-9fbb-c3e2b6b4bfc3.png">
<img width="453" alt="2021-05-17 21_46_02-MRTK - BB - Universal Windows Platform - Unity 2019 4 22f1  PREVIEW PACKAGES IN " src="https://user-images.githubusercontent.com/13754172/118593326-5839f680-b75c-11eb-80ee-7fd50174f90d.png">
<img width="479" alt="2021-05-17 21_56_37-MRTK - BB - Universal Windows Platform - Unity 2019 4 22f1  PREVIEW PACKAGES IN " src="https://user-images.githubusercontent.com/13754172/118593333-5a9c5080-b75c-11eb-971a-d1efadc4e9fe.png">
<img width="501" alt="2021-05-17 21_56_24-MRTK - BB - Universal Windows Platform - Unity 2019 4 22f1  PREVIEW PACKAGES IN " src="https://user-images.githubusercontent.com/13754172/118593336-5bcd7d80-b75c-11eb-9fb1-a94ddebf1c5e.png">

