### PR TITLE
Cherry-picking global input source for speech for 2.7

### DIFF
--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -132,6 +132,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         IMixedRealityInputSource RequestNewGenericInputSource(string name, IMixedRealityPointer[] pointers = null, InputSourceType sourceType = InputSourceType.Other);
 
+        BaseGlobalInputSource RequestNewGlobalInputSource(string name, IMixedRealityFocusProvider focusProvider = null, InputSourceType sourceType = InputSourceType.Other);
+
         /// <summary>
         /// Raise the event that the Input Source was detected.
         /// </summary>

--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityPointer.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityPointer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         bool IsInteractionEnabled { get; }
 
         /// <summary>
-        /// Controls whether the pointer dispatches input..
+        /// Controls whether the pointer dispatches input.
         /// </summary>
         bool IsActive { get; set; }
 

--- a/Assets/MRTK/Core/Providers/BaseGlobalInputSource.cs
+++ b/Assets/MRTK/Core/Providers/BaseGlobalInputSource.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Linq;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    /// <summary>
+    /// Base class for input sources whose pointers are all active pointers in the scene.
+    /// </summary>
+    /// <remarks>
+    /// <para>This base class is intended to represent input sources which raise events to all active pointers found by the FocusProvider in a scene.</para>
+    /// </remarks>
+    public class BaseGlobalInputSource : IMixedRealityInputSource, IDisposable
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public BaseGlobalInputSource(string name, IMixedRealityFocusProvider focusProvider, InputSourceType sourceType = InputSourceType.Other)
+        {
+            SourceId = (CoreServices.InputSystem != null) ? CoreServices.InputSystem.GenerateNewSourceId() : 0;
+            SourceName = name;
+            FocusProvider = focusProvider;
+            SourceType = sourceType;
+
+            UpdateActivePointers();
+        }
+
+        /// <inheritdoc />
+        public uint SourceId { get; }
+
+        /// <inheritdoc />
+        public string SourceName { get; }
+
+        /// <inheritdoc />
+        public virtual IMixedRealityPointer[] Pointers { get; set; }
+
+        /// <inheritdoc />
+        public InputSourceType SourceType { get; set; }
+
+        private IMixedRealityFocusProvider FocusProvider;
+
+        public void UpdateActivePointers()
+        {
+            Pointers = FocusProvider.GetPointers<IMixedRealityPointer>().Where(x => x.IsActive).ToArray();
+        }
+
+        #region IEquality Implementation
+
+        public static bool Equals(IMixedRealityInputSource left, IMixedRealityInputSource right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <inheritdoc />
+        bool IEqualityComparer.Equals(object left, object right)
+        {
+            return left.Equals(right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) { return false; }
+            if (ReferenceEquals(this, obj)) { return true; }
+            if (obj.GetType() != GetType()) { return false; }
+
+            return Equals((IMixedRealityInputSource)obj);
+        }
+
+        private bool Equals(IMixedRealityInputSource other)
+        {
+            return other != null && SourceId == other.SourceId && string.Equals(SourceName, other.SourceName);
+        }
+
+        /// <inheritdoc />
+        int IEqualityComparer.GetHashCode(object obj)
+        {
+            return obj.GetHashCode();
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = 0;
+                hashCode = (hashCode * 397) ^ (int)SourceId;
+                hashCode = (hashCode * 397) ^ (SourceName != null ? SourceName.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Dispose.
+        /// </summary>
+        public virtual void Dispose() { }
+
+        #endregion IEquality Implementation
+    }
+}

--- a/Assets/MRTK/Core/Providers/BaseGlobalInputSource.cs.meta
+++ b/Assets/MRTK/Core/Providers/BaseGlobalInputSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8df3f0069208a745ae81468723ed050
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
+++ b/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <summary>
         /// The global input source used by the the speech input provider to raise events.
         /// </summary>
-        private BaseGlobalInputSource globalInputSource;
+        private BaseGlobalInputSource globalInputSource = null;
 
         /// <inheritdoc />
         public bool IsRecognitionActive =>

--- a/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
+++ b/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
@@ -61,12 +61,17 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <summary>
         /// The Input Source for Windows Speech Input.
         /// </summary>
-        public IMixedRealityInputSource InputSource = null;
+        public IMixedRealityInputSource InputSource => globalInputSource;
 
         /// <summary>
         /// The minimum confidence level for the recognizer to fire an event.
         /// </summary>
         public RecognitionConfidenceLevel RecognitionConfidenceLevel { get; set; }
+
+        /// <summary>
+        /// The global input source used by the the speech input provider to raise events.
+        /// </summary>
+        private BaseGlobalInputSource globalInputSource;
 
         /// <inheritdoc />
         public bool IsRecognitionActive =>
@@ -152,7 +157,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 return;
             }
 
