### PR TITLE
Remove MRSceneContent script from scenes that don't have MRTK in them

### DIFF
--- a/Assets/MRTK/Tools/RuntimeTools/Tools/ControllerMappingTool/ControllerMappingTool.unity
+++ b/Assets/MRTK/Tools/RuntimeTools/Tools/ControllerMappingTool/ControllerMappingTool.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2402,7 +2402,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 808871986}
-  - component: {fileID: 808871987}
   m_Layer: 0
   m_Name: MixedRealitySceneContent
   m_TagString: Untagged
@@ -2428,19 +2427,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &808871987
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 808871985}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c65c9dd2f312b8d41b8849d58e1053fa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  alignmentType: 0
 --- !u!1001 &816478453
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/Tools/RuntimeTools/Tools/InputFeatureUsageTool/InputFeatureUsageTool.unity
+++ b/Assets/MRTK/Tools/RuntimeTools/Tools/InputFeatureUsageTool/InputFeatureUsageTool.unity
@@ -871,7 +871,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1687696869}
-  - component: {fileID: 1687696868}
   m_Layer: 0
   m_Name: MixedRealitySceneContent
   m_TagString: Untagged
@@ -879,19 +878,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1687696868
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687696867}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c65c9dd2f312b8d41b8849d58e1053fa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  alignmentType: 1
 --- !u!4 &1687696869
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Overview

These two tool-based scenes don't have MRTK objects in them (by-design, as they only talk directly to Unity in order to help with mapping various pieces into MRTK), so the MRSceneContent script was failing due to a lack of MRTK.