### PR TITLE
Fixing BC Scale Handles

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -1541,7 +1541,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 links.UpdateLinkScales(currentBoundsExtents);
 
                 translationHandles.CalculateHandlePositions(ref boundsCorners);
-                scaleHandles.UpdateHandles(ref boundsCorners);
+                scaleHandles.CalculateHandlePositions(ref boundsCorners);
 
                 boxDisplay.UpdateDisplay(currentBoundsExtents, flattenAxis);
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
@@ -16,8 +16,17 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         protected override HandlesBaseConfiguration BaseConfig => config;
         private ScaleHandlesConfiguration config;
         private bool areHandlesFlattened = false;
+
+        /// <summary>
+        /// Cached handle positions - we keep track of handle positions in this array
+        /// in case we have to reload the handles due to configuration changes.
+        /// </summary>
+        protected Vector3[] HandlePositions { get; private set; }
+        private int NumHandles => 8;
         internal ScaleHandles(ScaleHandlesConfiguration configuration)
         {
+            HandlePositions = new Vector3[NumHandles];
+
             Debug.Assert(configuration != null, "Can't create BoundsControlScaleHandles without valid configuration");
             config = configuration;
             config.handlesChanged.AddListener(HandlesChanged);
@@ -39,16 +48,30 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             }
         }
 
