### PR TITLE
Oculus visualization now integrated with MRTK

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
@@ -230,15 +230,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 {
                     EditorGUILayout.HelpBox("A controller type must be defined!", MessageType.Error);
                 }
-                else
-                {
-                    // Only check for Oculus if we already know the type is valid (otherwise, null ref)
-                    bool isOculusType = controllerType.Type.FullName.Contains("OculusXRSDKTouchController");
-                    if (isOculusType)
-                    {
-                        EditorGUILayout.HelpBox("Oculus Touch controller model visualization is not managed by MRTK, refer to the Oculus XRSDK Device Manager to configure controller visualization settings", MessageType.Error);
-                    }
-                }
 
                 var handednessValue = mixedRealityControllerHandedness.intValue - 1;
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -8,6 +8,8 @@ using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR;
 using System;
+using System.Threading.Tasks;
+using System.Threading;
 
 #if OCULUS_ENABLED
 using Unity.XR.Oculus;
@@ -32,6 +34,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions, new OculusTouchControllerDefinition(controllerHandedness))
         { }
+
+        public GameObject OculusControllerVisualization;
 
         private static readonly ProfilerMarker UpdateButtonDataPerfMarker = new ProfilerMarker("[MRTK] OculusXRSDKController.UpdateButtonData");
 
@@ -91,25 +95,58 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             }
         }
 
-        /// <summary>
-        /// Determines whether or not this controller is using MRTK for controller visualization
-        /// 
-        /// When false, the Oculus Touch controller model visualization will not be managed by MRTK
-        /// Ensure that the Oculus Integration Package is installed and the Ovr Camera Rig is set correctly in the Oculus XRSDK Device Manager to use the
-        /// Oculus Integration Package's visualization
-        /// </summary>
-        internal bool UseMRTKControllerVisualization
+        /// <inheritdoc />
+        protected override bool TryRenderControllerModel(System.Type controllerType, InputSourceType inputSourceType)
         {
-            get
+            if (GetControllerVisualizationProfile() != null && 
+                GetControllerVisualizationProfile().GetUsePlatformModelsOverride(GetType(), ControllerHandedness))
             {
-                return Visualizer != null && Visualizer.GameObjectProxy != null && Visualizer.GameObjectProxy.activeSelf;
+               TryRenderControllerModelFromOculus();
+               return true;
             }
-            set
+            else
             {
-                if(Visualizer != null && Visualizer.GameObjectProxy)
+                return base.TryRenderControllerModel(controllerType, inputSourceType);
+            }
+        }
+
+        private async void TryRenderControllerModelFromOculus()
+        {
+            await WaitForOculusVisuals();
+
+            if (this != null)
+            {
+                if (OculusControllerVisualization != null
+                    && MixedRealityControllerModelHelpers.TryAddVisualizationScript(OculusControllerVisualization, GetType(), ControllerHandedness)
+                    && TryAddControllerModelToSceneHierarchy(OculusControllerVisualization))
                 {
-                    Visualizer.GameObjectProxy.SetActive(value);
+                    OculusControllerVisualization.SetActive(true);
+                    return;
                 }
+
+                Debug.LogWarning("Failed to obtain Oculus controller model; defaulting to BaseController behavior.");
+                base.TryRenderControllerModel(GetType(), InputSource.SourceType);
+            }
+        }
+
+        private const int controllerInitializationTimeout = 1000;
+        private async Task WaitForOculusVisuals()
+        {
+            int timeWaited = 0;
+            while (OculusControllerVisualization == null || timeWaited > controllerInitializationTimeout)
+            {
+                await Task.Delay(100);
+                timeWaited += 100;
+            }
+        }
+
+        internal void RegisterControllerVisualization(GameObject visualization)
+        {
+            OculusControllerVisualization = visualization;
+            if (GetControllerVisualizationProfile() != null &&
+                !GetControllerVisualizationProfile().GetUsePlatformModelsOverride(GetType(), ControllerHandedness))
+            {
+                OculusControllerVisualization.SetActive(false);
             }
         }
     }

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             : base(trackingState, controllerHandedness, inputSource, interactions, new OculusTouchControllerDefinition(controllerHandedness))
         { }
 
