### PR TITLE
Fix Knuckles name lookup

### DIFF
--- a/Assets/MRTK/Providers/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenVR/OpenVRDeviceManager.cs
@@ -192,7 +192,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
                 return SupportedControllerType.ViveWand;
             }
 
-            if (joystickName.Contains("Vive Knuckles"))
+            if (joystickName.Contains("Knuckles"))
             {
                 return SupportedControllerType.ViveKnuckles;
             }


### PR DESCRIPTION
## Overview

![image](https://user-images.githubusercontent.com/3580640/119585508-b0d24a80-bd7f-11eb-824d-5339c8c0c680.png)

Turns out we've been using the wrong look-up name for a while! This fixes things.