### PR TITLE
Add standalone define directive to Leap example scene script

### DIFF
--- a/Assets/MRTK/Examples/Demos/HandTracking/Scripts/LeapMotionOrientationDisplay.cs
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scripts/LeapMotionOrientationDisplay.cs
@@ -4,7 +4,7 @@
 using UnityEngine;
 using Microsoft.MixedReality.Toolkit.Input;
 using TMPro;
-#if LEAPMOTIONCORE_PRESENT
+#if LEAPMOTIONCORE_PRESENT && UNITY_STANDALONE
 using Microsoft.MixedReality.Toolkit.LeapMotion.Input;
 #endif
 
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
     /// </summary>
     public class LeapMotionOrientationDisplay : MonoBehaviour
     {
-#if LEAPMOTIONCORE_PRESENT
+#if LEAPMOTIONCORE_PRESENT && UNITY_STANDALONE
         [SerializeField]
         private TextMeshProUGUI orientationText;
         private LeapMotionDeviceManagerProfile managerProfile;

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scripts/LeapMotionOrientationDisplay.cs
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scripts/LeapMotionOrientationDisplay.cs
@@ -4,7 +4,7 @@
 using UnityEngine;
 using Microsoft.MixedReality.Toolkit.Input;
 using TMPro;
-#if LEAPMOTIONCORE_PRESENT && UNITY_STANDALONE
+#if (LEAPMOTIONCORE_PRESENT && UNITY_STANDALONE) || (LEAPMOTIONCORE_PRESENT && UNITY_WSA && UNITY_EDITOR)
 using Microsoft.MixedReality.Toolkit.LeapMotion.Input;
 #endif
 
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
     /// </summary>
     public class LeapMotionOrientationDisplay : MonoBehaviour
     {
-#if LEAPMOTIONCORE_PRESENT && UNITY_STANDALONE
+#if (LEAPMOTIONCORE_PRESENT && UNITY_STANDALONE) || (LEAPMOTIONCORE_PRESENT && UNITY_WSA && UNITY_EDITOR)
         [SerializeField]
         private TextMeshProUGUI orientationText;
         private LeapMotionDeviceManagerProfile managerProfile;


### PR DESCRIPTION
## Overview

Enforces the standalone platform on the LeapMotionOrientationDisplay.cs example script.  If a user is on the UWP platform and tries to build with leap motion provider enabled, the following issues are logged:

![image](https://user-images.githubusercontent.com/53493796/123493288-d8137600-d5d0-11eb-82aa-df2bf48389fd.png)
 
The Leap Motion data provider is only supported in standalone builds, but is enabled for in-editor use while on UWP. 

This issue was raised on the docs repo: https://github.com/MicrosoftDocs/mixed-reality/issues/363
