### PR TITLE
Fixing BoundsControl auto-flatten and scale handle orientation

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -564,6 +564,21 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         private Vector3[] boundsCorners = new Vector3[8];
         public Vector3[] BoundsCorners { get; private set; }
 
+        // Current actual flattening axis, derived from FlattenAuto, if set
+        private FlattenModeType actualFlattenAxis {
+            get
+            {
+                if(FlattenAxis == FlattenModeType.FlattenAuto)
+                {
+                    return VisualUtils.DetermineAxisToFlatten(TargetBounds.bounds.extents);
+                }
+                else
+                {
+                    return FlattenAxis;
+                }
+            }
+        }
+
         #endregion
 
         #region public Properties
@@ -721,8 +736,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
 
         private void OnEnable()
         {
-            SetActivationFlags();
             CreateRig();
+            SetActivationFlags();
             CaptureInitialState();
         }
 
@@ -1235,16 +1250,15 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     // If non-uniform scaling or uniform scaling only on the non-flattened axes
                     if (ScaleHandlesConfig.ScaleBehavior != HandleScaleMode.Uniform || !UniformScaleOnFlattenedAxis)
                     {
-                        FlattenModeType determinedType = FlattenAxis == FlattenModeType.FlattenAuto ? VisualUtils.DetermineAxisToFlatten(TargetBounds.bounds.extents) : FlattenAxis;
-                        if (determinedType == FlattenModeType.FlattenX)
+                        if (actualFlattenAxis == FlattenModeType.FlattenX)
                         {
                             scaleFactor.x = 1;
                         }
-                        if (determinedType == FlattenModeType.FlattenY)
+                        if (actualFlattenAxis == FlattenModeType.FlattenY)
                         {
                             scaleFactor.y = 1;
                         }
-                        if (determinedType == FlattenModeType.FlattenZ)
+                        if (actualFlattenAxis == FlattenModeType.FlattenZ)
                         {
                             scaleFactor.z = 1;
                         }
@@ -1476,14 +1490,14 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             }
 
             boxDisplay.Reset(active);
-            boxDisplay.UpdateFlattenAxis(flattenAxis);
+            boxDisplay.UpdateFlattenAxis(actualFlattenAxis);
 
             bool isVisible = (active == true && wireframeOnly == false);
 
-            rotationHandles.Reset(isVisible, flattenAxis);
-            links.Reset(active, flattenAxis);
-            scaleHandles.Reset(isVisible, flattenAxis);
-            translationHandles.Reset(isVisible, flattenAxis);
+            rotationHandles.Reset(isVisible, actualFlattenAxis);
+            links.Reset(active, actualFlattenAxis);
+            scaleHandles.Reset(isVisible, actualFlattenAxis);
+            translationHandles.Reset(isVisible, actualFlattenAxis);
         }
 
         private void CreateVisuals()
@@ -1543,7 +1557,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 translationHandles.CalculateHandlePositions(ref boundsCorners);
                 scaleHandles.CalculateHandlePositions(ref boundsCorners);
 
