### PR TITLE
Fix tests on Unity 2020

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
@@ -63,7 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             if (trackedPoseDriver != null)
             {
-                Object.Destroy(trackedPoseDriver);
+                UnityObjectExtensions.DestroyObject(trackedPoseDriver);
                 trackedPoseDriver = null;
             }
 


### PR DESCRIPTION
## Overview

https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9740 exposed that some of our edit mode tests aren't working on Unity 2020. The culprit appears to have been an attempt at using `Object.Destroy` from edit mode.

Instead, this now uses the MRTK extension which calls the correct `Destroy`/`DestroyImmediate` method depending on context.