### PR TITLE
Marked Unity Joystick Manager as supported on XR SDK pipeline

### DIFF
--- a/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
@@ -17,8 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
     [MixedRealityDataProvider(
         typeof(IMixedRealityInputSystem),
         (SupportedPlatforms)(-1),  // All platforms supported by Unity
-        "Unity Joystick Manager",
-        supportedUnityXRPipelines: SupportedUnityXRPipelines.LegacyXR)]
+        "Unity Joystick Manager")]
 #if UNITY_2020_1_OR_NEWER
     [Obsolete("The legacy XR pipeline has been removed in Unity 2020 or newer. Please migrate to XR SDK.")]
 #endif // UNITY_2020_1_OR_NEWER


### PR DESCRIPTION
## Overview
The Unity Joystick Manager was previously marked as Legacy XR only, in anticipation of moving to Unity's new input system. This PR marks it as supported on the XR SDK pipeline until we formally make that shift.

## Changes
- Fixes: #9931