-                boxDisplay.UpdateDisplay(currentBoundsExtents, flattenAxis);
+                boxDisplay.UpdateDisplay(currentBoundsExtents, actualFlattenAxis);
 
                 // move rig into position and rotation
                 rigRoot.position = TargetBounds.bounds.center;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -1250,15 +1250,16 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     // If non-uniform scaling or uniform scaling only on the non-flattened axes
                     if (ScaleHandlesConfig.ScaleBehavior != HandleScaleMode.Uniform || !UniformScaleOnFlattenedAxis)
                     {
-                        if (ActualFlattenAxis == FlattenModeType.FlattenX)
+                        var currentActualFlattenAxis = ActualFlattenAxis; // Calculate flatten axis once
+                        if (currentActualFlattenAxis == FlattenModeType.FlattenX)
                         {
                             scaleFactor.x = 1;
                         }
-                        if (ActualFlattenAxis == FlattenModeType.FlattenY)
+                        if (currentActualFlattenAxis == FlattenModeType.FlattenY)
                         {
                             scaleFactor.y = 1;
                         }
-                        if (ActualFlattenAxis == FlattenModeType.FlattenZ)
+                        if (currentActualFlattenAxis == FlattenModeType.FlattenZ)
                         {
                             scaleFactor.z = 1;
                         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -565,7 +565,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         public Vector3[] BoundsCorners { get; private set; }
 
         // Current actual flattening axis, derived from FlattenAuto, if set
-        private FlattenModeType actualFlattenAxis {
+        private FlattenModeType ActualFlattenAxis {
             get
             {
                 if(FlattenAxis == FlattenModeType.FlattenAuto)
@@ -1250,15 +1250,15 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     // If non-uniform scaling or uniform scaling only on the non-flattened axes
                     if (ScaleHandlesConfig.ScaleBehavior != HandleScaleMode.Uniform || !UniformScaleOnFlattenedAxis)
                     {
-                        if (actualFlattenAxis == FlattenModeType.FlattenX)
+                        if (ActualFlattenAxis == FlattenModeType.FlattenX)
                         {
                             scaleFactor.x = 1;
                         }
-                        if (actualFlattenAxis == FlattenModeType.FlattenY)
+                        if (ActualFlattenAxis == FlattenModeType.FlattenY)
                         {
                             scaleFactor.y = 1;
                         }
-                        if (actualFlattenAxis == FlattenModeType.FlattenZ)
+                        if (ActualFlattenAxis == FlattenModeType.FlattenZ)
                         {
                             scaleFactor.z = 1;
                         }
@@ -1490,14 +1490,14 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             }
 
             boxDisplay.Reset(active);
-            boxDisplay.UpdateFlattenAxis(actualFlattenAxis);
+            boxDisplay.UpdateFlattenAxis(ActualFlattenAxis);
 
             bool isVisible = (active == true && wireframeOnly == false);
 
-            rotationHandles.Reset(isVisible, actualFlattenAxis);
-            links.Reset(active, actualFlattenAxis);
-            scaleHandles.Reset(isVisible, actualFlattenAxis);
-            translationHandles.Reset(isVisible, actualFlattenAxis);
+            rotationHandles.Reset(isVisible, ActualFlattenAxis);
+            links.Reset(active, ActualFlattenAxis);
+            scaleHandles.Reset(isVisible, ActualFlattenAxis);
+            translationHandles.Reset(isVisible, ActualFlattenAxis);
         }
 
         private void CreateVisuals()
@@ -1557,7 +1557,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 translationHandles.CalculateHandlePositions(ref boundsCorners);
                 scaleHandles.CalculateHandlePositions(ref boundsCorners);
 
-                boxDisplay.UpdateDisplay(currentBoundsExtents, actualFlattenAxis);
+                boxDisplay.UpdateDisplay(currentBoundsExtents, ActualFlattenAxis);
 
                 // move rig into position and rotation
                 rigRoot.position = TargetBounds.bounds.center;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
@@ -16,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         protected override HandlesBaseConfiguration BaseConfig => config;
         private ScaleHandlesConfiguration config;
         private bool areHandlesFlattened = false;
+        private FlattenModeType currentFlattenAxis = FlattenModeType.DoNotFlatten;
 
         /// <summary>
         /// Cached handle positions - we keep track of handle positions in this array
@@ -171,16 +172,9 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             handleVisual.transform.localPosition = Vector3.zero;
             handleVisual.transform.localRotation = Quaternion.identity;
 
-            if (isFlattened)
-            {
-                // Rotate 2D slate handle asset for proper orientation
-                parent.transform.Rotate(0, 0, -90);
-            }
-            else
-            {
-                Quaternion realignment = GetRotationRealignment(handleIndex);
-                parent.transform.localRotation = realignment;
-            }
+            
+            Quaternion realignment = GetRotationRealignment(handleIndex, isFlattened);
+            parent.transform.localRotation = realignment;
 
             if(config.HandleMaterial != null)
             {
@@ -190,7 +184,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             return handleVisualBounds;
         }
 
-        protected Quaternion GetRotationRealignment(int handleIndex)
+        protected Quaternion GetRotationRealignment(int handleIndex, bool isFlattened)
         {
             // Helper lambda to sign a vector.
             Vector3 signVector(Vector3 i) => new Vector3(Mathf.Sign(i.x), Mathf.Sign(i.y), Mathf.Sign(i.z));
@@ -200,14 +194,44 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             Vector3 neutralHandle = signVector(HandlePositions[6]);
             Vector3 handlePos = signVector(HandlePositions[handleIndex]);
 
-            // Flip the handle if it's on the underside of the bounds.
-            Quaternion flip = Quaternion.Euler(0, 0, handlePos.y > 0 ? 0 : 90);
+            if(isFlattened)
+            {
+                Vector3 axis = Vector3.forward;
+                switch(currentFlattenAxis)
+                {
+                    case FlattenModeType.FlattenAuto:
+                        Debug.LogError("ScaleHandles should never receive FlattenAuto. BoundsControl should pass actualFlattenAxis");
+                        break;
+                    case FlattenModeType.FlattenX:
+                        axis = Vector3.right;
+                        break;
+                    case FlattenModeType.FlattenY:
+                        axis = -Vector3.up;
+                        break;
+                    case FlattenModeType.FlattenZ:
+                        axis = Vector3.forward;
+                        break;
+                }
 
-            float angleAroundVertical = Vector3.SignedAngle(new Vector3(neutralHandle.x, 0, neutralHandle.z),
-                                                            new Vector3(handlePos.x, 0, handlePos.z),
-                                                            Vector3.up);
+                Vector3 neutralProjected = Vector3.ProjectOnPlane(neutralHandle, axis);
+                Vector3 handleProjected = Vector3.ProjectOnPlane(handlePos, axis);
 
-            return Quaternion.Euler(0, angleAroundVertical, 0) * flip;
+                float angleAroundAxis = Vector3.SignedAngle(neutralProjected,
+                                                                handleProjected,
+                                                                axis);
+
+                return Quaternion.AngleAxis(angleAroundAxis, axis) * Quaternion.LookRotation(axis, Vector3.up);
+            }
+            else
+            {
+                // Flip the handle if it's on the underside of the bounds.
+                Quaternion flip = Quaternion.Euler(0, 0, handlePos.y > 0 ? 0 : 90);
+
+                float angleAroundVertical = Vector3.SignedAngle(new Vector3(neutralHandle.x, 0, neutralHandle.z),
+                                                                new Vector3(handlePos.x, 0, handlePos.z),
+                                                                Vector3.up);
+                return Quaternion.Euler(0, angleAroundVertical, 0) * flip;
+            }   
         }
 
         internal void Reset(bool areHandlesActive, FlattenModeType flattenAxis)
@@ -215,6 +239,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             IsActive = areHandlesActive;
             ResetHandles();
             bool isFlattened = flattenAxis != FlattenModeType.DoNotFlatten;
+            currentFlattenAxis = flattenAxis;
             if (areHandlesFlattened != isFlattened)
             {
                 areHandlesFlattened = isFlattened;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/ScaleHandles.cs
@@ -200,7 +200,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 switch(currentFlattenAxis)
                 {
                     case FlattenModeType.FlattenAuto:
-                        Debug.LogError("ScaleHandles should never receive FlattenAuto. BoundsControl should pass actualFlattenAxis");
+                        Debug.LogError("ScaleHandles should never receive FlattenAuto. BoundsControl should pass ActualFlattenAxis");
                         break;
                     case FlattenModeType.FlattenX:
                         axis = Vector3.right;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/VisualUtils.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/Visuals/VisualUtils.cs
@@ -262,6 +262,9 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
         /// <returns>Flattened indices.</returns>
         internal static List<int> GetFlattenedIndices(FlattenModeType flattenAxis, CardinalAxisType[] axisArray)
         {
+            Debug.Assert(flattenAxis != FlattenModeType.FlattenAuto,
+                         "FlattenAuto passed to GetFlattenedIndices. Resolve FlattenAuto into an actual axis before calling.");
+                         
             List<int> flattenedIndices = new List<int>();
             for (int i = 0; i < axisArray.Length; ++i)
             {

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -2035,6 +2035,45 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test for verifying that per axis handles are properly switched off/on when
+        /// FlattenAuto mode is used.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator FlattenAutoTest([ValueSource("perAxisHandleTestData")] PerAxisHandleTestData testData)
+        {
+            // test flatten mode of per axis handle
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            boundsControl.TranslationHandlesConfig.ShowHandleForX = true; // make sure translation handle test handle is enabled for per axis tests
+
+            // Make cube very flat on X axis.
+            boundsControl.transform.localScale = new Vector3(0.01f, 1f, 1f);
+            boundsControl.HideElementsInInspector = false;
+
+            // cache rig root for verifying that we're not recreating the rig on config changes
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+
+            // get handle and make sure it's active per default
+            Transform handle = rigRoot.transform.Find(testData.handleName + "_0");
+            Assert.IsNotNull(handle, "couldn't find handle");
+            Assert.IsTrue(handle.gameObject.activeSelf, "handle wasn't enabled by default");
+
+            // Set FlattenModeType to FlattenAuto
+            boundsControl.FlattenAxis = FlattenModeType.FlattenAuto;
+
+            Assert.IsFalse(handle.gameObject.activeSelf, "handle wasn't disabled when FlattenAuto was used");
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+
+            // unflatten the control again and make sure handle gets activated accordingly
+            boundsControl.FlattenAxis = FlattenModeType.DoNotFlatten;
+            Assert.IsTrue(handle.gameObject.activeSelf, "handle wasn't enabled on unflatten");
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+
+            yield return null;
+        }
+
+        /// <summary>
         /// Test for verifying changing the per axis handle prefabs during runtime 
         /// and making sure the entire rig won't be recreated
         /// </summary>


### PR DESCRIPTION
## Overview
Since a while ago (at least 2.6.x) BoundsControl's `FlattenAuto` mode has been broken, such that per-axis handles are not properly disabling themselves when flattened. This has resulted in "doubled up" handles, where there are rotation handles "inside" scale handles, causing inconsistent manipulations.

This was the result of FlattenAuto being passed as the "current flattening axis" to the per-axis handles, which actually need a proper axis in order to determine which handles to disable. When "FlattenAuto" was passed instead of an actual axis, the handles did not know what to do, and as a result did not actually disable any handles.

This is because the per-axis handles used `VisualUtils.GetFlattenedIndices`, which, when given `FlattenAuto` as the axis, would simply not return any flattened indices.

**This was not caught by automated testing. There was a test coverage gap, as `FlattenAuto` was never tested in any BoundsControl test.** A new test is added that verifies per-axis handle flattening behavior when `FlattenAuto` is set.

The main fix is in the form of a new property, `actualFlattenedAxis`, which has a getter that evaluates the `FlattenAuto` policy against the current target bounds, and returns the actual flattened axis which can be fed to any handle, visual, or any other dependency. 

This PR also fixes a small issue with the scale handles not being properly rotated for slates.

## Changes
- Adds `actualFlattenedAxis` getter to `BoundsControl` which resolves the actual flattened axis from a `FlattenAuto` policy at get-time
- `BoundsControl` now passes `actualFlattenedAxis` to all dependent visuals and handles
- `ScaleHandles` now properly calculates handle realignment for flattened/slate scenarios
- Order of BoundsControl init calls is edited; `CreateRig` is now called before `SetActivationFlags`. This allows the target bounds to be determined before activation flags/events are triggered, which is necessary to avoid handle rebuilding before the target bounds have been calculated (and therefore a sticky situation where handles were trying to re-flatten against a target bounds that did not yet exist!)
- New test is added to resolve gap in test coverage.
- Fixes #10009

## Verification
A new test has been added that checks per-axis handle behaviors when `FlattenAuto` is used and the target object has been shrunk on one axis.
