### PR TITLE
Initialize global input source variable

### DIFF
--- a/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
+++ b/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <summary>
         /// The global input source used by the the speech input provider to raise events.
         /// </summary>
-        private BaseGlobalInputSource globalInputSource;
+        private BaseGlobalInputSource globalInputSource = null;
 
         /// <inheritdoc />
         public bool IsRecognitionActive =>


### PR DESCRIPTION
## Overview
We didn't initialize the global input source variable initially, causing warnings to appear.

## Changes
Fixed error introduced by #9770