### PR TITLE
Updates with Unity 2021 changes

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -650,7 +650,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     else
                     {
                         bool isNestedInCurrentPrefab = false;
-                        var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+#if UNITY_2021_2_OR_NEWER
+                        var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#else
+                        var prefabStage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#endif
                         if (prefabStage != null)
                         {
                             var instancePath = AssetDatabase.GetAssetPath(scriptable.objectReferenceValue);

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -531,7 +531,11 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 AddGazeInputCapability(rootElement);
             }
 
-            if (uwpBuildInfo.ResearchModeCapabilityEnabled && EditorUserBuildSettings.wsaSubtarget == WSASubtarget.HoloLens)
+            if (uwpBuildInfo.ResearchModeCapabilityEnabled
+#if !UNITY_2021_2_OR_NEWER
+                && EditorUserBuildSettings.wsaSubtarget == WSASubtarget.HoloLens
+#endif // !UNITY_2021_2_OR_NEWER
+                )
             {
                 AddResearchModeCapability(rootElement);
             }

--- a/Assets/MRTK/Core/Utilities/Scenes/EditorSceneUtils.cs
+++ b/Assets/MRTK/Core/Utilities/Scenes/EditorSceneUtils.cs
@@ -253,7 +253,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// </summary>
         public static bool IsEditingPrefab()
         {
+#if UNITY_2021_2_OR_NEWER
+            var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#else
             var prefabStage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#endif
             return prefabStage != null;
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1869,8 +1869,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void ExtractBoundsCorners(Transform childTransform, BoundsCalculationMethod boundsCalculationMethod)
         {
-            KeyValuePair<Transform, Collider> colliderByTransform;
-            KeyValuePair<Transform, Bounds> rendererBoundsByTransform;
+            KeyValuePair<Transform, Collider> colliderByTransform = default;
+            KeyValuePair<Transform, Bounds> rendererBoundsByTransform = default;
 
             if (boundsCalculationMethod != BoundsCalculationMethod.RendererOnly)
             {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -902,8 +902,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
 
         private void ExtractBoundsCorners(Transform childTransform, BoundsCalculationMethod boundsCalculationMethod)
         {
-            KeyValuePair<Transform, Collider> colliderByTransform;
-            KeyValuePair<Transform, Bounds> rendererBoundsByTransform;
+            KeyValuePair<Transform, Collider> colliderByTransform = default;
+            KeyValuePair<Transform, Bounds> rendererBoundsByTransform = default;
 
             if (boundsCalculationMethod != BoundsCalculationMethod.RendererOnly)
             {

--- a/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -220,7 +220,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 {
                     CameraCache.Main.gameObject.AddComponent<MixedRealityInputModule>();
                 }
+
+#if !UNITY_2021_1_OR_NEWER
                 inputModule.forceModuleActive = true;
+#endif // !UNITY_2021_1_OR_NEWER
             }
         }
 

--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -34,6 +34,19 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             DeployOptions
         }
 
+#if UNITY_2021_2_OR_NEWER
+        /// <summary>
+        /// Matches the deprecated WSASubtarget.
+        /// </summary>
+        private enum UWPSubtarget
+        {
+            AnyDevice = 0,
+            PC = 1,
+            Mobile = 2,
+            HoloLens = 3
+        }
+#endif // UNITY_2021_2_OR_NEWER
+
         #endregion Internal Types
 
         #region Constants and Readonly Values
@@ -166,7 +179,13 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             get
             {
                 bool canInstall = true;
-                if (EditorUserBuildSettings.wsaSubtarget == WSASubtarget.HoloLens)
+                if (
+#if UNITY_2021_2_OR_NEWER
+                    currentSubtarget == UWPSubtarget.HoloLens
+#else
+                    EditorUserBuildSettings.wsaSubtarget == WSASubtarget.HoloLens
+#endif // UNITY_2021_2_OR_NEWER
+                    )
                 {
                     canInstall = DevicePortalConnectionEnabled;
                 }
@@ -270,6 +289,10 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         private static bool lastTestConnectionSuccessful = false;
         private static DeviceInfo lastTestConnectionTarget;
         private static DateTime? lastTestConnectionTime = null;
+
+#if UNITY_2021_2_OR_NEWER
+        private static UWPSubtarget currentSubtarget = UWPSubtarget.AnyDevice;
+#endif // UNITY_2021_2_OR_NEWER
 
         #endregion Fields
 
@@ -380,7 +403,11 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private void RenderUnityBuildView()
         {
+#if UNITY_2021_2_OR_NEWER
+            currentSubtarget = (UWPSubtarget)EditorGUILayout.Popup("Target Device", (int)currentSubtarget, TARGET_DEVICE_OPTIONS, GUILayout.Width(HALF_WIDTH));
+#else
             EditorUserBuildSettings.wsaSubtarget = (WSASubtarget)EditorGUILayout.Popup("Target Device", (int)EditorUserBuildSettings.wsaSubtarget, TARGET_DEVICE_OPTIONS, GUILayout.Width(HALF_WIDTH));
+#endif // UNITY_2021_2_OR_NEWER
 
 #if !UNITY_2019_1_OR_NEWER
             var curScriptingBackend = PlayerSettings.GetScriptingBackend(BuildTargetGroup.WSA);

--- a/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
@@ -129,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 }
             }
 
-            if (guid != null && Guid.TryParse(guidString, out guid))
+            if (guidString != null && Guid.TryParse(guidString, out guid))
             {
                 return true;
             }


### PR DESCRIPTION
## Overview

1. Updates the namespace (no longer experimental) for `PrefabStageUtility`
2. Fixes `Assets\MRTK\Tools\MSBuild\Scripts\Utilities.cs(132,17): error CS0269: Use of unassigned out parameter 'guid'`
3. Fixes multiple instances of `error CS0618: 'EditorUserBuildSettings.wsaSubtarget' is obsolete: 'EditorUserBuildSettings.wsaSubtarget is obsolete and has no effect. It will be removed in a subsequent Unity release.'`
4. Fixes multiple instances of `error CS0618: 'WSASubtarget' is obsolete: 'WSASubtarget is obsolete and has no effect. It will be removed in a subsequent Unity release.'`
4. Fixes multiple instances of `error CS0165: Use of unassigned local variable 'colliderByTransform'`
5. Fixes multiple instances of `error CS0165: Use of unassigned local variable 'rendererBoundsByTransform'`
6. Fixes `Assets\MRTK\Tests\TestUtilities\PlayModeTestUtilities.cs(223,17): error CS0618: 'StandaloneInputModule.forceModuleActive' is obsolete: 'forceModuleActive has been deprecated. There is no need to force the module awake as StandaloneInputModule works for all platforms'`

## Changes

- Fixes: #9937 