-            InputSource = Service?.RequestNewGenericInputSource("Windows Speech Input Source", sourceType: InputSourceType.Voice);
+            globalInputSource = Service?.RequestNewGlobalInputSource("Windows Speech Input Source", sourceType: InputSourceType.Voice);
 
             var newKeywords = new string[Commands.Length];
 
@@ -243,6 +248,8 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 {
                     if (Commands[i].LocalizedKeyword == text)
                     {
+                        globalInputSource.UpdateActivePointers();
+
                         Service?.RaiseSpeechCommandRecognized(InputSource, (RecognitionConfidenceLevel)confidence, phraseDuration, phraseStartTime, Commands[i]);
                         break;
                     }

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -874,6 +874,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return new BaseGenericInputSource(name, pointers, sourceType);
         }
 
+        /// <inheritdoc />
+        public BaseGlobalInputSource RequestNewGlobalInputSource(string name, IMixedRealityFocusProvider focusProvider = null, InputSourceType sourceType = InputSourceType.Other)
+        {
+            var inputSourceFocusProvider = focusProvider.IsNull() ? FocusProvider : focusProvider;
+            return new BaseGlobalInputSource(name, inputSourceFocusProvider, sourceType);
+        }
+
+
         #region Input Source State Events
 
         private static readonly ProfilerMarker RaiseSourceDetectedPerfMarker = new ProfilerMarker("[MRTK] MixedRealityInputSystem.RaiseSourceDetected");

--- a/Assets/MRTK/Tests/PlayModeTests/Components/TestInputFocusListener.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Components/TestInputFocusListener.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    // For InputSystemGlobalListener
+#pragma warning disable 0618
+    [AddComponentMenu("Scripts/MRTK/Tests/TestInputFocusListener")]
+    internal class TestInputFocusListener : MonoBehaviour, IMixedRealityFocusHandler, IMixedRealityPointerHandler, IMixedRealitySpeechHandler
+    {
+        // Parameters, which are set by child classes
+        public bool useEventDataOnReception = false;
+
+        // Values changed by class to validate event receiving
+        public int pointerDownCount = 0;
+        public int pointerDraggedCount = 0;
+        public int pointerUpCount = 0;
+        public int pointerClickedCount = 0;
+
+        public int focusGainedCount = 0;
+        public int focusLostCount = 0;
+        public List<string> speechCommandsReceived = new List<string>();
+
+        protected void Start()
+        {
+            pointerDownCount = 0;
+            pointerDraggedCount = 0;
+            pointerUpCount = 0;
+            pointerClickedCount = 0;
+
+            focusGainedCount = 0;
+            focusLostCount = 0;
+            speechCommandsReceived = new List<string>();
+        }
+
+        public void OnPointerDown(MixedRealityPointerEventData eventData)
+        {
+            pointerDownCount++;
+
+            if (useEventDataOnReception)
+            {
+                eventData.Use();
+            }
+        }
+
+        public void OnPointerDragged(MixedRealityPointerEventData eventData)
+        {
+            pointerDraggedCount++;
+
+            if (useEventDataOnReception)
+            {
+                eventData.Use();
+            }
+        }
+
+        public void OnPointerUp(MixedRealityPointerEventData eventData)
+        {
+            pointerUpCount++;
+
+            if (useEventDataOnReception)
+            {
+                eventData.Use();
+            }
+        }
+
+        public virtual void OnPointerClicked(MixedRealityPointerEventData eventData)
+        {
+            pointerClickedCount++;
+
+            if (useEventDataOnReception)
+            {
+                eventData.Use();
+            }
+        }
+
+        public void OnSpeechKeywordRecognized(SpeechEventData eventData)
+        {
+            speechCommandsReceived.Add(eventData.Command.Keyword);
+
+            if(useEventDataOnReception)
+            {
+                eventData.Use();
+            }
+        }
+
+        public void OnFocusEnter(FocusEventData eventData)
+        {
+            focusGainedCount++;
+
+            if (useEventDataOnReception)
+            {
+                eventData.Use();
+            }
+        }
+
+        public void OnFocusExit(FocusEventData eventData)
+        {
+            focusLostCount++;
+
+            if (useEventDataOnReception)
+            {
+                eventData.Use();
+            }
+        }
+    }
+#pragma warning restore 0618
+}

