### PR TITLE
Logging and SpatialAwarenessSurfaceTypes fix for Scene Understanding

### DIFF
--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs
@@ -43,8 +43,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// </remarks>
         Platform = 1 << 4,
 
-        // Insert additional surface types here.
-
         /// <summary>
         /// A surface that does not fit one of the defined surface types.
         /// </summary>
@@ -53,16 +51,16 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <para>Background should not be confused with Unknown. There is sufficient data to 
         /// classify the surface and it has been found to not correspond to a defined type.</para>
         /// </remarks>
-        Background = 1 << 29,
+        Background = 1 << 5,
 
         /// <summary>
         /// A boundless world mesh.
         /// </summary>
-        World = 1 << 30,
+        World = 1 << 6,
 
         /// <summary>
         /// Objects for which we have no observations
         /// </summary>
-        Inferred = 1 << 31
+        Inferred = 1 << 7
     }
 }

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
@@ -1321,13 +1321,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
         /// </summary>
         private void CleanupInstantiatedSceneObjects()
         {
-            if (observedObjectParent != null)
+            if (ObservedObjectParent != null)
             {
-                int kidCount = observedObjectParent.transform.childCount;
+                int kidCount = ObservedObjectParent.transform.childCount;
 
                 for (int i = 0; i < kidCount; ++i)
                 {
-                    UnityEngine.Object.Destroy(observedObjectParent.transform.GetChild(i).gameObject);
+                    UnityEngine.Object.Destroy(ObservedObjectParent.transform.GetChild(i).gameObject);
                 }
             }
         }

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
@@ -166,7 +166,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
             // Terminate the background thread when we stop in editor.
             cancelToken = cancelTokenSource.Token;
 
-            task = Task.Run(() => RunObserverAsync(cancelToken));
+            task = Task.Run(() => RunObserverAsync(cancelToken)).ContinueWith(t =>
+            {
+                Debug.LogError($"{t.Exception.InnerException.GetType().Name}: {t.Exception.InnerException.Message} {t.Exception.InnerException.StackTrace}");
+            }, TaskContinuationOptions.OnlyOnFaulted);
 #else
             IsEnabled = false;
 #endif // SCENE_UNDERSTANDING_PRESENT && UNITY_WSA
@@ -180,7 +183,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
             if (instantiationQueue.Count > 0)
             {
                 // Make our new objects in batches and tell observers about it
-                int batchCount = Math.Min(InstantiationBatchRate, instantiationQueue.Count);
+                int batchCount = CreateGameObjects ? Math.Min(InstantiationBatchRate, instantiationQueue.Count) : instantiationQueue.Count;
 
                 for (int i = 0; i < batchCount; ++i)
                 {
@@ -313,7 +316,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
         public void SaveScene(string filenamePrefix)
         {
 #if WINDOWS_UWP && SCENE_UNDERSTANDING_PRESENT
-            Task.Run(() => SaveToFile(filenamePrefix));
+            Task.Run(() => SaveToFile(filenamePrefix)).ContinueWith(t =>
+            {
+                Debug.LogError($"{t.Exception.InnerException.GetType().Name}: {t.Exception.InnerException.Message} {t.Exception.InnerException.StackTrace}");
+            }, TaskContinuationOptions.OnlyOnFaulted);
 #else // WINDOWS_UWP && SCENE_UNDERSTANDING_PRESENT
             Debug.LogWarning("SaveScene() only supported at runtime! Ignoring request.");
 #endif // WINDOWS_UWP && SCENE_UNDERSTANDING_PRESENT
@@ -660,7 +666,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
 
                     case ObserverState.GetScene:
                         observerState = ObserverState.Working;
-                        if (CreateGameObjects && instantiationQueue.Count > 0)
+                        while (CreateGameObjects && instantiationQueue.Count > 0)
                         {
                             await new WaitForUpdate();
                         }


### PR DESCRIPTION
## Overview
This PR fixes the issue of the set surface types in the SU profile does not correctly translate into matching behavior due to the way the enum was setup. Also added logging when the SU observer's task fails.

## Changes
- Fixes: #9987