### PR TITLE
Include OpenXR on all platforms

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
@@ -9,13 +9,7 @@
         "Unity.XR.Management",
         "Unity.XR.OpenXR"
     ],
-    "includePlatforms": [
-        "Android",
-        "Editor",
-        "WSA",
-        "WindowsStandalone32",
-        "WindowsStandalone64"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
## Overview

Marks the MRTK OpenXR asmdef as valid for all platforms.

![image](https://user-images.githubusercontent.com/3580640/119577318-40bbc880-bd6f-11eb-9657-9fdadcc8fa16.png)

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9856
