### PR TITLE
Partial fix for BoundsControl collider issues and inconsistency

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
@@ -95,7 +95,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 {
                     // attach new collider
                     var handleBounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
-                    var invScale = handleBounds.size.x == 0.0f ? 0.0f : config.HandleSize / handleBounds.size.x;
+                    float maxDim = VisualUtils.GetMaxComponent(handleBounds.size);
+                    float invScale = maxDim == 0.0f ? 0.0f : config.HandleSize / maxDim;
                     Vector3 colliderSizeScaled = handleBounds.size * invScale;
                     Vector3 colliderCenterScaled = handleBounds.center * invScale;
                     if (config.HandlePrefabColliderType == HandlePrefabCollider.Box)
@@ -109,7 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     {
                         SphereCollider sphere = handle.gameObject.AddComponent<SphereCollider>();
                         sphere.center = colliderCenterScaled;
-                        sphere.radius = colliderSizeScaled.x * 0.5f;
+                        sphere.radius = VisualUtils.GetMaxComponent(colliderSizeScaled) * 0.5f;
                         sphere.radius += VisualUtils.GetMaxComponent(config.ColliderPadding);
                     }
                 }
@@ -236,7 +237,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
 
         protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)
         {
-            var invScale = visualSize.x == 0.0f ? 0.0f : config.HandleSize / visualSize.x;
+            float maxDim = VisualUtils.GetMaxComponent(visualSize);
+            float invScale = maxDim == 0.0f ? 0.0f : config.HandleSize / maxDim;
             GetVisual(handle).transform.localScale = new Vector3(invScale, invScale, invScale);
             Vector3 colliderSizeScaled = visualSize * invScale;
             if (config.HandlePrefabColliderType == HandlePrefabCollider.Box)
@@ -248,7 +250,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             else
             {
                 SphereCollider collider = handle.gameObject.GetComponent<SphereCollider>();
-                collider.radius = colliderSizeScaled.x * 0.5f;
+                collider.radius = VisualUtils.GetMaxComponent(colliderSizeScaled) * 0.5f;
                 collider.radius += VisualUtils.GetMaxComponent(config.ColliderPadding);
             }
         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
@@ -286,6 +286,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             handleVisual.transform.parent = parent.transform;
             handleVisual.transform.localScale = new Vector3(invScale, invScale, invScale);
             handleVisual.transform.localPosition = Vector3.zero;
+            handleVisual.transform.localRotation = Quaternion.identity;
 
             Quaternion realignment = GetRotationRealignment(handleIndex);
             parent.transform.localRotation = realignment;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/PerAxisHandles.cs
@@ -75,17 +75,20 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 // remove old colliders
                 bool shouldCreateNewCollider = false;
                 var oldBoxCollider = handle.GetComponent<BoxCollider>();
+
+                // Caution, Destroy() will destroy one frame later.
+                // Do not check later for presence this frame!
                 if (oldBoxCollider != null && config.HandlePrefabColliderType == HandlePrefabCollider.Sphere)
                 {
                     shouldCreateNewCollider = true;
-                    Object.DestroyImmediate(oldBoxCollider);
+                    Object.Destroy(oldBoxCollider);
                 }
 
                 var oldSphereCollider = handle.GetComponent<SphereCollider>();
                 if (oldSphereCollider != null && config.HandlePrefabColliderType == HandlePrefabCollider.Box)
                 {
                     shouldCreateNewCollider = true;
-                    Object.DestroyImmediate(oldSphereCollider);
+                    Object.Destroy(oldSphereCollider);
                 }
 
                 if (shouldCreateNewCollider)
@@ -211,7 +214,10 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 {
                     // get old child and remove it
                     obsoleteChild.parent = null;
-                    Object.DestroyImmediate(obsoleteChild.gameObject);
+
+                    // Caution, Destroy() will destroy one frame later.
+                    // Do not check later for presence this frame!
+                    Object.Destroy(obsoleteChild.gameObject);
                 }
                 else
                 {
@@ -263,7 +269,10 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 // so we can manually add our own properly configured collider later.
                 var collider = handleVisual.GetComponent<SphereCollider>();
                 collider.enabled = false;
-                Object.DestroyImmediate(collider);
+
+                // Caution, Destroy() will destroy one frame later.
+                // Do not check later for presence this frame!
+                Object.Destroy(collider);
             }           
 
             // handleVisualBounds are returned in handleVisual-local space.

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
@@ -276,8 +276,9 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     weight = lerp ? config.CloseGrowRate : 1.0f;
                     break;
             }
