### PR TITLE
Update internal CI to run on regular pool

### DIFF
--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -13,11 +13,13 @@ jobs:
 - job: UnityValidation
   timeoutInMinutes: 90
   pool:
-    name: Analog N-1
+    name: Analog On-Prem
     demands:
     - ${{ variables.Unity2018VersionInternal }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
+  workspace:
+    clean: resources
   steps:
   - template: templates/ci-common.yml
     parameters:

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -17,11 +17,13 @@ jobs:
 - job: CIReleaseValidation
   timeoutInMinutes: 90
   pool:
-    name: Analog N-1
+    name: Analog On-Prem
     demands:
     - ${{ variables.Unity2018VersionInternal }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
+  workspace:
+    clean: resources
   steps:
   - template: templates/compilemsbuild.yml
     parameters:

--- a/pipelines/ci-weekly-internal.yml
+++ b/pipelines/ci-weekly-internal.yml
@@ -5,7 +5,7 @@ schedules:
 - cron: 0 8 * * 1  # every Monday at 8:00 UTC
   displayName: Weekly build
   branches:
-    include: 
+    include:
     - main
 
 variables:
@@ -19,11 +19,13 @@ jobs:
 - job: Compliance
   timeoutInMinutes: 90
   pool:
-    name: Analog N-1
+    name: Analog On-Prem
     demands:
     - ${{ variables.Unity2018VersionInternal }}
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
+  workspace:
+    clean: resources
   steps:
   # the following tasks should only be run on main branch, otherwise we risk issue being reported multiple times on topic/release branches
   - task: PoliCheck@1

--- a/pipelines/config/settings.yml
+++ b/pipelines/config/settings.yml
@@ -3,7 +3,7 @@ variables:
   Unity2018Version: Unity2018.4.26f1
   Unity2019Version: Unity2019.4.8f1
   # Unity version on internal build agents (release builds)
-  Unity2018VersionInternal: Unity2018.4.23f1
+  Unity2018VersionInternal: Unity2018.4.26f1
   Unity2019VersionInternal: Unity2019.4.17f1
   Unity2020VersionInternal: Unity2020.2.2f1
 

--- a/pipelines/docs-binaries.yml
+++ b/pipelines/docs-binaries.yml
@@ -64,7 +64,7 @@ jobs:
 
 - job: BuildUnity2018
   pool:
-    name: Analog N-1
+    name: Analog On-Prem
     demands:
     - ${{ variables.Unity2018VersionInternal }}
     - COG-UnityCache-WUS2-01


### PR DESCRIPTION
## Overview

In preparation for some upcoming changes, this PR moves us back off the custom one-off pool and back onto the "regular" shared pool of VMs.

Adding the workspace clean step seems to have fixed the issues we were previously seeing.