-        internal void UpdateHandles(ref Vector3[] boundsCorners)
+        internal void UpdateHandles()
         {
             for (int i = 0; i < handles.Count; ++i)
             {
-                handles[i].position = boundsCorners[i];
+                handles[i].position = HandlePositions[i];
+            }
+        }
+
+        internal void CalculateHandlePositions(ref Vector3[] boundsCorners)
+        {
+            if (boundsCorners != null && HandlePositions != null)
+            {
+                for (int i = 0; i < HandlePositions.Length; ++i)
+                {
+                    HandlePositions[i] = boundsCorners[i];
+                }
+                UpdateHandles();
             }
         }
 
         internal void Create(ref Vector3[] boundsCorners, Transform parent, bool isFlattened)
         {
+            CalculateHandlePositions(ref boundsCorners);
+
             // create corners
             for (int i = 0; i < boundsCorners.Length; ++i)
             {
@@ -57,20 +80,9 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     name = "corner_" + i.ToString()
                 };
                 corner.transform.parent = parent;
-                corner.transform.localPosition = boundsCorners[i];
+                corner.transform.localPosition = HandlePositions[i];
 
-                GameObject visualsScale = new GameObject();
-                visualsScale.name = "visualsScale";
-                visualsScale.transform.parent = corner.transform;
-                visualsScale.transform.localPosition = Vector3.zero;
-
-                // Compute mirroring scale
-                {
-                    Vector3 p = boundsCorners[i];
-                    visualsScale.transform.localScale = new Vector3(Mathf.Sign(p[0]), Mathf.Sign(p[1]), Mathf.Sign(p[2]));
-                }
-
-                Bounds visualBounds = CreateVisual(visualsScale, isFlattened);
+                Bounds visualBounds = CreateVisual(i, corner, isFlattened);
                 var invScale = visualBounds.size.x == 0.0f ? 0.0f : config.HandleSize / visualBounds.size.x;
                 VisualUtils.AddComponentsToAffordance(corner, new Bounds(visualBounds.center * invScale, visualBounds.size * invScale),
                     HandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, config.ColliderPadding, parent, config.DrawTetherWhenManipulating);
@@ -85,28 +97,23 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         {
             for (int i = 0; i < handles.Count; ++i)
             {
-                // get parent of visual
-                Transform visualsScaleParent = handles[i].Find("visualsScale");
-                if (visualsScaleParent)
+                
+                Transform obsoleteChild = handles[i].Find(visualsName);
+                if (obsoleteChild)
                 {
-                    // get old child and remove it
-                    Transform obsoleteChild = visualsScaleParent.Find(visualsName);
-                    if (obsoleteChild)
-                    {
-                        obsoleteChild.parent = null;
-                        Object.Destroy(obsoleteChild.gameObject);
-                    }
-                    else
-                    {
-                        Debug.LogError("couldn't find corner visual on recreating visuals");
-                    }
-
-                    // create new visual
-                    Bounds cornerBounds = CreateVisual(visualsScaleParent.gameObject, areHandlesFlattened);
-
-                    // update handle collider bounds
-                    UpdateColliderBounds(handles[i], cornerBounds.size);
+                    obsoleteChild.parent = null;
+                    Object.Destroy(obsoleteChild.gameObject);
                 }
+                else
+                {
+                    Debug.LogError("couldn't find corner visual on recreating visuals");
+                }
+
+                // create new visual
+                Bounds visualBounds = CreateVisual(i, handles[i].gameObject, areHandlesFlattened);
+
+                // update handle collider bounds
+                UpdateColliderBounds(handles[i], visualBounds.size);
             }
 
             objectsChangedEvent.Invoke(this);
@@ -114,64 +121,91 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
 
         protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)
         {
-            var invScale = visualSize.x == 0.0f ? 0.0f : config.HandleSize / visualSize.x;
+            float maxDim = VisualUtils.GetMaxComponent(visualSize);
+            float invScale = maxDim == 0.0f ? 0.0f : config.HandleSize / maxDim;
             GetVisual(handle).transform.localScale = new Vector3(invScale, invScale, invScale);
             BoxCollider collider = handle.gameObject.GetComponent<BoxCollider>();
             Vector3 colliderSize = visualSize * invScale;
             collider.size = colliderSize;
             collider.size += BaseConfig.ColliderPadding;
-            collider.center = new Vector3(collider.size.x, collider.size.y, collider.size.z) * 0.5f;
+            collider.center = Vector3.zero;
         }
 
         /// <summary>
         /// Creates the corner visual and returns the bounds of the created visual
         /// </summary>
+        /// <param name="handleIndex">cornerIndex</param>
         /// <param name="parent">parent of visual</param>
         /// <param name="isFlattened">instantiate in flattened mode - slate</param>
         /// <returns>bounds of the created visual</returns>
-        private Bounds CreateVisual(GameObject parent, bool isFlattened)
+        private Bounds CreateVisual(int handleIndex, GameObject parent, bool isFlattened)
         {
             // figure out which prefab to instantiate
-            GameObject cornerVisual = null;
+            GameObject handleVisual = null;
             areHandlesFlattened = isFlattened;
             GameObject prefabType = isFlattened ? config.HandleSlatePrefab : config.HandlePrefab;
             if (prefabType == null)
             {
                 // instantiate default prefab, a cube with box collider
-                cornerVisual = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                cornerVisual.transform.parent = parent.transform;
-                cornerVisual.transform.localPosition = Vector3.zero;
+                handleVisual = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                
                 // deactivate collider on visuals and register for deletion - actual collider
                 // of handle is attached to the handle gameobject, not the visual
-                var collider = cornerVisual.GetComponent<BoxCollider>();
+                var collider = handleVisual.GetComponent<BoxCollider>();
                 collider.enabled = false;
-                Object.Destroy(collider);
+                UnityEngine.Object.Destroy(collider);
             }
             else
             {
-                cornerVisual = GameObject.Instantiate(prefabType, parent.transform);
+                handleVisual = GameObject.Instantiate(prefabType, parent.transform);
             }
+            
+            // this is the size of the corner visuals
+            var handleVisualBounds = VisualUtils.GetMaxBounds(handleVisual);
+            float maxDim = VisualUtils.GetMaxComponent(handleVisualBounds.size);
+            float invScale = maxDim == 0.0f ? 0.0f : config.HandleSize / maxDim;
+
+            handleVisual.name = visualsName;
+            handleVisual.transform.parent = parent.transform;
+            handleVisual.transform.localScale = new Vector3(invScale, invScale, invScale);
+            handleVisual.transform.localPosition = Vector3.zero;
+            handleVisual.transform.localRotation = Quaternion.identity;
 
             if (isFlattened)
             {
                 // Rotate 2D slate handle asset for proper orientation
-                cornerVisual.transform.Rotate(0, 0, -90);
+                parent.transform.Rotate(0, 0, -90);
+            } else {
+                Quaternion realignment = GetRotationRealignment(handleIndex);
+                parent.transform.localRotation = realignment;
             }
 
-            cornerVisual.name = visualsName;
+            if(config.HandleMaterial != null)
+            {
+                VisualUtils.ApplyMaterialToAllRenderers(handleVisual, config.HandleMaterial);
+            }
 
-            // this is the size of the corner visuals
-            var cornerbounds = VisualUtils.GetMaxBounds(cornerVisual);
-            float maxDim = Mathf.Max(Mathf.Max(cornerbounds.size.x, cornerbounds.size.y), cornerbounds.size.z);
-            cornerbounds.size = maxDim * Vector3.one;
+            return handleVisualBounds;
+        }
 
-            // we need to multiply by this amount to get to desired scale handle size
-            var invScale = cornerbounds.size.x == 0.0f ? 0.0f : config.HandleSize / cornerbounds.size.x;
-            cornerVisual.transform.localScale = new Vector3(invScale, invScale, invScale);
+        protected Quaternion GetRotationRealignment(int handleIndex)
+        {
+            // Helper lambda to sign a vector.
+            Vector3 signVector(Vector3 i) => new Vector3(Mathf.Sign(i.x), Mathf.Sign(i.y), Mathf.Sign(i.z));
 
-            VisualUtils.ApplyMaterialToAllRenderers(cornerVisual, config.HandleMaterial);
+            // The neutral handle is the handle position at which
+            // the corner handle model is appropriately aligned, sans any rotation
+            Vector3 neutralHandle = signVector(HandlePositions[6]);
+            Vector3 handlePos = signVector(HandlePositions[handleIndex]);
 
-            return cornerbounds;
+            // Flip the handle if it's on the underside of the bounds.
+            Quaternion flip = Quaternion.Euler(0, 0, handlePos.y > 0 ? 0 : 90);
+
+            float angleAroundVertical = Vector3.SignedAngle(new Vector3(neutralHandle.x, 0, neutralHandle.z),
+                                                            new Vector3(handlePos.x, 0, handlePos.z),
+                                                            Vector3.up);
+
+            return Quaternion.Euler(0, angleAroundVertical, 0) * flip;
         }
 
         internal void Reset(bool areHandlesActive, FlattenModeType flattenAxis)
@@ -191,13 +225,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
 
         protected override Transform GetVisual(Transform handle)
         {
-            Transform firstChild = handle.GetChild(0);
-            if (firstChild == null)
-            {
-                return null;
-            }
-
-            Transform visual = firstChild.GetChild(0);
+            Transform visual = handle.GetChild(0);
             if (visual != null && visual.name == visualsName)
             {
                 return visual;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 }
                 else
                 {
-                    Debug.LogError("couldn't find corner visual on recreating visuals");
+                    Debug.LogError("Couldn't find corner visual on recreating visuals");
                 }
 
                 // create new visual

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
@@ -175,7 +175,9 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             {
                 // Rotate 2D slate handle asset for proper orientation
                 parent.transform.Rotate(0, 0, -90);
-            } else {
+            }
+            else
+            {
                 Quaternion realignment = GetRotationRealignment(handleIndex);
                 parent.transform.localRotation = realignment;
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         /// in case we have to reload the handles due to configuration changes.
         /// </summary>
         protected Vector3[] HandlePositions { get; private set; }
-        private int NumHandles => 8;
+        private const int NumHandles = 8;
         internal ScaleHandles(ScaleHandlesConfiguration configuration)
         {
             HandlePositions = new Vector3[NumHandles];

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -111,7 +111,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             boundsControlGameObject.transform.position = boundsControlStartCenter;
             boundsControlGameObject.transform.localScale = boundsControlStartScale;
             BoundsControl boundsControl = boundsControlGameObject.AddComponent<BoundsControl>();
-            boundsControl.HideElementsInInspector = false;
             if (target != null)
             {
                 target.transform.parent = boundsControlGameObject.transform;

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -2088,22 +2088,23 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Test for verifying automatically generated handle colliders are properly aligned to the handle visual
         /// </summary>
         [UnityTest]
-        public IEnumerator PerAxisHandleAlignmentTest([ValueSource("perAxisHandleTestData")] PerAxisHandleTestData testData)
+        public IEnumerator HandleAlignmentTest([ValueSource("handleTestData")] HandleTestData testData)
         {
             var boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
 
             // Create an oblong-shaped handle
             // (cylinder primitive will do, as it is longer than it is wide!)
+            // Testing oblong handles will stress the alignment/rotation behavior
             var cylinder = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
             GameObject.Destroy(cylinder.GetComponent<CapsuleCollider>());
 
             // Wait for Destroy() to do its thing
             yield return null;
 
-            // Set the rotation handles to be cylinders!
+            // Set the handles to be cylinders!
             System.Reflection.PropertyInfo propName = boundsControl.GetType().GetProperty(testData.configPropertyName);
-            PerAxisHandlesConfiguration config = (PerAxisHandlesConfiguration)propName.GetValue(boundsControl);
+            HandlesBaseConfiguration config = (HandlesBaseConfiguration)propName.GetValue(boundsControl);
             config.HandlePrefab = cylinder;
 
             // Reflection voodoo to retrieve the ColliderPadding value regardless of which

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         static HandleTestData[] handleTestData = new HandleTestData[]
         {
-            new HandleTestData("corner_3", "corner_3/visualsScale/visuals", "ScaleHandlesConfig"),
+            new HandleTestData("corner_3", "corner_3/visuals", "ScaleHandlesConfig"),
             new HandleTestData("midpoint_2", "midpoint_2/visuals", "RotationHandlesConfig"),
             new HandleTestData("faceCenter_2", "faceCenter_2/visuals", "TranslationHandlesConfig")
         };
@@ -111,6 +111,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             boundsControlGameObject.transform.position = boundsControlStartCenter;
             boundsControlGameObject.transform.localScale = boundsControlStartScale;
             BoundsControl boundsControl = boundsControlGameObject.AddComponent<BoundsControl>();
+            boundsControl.HideElementsInInspector = false;
             if (target != null)
             {
                 target.transform.parent = boundsControlGameObject.transform;
@@ -1273,7 +1274,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 initialHandPosition = new Vector3(0, 0, 0f);
             // this is specific to scale handles
             Transform scaleHandle = boundsControl.gameObject.transform.Find("rigRoot/corner_3");
-            Transform proximityScaledVisual = (scaleHandle.GetChild(0) != null) ? scaleHandle.GetChild(0).GetChild(0) : null;
+            Transform proximityScaledVisual = scaleHandle.GetChild(0);
             var frontRightCornerPos = scaleHandle.position; // front right corner is corner 
             Assert.IsNotNull(proximityScaledVisual, "Couldn't get visual gameobject for scale handle");
             Assert.IsTrue(proximityScaledVisual.name == "visuals", "scale visual has unexpected name");
@@ -1331,7 +1332,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             ScaleHandlesConfiguration scaleHandleConfig = boundsControl.ScaleHandlesConfig;
             Vector3 defaultHandleSize = Vector3.one * scaleHandleConfig.HandleSize;
             Transform scaleHandle = boundsControl.gameObject.transform.Find("rigRoot/corner_3");
-            Transform proximityScaledVisual = (scaleHandle.GetChild(0) != null) ? scaleHandle.GetChild(0).GetChild(0) : null;
+            Transform proximityScaledVisual = scaleHandle.GetChild(0);
             var frontRightCornerPos = scaleHandle.position;
             // check far scale applied
             ProximityEffectConfiguration proximityConfig = boundsControl.HandleProximityEffectConfig;
@@ -1456,7 +1457,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsTrue(boundsControl.WireframeOnly, "wireframeonly should be enabled");
 
             // move to bounds control with hand and check if it activates on proximity
-            Transform cornerVisual = rigRoot.transform.Find("corner_1/visualsScale/visuals");
+            Transform cornerVisual = rigRoot.transform.Find("corner_1/visuals");
             Assert.IsNotNull(cornerVisual, "couldn't find scale handle visual");
             TestHand hand = new TestHand(Handedness.Right);
             Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where hand ray points on center of the test cube
@@ -1719,7 +1720,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // fetch rigroot
             GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
             Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
-            Transform cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            Transform cornerVisual = rigRoot.transform.Find("corner_3/visuals");
             Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
             var cornerVisualPosition = cornerVisual.position;
             var defaultPadding = boundsControl.BoxPadding;
@@ -1939,7 +1940,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(boxVisual.GetComponent<Renderer>().material.color, testMaterial.color, "box material wasn't applied to visual");
 
             // grab one of the scale handles and make sure grabbed material is applied to box
-            Transform cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            Transform cornerVisual = rigRoot.transform.Find("corner_3/visuals");
             Assert.IsNotNull(cornerVisual, "couldn't find scale handle visual");
             TestHand hand = new TestHand(Handedness.Right);
             yield return hand.Show(Vector3.zero);
@@ -2053,7 +2054,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // check default mesh filter
             Transform perAxisVisual = rigRoot.transform.Find(testData.handleName + "_2/visuals");
-            Transform cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            Transform cornerVisual = rigRoot.transform.Find("corner_3/visuals");
             Assert.IsNotNull(perAxisVisual, "couldn't find axis handle visual");
             Assert.IsNotNull(cornerVisual, "couldn't find scale handle visual");
             var handleVisualMeshFilter = perAxisVisual.GetComponent<MeshFilter>();
@@ -2184,7 +2185,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
 
             // check default mesh filter
-            Transform cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            Transform cornerVisual = rigRoot.transform.Find("corner_3/visuals");
             Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
             Transform rotationHandleVisual = rigRoot.transform.Find("midpoint_2/visuals");
             Assert.IsNotNull(rotationHandleVisual, "couldn't find rotation handle visual");
@@ -2204,7 +2205,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNull(cornerVisual, "corner visual wasn't destroyed when swapping the prefab");
 
             // fetch new corner visual
-            cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            cornerVisual = rigRoot.transform.Find("corner_3/visuals");
             Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
             cornerMeshFilter = cornerVisual.GetComponent<MeshFilter>();
             // check if new mesh filter was applied
@@ -2220,7 +2221,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNull(cornerVisual, "corner visual wasn't destroyed when swapping the prefab");
 
             // mesh should be cube again
-            cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            cornerVisual = rigRoot.transform.Find("corner_3/visuals");
             Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
             cornerMeshFilter = cornerVisual.GetComponent<MeshFilter>();
             Assert.IsTrue(cornerMeshFilter.mesh.name == "Cube Instance", "Flattened scale handles weren't created with default cube");
@@ -2236,7 +2237,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNull(cornerVisual, "corner visual wasn't destroyed when swapping the prefab");
 
             // fetch new corner visual
-            cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            cornerVisual = rigRoot.transform.Find("corner_3/visuals");
             Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
             cornerMeshFilter = cornerVisual.GetComponent<MeshFilter>();
 
@@ -2346,7 +2347,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestHand hand = new TestHand(Handedness.Right);
             yield return hand.Show(Vector3.zero);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
-
             // set test materials so we know if we're interacting with the handle later in the test
             System.Reflection.PropertyInfo propName = boundsControl.GetType().GetProperty(testData.configPropertyName);
             HandlesBaseConfiguration handleConfig = (HandlesBaseConfiguration)propName.GetValue(boundsControl);


### PR DESCRIPTION
## Overview

This is a _non-breaking_ fix for the collider alignment behavior of the scale handles on BoundsControl-equipped objects. This change brings many of the calculations and behaviors of the scale handles inline with what the newer rotation and translation handles are already doing; i.e., instead of using a two-stage container-scale-visual hierarchy, it uses a single container-visual structure, exactly the same as the rotation and translation handles. This also moves the job of realigning the collider to the container, instead of the visual. Part of this is reworking the scale handles to use _rotation_ realignment, instead of _scaling_ realignment. Previously, the scale handles realigned the colliders by simply flipping the scale of an intermediary object ("visualsScale"), but this causes issues with oblong handles, collider alignment, etc. Now, "visualsScale" is completely removed, and all of the handle alignment behavior is implemented with rotations, exactly like the other handles. Now, all of the handle colliders (translate, rotate, scale) are perfectly aligned and coherent with any collider mesh/shape/rotation/etc.

### Old

<img src=https://user-images.githubusercontent.com/5544935/122824062-fc034e80-d294-11eb-9146-98d43ccae499.jpg width=500>

In this diagram, you can see how the scale colliders were not correctly aligned to the handles. The collider padding was applied inconsistently across the different handles, as the collider was not able to be rotated/realigned properly to the underlying handle visual. 

### New

<img src=https://user-images.githubusercontent.com/5544935/122824190-2ead4700-d295-11eb-974b-403e97dc1855.jpg width=500>

Now that the scale handles have been refactored to use proper rotation-based realignment, all the collider padding and spacing is applied coherently across all handles, with the proper spacing/padding/alignment applied regardless of the rotation of the underlying visual.

Several of the functions and mechanisms for scale handles have been reworked to function identically to the rotation/translation handles, i.e. the `GetRotationRealignment` function that returns a quaternion to align the handle, and moving from the `UpdateHandles(ref boundsCorners)` pattern to the `CalculateHandlePositions(ref boundscorners)` pattern. Scale handles now also use an internal cache of the bounds corners, to bring the calculation of handle positions inline with how all other handles perform the same task.

`CreateVisual` is slightly reworked to be functionally identical in calling pattern/behavior to the other handles' `CreateVisual`. 

Very important: the handle collider alignment test that was introduced in a previous PR for rigorously checking the exact collider dimensions and alignments of the handles has been expanded/generalized to cover all three handle types.

**This is a intermediate PR to fix handle alignment in a non-breaking way.  This _does not fix the code copypasta issue,_ the scale handles still reuse a lot of code without proper DRY techniques. ** A future PR will refactor scale handles and the entire handle class hierarchy to properly DRY-ly reuse code and be far more generalized. This is a much larger refactor and may introduce a couple of breaking changes. _This_ PR is safe to merge for 2.x. The future PR may need to be merged in 3.x due to breaking changes.

## Changes
- `visualsScale` intermediary hierarchy transform is removed. Scale handles now use a single container transform and single visuals transform.
- Scale handle alignment is now achieved through rotations/quats, same as all other handles, instead of wonky scaling
- Scale handle alignment is now performed at the container transform level, instead of the visual level, same as the other handles
- Scale handle code has been slightly refactored to more closely match the behavior/structure/mechanisms of other handles
- Tests for exact/precise collider alignment have been generalized to include scale handles, utilizing the `HandleTestData` data provider pattern
- Tests have been updated to match the new hierarchy pattern (aka, don't look for `visualsScale`)
- Should finally completely fix #9946 ! Woohoo.


## Verification
Test for exact collider alignment has been expanded to include scale handles. Full and precise test coverage of this issue.
