### PR TITLE
Fixes floating stale hands and doubled mesh with Windows XR Plugin

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -216,7 +216,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                         if (meshTransform.HasValue)
                         {
                             System.Numerics.Matrix4x4.Decompose(meshTransform.Value,
-                                out System.Numerics.Vector3 scale,
+                                out _,
                                 out System.Numerics.Quaternion rotation,
                                 out System.Numerics.Vector3 translation);
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -209,7 +209,21 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 
                     if (vertexAndNormals != null && handMeshTriangleIndices != null)
                     {
-                        var handMeshVertexState = handMeshObserver.GetVertexStateForPose(handPose);
+                        HandMeshVertexState handMeshVertexState = null;
+                        try
+                        {
+                            handMeshVertexState = handMeshObserver.GetVertexStateForPose(handPose);
+                        }
+                        catch (ArgumentException)
+                        {
+                            Debug.Log($"{nameof(WindowsMixedRealityHandMeshProvider)} failed to update the hand mesh. This might happen if a source was detected and lost rapidly. Otherwise, the mesh might be stale this frame.");
+                        }
+
+                        if (handMeshVertexState == null)
+                        {
+                            return;
+                        }
+
                         handMeshVertexState.GetVertices(vertexAndNormals);
 
                         var meshTransform = handMeshVertexState.CoordinateSystem.TryGetTransformTo(WindowsMixedRealityUtilities.SpatialCoordinateSystem);


### PR DESCRIPTION
## Overview

After Unity fixed their head tracking bug on pause/resume, it revealed that we still had _some_ issue with hands not being thoroughly cleaned up.

Thanks to @Holo-Fiedel's research at https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9238#issuecomment-774459693, and verifying the logs locally, this was fixable by guarding against an incorrect hand pose throwing an exception in the hand mesh provider.

The underlying issue appears to be if Windows XR Plugin reports an InputDevice that represents a SpatialInteractionSource that happens to be lost between the time Windows XR Plugin reported its devices and the time MRTK asks the platform for a hand mesh. This should only really happen within the span of a single frame, so the next frame will properly report the InputDevice as lost.

This exception was causing the rest of the `Update` loop to stop running, which put MRTK's local InputDevice tracking out of sync and caused the MRTK source to never be reported as lost.

After this change, I've been unable to repro any of the hand joint / hand mesh related issues.

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9238, fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9151, fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9165

