### PR TITLE
Restore hand physics profile to example scene

### DIFF
--- a/Assets/MRTK/Extensions/HandPhysicsService/Examples/HandPhysicsServiceExample.unity
+++ b/Assets/MRTK/Extensions/HandPhysicsService/Examples/HandPhysicsServiceExample.unity
@@ -2344,7 +2344,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83d9acc7968244a8886f3af591305bcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  activeProfile: {fileID: 11400000, guid: fbb8235a0e1db804880e49990996f5a4, type: 2}
+  activeProfile: {fileID: 11400000, guid: ec6c5962fb980c041854a25f84d6f2e6, type: 2}
 --- !u!4 &1462653017
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Overview

The hand physics example scene was using the obsolete XR SDK profile instead of its feature-specific hand physics profile.

![image](https://user-images.githubusercontent.com/3580640/120033850-0477aa80-bfb1-11eb-8eac-eb7af6a5ea08.png)
