### PR TITLE
Fixing BoundingBoxHelper.GetRawBoundsCorners protection level

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
@@ -80,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Calculates the untransformed corner points of the given collider bounds
         /// </summary>
         /// <param name="colliderBounds">The collider bounds the corner points are calculated from.</param>
-        internal void GetRawBoundsCorners(BoxCollider colliderBounds)
+        public void GetRawBoundsCorners(BoxCollider colliderBounds)
         {
             targetBounds = colliderBounds;
             rawBoundingCorners.Clear();

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
@@ -70,7 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// This function calculates the untransformed bounding box corner points of a GameObject.
         /// </summary>
-        [Obsolete("Use GetRawBBCorners and pass in TargetBounds")]
+        [Obsolete("Use GetRawBoundsCorners and pass in boundingBox.TargetBounds")]
         public void GetRawBBCorners(BoundingBox boundingBox)
         {
             GetRawBoundsCorners(boundingBox.TargetBounds);


### PR DESCRIPTION
## Overview
When `GetRawBBCorners` was deprecated in favor of `GetRawBoundsCorners`, the protection level of `GetRawBoundsCorners` was not set to public. In addition, the Obsolete warning comment was incorrectly written to refer to the obsolete method, instead of the new one. 

It should be safe to mark this as `public`, as it seems to be the intended behavior (the other methods in this class that replaced their obsolete counterparts are all public, to match their deprecated siblings.)

## Changes
- Fixes: #10083  
- Makes `GetRawBoundsCorners` public, as it is the recommended replacement for a previously-public function.
- Fixes the obsolete warning to refer to the correct method.
