### PR TITLE
Fix link.xml for Unity 2021

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitPreserveSettings.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitPreserveSettings.cs
@@ -17,42 +17,42 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// behalf of the project.
         /// </summary>
         private const string defaultLinkXmlContents =
-            "<linker> \n" +
-            "  <!-- \n" +
-            "    This link.xml file is provided to prevent MRTK code from being optimized away \n" +
-            "    during IL2CPP builds.More details on when this is needed and why this is needed \n" +
-            "    can be found here: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5273 \n" +
-            "    If your application doesn't use some specific services (for example, if teleportation system is \n" +
-            "    disabled in the profile), it is possible to remove their corresponding lines down \n" +
-            "    below (in the previous example, we would remove the TeleportSystem below). \n" +
-            "    It's recommended to start with this list and narrow down if you want to ensure \n" +
-            "    specific bits of code get optimized away. \n" +
-            "  --> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit\" preserve=\"all\"/> \n " +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.SDK\" preserve=\"all\"/> \n " +
-            "  <!-- Core systems --> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Services.BoundarySystem\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Services.CameraSystem\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Services.InputSystem\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Services.SceneSystem\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Services.TeleportSystem\" preserve=\"all\"/> \n" +
-            "  <!-- Data providers --> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.LeapMotion\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.OpenVR\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.OpenXR\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.UnityAR\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.XRSDK\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Providers.WindowsSceneUnderstanding\" preserve=\"all\"/> \n" +
-            "  <!-- Extension services --> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Extensions.HandPhysics\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Extensions.Tracking\" preserve=\"all\"/> \n" +
-            "  <assembly fullname = \"Microsoft.MixedReality.Toolkit.Extensions.SceneTransitionService\" preserve=\"all\"/> \n" +
+            "<linker>\n" +
+            "  <!--\n" +
+            "    This link.xml file is provided to prevent MRTK code from being optimized away\n" +
+            "    during IL2CPP builds. More details on when this is needed and why this is needed\n" +
+            "    can be found here: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5273\n" +
+            "    If your application doesn't use some specific services (for example, if teleportation system is\n" +
+            "    disabled in the profile), it is possible to remove their corresponding lines down\n" +
+            "    below (in the previous example, we would remove the TeleportSystem below).\n" +
+            "    It's recommended to start with this list and narrow down if you want to ensure\n" +
+            "    specific bits of code get optimized away.\n" +
+            "  -->\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.SDK\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <!-- Core systems -->\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Services.BoundarySystem\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Services.CameraSystem\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Services.InputSystem\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Services.SceneSystem\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Services.TeleportSystem\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <!-- Data providers -->\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.LeapMotion\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.OpenVR\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.OpenXR\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.UnityAR\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.XRSDK\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Providers.WindowsSceneUnderstanding\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <!-- Extension services -->\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Extensions.HandPhysics\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Extensions.Tracking\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
+            "  <assembly fullname=\"Microsoft.MixedReality.Toolkit.Extensions.SceneTransitionService\" preserve=\"all\" ignoreIfMissing=\"1\" />\n" +
             "</linker>";
 
         /// <summary>


### PR DESCRIPTION
## Overview

Updates the default link.xml text to include `ignoreIfMissing="1"`.
Also adds a patching step to any MRTK entries in existing link.xml files in the MRTK.Generated folder.

## Changes

- Fixes: #9936 
