### PR TITLE
Update XR pipeline doc URL

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     {
         private const float Default_Window_Height = 500.0f;
         private const float Default_Window_Width = 300.0f;
-        private const string XRPipelineDocsUrl = "https://aka.ms/mrtkxrpipeline"; // Putting the generic MR docs on Unity versions/pipelines here before the MRTK XR pipeline doc is published.
+        private const string XRPipelineDocsUrl = "https://aka.ms/mrtkxrpipeline";
         private const string XRSDKUnityDocsUrl = "https://docs.unity3d.com/Manual/configuring-project-for-xr.html";
         private const string MSOpenXRPluginUrl = "https://aka.ms/openxr-unity-install";
         private const string MRTKConfiguratorLogPrefix = "[MRTK Configurator]";

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     {
         private const float Default_Window_Height = 500.0f;
         private const float Default_Window_Width = 300.0f;
-        private const string XRPipelineDocsUrl = "https://docs.microsoft.com/windows/mixed-reality/develop/unity/choosing-unity-version"; // Putting the generic MR docs on Unity versions/pipelines here before the MRTK XR pipeline doc is published.
+        private const string XRPipelineDocsUrl = "https://aka.ms/mrtkxrpipeline"; // Putting the generic MR docs on Unity versions/pipelines here before the MRTK XR pipeline doc is published.
         private const string XRSDKUnityDocsUrl = "https://docs.unity3d.com/Manual/configuring-project-for-xr.html";
         private const string MSOpenXRPluginUrl = "https://aka.ms/openxr-unity-install";
         private const string MRTKConfiguratorLogPrefix = "[MRTK Configurator]";


### PR DESCRIPTION
Update the doc URL in the configurator window so that when the MRTK specific pipeline selection page goes live we can direct users to that page.