### PR TITLE
Add early return if array length is 0

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
@@ -122,7 +122,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             if (neutralPoseVertices.Length == 0)
             {
-                Debug.LogError("Loaded 0 verts for neutralPoseVertices");
+                Debug.LogError("Loaded 0 vertices for neutralPoseVertices");
+                return System.Array.Empty<Vector2>();
             }
 
             float minY = neutralPoseVertices[0].y;

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -78,7 +78,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         {
             if (poseVertices.Length == 0)
             {
-                Debug.LogError("Loaded 0 verts for poseVertices");
+                Debug.LogError("Loaded 0 vertices for poseVertices");
+                return System.Array.Empty<Vector2>();
             }
 
             float minY = poseVertices[0].y;


### PR DESCRIPTION
## Overview

In a specific holographic app remoting case, this API may return an empty array. On first look, this shouldn't be a normal case, but we still account for it but then attempt to access the 0th index a couple lines later.