### PR TITLE
Update reprojection mode API for OpenXR

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/Profiles/DefaultOpenXRCameraSettingsProfile.asset
+++ b/Assets/MRTK/Providers/OpenXR/Profiles/DefaultOpenXRCameraSettingsProfile.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: DefaultOpenXRCameraSettingsProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
-  reprojectionMethod: 1
+  reprojectionMethod: 0

--- a/Assets/MRTK/Providers/OpenXR/Scripts/HolographicReprojectionMethod.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/HolographicReprojectionMethod.cs
@@ -11,26 +11,26 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// <summary>
         /// Turns any reprojection off.
         /// </summary>
-        NoReprojection = 0,
+        NoReprojection = -1,
 
         /// <summary>
         /// Use the depth buffer.
         /// </summary>
-        Depth = 1,
+        Depth = 0,
 
         /// <summary>
         /// Automatically-placed plane based on the depth buffer.
         /// </summary>
-        PlanarFromDepth = 2,
+        PlanarFromDepth = 1,
 
         /// <summary>
         /// Manually-placed plane.
         /// </summary>
-        PlanarManual = 3,
+        PlanarManual = 2,
 
         /// <summary>
         /// Reprojection for an orientation-only experience.
         /// </summary>
-        OrientationOnly = 4
+        OrientationOnly = 3,
     }
 }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRCameraSettingsProfile.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRCameraSettingsProfile.cs
@@ -11,13 +11,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
     public class OpenXRCameraSettingsProfile : BaseCameraSettingsProfile
     {
         [SerializeField]
-        [Tooltip("Specifies the default reprojection method for HoloLens 2. Note: AutoPlanar requires the DotNetWinRT adapter. DepthReprojection is the default if the adapter isn't present.")]
+        [Tooltip("Specifies the default reprojection method for HoloLens 2.")]
         private HolographicReprojectionMethod reprojectionMethod = HolographicReprojectionMethod.Depth;
 
         /// <summary>
         /// Specifies the default reprojection method for HoloLens 2.
         /// </summary>
-        /// <remarks>AutoPlanar requires the DotNetWinRT adapter. DepthReprojection is the default if the adapter isn't present.</remarks>
         public HolographicReprojectionMethod ReprojectionMethod => reprojectionMethod;
     }
 }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRReprojectionUpdater.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRReprojectionUpdater.cs
@@ -6,7 +6,6 @@ using UnityEngine;
 #if MSFT_OPENXR_0_9_4_OR_NEWER
 using Microsoft.MixedReality.OpenXR;
 using System.Linq;
-using UnityEngine.XR.OpenXR;
 #endif // MSFT_OPENXR_0_9_4_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
@@ -19,14 +18,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         public HolographicReprojectionMethod ReprojectionMethod { get; set; }
 
 #if MSFT_OPENXR_0_9_4_OR_NEWER
-        private static readonly bool IsReprojectionModeSupported = OpenXRRuntime.IsExtensionEnabled("XR_MSFT_composition_layer_reprojection_preview");
         private ReprojectionSettings reprojectionSettings = default;
 
         private void OnPostRender()
         {
             // The reprojection method needs to be set each frame.
-            if (IsReprojectionModeSupported
-                && ReprojectionMethod != HolographicReprojectionMethod.Depth)
+            if (ReprojectionMethod != HolographicReprojectionMethod.Depth)
             {
                 ReprojectionMode reprojectionMode = MapMRTKReprojectionMethodToOpenXR(ReprojectionMethod);
                 reprojectionSettings.ReprojectionMode = reprojectionMode;

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRReprojectionUpdater.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRReprojectionUpdater.cs
@@ -45,6 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             switch (reprojectionMethod)
             {
                 case HolographicReprojectionMethod.Depth:
+                default:
                     return ReprojectionMode.Depth;
                 case HolographicReprojectionMethod.PlanarFromDepth:
                     return ReprojectionMode.PlanarFromDepth;
@@ -53,7 +54,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 case HolographicReprojectionMethod.OrientationOnly:
                     return ReprojectionMode.OrientationOnly;
                 case HolographicReprojectionMethod.NoReprojection:
-                default:
                     return ReprojectionMode.NoReprojection;
             }
         }


### PR DESCRIPTION
## Overview

The OpenXR plugin's API went through a slight change before shipping. This brings us up to date with the latest expected behavior.

1. `NoReprojection` moved to `-1` so that `0` defaults to `Depth`
2. Removed some stale, copied remarks
3. Remove the `IsReprojectionModeSupported` check, since the extension string may change in the future