### PR TITLE
Fix automatic remoting for Windows XR Plugin

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -131,10 +131,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (unityJointPoses.TryGetValue(TrackedHandJoint.Palm, out palmJoint))
                 {
                     Vector3 palmNormal = palmJoint.Rotation * (-1 * Vector3.up);
-                    if (cursorBeamBackwardTolerance >= 0)
+                    if (cursorBeamBackwardTolerance >= 0 && CameraCache.Main != null)
                     {
-                        Vector3 cameraBackward = -CameraCache.Main.transform.forward;
-                        if (Vector3.Dot(palmNormal.normalized, cameraBackward) > cursorBeamBackwardTolerance)
+                        if (Vector3.Dot(palmNormal.normalized, -CameraCache.Main.transform.forward) > cursorBeamBackwardTolerance)
                         {
                             return false;
                         }

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK.Oculus.asmdef
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK.Oculus.asmdef
@@ -1,6 +1,8 @@
 {
     "name": "Microsoft.MixedReality.Toolkit.Providers.XRSDK.Oculus",
+    "rootNamespace": "",
     "references": [
+        "Microsoft.MixedReality.Toolkit.Async",
         "Microsoft.MixedReality.Toolkit",
         "Microsoft.MixedReality.Toolkit.Services.InputSystem",
         "Microsoft.MixedReality.Toolkit.SDK",

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.XRSDK.Input;
 using System;
+using UnityEngine;
 using UnityEngine.XR;
 
 #if OCULUS_ENABLED
@@ -154,7 +155,7 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
 
         #endregion Controller Utilities
 
-        private bool IsActiveLoader =>
+        private bool? IsActiveLoader =>
 #if OCULUS_ENABLED
             LoaderHelpers.IsLoaderActive<OculusLoader>();
 #else
@@ -164,18 +165,33 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
         /// <inheritdoc/>
         public override void Enable()
         {
-            if (!IsActiveLoader)
+            if (!IsActiveLoader.HasValue)
+            {
+                IsEnabled = false;
+                EnableIfLoaderBecomesActive();
+                return;
+            }
+            else if (!IsActiveLoader.Value)
             {
                 IsEnabled = false;
                 return;
             }
 
-            base.Enable();
-
 #if OCULUSINTEGRATION_PRESENT
             SetupInput();
             ConfigurePerformancePreferences();
 #endif // OCULUSINTEGRATION_PRESENT
+
+            base.Enable();
+        }
+
+        private async void EnableIfLoaderBecomesActive()
+        {
+            await new WaitUntil(() => IsActiveLoader.HasValue);
+            if (IsActiveLoader.Value)
+            {
+                Enable();
+            }
         }
 
 #if OCULUSINTEGRATION_PRESENT

--- a/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "Microsoft.MixedReality.Toolkit.XRSDK.OpenXR",
     "references": [
         "Microsoft.MixedReality.OpenXR",
+        "Microsoft.MixedReality.Toolkit.Async",
         "Microsoft.MixedReality.Toolkit",
         "Microsoft.MixedReality.Toolkit.Gltf",
         "Microsoft.MixedReality.Toolkit.Providers.XRSDK",

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             gazeSmoother.OnSaccadeY += GazeSmoother_OnSaccadeY;
         }
 
-        private bool IsActiveLoader =>
+        private bool? IsActiveLoader =>
 #if UNITY_OPENXR
             LoaderHelpers.IsLoaderActive<OpenXRLoaderBase>();
 #else
@@ -99,13 +99,28 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// <inheritdoc />
         public override void Enable()
         {
-            if (!IsActiveLoader)
+            if (!IsActiveLoader.HasValue)
+            {
+                IsEnabled = false;
+                EnableIfLoaderBecomesActive();
+                return;
+            }
+            else if (!IsActiveLoader.Value)
             {
                 IsEnabled = false;
                 return;
             }
 
             base.Enable();
+        }
+
+        private async void EnableIfLoaderBecomesActive()
+        {
+            await new WaitUntil(() => IsActiveLoader.HasValue);
+            if (IsActiveLoader.Value)
+            {
+                Enable();
+            }
         }
 
         private void ReadProfile()

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         { }
 
-        protected override bool IsActiveLoader =>
+        protected override bool? IsActiveLoader =>
 #if MSFT_OPENXR_0_9_4_OR_NEWER
             LoaderHelpers.IsLoaderActive<OpenXRLoaderBase>();
 #else

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/MRTK.WMR.XRSDK.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/MRTK.WMR.XRSDK.asmdef
@@ -1,6 +1,7 @@
 {
     "name": "Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality",
     "references": [
+        "Microsoft.MixedReality.Toolkit.Async",
         "Microsoft.MixedReality.Toolkit",
         "Microsoft.MixedReality.Toolkit.Editor.Utilities",
         "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared",

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 {
@@ -33,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             BaseCameraSettingsProfile profile = null) : base(cameraSystem, name, priority, profile)
         { }
 
-        private bool IsActiveLoader =>
+        private bool? IsActiveLoader =>
 #if WMR_ENABLED
             LoaderHelpers.IsLoaderActive("Windows MR Loader");
 #else
@@ -43,13 +44,28 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         public override void Enable()
         {
-            if (!IsActiveLoader)
+            if (!IsActiveLoader.HasValue)
+            {
+                IsEnabled = false;
+                EnableIfLoaderBecomesActive();
+                return;
+            }
+            else if (!IsActiveLoader.Value)
             {
                 IsEnabled = false;
                 return;
             }
 
             base.Enable();
+        }
+
+        private async void EnableIfLoaderBecomesActive()
+        {
+            await new WaitUntil(() => IsActiveLoader.HasValue);
+            if (IsActiveLoader.Value)
+            {
+                Enable();
+            }
         }
 
         #region IMixedRealityCameraSettings

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -7,6 +7,7 @@ using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 using Microsoft.MixedReality.Toolkit.XRSDK.Input;
 using System;
+using UnityEngine;
 using UnityEngine.XR;
 
 #if HP_CONTROLLER_ENABLED
@@ -51,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(inputSystem, name, priority, profile) { }
 
-        private bool IsActiveLoader =>
+        private bool? IsActiveLoader =>
 #if WMR_ENABLED
             LoaderHelpers.IsLoaderActive("Windows MR Loader");
 #else
@@ -63,13 +64,17 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         public override void Enable()
         {
-            if (!IsActiveLoader)
+            if (!IsActiveLoader.HasValue)
+            {
+                IsEnabled = false;
+                EnableIfLoaderBecomesActive();
+                return;
+            }
+            else if (!IsActiveLoader.Value)
             {
                 IsEnabled = false;
                 return;
             }
-
-            base.Enable();
 
             if (WindowsMixedRealityUtilities.UtilitiesProvider == null)
             {
@@ -87,6 +92,17 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             motionControllerWatcher.MotionControllerRemoved += RemoveTrackedMotionController;
             var nowait = motionControllerWatcher.StartAsync();
 #endif // HP_CONTROLLER_ENABLED
+
+            base.Enable();
+        }
+
+        private async void EnableIfLoaderBecomesActive()
+        {
+            await new WaitUntil(() => IsActiveLoader.HasValue);
+            if (IsActiveLoader.Value)
+            {
+                Enable();
+            }
         }
 
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -4,13 +4,13 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
+using UnityEngine;
 
 // These versions represent the first version eye tracking became usable across Unity 2019/2020/2021
 // WMR_2_7_0_OR_NEWER stops being defined at 3.0 and WMR_4_4_2_OR_NEWER stops being defined at 5.0, exclusive
 #if WMR_2_7_0_OR_NEWER || WMR_4_4_2_OR_NEWER || WMR_5_2_2_OR_NEWER
 using Unity.Profiling;
 using Unity.XR.WindowsMR;
-using UnityEngine;
 using UnityEngine.XR;
 #endif // WMR_2_7_0_OR_NEWER || WMR_4_4_2_OR_NEWER || WMR_5_2_2_OR_NEWER
 
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             gazeSmoother.OnSaccadeY += GazeSmoother_OnSaccadeY;
         }
 
-        private bool IsActiveLoader =>
+        private bool? IsActiveLoader =>
 #if WMR_ENABLED
             LoaderHelpers.IsLoaderActive("Windows MR Loader");
 #else
@@ -78,13 +78,28 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         public override void Enable()
         {
-            if (!IsActiveLoader)
+            if (!IsActiveLoader.HasValue)
+            {
+                IsEnabled = false;
+                EnableIfLoaderBecomesActive();
+                return;
+            }
+            else if (!IsActiveLoader.Value)
             {
                 IsEnabled = false;
                 return;
             }
 
             base.Enable();
+        }
+
+        private async void EnableIfLoaderBecomesActive()
+        {
+            await new WaitUntil(() => IsActiveLoader.HasValue);
+            if (IsActiveLoader.Value)
+            {
+                Enable();
+            }
         }
 
         #region IMixedRealityCapabilityCheck Implementation

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         { }
 
-        protected override bool IsActiveLoader =>
+        protected override bool? IsActiveLoader =>
 #if WMR_ENABLED
             LoaderHelpers.IsLoaderActive("Windows MR Loader");
 #else

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -41,18 +41,33 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         { }
 
-        protected virtual bool IsActiveLoader => true;
+        protected virtual bool? IsActiveLoader => true;
 
         /// <inheritdoc />
         public override void Enable()
         {
-            if (!IsActiveLoader)
+            if (!IsActiveLoader.HasValue)
+            {
+                IsEnabled = false;
+                EnableIfLoaderBecomesActive();
+                return;
+            }
+            else if (!IsActiveLoader.Value)
             {
                 IsEnabled = false;
                 return;
             }
 
             base.Enable();
+        }
+
+        private async void EnableIfLoaderBecomesActive()
+        {
+            await new WaitUntil(() => IsActiveLoader.HasValue);
+            if (IsActiveLoader.Value)
+            {
+                Enable();
+            }
         }
 
         #region BaseSpatialObserver Implementation
@@ -133,7 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             var descriptors = new List<XRMeshSubsystemDescriptor>();
             SubsystemManager.GetSubsystemDescriptors(descriptors);
 
-            return descriptors.Count > 0 && IsActiveLoader;
+            return descriptors.Count > 0 && (IsActiveLoader ?? false);
         }
 
         #endregion IMixedRealityCapabilityCheck Implementation

--- a/Assets/MRTK/Providers/XRSDK/LoaderHelpers.cs
+++ b/Assets/MRTK/Providers/XRSDK/LoaderHelpers.cs
@@ -13,27 +13,40 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         /// Checks if the active loader has a specific name. Used in cases where the loader class is internal, like WindowsMRLoader.
         /// </summary>
         /// <param name="loaderName">The string name to compare against the active loader.</param>
-        /// <returns>True if the active loader has the same name as the parameter.</returns>
-        public static bool IsLoaderActive(string loaderName) =>
+        /// <returns>True if the active loader has the same name as the parameter. Null if there isn't an active loader.</returns>
+        public static bool? IsLoaderActive(string loaderName)
+        {
 #if XR_MANAGEMENT_ENABLED
-            XRGeneralSettings.Instance != null
-            && XRGeneralSettings.Instance.Manager != null
-            && XRGeneralSettings.Instance.Manager.activeLoader != null
-            && XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
+            if (XRGeneralSettings.Instance != null
+                && XRGeneralSettings.Instance.Manager != null
+                && XRGeneralSettings.Instance.Manager.activeLoader != null)
+            {
+                return XRGeneralSettings.Instance.Manager.activeLoader.name == loaderName;
+            }
+
+            return null;
 #else
-            false;
+            return false;
 #endif
+        }
 
 #if XR_MANAGEMENT_ENABLED
         /// <summary>
         /// Checks if the active loader is of a specific type. Used in cases where the loader class is accessible, like OculusLoader.
         /// </summary>
         /// <typeparam name="T">The loader class type to check against the active loader.</typeparam>
-        /// <returns>True if the active loader is of the specified type.</returns>
-        public static bool IsLoaderActive<T>() where T : XRLoader =>
-            XRGeneralSettings.Instance != null
-            && XRGeneralSettings.Instance.Manager != null
-            && XRGeneralSettings.Instance.Manager.activeLoader is T;
+        /// <returns>True if the active loader is of the specified type. Null if there isn't an active loader.</returns>
+        public static bool? IsLoaderActive<T>() where T : XRLoader
+        {
+            if (XRGeneralSettings.Instance != null
+                && XRGeneralSettings.Instance.Manager != null
+                && XRGeneralSettings.Instance.Manager.activeLoader != null)
+            {
+                return XRGeneralSettings.Instance.Manager.activeLoader is T;
+            }
+
+            return null;
+        }
 #endif
     }
 }

--- a/Assets/MRTK/Providers/XRSDK/MRTK.XRSDK.asmdef
+++ b/Assets/MRTK/Providers/XRSDK/MRTK.XRSDK.asmdef
@@ -1,6 +1,7 @@
 {
     "name": "Microsoft.MixedReality.Toolkit.Providers.XRSDK",
     "references": [
+        "Microsoft.MixedReality.Toolkit.Async",
         "Microsoft.MixedReality.Toolkit",
         "Unity.XR.Management",
         "UnityEngine.SpatialTracking"

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -64,7 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// <param name="loaderName">The string name to compare against the active loader.</param>
         /// <returns>True if the active loader has the same name as the parameter.</returns>
         [Obsolete("Use XRSDKLoaderHelpers instead.")]
-        protected virtual bool IsLoaderActive(string loaderName) => LoaderHelpers.IsLoaderActive(loaderName);
+        protected virtual bool IsLoaderActive(string loaderName) => LoaderHelpers.IsLoaderActive(loaderName) ?? false;
 
         /// <summary>
         /// Checks if the active loader is of a specific type. Used in cases where the loader class is accessible, like OculusLoader.
@@ -72,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// <typeparam name="T">The loader class type to check against the active loader.</typeparam>
         /// <returns>True if the active loader is of the specified type.</returns>
         [Obsolete("Use XRSDKLoaderHelpers instead.")]
-        protected virtual bool IsLoaderActive<T>() where T : XRLoader => LoaderHelpers.IsLoaderActive<T>();
+        protected virtual bool IsLoaderActive<T>() where T : XRLoader => LoaderHelpers.IsLoaderActive<T>() ?? false;
 #endif // XR_MANAGEMENT_ENABLED
 
         private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] XRSDKDeviceManager.Update");


### PR DESCRIPTION
## Overview

Adds an optional waiting period in the various data providers to ensure that XR is properly initialized before assuming they're properly enabled/disabled.

Previously, data providers would check if their specified loader is the active loader once at initialization, though in some scenarios (like holographic remoting), XR itself isn't initialized until some point later (like when remoting makes a successful connection, which might not be instant).

Now, data providers will wait until an active loader exists before determining their enabled state.

Also fixes a potential null ref in `ArticulatedHandDefinition` which I noticed during shutdown of remoting when a hand is detected.

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9682, fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9586

