### PR TITLE
Experience Settings profile can now be set to None

### DIFF
--- a/Assets/MRTK/Core/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityToolkitInspector.cs
@@ -12,10 +12,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     {
         private SerializedProperty activeProfile;
         private UnityEditor.Editor activeProfileEditor;
+        private Object cachedProfile;
 
         private void OnEnable()
         {
             activeProfile = serializedObject.FindProperty("activeProfile");
+            cachedProfile = activeProfile.objectReferenceValue;
         }
 
         public override void OnInspectorGUI()
@@ -53,7 +55,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 EditorGUILayout.HelpBox("MixedRealityToolkit cannot initialize unless an Active Profile is assigned!", MessageType.Error);
             }
 
-            bool changed = MixedRealityInspectorUtility.DrawProfileDropDownList(activeProfile, null, activeProfile.objectReferenceValue, typeof(MixedRealityToolkitConfigurationProfile), false, false);
+            bool changed = MixedRealityInspectorUtility.DrawProfileDropDownList(activeProfile, null, activeProfile.objectReferenceValue, typeof(MixedRealityToolkitConfigurationProfile), false, false) ||
+                cachedProfile != activeProfile.objectReferenceValue;
 
             serializedObject.ApplyModifiedProperties();
 
@@ -61,6 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 MixedRealityToolkit.Instance.ResetConfiguration((MixedRealityToolkitConfigurationProfile)activeProfile.objectReferenceValue);
                 activeProfileEditor = null;
+                cachedProfile = activeProfile.objectReferenceValue;
             }
 
             if (activeProfile.objectReferenceValue != null && activeProfileEditor == null)

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -443,13 +443,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 if (GUILayout.Button("Copy & Customize"))
                 {
                     SerializedProperty targetProperty = null;
+                    UnityEngine.Object selectionTarget = null;
                     // If we have an active MRTK instance, find its config profile serialized property
                     if (MixedRealityToolkit.IsInitialized)
                     {
+                        selectionTarget = MixedRealityToolkit.Instance;
                         SerializedObject mixedRealityToolkitObject = new SerializedObject(MixedRealityToolkit.Instance);
                         targetProperty = mixedRealityToolkitObject.FindProperty("activeProfile");
                     }
-                    MixedRealityProfileCloneWindow.OpenWindow(null, target as BaseMixedRealityProfile, targetProperty);
+                    MixedRealityProfileCloneWindow.OpenWindow(null, target as BaseMixedRealityProfile, targetProperty, selectionTarget);
                 }
 
                 if (MixedRealityToolkit.IsInitialized)

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -21,7 +21,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static readonly GUIContent TargetScaleContent = new GUIContent("Target Scale:");
 
         // Experience properties
-        private SerializedProperty experienceSettingsType;
         private SerializedProperty experienceSettingsProfile;
 
         // Tracking the old experience scale property for compatibility
@@ -97,7 +96,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             MixedRealityToolkitConfigurationProfile mrtkConfigProfile = target as MixedRealityToolkitConfigurationProfile;
 
             // Experience configuration
-            experienceSettingsType = serializedObject.FindProperty("experienceSettingsType");
             experienceSettingsProfile = serializedObject.FindProperty("experienceSettingsProfile");
             experienceScaleMigration = serializedObject.FindProperty("targetExperienceScale");
 
@@ -155,7 +153,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                             // Reconciling old Experience Scale property with the Experience Settings Profile
                             var oldExperienceSettigsScale = (experienceSettingsProfile.objectReferenceValue as MixedRealityExperienceSettingsProfile)?.TargetExperienceScale;
 
-                            changed |= RenderProfile(experienceSettingsProfile, typeof(MixedRealityExperienceSettingsProfile), true, false,  null, true);
+                            changed |= RenderProfile(experienceSettingsProfile, typeof(MixedRealityExperienceSettingsProfile), true, false,  null);
 
                             // Experience configuration
                             if(!mrtkConfigProfile.ExperienceSettingsProfile.IsNull())
@@ -247,13 +245,23 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         return changed;
                     },
                     () => {
-                        var experienceScale = mrtkConfigProfile.ExperienceSettingsProfile.TargetExperienceScale;
-                        if (experienceScale != ExperienceScale.Room)
+                        if(mrtkConfigProfile.ExperienceSettingsProfile.IsNull())
                         {
-                            // Alert the user if the experience scale does not support boundary features.
+                            // Alert that an experience settings profile has not been selected
                             GUILayout.Space(6f);
-                            EditorGUILayout.HelpBox("Boundaries are only supported in Room scale experiences.", MessageType.Warning);
+                            EditorGUILayout.HelpBox("Boundaries require an experience settings profile with a Room scale target experience scale.", MessageType.Warning);
                             GUILayout.Space(6f);
+                        }
+                        else
+                        {
+                            var experienceScale = mrtkConfigProfile.ExperienceSettingsProfile.TargetExperienceScale;
+                            if (experienceScale != ExperienceScale.Room)
+                            {
+                                // Alert the user if the experience scale does not support boundary features.
+                                GUILayout.Space(6f);
+                                EditorGUILayout.HelpBox("Boundaries are only supported in Room scale experiences.", MessageType.Warning);
+                                GUILayout.Space(6f);
+                            }
                         }
 
                         bool changed = false;
@@ -435,15 +443,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 if (GUILayout.Button("Copy & Customize"))
                 {
                     SerializedProperty targetProperty = null;
-                    UnityEngine.Object selectionTarget = null;
                     // If we have an active MRTK instance, find its config profile serialized property
                     if (MixedRealityToolkit.IsInitialized)
                     {
-                        selectionTarget = MixedRealityToolkit.Instance;
                         SerializedObject mixedRealityToolkitObject = new SerializedObject(MixedRealityToolkit.Instance);
                         targetProperty = mixedRealityToolkitObject.FindProperty("activeProfile");
                     }
-                    MixedRealityProfileCloneWindow.OpenWindow(null, target as BaseMixedRealityProfile, targetProperty, selectionTarget);
+                    MixedRealityProfileCloneWindow.OpenWindow(null, target as BaseMixedRealityProfile, targetProperty);
                 }
 
                 if (MixedRealityToolkit.IsInitialized)


### PR DESCRIPTION
## Overview
Some quirks with how the Unity Assets are loaded vs when the inspector code runs causes issues in Unity 2020 with MRTK profiles. This PR fixes two points.

1. Experience settings profiles can now be set to None by default. This fixes issues with new profiles not having their experience settings loaded correctly by default upon creation. Additional checks and warnings are raised in the case of the Experience Settings profile being set to None

2. Cloning a profile no longer forces focus back to the MixedRealityToolkit object. Previously, the inspector of the profile would update to reflect the new, editable status of the profile, but as of Unity 2020, the profile will appear to still be a "default" profile and have it's fields disabled. By changing the selection focus, we circumvent this issue

## Changes
- Fixes: #9979

