### PR TITLE
Make Oculus use MRTK visualization by default

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -92,24 +92,24 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         }
 
         /// <summary>
-        /// Determines whether or not this controller uses MRTK for controller visualization or not
+        /// Determines whether or not this controller is using MRTK for controller visualization
+        /// 
+        /// When false, the Oculus Touch controller model visualization will not be managed by MRTK
+        /// Ensure that the Oculus Integration Package is installed and the Ovr Camera Rig is set correctly in the Oculus XRSDK Device Manager to use the
+        /// Oculus Integration Package's visualization
         /// </summary>
-        internal bool UseMRTKControllerVisualization { get; set; } = true;
-
-        /// <inheritdoc/>
-        /// <remarks>
-        /// If UseMRTKControllerVisualization is false, Oculus Touch controller model visualization will not be managed by MRTK
-        /// Ensure that the Oculus Integration Package is installed and the Ovr Camera Rig is set correctly in the Oculus XRSDK Device Manager
-        /// </remarks>
-        protected override bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)
+        internal bool UseMRTKControllerVisualization
         {
-            if (UseMRTKControllerVisualization)
+            get
             {
-                return base.TryRenderControllerModel(controllerType, inputSourceType);
+                return Visualizer != null && Visualizer.GameObjectProxy != null && Visualizer.GameObjectProxy.activeSelf;
             }
-            else
+            set
             {
-                return false;
+                if(Visualizer != null && Visualizer.GameObjectProxy)
+                {
+                    Visualizer.GameObjectProxy.SetActive(value);
+                }
             }
         }
     }

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -94,7 +94,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         /// <summary>
         /// Determines whether or not this controller uses MRTK for controller visualization or not
         /// </summary>
-        internal bool UseMRTKControllerVisualization { get; set; } = false;
+        internal bool UseMRTKControllerVisualization { get; set; } = true;
 
         /// <inheritdoc/>
         /// <remarks>


### PR DESCRIPTION
## Overview
Adjusts #9589  so that the Oculus Quest uses the MRTK controller visualizations by default.

Previously, we disabled the MRTK visualization since the Oculus Integration Package comes with it's own visualization. However, this resulted in invisible controllers when the Oculus Integration Package was not present

The crux of the fix is that the previous implementation attempted to stop the TryRenderController() function from running, however, that is only called on controller initialization. The new implementation introduces a mechanism to disable the visualizer after the controller was instantiated.

## Changes
- Fixes: #9861

