### PR TITLE
Add support for the Leap Motion 4.8.0 Unity Modules 

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         private static bool isLeapRecognizedByMRTK = false;
 
         // The current supported Leap Core Assets version numbers.
-        private static string[] leapCoreAssetsVersionsSupported = new string[] { "4.5.0", "4.5.1", "4.6.0", "4.7.0", "4.7.1" };
+        private static string[] leapCoreAssetsVersionsSupported = new string[] { "4.5.0", "4.5.1", "4.6.0", "4.7.0", "4.7.1", "4.8.0" };
 
         // The current Leap Core Assets version in this project
         private static string currentLeapCoreAssetsVersion = "";
@@ -132,7 +132,14 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
 
                 if (isLeapCoreAssetsVersionSupported)
                 {
-                    Debug.Log($"Integrating the Leap Motion Unity Modules Version {currentLeapCoreAssetsVersion} with MRTK");
+                    if (currentLeapCoreAssetsVersion == "4.7.1")
+                    {
+                        Debug.Log($"Integrating the Leap Motion Unity Modules Version {currentLeapCoreAssetsVersion} or 4.8.0 with MRTK");
+                    }
+                    else
+                    {
+                        Debug.Log($"Integrating the Leap Motion Unity Modules Version {currentLeapCoreAssetsVersion} with MRTK");
+                    }
 
                     RemoveTestingFolders();
                     AddAndUpdateAsmDefs();
@@ -170,7 +177,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                         {
                             currentLeapCoreAssetsVersion = versionNumberSupported;
 
-                            // The Leap Motion Unity modules Version.txt has remained 4.5.1 across versions 4.6.0, 4.7.0 and 4.7.1, check for the presence
+                            // The Leap Motion Unity modules Version.txt has remained 4.5.1 across versions 4.6.0, 4.7.0, 4.7.1, and 4.8.0 check for the presence
                             // of certain paths to infer the version number.
 
                             // This path is only present in 4.7.1
@@ -184,6 +191,9 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
 
                             if (File.Exists(leap471Path))
                             {
+                                // The Leap Motion Unity modules Core package version 4.7.1 is identical to the version 4.8.0 
+                                // Core package. Due to the lack of differences between the two versions, the modules will be marked as 4.7.1 even
+                                // if they are version 4.8.0.
                                 currentLeapCoreAssetsVersion = "4.7.1";
                             }
                             else if (!File.Exists(leap471Path) && Directory.Exists(testDirectoryPath))


### PR DESCRIPTION
## Overview
Leap released the 4.8.0 Unity Modules yesterday: https://github.com/leapmotion/UnityModules/releases/tag/UM-4.8.0

Support for the 4.8.0 modules did not require a code change, this PR adds comments to the Leap MotionConfigurationChecker file about version 4.8.0.

There are no differences between the 4.7.1 core package and the 4.8.0 core package.  The primary changes from 4.7.1 to 4.8.0 are in the Hands modules, which MRTK does not depend on.  The MRTK Leap Motion support only depends on the presence of the Core unity package:
 
![image](https://user-images.githubusercontent.com/53493796/119538296-d2134680-bd3f-11eb-919f-cf8f7da3b370.png)

Due to the lack of differences in the core package between 4.7.1 and 4.8.0, the version will be marked as 4.7.1 even if it is version 4.8.0 because the Version.txt file has remained version 4.5.1.
