### PR TITLE
Fixing protection level

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/ConstraintExecOrderComparer.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/ConstraintExecOrderComparer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// Returns > 0 if y should be executed first.
         /// Returns = 0 if they are of equivalent execution priority.
         /// </returns>	
-        internal virtual int Compare(TransformConstraint x, TransformConstraint y)
+        public virtual int Compare(TransformConstraint x, TransformConstraint y)
         {
             return x.ExecutionPriority - y.ExecutionPriority;
         }


### PR DESCRIPTION
## Overview
CI didn't run on the last commit on the constraints priority PR. Accidentally changed the protection level on the IComparer implementation, causing compilation issues.

## Changes
- Changes IComparer.Compare implementation to public, instead of internal. Class is still internal.