### PR TITLE
Update controller mapping list header and alignment

### DIFF
--- a/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
@@ -319,35 +319,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             GUIStyle headerStyle = new GUIStyle();
             headerStyle.richText = true;
 
-            if (currentControllerOption == null || currentControllerTexture == null)
+            using (new EditorGUILayout.VerticalScope())
             {
-                using (new EditorGUILayout.VerticalScope())
-                {
-                    GUILayout.FlexibleSpace();
-                    EditorGUILayout.LabelField("<b>Controllers affected by this mapping</b>", headerStyle);
-                    for (int i = 0; i < controllerList.Count; i++)
-                    {
-                        EditorGUILayout.LabelField(controllerList[i]);
-                    }
-                }
-            }
-            else
-            {
-                float max_y = currentControllerOption.InputLabelPositions.Max(x => x.y);
-
-                var titleRectPosition = Vector2.up * (max_y + 4 * EditorGUIUtility.singleLineHeight);
-                var titleRectSize = new Vector2(500, EditorGUIUtility.singleLineHeight);
-
-                var titleRect = new Rect(titleRectPosition, titleRectSize);
-                EditorGUI.LabelField(titleRect, "<b>Controllers affected by this mapping</b>", headerStyle);
-
+                GUILayout.FlexibleSpace();
+                EditorGUILayout.LabelField("<b>Controllers affected by this mapping</b>", headerStyle);
                 for (int i = 0; i < controllerList.Count; i++)
                 {
-                    var rectPosition = Vector2.up * (max_y + (i + 5) * EditorGUIUtility.singleLineHeight);
-                    var rectSize = new Vector2(1000, EditorGUIUtility.singleLineHeight);
-
-                    var labelRect = new Rect(rectPosition, rectSize);
-                    EditorGUI.LabelField(labelRect, controllerList[i]);
+                    EditorGUILayout.LabelField(controllerList[i]);
                 }
             }
         }

--- a/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
@@ -316,13 +316,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 return;
             }
 
-            GUIStyle headerStyle = new GUIStyle();
-            headerStyle.richText = true;
-
             using (new EditorGUILayout.VerticalScope())
             {
                 GUILayout.FlexibleSpace();
-                EditorGUILayout.LabelField("<b>Controllers affected by this mapping</b>", headerStyle);
+                EditorGUILayout.LabelField("Controllers affected by this mapping", EditorStyles.boldLabel);
                 for (int i = 0; i < controllerList.Count; i++)
                 {
                     EditorGUILayout.LabelField(controllerList[i]);

--- a/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
@@ -321,7 +321,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             if (currentControllerOption == null || currentControllerTexture == null)
             {
-                GUILayout.BeginVertical();
                 using (new EditorGUILayout.VerticalScope())
                 {
                     GUILayout.FlexibleSpace();
@@ -331,7 +330,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         EditorGUILayout.LabelField(controllerList[i]);
                     }
                 }
-                GUILayout.EndVertical();
             }
             else
             {


### PR DESCRIPTION
## Overview

Currently, the "affected controllers" list header doesn't change color based on the Unity theme, so we run into cases like

![image](https://user-images.githubusercontent.com/3580640/122094689-48e0b400-cdc1-11eb-9ac9-aae0e7b42f2f.png)

With this PR:

1. The header is updated to use a built-in Unity style, which will adjust according to the Unity theme
2. Split logic depending on if the current mapping has a texture or not is removed, as the result was sometimes misaligned (see screenshot above)

![image](https://user-images.githubusercontent.com/3580640/122094439-0b7c2680-cdc1-11eb-9b3d-2c7a1da75736.png)
