### PR TITLE
[2.6.2] Cherry-pick #9819 

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -495,8 +495,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                         }
                         meshes.Add(meshObject.Id, meshObject);
 
-                        meshObject.GameObject.transform.parent = (ObservedObjectParent.transform != null) ?
-                            ObservedObjectParent.transform : null;
+                        // This is important. We need to preserve the mesh's local transform here, not its global pose.
+                        // Think of it like this. If we set the camera's coordinates 3 meters to the left, the physical camera
+                        // hasn't moved, only its coordinates have changed. Likewise, the physical room hasn't moved (relative to
+                        // the physical camera), so we also want to set its coordinates 3 meters to the left.
+                        Transform meshObjectParent = (ObservedObjectParent.transform != null) ? ObservedObjectParent.transform : null;
+                        meshObject.GameObject.transform.SetParent(meshObjectParent, false);
 
                         meshEventData.Initialize(this, meshObject.Id, meshObject);
                         if (isMeshUpdate)


### PR DESCRIPTION
Correct parenting of spatial mesh to preserve local transform.

Cherry-picked for a 2.6.2 patch