### PR TITLE
Changed default pointer extent to make mouse pointer behavior more intuitive

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/MousePointer.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/MousePointer.prefab
@@ -71,7 +71,7 @@ MonoBehaviour:
   requiresActionBeforeEnabling: 1
   overrideGlobalPointerExtent: 0
   pointerExtent: 10
-  defaultPointerExtent: 10
+  defaultPointerExtent: 1
   sphereCastRadius: 0.1
   hideCursorWhenInactive: 1
   movementThresholdToUnHide: 0.5

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ScreenSpaceMousePointer.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ScreenSpaceMousePointer.prefab
@@ -71,7 +71,7 @@ MonoBehaviour:
   requiresActionBeforeEnabling: 1
   overrideGlobalPointerExtent: 0
   pointerExtent: 10
-  defaultPointerExtent: 10
+  defaultPointerExtent: 1
   sphereCastRadius: 0.1
   hideCursorWhenInactive: 1
   movementThresholdToUnHide: 0.1


### PR DESCRIPTION
## Overview
Changes the default pointing extent for the screen space mouse pointer to be much smaller, thus making the mouse pointer interactions with the sliders much more natural and intuitive.

The reason for this change is because a mouse pointer's "position" is determined by the following

Camera Position + mouse pointer forward transform * DefaultPointerExtent.

This means that the mouse pointer's position is always DefaultPointerExtent units away from the camera, which makes the mosue pointer's position in world space change pretty drastically. In the current architecture, it's quite a bit more work to make the mouse pointer's position coincide with the position of it's raycast hit target, so this PR alleviates the high variance issue by decreasing DefaultPointerExtent to a more reasonable value of 1.

Old:
![Mouseold](https://user-images.githubusercontent.com/39840334/125538840-e165e4bb-5b45-4ea0-9f13-30196dd6eaee.gif)

New (There are still some distances where the alignment isn't quite right when sliding):
![MouseNew](https://user-images.githubusercontent.com/39840334/125538833-be9df2d0-e3cf-4f92-947d-da81435746bb.gif)

## Changes
- Fixes: #10071