### PR TITLE
Add editor window and menu item for displaying the current MRTK version

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static readonly Vector2 WindowSize = new Vector2(300, 150);
         private static readonly GUIContent Title = new GUIContent("Mixed Reality Toolkit");
 
-        [MenuItem("Mixed Reality/Toolkit/Show version...")]
+        [MenuItem("Mixed Reality/Toolkit/Show version...", priority = int.MaxValue)]
         private static void Init()
         {
             if (window != null)

--- a/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs
@@ -20,7 +20,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             if (window != null)
             {
-                window.Close();
+                window.ShowUtility();
+                return;
             }
 
             window = CreateInstance<MRTKVersionPopup>();

--- a/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    internal class MRTKVersionPopup : EditorWindow
+    {
+        private static MRTKVersionPopup window;
+        private static readonly Version MRTKVersion = typeof(MixedRealityToolkit).Assembly.GetName().Version;
+        private static readonly Vector2 WindowSize = new Vector2(300, 150);
+        private static readonly GUIContent Title = new GUIContent("Mixed Reality Toolkit");
+
+        [MenuItem("Mixed Reality/Toolkit/Show version...")]
+        private static void Init()
+        {
+            if (window != null)
+            {
+                window.Close();
+            }
+
+            window = CreateInstance<MRTKVersionPopup>();
+            window.titleContent = Title;
+            window.maxSize = WindowSize;
+            window.minSize = WindowSize;
+            window.ShowUtility();
+        }
+
+        private void OnGUI()
+        {
+            using (new EditorGUILayout.VerticalScope())
+            {
+                MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
+
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    GUILayout.FlexibleSpace();
+                    EditorGUILayout.LabelField($"Version {MRTKVersion}", EditorStyles.wordWrappedLabel);
+                    GUILayout.FlexibleSpace();
+                }
+            }
+        }
+    }
+}

--- a/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs
@@ -10,10 +10,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 {
     internal class MRTKVersionPopup : EditorWindow
     {
-        private static MRTKVersionPopup window;
+        private const string DefaultVersion = "0.0.0.0";
+        private const string NotFoundMessage = "The version could not be read. This is most often due to (and expected when) using MRTK directly from the repo. If you're using an official distribution and seeing this message, please file a GitHub issue!";
         private static readonly Version MRTKVersion = typeof(MixedRealityToolkit).Assembly.GetName().Version;
-        private static readonly Vector2 WindowSize = new Vector2(300, 150);
+        private static readonly bool FoundVersion = MRTKVersion.ToString() != DefaultVersion;
+        private static readonly Vector2 WindowSize = new Vector2(300, 140);
+        private static readonly Vector2 NotFoundWindowSize = new Vector2(300, 175);
         private static readonly GUIContent Title = new GUIContent("Mixed Reality Toolkit");
+        private static MRTKVersionPopup window;
 
         [MenuItem("Mixed Reality/Toolkit/Show version...", priority = int.MaxValue)]
         private static void Init()
@@ -26,8 +30,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             window = CreateInstance<MRTKVersionPopup>();
             window.titleContent = Title;
-            window.maxSize = WindowSize;
-            window.minSize = WindowSize;
+            window.maxSize = FoundVersion ? WindowSize : NotFoundWindowSize;
+            window.minSize = FoundVersion ? WindowSize : NotFoundWindowSize;
             window.ShowUtility();
         }
 
@@ -40,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 using (new EditorGUILayout.HorizontalScope())
                 {
                     GUILayout.FlexibleSpace();
-                    EditorGUILayout.LabelField($"Version {MRTKVersion}", EditorStyles.wordWrappedLabel);
+                    EditorGUILayout.LabelField(FoundVersion ? $"Version {MRTKVersion}" : NotFoundMessage, EditorStyles.wordWrappedLabel);
                     GUILayout.FlexibleSpace();
                 }
             }

--- a/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs.meta
+++ b/Assets/MRTK/Core/Inspectors/Setup/MRTKVersionPopup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d250538bcdbf854691a77d97a3b425f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

For ease of figuring out which MRTK version you're running, this PR adds a menu item and corresponding pop-up to discover it!

![image](https://user-images.githubusercontent.com/3580640/121979641-6836fd00-cd3f-11eb-8fd7-25e7f4f9575a.png)

IMPORTANT: This feature uses the AssemblyInfo.cs files that our CI generates. Therefore, if run from a clone of the repo, it will display `0.0.0.0` instead of any meaningful number.

## Changes
- Fixes: I thought we had an issue for this, but I can't find it...