### PR TITLE
Increased the frame wait timer to account for Holographic Remoting latency

### DIFF
--- a/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
+++ b/Assets/MRTK/Core/Utilities/SceneContent/MixedRealitySceneContent.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit
         private Transform containerObject = null;
 
         private Vector3 contentPosition = Vector3.zero;
-        private const uint MaxEditorFrameWaitCount = 5;
+        private const uint MaxEditorFrameWaitCount = 15;
         private Coroutine initializeSceneContentWithDelay;
 
         private void Awake()

--- a/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             PlayModeTestUtilities.Setup(profile);
 
-            yield return PlayModeTestUtilities.WaitForSeconds(0.5f);
+            yield return new WaitForSeconds(0.5f);
 
             // Ensure that the SceneContent object is contentOffset units above the origin
             Assert.AreEqual(GameObject.Find("MixedRealitySceneContent").transform.position.y, contentOffset, 0.005f);

--- a/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             PlayModeTestUtilities.Setup(profile);
 
-            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            yield return PlayModeTestUtilities.WaitForSeconds(0.5f);
 
             // Ensure that the SceneContent object is contentOffset units above the origin
             Assert.AreEqual(GameObject.Find("MixedRealitySceneContent").transform.position.y, contentOffset, 0.005f);


### PR DESCRIPTION
## Overview
Latency when connecting via holographic remoting is not standard, and on the 2.8.0 version of the windows XR plugin, the time it takes to register the Hololens is a bit longer, causing the scene content system to mistakenly place the scene content in a different area. This PR increases the wait time before setting the scene content's position, giving Unity a bit more time to initialize the camera in the proper place

## Changes
- Fixes: #9867
