### PR TITLE
update repository's project version to last 2018.4 lts

### DIFF
--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.4.34f1
+m_EditorVersion: 2018.4.36f1


### PR DESCRIPTION
Per the linked message in Unity's forum, 2018.4.36f1 will be the final release of the 2018 product.

https://forum.unity.com/threads/unity-lts-release-announcements.529171/page-3#post-7249982

This change updates the repository's project version to match.