### PR TITLE
Turn off mergetool

### DIFF
--- a/pipelines/mergetool.yml
+++ b/pipelines/mergetool.yml
@@ -2,11 +2,12 @@
 
 schedules:
 # Cron schedules use UTC time. This is 2pm UTC on every weekday.
-- cron: 0 14 * * 1,2,3,4,5
-  branches:
-    include:
-    - main
-  always: true
+# Uncomment the following lines and update sourceBranch below when mergetool is needed again.
+# - cron: 0 14 * * 1,2,3,4,5
+#   branches:
+#     include:
+#     - main
+#   always: true
 
 pr: none
 trigger: none


### PR DESCRIPTION
## Overview

Now that 2.7.0 stabilization is over, this isn't currently needed.