### PR TITLE
Some cleanup to the HandConstraint* scripts

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -547,7 +547,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                             direction = IsPalmFacingCamera(hand) ? direction : -direction;
                         }
 
-                        if (hand.ControllerHandedness == Handedness.Right)
+                        if (hand.ControllerHandedness.IsRight())
                         {
                             direction = -direction;
                         }
@@ -672,7 +672,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </remarks>
         private static bool IsApplicableController(IMixedRealityController controller)
         {
-            return controller.ControllerHandedness != Handedness.None;
+            return !controller.ControllerHandedness.IsNone();
         }
 
         /// <summary>

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -367,10 +367,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                     referenceJoint2 = TrackedHandJoint.Palm;
                     break;
                 case SolverSafeZone.RadialSide:
-                case SolverSafeZone.UlnarSide:
-                default:
                     referenceJoint1 = TrackedHandJoint.IndexKnuckle;
                     referenceJoint2 = TrackedHandJoint.ThumbProximalJoint;
+                    break;
+                case SolverSafeZone.UlnarSide:
+                default:
+                    referenceJoint1 = TrackedHandJoint.PinkyKnuckle;
+                    referenceJoint2 = TrackedHandJoint.Wrist;
                     break;
             }
 

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -367,9 +367,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                     referenceJoint2 = TrackedHandJoint.Palm;
                     break;
                 case SolverSafeZone.RadialSide:
-                    referenceJoint1 = TrackedHandJoint.IndexKnuckle;
-                    referenceJoint2 = TrackedHandJoint.ThumbProximalJoint;
-                    break;
                 case SolverSafeZone.UlnarSide:
                 default:
                     referenceJoint1 = TrackedHandJoint.IndexKnuckle;


### PR DESCRIPTION
This change cleans up some unneeded code and improves consistency.

1. Merge Radial and Ulnar/default in the HandConstraintPalmUp switch as they performed idential code.
2. Replace instances of == Handeness with IsHand().  ex: == Handedness.Right -> IsRight()