-        public GameObject OculusControllerVisualization;
+        internal GameObject OculusControllerVisualization;
 
         private static readonly ProfilerMarker UpdateButtonDataPerfMarker = new ProfilerMarker("[MRTK] OculusXRSDKController.UpdateButtonData");
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             : base(trackingState, controllerHandedness, inputSource, interactions, new OculusTouchControllerDefinition(controllerHandedness))
         { }
 
-        internal GameObject OculusControllerVisualization;
+        internal GameObject OculusControllerVisualization { get; private set; }
 
         private static readonly ProfilerMarker UpdateButtonDataPerfMarker = new ProfilerMarker("[MRTK] OculusXRSDKController.UpdateButtonData");
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -97,27 +97,21 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
         {
             GenericXRSDKController controller = base.GetOrAddController(inputDevice);
 
-            if (controller is OculusXRSDKTouchController oculusTouchController)
+            if (!cameraRig.IsNull() && controller is OculusXRSDKTouchController oculusTouchController && oculusTouchController.OculusControllerVisualization == null)
             {
-                if (!cameraRig.IsNull())
+                GameObject platformVisualization = null; 
+                if (oculusTouchController.ControllerHandedness == Handedness.Left)
                 {
-                    if(oculusTouchController.OculusControllerVisualization == null)
-                    {
-                        GameObject platformVisualization = null; 
-                        if (oculusTouchController.ControllerHandedness == Handedness.Left)
-                        {
-                            platformVisualization = leftControllerHelper.gameObject;
-                        }
-                        if (oculusTouchController.ControllerHandedness == Handedness.Right)
-                        {
-                            platformVisualization = rightControllerHelper.gameObject;
-                        }
+                    platformVisualization = leftControllerHelper.gameObject;
+                }
+                if (oculusTouchController.ControllerHandedness == Handedness.Right)
+                {
+                    platformVisualization = rightControllerHelper.gameObject;
+                }
 
-                        if(platformVisualization != null)
-                        {
-                            oculusTouchController.RegisterControllerVisualization(platformVisualization);
-                        }
-                    }
+                if(platformVisualization != null)
+                {
+                    oculusTouchController.RegisterControllerVisualization(platformVisualization);
                 }
             }
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -14,7 +14,6 @@ using Unity.XR.Oculus;
 
 #if OCULUSINTEGRATION_PRESENT
 using System.Collections.Generic;
-using UnityEngine;
 #endif // OCULUSINTEGRATION_PRESENT
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
@@ -58,6 +57,8 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
         private readonly Dictionary<Handedness, OculusHand> trackedHands = new Dictionary<Handedness, OculusHand>();
 
         private OVRCameraRig cameraRig;
+        private OVRControllerHelper leftControllerHelper;
+        private OVRControllerHelper rightControllerHelper;
 
         private OVRHand rightHand;
         private OVRSkeleton rightSkeleton;
@@ -95,9 +96,29 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
         protected override GenericXRSDKController GetOrAddController(InputDevice inputDevice)
         {
             GenericXRSDKController controller = base.GetOrAddController(inputDevice);
+
             if (controller is OculusXRSDKTouchController oculusTouchController)
             {
-                oculusTouchController.UseMRTKControllerVisualization = cameraRig.IsNull();
+                if (!cameraRig.IsNull())
+                {
+                    if(oculusTouchController.OculusControllerVisualization == null)
+                    {
+                        GameObject platformVisualization = null; 
+                        if (oculusTouchController.ControllerHandedness == Handedness.Left)
+                        {
+                            platformVisualization = leftControllerHelper.gameObject;
+                        }
+                        if (oculusTouchController.ControllerHandedness == Handedness.Right)
+                        {
+                            platformVisualization = rightControllerHelper.gameObject;
+                        }
+
+                        if(platformVisualization != null)
+                        {
+                            oculusTouchController.RegisterControllerVisualization(platformVisualization);
+                        }
+                    }
+                }
             }
 
             return controller;
@@ -248,21 +269,31 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
                 cameraRig.EnsureGameObjectIntegrity();
             }
 
-            bool useAvatarHands = SettingsProfile.RenderAvatarHandsInsteadOfController;
-            // If using Avatar hands, deactivate ovr controller rendering
-            foreach (var controllerHelper in cameraRig.gameObject.GetComponentsInChildren<OVRControllerHelper>())
-            {
-                controllerHelper.gameObject.SetActive(!useAvatarHands);
-            }
-
+            bool useAvatarHands = SettingsProfile.RenderAvatarHandsWithControllers;
+            // If using Avatar hands, initialize the local avatar controller
             if (useAvatarHands)
             {
-                // Initialize the local avatar controller
                 GameObject.Instantiate(SettingsProfile.LocalAvatarPrefab, cameraRig.trackingSpace);
             }
 
-            var ovrHands = cameraRig.GetComponentsInChildren<OVRHand>();
 
+            var ovrControllerHelpers = cameraRig.GetComponentsInChildren<OVRControllerHelper>();
+            foreach (var ovrControllerHelper in ovrControllerHelpers)
+            {
+                switch (ovrControllerHelper.m_controller)
+                {
+                    case OVRInput.Controller.LTouch:
+                        leftControllerHelper = ovrControllerHelper;
+                        break;
+                    case OVRInput.Controller.RTouch:
+                        rightControllerHelper = ovrControllerHelper;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            var ovrHands = cameraRig.GetComponentsInChildren<OVRHand>();
             foreach (var ovrHand in ovrHands)
             {
                 // Manage Hand skeleton data

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManagerProfile.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManagerProfile.cs
@@ -29,7 +29,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
 {
@@ -60,15 +62,23 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
 
 
         [SerializeField]
+        [FormerlySerializedAs("renderAvatarHandsInsteadOfControllers")]
         [Tooltip("Using avatar hands requires a local avatar prefab. Failure to provide one will result in nothing being displayed. \n\n" +
          "Note: In order to render avatar hands, you will need to set an app id in Assets/Resources/OvrAvatarSettings. Any number will do, but it needs to be set.")]
-        private bool renderAvatarHandsInsteadOfControllers = true;
+        private bool renderAvatarHandsWithControllers = true;
 
         /// <summary>
         /// Using avatar hands requires a local avatar prefab. Failure to provide one will result in nothing being displayed.
         /// "Note: In order to render avatar hands, you will need to set an app id in Assets/Resources/OvrAvatarSettings. Any number will do, but it needs to be set.")]
         /// </summary>
-        public bool RenderAvatarHandsInsteadOfController => renderAvatarHandsInsteadOfControllers;
+        [Obsolete("Use RenderAvatarHandsWithControllers instead")]
+        public bool RenderAvatarHandsInsteadOfController => renderAvatarHandsWithControllers;
+
+        /// <summary>
+        /// Using avatar hands requires a local avatar prefab. Failure to provide one will result in nothing being displayed.
+        /// "Note: In order to render avatar hands, you will need to set an app id in Assets/Resources/OvrAvatarSettings. Any number will do, but it needs to be set.")]
+        /// </summary>
+        public bool RenderAvatarHandsWithControllers => renderAvatarHandsWithControllers;
 
         [SerializeField]
         [Tooltip("Prefab reference for LocalAvatar to load, if none are found in scene.")]

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Profiles/DefaultOculusXRSDKDeviceManagerProfile.asset
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Profiles/DefaultOculusXRSDKDeviceManagerProfile.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   isCustomProfile: 0
   ovrCameraRigPrefab: {fileID: 2343937678421323989, guid: 69a746aa83d0d0e45b4e2d33eab0fff4,
     type: 3}
-  renderAvatarHandsInsteadOfControllers: 1
+  renderAvatarHandsWithControllers: 0
   localAvatarPrefab: {fileID: 6297684789857299957, guid: 5357c8e6c4495c04f90e97272375c294,
     type: 3}
   minimumHandConfidence: 0


### PR DESCRIPTION
## Overview
Previously Oculus controllers managed their visuals completely separately from MRTK. This PR refactors the Oculus Touch Controllers to use the visualizer in a similar manner as the WMR controllers. For consistency, it also makes it so avatar hands can be rendered at the same time as the controller models, since Oculus's OvrAvatar functionality operates in it's own system and cannot be managed easily by MRTK.

## Changes
- Fixes: #10002
