### PR TITLE
Add ClearProgressBar call to fix Build Window freeze on Unity 2020

### DIFF
--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
@@ -132,6 +132,8 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             // Call the post-build action, if any
             buildInfo.PostBuildAction?.Invoke(buildInfo, buildReport);
 
+            EditorUtility.ClearProgressBar();
+
             return buildReport;
         }
 


### PR DESCRIPTION
## Overview

Unity made some fixes to harden the requirement to call `EditorUtility.ClearProgressBar()` after calling `EditorUtility.DisplayProgressBar`, which ended up causing us to end up in an infinite loop. Adding this call resolves it.

Tested in Unity 2020.3.13f1

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9723