--- a/Assets/MRTK/Tests/PlayModeTests/Components/TestInputFocusListener.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/Components/TestInputFocusListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e05a26205f1c0242ab5f2a9472dac0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/PlayModeTests/InputEventSystemTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputEventSystemTests.cs
@@ -164,6 +164,108 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// </summary>
         [UnityTest]
+        public IEnumerator TestGlobalInputSourceFocusedObjectEvents()
+        {
+            // Initialize
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Create cubes with focus listeners on them
+            var object1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var focusBasedListener1 = object1.AddComponent<TestInputFocusListener>();
+
+            var object2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var focusBasedListener2 = object2.AddComponent<TestInputFocusListener>();
+
+            // Position the objects
+            object1.transform.position = new Vector3(-1, 0, 2);
+            object2.transform.position = new Vector3(1, 0, 2);
+
+            var globalInputSource = CoreServices.InputSystem.RequestNewGlobalInputSource("GlobalInputSource", sourceType: InputSourceType.Voice);
+            globalInputSource.UpdateActivePointers();
+
+            // Emit speech events, which should be received by nothing
+            SpeechCommands[] commandList = CoreServices.InputSystem.InputSystemProfile.SpeechCommandsProfile.SpeechCommands;
+            foreach (SpeechCommands command in commandList)
+            {
+                CoreServices.InputSystem.RaiseSpeechCommandRecognized(globalInputSource, RecognitionConfidenceLevel.High, new System.TimeSpan(), System.DateTime.Now, new SpeechCommands(command.Keyword, command.KeyCode, MixedRealityInputAction.None));
+            }
+
+            Assert.True(focusBasedListener1.speechCommandsReceived.Count == 0, "Speech events were received when object was out of focus");
+            Assert.True(focusBasedListener2.speechCommandsReceived.Count == 0, "Speech events were received when object was out of focus");
+
+            // Bring up the hands
+            TestHand leftHand = new TestHand(Handedness.Left);
+            TestHand rightHand = new TestHand(Handedness.Right);
+
+            yield return leftHand.Show(object1.transform.position + Vector3.back * 0.5f);
+            yield return rightHand.Show(object2.transform.position + Vector3.back * 0.5f);
+
+            globalInputSource.UpdateActivePointers();
+
+            // Emit speech events, which should be received by both hands
+            foreach (SpeechCommands command in commandList)
+            {
+                CoreServices.InputSystem.RaiseSpeechCommandRecognized(globalInputSource, RecognitionConfidenceLevel.High, new System.TimeSpan(), System.DateTime.Now, new SpeechCommands(command.Keyword, command.KeyCode, MixedRealityInputAction.None));
+            }
+
+            Assert.True(focusBasedListener1.speechCommandsReceived.SequenceEqual(commandList.Select(x => x.Keyword)), "Speech events were not received correctly.");
+            Assert.True(focusBasedListener2.speechCommandsReceived.SequenceEqual(commandList.Select(x => x.Keyword)), "Speech events were not received correctly.");
+
+            // hide one hand and see only 1 object receive events
+            focusBasedListener1.speechCommandsReceived.Clear();
+            focusBasedListener2.speechCommandsReceived.Clear();
+
+            yield return leftHand.Hide();
+            yield return rightHand.Show(object2.transform.position + Vector3.back * 0.5f);
+            globalInputSource.UpdateActivePointers();
+
+            foreach (SpeechCommands command in commandList)
+            {
+                CoreServices.InputSystem.RaiseSpeechCommandRecognized(globalInputSource, RecognitionConfidenceLevel.High, new System.TimeSpan(), System.DateTime.Now, new SpeechCommands(command.Keyword, command.KeyCode, MixedRealityInputAction.None));
+            }
+
+            Assert.True(focusBasedListener1.speechCommandsReceived.Count == 0, "Speech events were received when object was out of focus");
+            Assert.True(focusBasedListener2.speechCommandsReceived.SequenceEqual(commandList.Select(x => x.Keyword)), "Speech events were not received correctly.");
+
+            // point both hands at 1 object and see that it gets double the events
+            focusBasedListener1.speechCommandsReceived.Clear();
+            focusBasedListener2.speechCommandsReceived.Clear();
+
+            yield return leftHand.Show(object2.transform.position + Vector3.back * 0.5f);
+            yield return rightHand.Show(object2.transform.position + Vector3.back * 0.5f);
+            globalInputSource.UpdateActivePointers();
+
+            foreach (SpeechCommands command in commandList)
+            {
+                CoreServices.InputSystem.RaiseSpeechCommandRecognized(globalInputSource, RecognitionConfidenceLevel.High, new System.TimeSpan(), System.DateTime.Now, new SpeechCommands(command.Keyword, command.KeyCode, MixedRealityInputAction.None));
+            }
+
+            Assert.True(focusBasedListener1.speechCommandsReceived.Count == 0, "Speech events were received when object was out of focus");
+            Assert.True(focusBasedListener2.speechCommandsReceived.Count == commandList.Count() * 2, "Speech events were not received correctly.");
+
+            // Tests that events are expended upon use
+            focusBasedListener1.useEventDataOnReception = true;
+            focusBasedListener2.useEventDataOnReception = true;
+
+            focusBasedListener1.speechCommandsReceived.Clear();
+            focusBasedListener2.speechCommandsReceived.Clear();
+
+            yield return leftHand.Show(object2.transform.position + Vector3.back * 0.5f);
+            yield return rightHand.Show(object2.transform.position + Vector3.back * 0.5f);
+            globalInputSource.UpdateActivePointers();
+
+            foreach (SpeechCommands command in commandList)
+            {
+                CoreServices.InputSystem.RaiseSpeechCommandRecognized(globalInputSource, RecognitionConfidenceLevel.High, new System.TimeSpan(), System.DateTime.Now, new SpeechCommands(command.Keyword, command.KeyCode, MixedRealityInputAction.None));
+            }
+
+            Assert.True(focusBasedListener1.speechCommandsReceived.Count == 0, "Speech events were received when object was out of focus");
+            Assert.True(focusBasedListener2.speechCommandsReceived.Count == commandList.Count(), "Speech events were not received correctly.");
+        }
+
+        /// <summary>
+        /// </summary>
+        [UnityTest]
         public IEnumerator TestPointerEventCallsForGlobalHandlers()
         {
             // We need Gaze Cursor in this test to use it as source to emit events.


### PR DESCRIPTION
## Overview
Cherry-picking #9770 for 2.7 as well as it's followup bugfix #9889
Introduced the concept of a global input source and enabled it with speech (#9770)
