### PR TITLE
Updated button config inspector to show icon names

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -387,6 +387,8 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(iconSetProp);
+
+            EditorGUILayout.Space();
             if (iconSet == null)
             {
                 EditorGUILayout.HelpBox("No icon set assigned. You can specify custom icons manually by assigning them to the field below:", MessageType.Info);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -249,7 +249,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 EditorGUILayout.BeginHorizontal();
 
                 EditorGUILayout.LabelField("Current Icon Name", EditorStyles.boldLabel);
-                EditorGUILayout.LabelField(quadIcons[currentSelection].name);
+                EditorGUILayout.LabelField(charIcons[currentSelection].name);
 
                 EditorGUILayout.EndHorizontal();
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -249,7 +249,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 EditorGUILayout.BeginHorizontal();
 
                 EditorGUILayout.LabelField("Current Icon Name", EditorStyles.boldLabel);
-                EditorGUILayout.LabelField(charIcons[currentSelection].name);
+                EditorGUILayout.LabelField(charIcons[currentSelection].Name);
 
                 EditorGUILayout.EndHorizontal();
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -330,7 +330,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 EditorGUILayout.BeginHorizontal();
 
                 EditorGUILayout.LabelField("Current Icon Name", EditorStyles.boldLabel);
-                EditorGUILayout.LabelField(quadIcons[currentSelection].name);
+                EditorGUILayout.LabelField(spriteIcons[currentSelection].name);
 
                 EditorGUILayout.EndHorizontal();
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -244,6 +244,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
+            if (currentSelection >= 0)
+            {
+                EditorGUILayout.BeginHorizontal();
+
+                EditorGUILayout.LabelField("Current Icon Name", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField(quadIcons[currentSelection].name);
+
+                EditorGUILayout.EndHorizontal();
+            }
+
             using (new EditorGUI.IndentLevelScope(indentLevel))
             {
                 int column = 0;
@@ -315,6 +325,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
+            if (currentSelection >= 0)
+            {
+                EditorGUILayout.BeginHorizontal();
+
+                EditorGUILayout.LabelField("Current Icon Name", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField(quadIcons[currentSelection].name);
+
+                EditorGUILayout.EndHorizontal();
+            }
+
             if (spriteIconTextures == null || spriteIconTextures.Length != spriteIcons.Length)
             {
                 UpdateSpriteIconTextures();
@@ -384,6 +404,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     currentSelection = i;
                     break;
                 }
+            }
+
+            if(currentSelection >= 0)
+            {
+                EditorGUILayout.BeginHorizontal();
+
+                EditorGUILayout.LabelField("Current Icon Name", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField(quadIcons[currentSelection].name);
+
+                EditorGUILayout.EndHorizontal();
             }
 
             using (new EditorGUI.IndentLevelScope(indentLevel))


### PR DESCRIPTION
## Overview
Updating the button config helper to display the icon's texture name.

https://user-images.githubusercontent.com/39840334/121963508-0cf51280-cd1f-11eb-97f9-17f2476cb387.png

## Changes
- Fixes: #9969