-
-            float newLocalScale = (scaleVisual.localScale.x * (1.0f - weight)) + (objectSize * targetScale * weight);
+            
+            float maxScaleAxis = VisualUtils.GetMaxComponent(scaleVisual.localScale);
+            float newLocalScale = (maxScaleAxis * (1.0f - weight)) + (objectSize * targetScale * weight);
             scaleVisual.localScale = new Vector3(newLocalScale, newLocalScale, newLocalScale);
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -2084,6 +2084,91 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test for verifying automatically generated handle colliders are properly aligned to the handle visual
+        /// </summary>
+        [UnityTest]
+        public IEnumerator PerAxisHandleAlignmentTest([ValueSource("perAxisHandleTestData")] PerAxisHandleTestData testData)
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            // Create an oblong-shaped handle
+            // (cylinder primitive will do, as it is longer than it is wide!)
+            var cylinder = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            GameObject.Destroy(cylinder.GetComponent<CapsuleCollider>());
+
+            // Wait for Destroy() to do its thing
+            yield return null;
+
+            // Set the rotation handles to be cylinders!
+            System.Reflection.PropertyInfo propName = boundsControl.GetType().GetProperty(testData.configPropertyName);
+            PerAxisHandlesConfiguration config = (PerAxisHandlesConfiguration)propName.GetValue(boundsControl);
+            config.HandlePrefab = cylinder;
+
+            // Reflection voodoo to retrieve the ColliderPadding value regardless of which
+            // handle configuration subclass we're currently using
+            System.Type configType = config.GetType();
+            var paddingProperty = configType.GetProperty("ColliderPadding");
+            Vector3 padding = (Vector3)paddingProperty.GetValue(config);
+
+            // Wait for BoundsControl to update to new handle prefab/rebuild rig
+            yield return null;
+            yield return new WaitForFixedUpdate();
+
+            // Iterate over all handle transforms
+            foreach(Transform handle in boundsControl.transform.Find("rigRoot"))
+            {   
+                // Is this the handle type we're currently looking for?
+                if(handle.name.StartsWith(testData.handleName))
+                {
+                    BoxCollider handleCollider = handle.GetComponent<BoxCollider>();
+
+                    Vector3[] colliderPoints = new Vector3[8];
+                    Vector3[] globalColliderPoints = new Vector3[8];
+
+                    // Strip the padding off the collider bounds, so that these bounds will match up
+                    // correctly with the visual bounds, if the alignment was properly done.
+                    VisualUtils.GetCornerPositionsFromBounds(new Bounds(handleCollider.center, handleCollider.size - padding), ref colliderPoints);
+
+                    // Perform a local-global transformation on all corners of the local collider bounds.
+                    for(int i = 0; i < colliderPoints.Length; ++i)
+                    {
+                        globalColliderPoints[i] = handle.TransformPoint(colliderPoints[i]);
+                    }
+
+                    Transform visual = handle.GetChild(0);
+                    Bounds handleBounds = VisualUtils.GetMaxBounds(visual.gameObject);
+
+                    Vector3[] visualPoints = new Vector3[8];
+                    Vector3[] globalVisualPoints = new Vector3[8];
+
+                    VisualUtils.GetCornerPositionsFromBounds(handleBounds, ref visualPoints);
+
+                    // Perform a local-global transformation on all corners of the local visual handle bounds.
+                    for(int i = 0; i < visualPoints.Length; ++i)
+                    {
+                        globalVisualPoints[i] = visual.TransformPoint(visualPoints[i]);
+                    }
+
+                    // Make sure all corners/vertices of the bounds are coherent after realignment, in global space
+                    bool flag = true;
+                    for(int i = 0; i < globalColliderPoints.Length; ++i)
+                    {
+                        if(globalColliderPoints[i] != globalVisualPoints[i])
+                        {
+                            flag = false;
+                            Debug.LogError($"Bounds mismatch, collider point: {globalColliderPoints[i].ToString("F3")}, visual point: {globalVisualPoints[i].ToString("F3")}");
+                        }
+                    }
+
+                    Assert.IsTrue(flag, "Handle collider does not match visual bounds, likely incorrect realignment of handle/visual transforms");
+                }
+            }
+
+            yield return null;
+        }
+
+        /// <summary>
         /// Test for verifying changing the handle prefabs during runtime 
         /// in regular and flatten mode and making sure the entire rig won't be recreated
         /// </summary>


