### PR TITLE
Squash some syntax in the packing pipeline

### DIFF
--- a/pipelines/packageupmpublic.yaml
+++ b/pipelines/packageupmpublic.yaml
@@ -4,12 +4,9 @@ variables:
 - template: config/settings.yml
 
 parameters:
-- name: IsFinal
-  type: boolean
-  default: false
 - name: PreviewNumber
-  type: string
-  default: 0
+  type: number
+  default: -1
 
 jobs:
 - job: UPMPublicRelease
@@ -17,11 +14,9 @@ jobs:
   pool:
     vmImage: windows-2019
   steps:
-  - ${{ if eq(parameters.IsFinal, false) }}:
-    - template: templates/tasks/pack-upm.yml
-      parameters:
+  - template: templates/tasks/pack-upm.yml
+    parameters:
+      ${{ if ge(parameters.PreviewNumber, 0) }}:
         previewNumber: ${{ parameters.PreviewNumber }}
-  - ${{ if eq(parameters.IsFinal, true) }}:
-    - template: templates/tasks/pack-upm.yml
-      parameters:
+      ${{ if lt(parameters.PreviewNumber, 0) }}:
         previewNumber: ""


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9728, https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9909, and https://github.com/microsoft/MixedRealityToolkit-Unity/pull/9910.

Re-removes the `IsFinal` flag in favor of keying off whether the passed-in preview number is `>= 0` or `< 0`. Defaults to `-1`.