### PR TITLE
Better handling of multiple AsyncCoroutineRunner

### DIFF
--- a/Assets/MRTK/Core/Utilities/Async/Internal/AsyncCoroutineRunner.cs
+++ b/Assets/MRTK/Core/Utilities/Async/Internal/AsyncCoroutineRunner.cs
@@ -125,6 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             if (Instance != this)
             {
+                Debug.Log("[AsyncCoroutineRunner] Multiple active AsyncCoroutineRunners is present in the scene. Disabling duplicate ones.");
                 enabled = false;
                 return;
             }

--- a/Assets/MRTK/Core/Utilities/Async/Internal/AsyncCoroutineRunner.cs
+++ b/Assets/MRTK/Core/Utilities/Async/Internal/AsyncCoroutineRunner.cs
@@ -53,14 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             {
                 if (instance == null)
                 {
-                    AsyncCoroutineRunner[] instances = FindObjectsOfType<AsyncCoroutineRunner>();
-                    Debug.Assert(instances.Length <= 1, "[AsyncCoroutineRunner] There should only be one AsyncCoroutineRunner in the scene.");
-                    instance = instances.Length == 1 ? instances[0] : null;
-                    if (instance != null && !instance.enabled)
-                    {
-                        Debug.LogWarning("[AsyncCoroutineRunner] Found a disabled AsyncCoroutineRunner component. Enabling the component.");
-                        instance.enabled = true;
-                    }
+                    instance = FindObjectOfType<AsyncCoroutineRunner>();
                 }
 
                 // FindObjectOfType() only search for objects attached to active GameObjects. The FindObjectOfType(bool includeInactive) variant is not available to Unity 2019.4 and earlier so cannot be used.
@@ -78,19 +71,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                             Debug.Log("[AsyncCoroutineRunner] Found a \"AsyncCoroutineRunner\" GameObject but didn't have the AsyncCoroutineRunner component attached. Attaching the script.");
                             instance = instanceGameObject.AddComponent<AsyncCoroutineRunner>();
                         }
-                        else
-                        {
-                            if (!instance.enabled)
-                            {
-                                Debug.LogWarning("[AsyncCoroutineRunner] Found a disabled AsyncCoroutineRunner component. Enabling the component.");
-                                instance.enabled = true;
-                            }
-                            if (!instanceGameObject.activeSelf)
-                            {
-                                Debug.LogWarning("[AsyncCoroutineRunner] Found an AsyncCoroutineRunner attached to an inactive GameObject. Setting the GameObject active.");
-                                instanceGameObject.SetActive(true);
-                            }
-                        }
                     }
                 }
 
@@ -98,6 +78,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 {
                     Debug.Log("[AsyncCoroutineRunner] There is no AsyncCoroutineRunner in the scene. Adding a GameObject with AsyncCoroutineRunner attached at the root of the scene.");
                     instance = new GameObject("AsyncCoroutineRunner").AddComponent<AsyncCoroutineRunner>();
+                }
+                else if (!instance.isActiveAndEnabled)
+                {
+                    if (!instance.enabled)
+                    {
+                        Debug.LogWarning("[AsyncCoroutineRunner] Found a disabled AsyncCoroutineRunner component. Enabling the component.");
+                        instance.enabled = true;
+                    }
+                    if (!instance.gameObject.activeSelf)
+                    {
+                        Debug.LogWarning("[AsyncCoroutineRunner] Found an AsyncCoroutineRunner attached to an inactive GameObject. Setting the GameObject active.");
+                        instance.gameObject.SetActive(true);
+                    }
                 }
 
                 instance.gameObject.hideFlags = HideFlags.None;
@@ -130,7 +123,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private void Update()
         {
-            Debug.Assert(Instance == this, "[AsyncCoroutineRunner] There should only be one AsyncCoroutineRunner in the scene.");
+            if (Instance != this)
+            {
+                enabled = false;
+                return;
+            }
             isInstanceRunning = true;
 
             int actionCount;
@@ -163,8 +160,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private void OnEnable()
         {
-            Debug.Assert(Instance == this, "[AsyncCoroutineRunner] There should only be one AsyncCoroutineRunner in the scene.");
-            isInstanceRunning = true;
+            if (Instance != this)
+            {
+                Debug.Log("[AsyncCoroutineRunner] Multiple active AsyncCoroutineRunners is present in the scene. Disabling duplicate ones.");
+                enabled = false;
+            }
+            else
+            {
+                isInstanceRunning = true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Overview
This PR takes a more flexible approach to cases where multiple AsyncCoroutineRunner are present in the scene in recognition of the necessity of such arrangement under certain circumstances (e.g. scene transition).

## Changes
- Fixes: #9896