### PR TITLE
Fixing SurfaceMagnetism quaternion math

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
@@ -388,14 +388,25 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// <returns>Quaternion, the orientation to use for the object</returns>
         private Quaternion CalculateMagnetismOrientation(Vector3 direction, Vector3 surfaceNormal)
         {
+            
+            // Compute the up vector of our current working rotation,
+            // to avoid gimbal lock instability when normal is also pointing upwards.
+            // This "current" up vector is used in the LookRotation, which causes
+            // the derived rotation to fit "closest" to the current up vector.
+            Vector3 currentUpVector = WorkingRotation * Vector3.up;
+
+            Quaternion trackedReferenceRotation = Quaternion.LookRotation(-direction, currentUpVector);
+            Quaternion surfaceReferenceRotation = Quaternion.LookRotation(-surfaceNormal, currentUpVector);
+
+            // If requested, compute FromTo from the current computed Up to global Up,
+            // and apply to the computed quat; this will ensure object stays globally vertical.
             if (KeepOrientationVertical)
             {
-                direction.y = 0;
-                surfaceNormal.y = 0;
+                Vector3 trackedReferenceUp = trackedReferenceRotation * Vector3.up;
+                trackedReferenceRotation = Quaternion.FromToRotation(trackedReferenceUp, Vector3.up) * trackedReferenceRotation;
+                Vector3 surfaceReferenceUp = surfaceReferenceRotation * Vector3.up;
+                surfaceReferenceRotation = Quaternion.FromToRotation(surfaceReferenceUp, Vector3.up) * surfaceReferenceRotation;
             }
-
-            var trackedReferenceRotation = Quaternion.LookRotation(-direction, Vector3.up);
-            var surfaceReferenceRotation = Quaternion.LookRotation(-surfaceNormal, Vector3.up);
 
             switch (CurrentOrientationMode)
             {

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
@@ -388,7 +388,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// <returns>Quaternion, the orientation to use for the object</returns>
         private Quaternion CalculateMagnetismOrientation(Vector3 direction, Vector3 surfaceNormal)
         {
-            
             // Compute the up vector of our current working rotation,
             // to avoid gimbal lock instability when normal is also pointing upwards.
             // This "current" up vector is used in the LookRotation, which causes

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -288,8 +288,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Make sure that the target's right vector has not flip-flopped
             Assert.IsTrue(Mathf.Sign(targetTransform.transform.right.x) == Mathf.Sign(rightVector.x));
-
-
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -220,6 +220,79 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test Surface Magnetism against vertical normal and ensure no temporal instability (gimbal lock)
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestSurfaceMagnetismGimbalLock()
+        {
+            Vector3 floorCenter = Vector3.forward * 10.0f + Vector3.up * -2.0f;
+
+            // Reset view to origin
+            MixedRealityPlayspace.PerformTransformation(p =>
+            {
+                p.position = Vector3.zero;
+                p.LookAt(floorCenter);
+            });
+
+            // Build floor to collide against
+            var floor = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            floor.transform.localScale = new Vector3(25.0f, 0.2f, 25.0f);
+            floor.transform.position = floorCenter;
+
+            // Give the floor a very small tilt
+            floor.transform.rotation = Quaternion.Euler(10, 0, 0);
+            
+            yield return WaitForFrames(2);
+
+            // Instantiate our test GameObject with solver. 
+            // Set layer to ignore raycast so solver doesn't raycast itself (i.e BoxCollider)
+            var testObjects = InstantiateTestSolver<SurfaceMagnetism>();
+            testObjects.target.layer = LayerMask.NameToLayer("Ignore Raycast");
+            SurfaceMagnetism surfaceMag = testObjects.solver as SurfaceMagnetism;
+
+            var targetTransform = testObjects.target.transform;
+            var cameraTransform = CameraCache.Main.transform;
+
+            yield return WaitForFrames(2);
+
+            // Change default orientation mode to surface normal
+            surfaceMag.CurrentOrientationMode = SurfaceMagnetism.OrientationMode.SurfaceNormal;
+            surfaceMag.KeepOrientationVertical = false;
+
+            yield return WaitForFrames(2);
+
+            // Test object should now be facing the floor
+            Assert.IsTrue(Mathf.Approximately(1.0f, Vector3.Dot(-targetTransform.forward.normalized, floor.transform.up)));
+
+            // Cache test object's current right vector
+            Vector3 rightVector = testObjects.target.transform.right;
+
+            floor.transform.Rotate(new Vector3(-20, 0, 0));
+            yield return WaitForFrames(2);
+
+            // Make sure that the target's right vector has not flip-flopped
+            Assert.IsTrue(Mathf.Sign(targetTransform.transform.right.x) == Mathf.Sign(rightVector.x));
+
+            // Do the same, but with KeepOrientationVertical = true
+            surfaceMag.KeepOrientationVertical = true;
+
+            // Cache test object's current right vector
+            rightVector = testObjects.target.transform.right;
+
+            yield return WaitForFrames(2);
+
+            // Test object should now have proper upright orientation
+            Assert.IsTrue(Mathf.Approximately(1.0f, Vector3.Dot(targetTransform.up.normalized, Vector3.up)));
+            floor.transform.Rotate(new Vector3(20, 0, 0));
+            yield return WaitForFrames(2);
+
+            // Make sure that the target's right vector has not flip-flopped
+            Assert.IsTrue(Mathf.Sign(targetTransform.transform.right.x) == Mathf.Sign(rightVector.x));
+
+
+        }
+
+        /// <summary>
         /// Test solver system's ability to change target types at runtime
         /// </summary>
         [UnityTest]


### PR DESCRIPTION
## Overview
Currently, SurfaceMagnetism uses `Vector3.up` as the up vector for all surface normal `Quaternion.LookRotation` calculations. This causes gimbal-lock-like behavior when the surface that is being magnetized to is mostly looking upwards. This manifests in ugly temporal instability when a hologram is magnetized to the floor of the scene reconstruction mesh.

The quaternion math in `SurfaceMagnetism` has been fixed to now use the "best guess" up vector, derived from the current working rotation's up vector. This ensures temporal stability in all cases. Compatibility has been ensured with both modes of `KeepOrientationVertical`, as well as `OrientationMode.TrackedTarget`.

A unit test has been added that verifies the absence of any gimbal locking behavior when a floor-like surface is tilted/updated.

## Changes
- Fixes: #10064.
- Edits the quaternion math in `SurfaceMagnetism` to properly calculate a temporally stable look rotation.
- Adds unit test to verify temporal stability of magnetism.

## Verification
The test should cover #10064's reported incident. @holomatt feel free to clone this PR and verify that your issue is fixed.