### PR TITLE
Ensure mergetool always runs

### DIFF
--- a/pipelines/mergetool.yml
+++ b/pipelines/mergetool.yml
@@ -6,6 +6,7 @@ schedules:
   branches:
     include:
     - main
+  always: true
 
 pr: none
 trigger: none


### PR DESCRIPTION
## Overview

Without this flag, the pipeline will only run if something changes on the `main` branch, which doesn't always happen daily during stabilization.