### PR TITLE
Update serialization for font assets

### DIFF
--- a/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/segoeui SDF_zwrite_off.asset
+++ b/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/segoeui SDF_zwrite_off.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: segoeui SDF
+  m_Name: segoeui SDF_zwrite_off
   m_EditorClassIdentifier: 
   hashCode: -1937467786
   material: {fileID: 21340371490990018}

--- a/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/segoeuib SDF_zwrite_off.asset
+++ b/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/segoeuib SDF_zwrite_off.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: segoeuib SDF
+  m_Name: segoeuib SDF_zwrite_off
   m_EditorClassIdentifier: 
   hashCode: 406046580
   material: {fileID: 21433621844796372}

--- a/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/segoeuil SDF_zwrite_off.asset
+++ b/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/segoeuil SDF_zwrite_off.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: segoeuil SDF
+  m_Name: segoeuil SDF_zwrite_off
   m_EditorClassIdentifier: 
   hashCode: 413153786
   material: {fileID: 21184075213967186}

--- a/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/segoeuisl SDF_zwrite_off.asset
+++ b/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/segoeuisl SDF_zwrite_off.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: segoeuisl SDF
+  m_Name: segoeuisl SDF_zwrite_off
   m_EditorClassIdentifier: 
   hashCode: 1253993545
   material: {fileID: 21150606767620462}

--- a/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/seguibl SDF_zwrite_off.asset
+++ b/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/seguibl SDF_zwrite_off.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: seguibl SDF
+  m_Name: seguibl SDF_zwrite_off
   m_EditorClassIdentifier: 
   hashCode: -590888814
   material: {fileID: 21676655947040158}

--- a/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/seguisb SDF_zwrite_off.asset
+++ b/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOff/seguisb SDF_zwrite_off.asset
@@ -10,9 +10,9 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: seguisb SDF
+  m_Name: seguisb SDF_zwrite_off
   m_EditorClassIdentifier: 
-  hashCode: -1538538459
+  hashCode: -219588947
   material: {fileID: 21202819797275496}
   materialHashCode: -1061388922
   m_Version: 1.1.0

--- a/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOn/segoeuisl SDF.asset
+++ b/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOn/segoeuisl SDF.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: segoeuisl SDF 1
+  m_Name: segoeuisl SDF
   m_EditorClassIdentifier: 
   hashCode: 1253993545
   material: {fileID: 21150606767620462}

--- a/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOn/seguibl SDF.asset
+++ b/Assets/MRTK/StandardAssets/FontsSDFTextures/DepthWriteOn/seguibl SDF.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: seguibl SDF 1
+  m_Name: seguibl SDF
   m_EditorClassIdentifier: 
   hashCode: -590888814
   material: {fileID: 21676655947040158}


### PR DESCRIPTION
## Overview

Unity keeps reimporting and reserializing these assets, so their serialized names match their file names. This PR gets them in the state Unity appears to require.