### PR TITLE
Remove calls to .gameObject on GameObjects

### DIFF
--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -507,8 +507,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
         {
             GltfMesh gltfMesh = gltfObject.meshes[meshId];
 
-            var renderer = parent.gameObject.AddComponent<MeshRenderer>();
-            var filter = parent.gameObject.AddComponent<MeshFilter>();
+            var renderer = parent.AddComponent<MeshRenderer>();
+            var filter = parent.AddComponent<MeshFilter>();
 
             if (gltfMesh.primitives.Length == 1)
             {

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetSelections/Scripts/TargetGroupCreatorRadial.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetSelections/Scripts/TargetGroupCreatorRadial.cs
@@ -171,7 +171,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
             // Assign parent
             _target.transform.SetParent(transform);
 
-            _target.gameObject.SetActive(true);
+            _target.SetActive(true);
 
             // Add it to our list of instantiated targets
             instantiatedTargets.Add(_target);

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetSelections/Scripts/TargetGroupIterator.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetSelections/Scripts/TargetGroupIterator.cs
@@ -132,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
                 // 2. If "DisableDistractors" is true then let's hide the selected target
                 if (DeactiveDistractors)
-                    CurrentTarget.gameObject.SetActive(false);
+                    CurrentTarget.SetActive(false);
 
                 // 3. Let's update to highlight the new target.
                 currTargetIndex++;
@@ -205,7 +205,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
             if (CurrentTarget == null)
                 ProceedToNextTarget();
 
-            CurrentTarget.gameObject.SetActive(true);
+            CurrentTarget.SetActive(true);
             HighlightTarget(highlightColor);
         }
 

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/InputPointerVisualizer.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/InputPointerVisualizer.cs
@@ -148,7 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
             {
                 for (int i = array.Length - 1; i >= 0; i--)
                 {
-                    Destroy(array[i].gameObject);
+                    Destroy(array[i]);
                 }
             }
         }

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -159,7 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                             if (seeItSayItLabel.activeSelf != seeItSayItLabelActive)
                             {
                                 seeItSayItLabel.SetActive(seeItSayItLabelActive);
-                                EditorUtility.SetDirty(seeItSayItLabel.gameObject);
+                                EditorUtility.SetDirty(seeItSayItLabel);
                             }
 
                             if (seeItSayItLabel.activeSelf)

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
@@ -176,7 +176,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
 #if UNITY_EDITOR
             debugMesh = GameObject.CreatePrimitive(PrimitiveType.Quad);
             debugMesh.hideFlags |= HideFlags.HideInHierarchy;
-            debugMesh.gameObject.SetActive(false);
+            debugMesh.SetActive(false);
             debugMeshFilter = debugMesh.GetComponent<MeshFilter>();
 #endif
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs
@@ -181,7 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 for (int index = 0; index < deployedCount; ++index)
                 {
                     float acceleratedDegrees = (rotationSpeedRawDegrees * (acceleration + -Mathf.Cos(Mathf.Deg2Rad * angles[index]))) * timeSlice;
-                    orbs[index].gameObject.transform.Rotate(0, 0, acceleratedDegrees);
+                    orbs[index].transform.Rotate(0, 0, acceleratedDegrees);
                     angles[index] += Mathf.Abs(acceleratedDegrees);
 
                     Color orbColor = propertyBlocks[index].GetColor("_Color");

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 {
                     spawnable.transform.localRotation = Quaternion.identity;
                 }
-                spawnable.gameObject.SetActive(false);
+                spawnable.SetActive(false);
             }
             if (appearType == AppearType.AppearOnFocusEnter)
             {
@@ -112,11 +112,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
-            spawnable.gameObject.SetActive(true);
+            spawnable.SetActive(true);
 
             SpawnableActivated(spawnable);
 
-            while (spawnable.gameObject.activeSelf)
+            while (spawnable.activeSelf)
             {
                 if (remainType == RemainType.Timeout)
                 {
@@ -125,7 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         case AppearType.AppearOnTap:
                             if (Time.unscaledTime - tappedTime >= lifetime)
                             {
-                                spawnable.gameObject.SetActive(false);
+                                spawnable.SetActive(false);
                                 return;
                             }
 
@@ -133,7 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         case AppearType.AppearOnFocusEnter:
                             if (Time.unscaledTime - focusEnterTime >= lifetime)
                             {
-                                spawnable.gameObject.SetActive(false);
+                                spawnable.SetActive(false);
                                 return;
                             }
 
@@ -147,7 +147,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     case VanishType.VanishOnFocusExit:
                         if (!HasFocus)
                         {
-                            spawnable.gameObject.SetActive(false);
+                            spawnable.SetActive(false);
                         }
 
                         break;
@@ -155,7 +155,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     case VanishType.VanishOnTap:
                         if (!tappedTime.Equals(tappedTimeOnStart))
                         {
-                            spawnable.gameObject.SetActive(false);
+                            spawnable.SetActive(false);
                         }
 
                         break;
@@ -164,7 +164,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     default:
                         if (!HasFocus && HasVanishDelayElapsed())
                         {
-                            spawnable.gameObject.SetActive(false);
+                            spawnable.SetActive(false);
                         }
                         break;
                 }
@@ -216,7 +216,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             tappedTime = Time.unscaledTime;
 
-            if (spawnable == null || !spawnable.gameObject.activeSelf)
+            if (spawnable == null || !spawnable.activeSelf)
             {
                 switch (appearType)
                 {
@@ -230,7 +230,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 switch (vanishType)
                 {
                     case VanishType.VanishOnTap:
-                        spawnable.gameObject.SetActive(false);
+                        spawnable.SetActive(false);
                         break;
                 }
             }
@@ -240,7 +240,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             focusEnterTime = Time.unscaledTime;
 
-            if (spawnable == null || !spawnable.gameObject.activeSelf)
+            if (spawnable == null || !spawnable.activeSelf)
             {
                 switch (appearType)
                 {

--- a/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
@@ -402,7 +402,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // FIRST DISTANCE
             float firstAngularScale = 2 * Mathf.Atan2(baseCursor.LocalScale.y * 0.5f, Vector3.Distance(cam.transform.position, baseCursor.transform.position));
 
-            cube.gameObject.SetActive(false);
+            cube.SetActive(false);
 
             yield return new WaitForFixedUpdate();
             yield return null;

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -902,7 +902,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             const int numHandSteps = 1;
 
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
-            var frontRightCornerPos = boundsControl.Target.gameObject.transform.Find("rigRoot/corner_3").position; // front right corner is corner 3
+            var frontRightCornerPos = boundsControl.Target.transform.Find("rigRoot/corner_3").position; // front right corner is corner 3
             TestHand hand = new TestHand(Handedness.Right);
 
             // Hands grab object at initial position


### PR DESCRIPTION
## Overview

This indirection is unnecessary (you already have the GameObject directly!) and _can_ have some amount of perf impact if done too often.