### PR DESCRIPTION
## Overview
Currently, `BoundsControl` has several issues and inconsistencies regarding the handles and activation mechanisms. This PR is the first in a series to address these problems.

This PR adjusts how the colliders on the per-axis handles are constructed and aligned, resolving the collider alignment issues _**for the rotate and translate handle types only.**_ Currently, scale handles are a different type of Handle entirely, and this PR will not resolve scale handle collider issues. A future PR will address those issues.

`BoundsControl` constructs a container transform for each handle and an accompanying child transform which holds the "visual" of the handle. This separation allows `BoundsControl` to independently scale the handle visual without affecting the collider, which improves reliability and collision detection. (Scaling of the handle is necessary for `ProximityEffect` and the "grow" animation that triggers on proximity.) However, this separation induces an issue where per-axis handle visuals are rotated to fit the object, but the colliders cannot be rotated to match their visual counterparts. (Colliders are axis-aligned `Bounds`, and therefore cannot be rotated easily). 

Originally, these container transforms that held the colliders would not be rotated, but the underlying visual object would be rotated. To solve the issue of not being able to rotate the axis-aligned colliders, this PR revises the handle construction code to instead rotate the container transform, and leave the handle visual un-rotated. By letting the container transform perform the rotation instead of the visual, the collider remains properly aligned with the handle visual.

Old: the handle is rotated separately from the collider, causing misalignment:

<img src=https://user-images.githubusercontent.com/5544935/121971575-e094c280-cd2d-11eb-9b74-9dc98ff0cfb8.jpg height=200><img src=https://user-images.githubusercontent.com/5544935/121972610-57cb5600-cd30-11eb-9bbb-1afca4cbccb2.jpg height=200>


New: the transform container performs the rotation, keeping the collider aligned:

<img src=https://user-images.githubusercontent.com/5544935/121971613-f99d7380-cd2d-11eb-924a-68bb1bfad110.jpg height=200><img src=https://user-images.githubusercontent.com/5544935/121972621-60bc2780-cd30-11eb-8fee-9e31bfc331b2.jpg height=200>


Included in this PR is also several amendments to variable naming schemes and inline comments/doccomments. Due to a previous refactor, the `PerAxisHandles` class was previously exclusively used for rotation handles. This PR removes several instances of comments/variables referring exclusively to rotation affordances.

A TODO is marked to fix a hard-coded cursor icon issue. A future PR in this series will resolve that as well.

This PR partially solves #9946, but requires additional PRs to cover all functionalities affected by this issue (including scale handles!)

## Changes
- Edits variable names and comments in `PerAxisHandles` to more accurately and consistently reflect the current usage
- Changes how rotation realignments are applied to handle affordances and their colliders
- Improves the scaling logic across the handles and `VisualUtils` so that `GetMaxComponent` is always used to determine handle size, rather than an arbitrary axis
- Zeroes out local handle visual rotation on rig rebuild


## Verification
Existing BoundsControl tests cover this functionality, but they previously passed due to the margin of error/tolerance in the test case. Tighter test tolerances, in my opinion, are not strictly necessary. The issue this solves is more visible with larger/more strangely shaped colliders, as seen in the linked issue.
