### PR TITLE
Disabled components no longer focus lock pointers.

### DIFF
--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -1191,13 +1191,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 IMixedRealityPointerHandler ancestorPointerHandler = null;
                 while (currentObject != null && ancestorPointerHandler == null)
                 {
-                    foreach (var component in currentObject.GetComponents<Component>())
+                    foreach (IMixedRealityPointerHandler handler in currentObject.GetComponents<IMixedRealityPointerHandler>())
                     {
-                        if (component is IMixedRealityPointerHandler handler)
+                        if(handler is MonoBehaviour behavior && !behavior.enabled)
                         {
-                            ancestorPointerHandler = handler;
-                            break;
+                            continue;
                         }
+                        ancestorPointerHandler = handler;
+                        break;
                     }
                     currentObject = currentObject.transform.parent;
                 }

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -474,7 +474,51 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 yield return hand.Hide();
 
             }
+        }
 
+        /// <summary>
+        /// This tests that the cursor doesn't become focus locked when the Object Manipulator component is disabled
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ObjectManipulatorNoFocusOnDisable()
+        {
+            // set up cube with manipulation handler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.transform.localScale = Vector3.one * 0.2f;
+            Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
+            testObject.transform.position = initialObjectPosition;
+            var manipHandler = testObject.AddComponent<ObjectManipulator>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingFar = false;
+            manipHandler.SmoothingNear = false;
+            manipHandler.ManipulationType = ManipulationHandFlags.OneHanded;
+
+            // Disable the manipulation handler
+            manipHandler.enabled = false;
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            // Hand pointing at middle of cube
+            Vector3 initialHandPosition = new Vector3(0.044f, -0.1f, 0.45f);
+            TestHand hand = new TestHand(Handedness.Right);
+
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            yield return hand.Show(initialHandPosition);
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            Vector3 initialPosition = testObject.transform.position;
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            Assert.IsFalse(hand.GetPointer<ShellHandRayPointer>().IsFocusLocked);
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            Assert.IsFalse(hand.GetPointer<ShellHandRayPointer>().IsFocusLocked);
+            yield return hand.Hide();
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
To check if a pointer is focus locked, we see if there are any IMixedRealityPointerHandler when the OnPointerDown event is raised. 

This PR fixes an edge case where an component implements that interface, but is itself disabled.

## Changes
- Fixes: #9921
