### PR TITLE
Assorted Unity improvements

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -153,21 +153,32 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         using (var c = new EditorGUI.ChangeCheckScope())
                         {
                             // Reconciling old Experience Scale property with the Experience Settings Profile
-                            var oldExperienceSettigsScale = (experienceSettingsProfile.objectReferenceValue as MixedRealityExperienceSettingsProfile)?.TargetExperienceScale;
+                            ExperienceScale? oldExperienceSettingsScale = null;
+                            if (experienceSettingsProfile.objectReferenceValue is MixedRealityExperienceSettingsProfile oldExperienceSettingsProfile
+                                && oldExperienceSettingsProfile != null)
+                            {
+                                oldExperienceSettingsScale = oldExperienceSettingsProfile.TargetExperienceScale;
+                            }
 
                             changed |= RenderProfile(experienceSettingsProfile, typeof(MixedRealityExperienceSettingsProfile), true, false,  null, true);
 
                             // Experience configuration
-                            if(!mrtkConfigProfile.ExperienceSettingsProfile.IsNull())
-                            {                            
+                            if (mrtkConfigProfile.ExperienceSettingsProfile != null)
+                            {
                                 // If the Experience Scale property changed, make sure we also alter the configuration profile's target experience scale property for compatibility
-                                var newExperienceSettigs = (experienceSettingsProfile.objectReferenceValue as MixedRealityExperienceSettingsProfile)?.TargetExperienceScale;
-                                if(oldExperienceSettigsScale.HasValue && newExperienceSettigs.HasValue && oldExperienceSettigsScale != newExperienceSettigs)
+                                ExperienceScale? newExperienceSettingsScale = null;
+                                if (experienceSettingsProfile.objectReferenceValue is MixedRealityExperienceSettingsProfile newExperienceSettingsProfile
+                                    && newExperienceSettingsProfile != null)
                                 {
-                                    experienceScaleMigration.intValue = (int)newExperienceSettigs;
+                                    newExperienceSettingsScale = newExperienceSettingsProfile.TargetExperienceScale;
+                                }
+
+                                if (oldExperienceSettingsScale.HasValue && newExperienceSettingsScale.HasValue && oldExperienceSettingsScale != newExperienceSettingsScale)
+                                {
+                                    experienceScaleMigration.intValue = (int)newExperienceSettingsScale;
                                     experienceScaleMigration.serializedObject.ApplyModifiedProperties();
                                 }
-                                // If we have not changed the Experience Settings profile and it's value is out of sync with the top level configuration profile, display a migration prompt
+                                // If we have not changed the Experience Settings profile and its value is out of sync with the top level configuration profile, display a migration prompt
                                 else if ((ExperienceScale)experienceScaleMigration.intValue != mrtkConfigProfile.ExperienceSettingsProfile.TargetExperienceScale)
                                 {
                                     Color errorColor = Color.Lerp(Color.white, Color.red, 0.5f);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -517,9 +517,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
+#if UNITY_EDITOR
         private void Awake()
         {
-#if UNITY_EDITOR
             if (!EditorApplication.isPlaying)
             {
                 if (assetVersion != CurrentAssetVersion)
@@ -528,8 +528,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     PerformVersionPatching();
                 }
             }
-#endif
         }
+#endif
 
         #region asset version migration
         private const int CurrentAssetVersion = 1;

--- a/Assets/MRTK/Tests/EditModeTests/Tools/MigrationToolTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Tools/MigrationToolTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
             quadRenderer.sharedMaterial = testMat;
 
             ButtonConfigHelper buttonConfig = buttonGameObject.GetComponent<ButtonConfigHelper>();
-            ButtonIconSet testIconSet = new ButtonIconSet();
+            ButtonIconSet testIconSet = ScriptableObject.CreateInstance<ButtonIconSet>();
             buttonConfig.IconStyle = ButtonIconStyle.Quad;
             buttonConfig.IconSet = testIconSet;
             buttonConfig.EditorSetDefaultIconSet(testIconSet);


### PR DESCRIPTION
## Overview

1. Removes some uses of `?.` on ScriptableObjects, which isn't supported due to [Unity's custom == operator](https://blog.unity.com/technology/custom-operator-should-we-keep-it).
2. Rescopes an `#if` to not leave an empty method behind
3. Updates a test to use Unity's methods for creating a ScriptableObject instead of `new`ing it