### PR TITLE
Remove support for preview MROpenXR versions

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
@@ -26,21 +26,6 @@
             "define": "MSFT_OPENXR"
         },
         {
-            "name": "com.microsoft.mixedreality.openxr",
-            "expression": "0.9.4-preview",
-            "define": "MSFT_OPENXR_0_9_4_OR_NEWER"
-        },
-        {
-            "name": "com.microsoft.mixedreality.openxr",
-            "expression": "0.2.0",
-            "define": "MSFT_OPENXR_0_2_0_OR_NEWER"
-        },
-        {
-            "name": "com.microsoft.mixedreality.openxr",
-            "expression": "0.1.3",
-            "define": "MSFT_OPENXR_0_1_3_OR_NEWER"
-        },
-        {
             "name": "com.unity.xr.openxr",
             "expression": "",
             "define": "UNITY_OPENXR"

--- a/Assets/MRTK/Providers/OpenXR/Scripts/HPReverbG2Controller.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/HPReverbG2Controller.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             }
         }
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER
+#if MSFT_OPENXR
         private MicrosoftControllerModelProvider controllerModelProvider;
 
         /// <inheritdoc />
@@ -114,6 +114,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 controllerModel.SetActive(false);
             }
         }
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER
+#endif // MSFT_OPENXR
     }
 }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -9,24 +9,10 @@ using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR;
+using Handedness = Microsoft.MixedReality.Toolkit.Utilities.Handedness;
 
 #if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
-#if MSFT_OPENXR_0_1_3_OR_NEWER
-using FrameTime = Microsoft.MixedReality.OpenXR.FrameTime;
-#else
-using FrameTime = Microsoft.MixedReality.OpenXR.Preview.FrameTime;
-#endif // MSFT_OPENXR_0_1_3_OR_NEWER
-
-#if MSFT_OPENXR_0_2_0_OR_NEWER
-using HandJoint = Microsoft.MixedReality.OpenXR.HandJoint;
-using HandJointLocation = Microsoft.MixedReality.OpenXR.HandJointLocation;
-using HandTracker = Microsoft.MixedReality.OpenXR.HandTracker;
-#else
-using HandJoint = Microsoft.MixedReality.OpenXR.Preview.HandJoint;
-using HandJointLocation = Microsoft.MixedReality.OpenXR.Preview.HandJointLocation;
-using HandTracker = Microsoft.MixedReality.OpenXR.Preview.HandTracker;
-using Preview = Microsoft.MixedReality.OpenXR.Preview;
-#endif // MSFT_OPENXR_0_2_0_OR_NEWER
+using Microsoft.MixedReality.OpenXR;
 #endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
@@ -52,11 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             handMeshProvider?.SetInputSource(inputSource);
 
 #if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
-#if MSFT_OPENXR_0_2_0_OR_NEWER
             handTracker = controllerHandedness == Handedness.Left ? HandTracker.Left : HandTracker.Right;
-#else
-            handTracker = new HandTracker(controllerHandedness == Handedness.Left ? Preview.Handedness.Left : Preview.Handedness.Right, Preview.HandPoseType.Tracked);
-#endif
 #endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
         }
 
@@ -266,14 +248,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
                         // We want input sources to follow the playspace, so fold in the playspace transform here to
                         // put the pose into world space.
-#if MSFT_OPENXR_0_2_0_OR_NEWER
                         Vector3 position = MixedRealityPlayspace.TransformPoint(handJointLocation.Pose.position);
                         Quaternion rotation = MixedRealityPlayspace.Rotation * handJointLocation.Pose.rotation;
-
-#else
-                        Vector3 position = MixedRealityPlayspace.TransformPoint(handJointLocation.Position);
-                        Quaternion rotation = MixedRealityPlayspace.Rotation * handJointLocation.Rotation;
-#endif // MSFT_OPENXR_0_2_0_OR_NEWER
 
                         unityJointPoses[ConvertToTrackedHandJoint(handJoint)] = new MixedRealityPose(position, rotation);
                     }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftControllerModelProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftControllerModelProvider.cs
@@ -4,11 +4,11 @@
 using System.Threading.Tasks;
 using UnityEngine;
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 using Microsoft.MixedReality.OpenXR;
 using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization;
 using System.Collections.Generic;
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 {
@@ -19,15 +19,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
     {
         public MicrosoftControllerModelProvider(Utilities.Handedness handedness)
         {
-#if MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
             controllerModelProvider = handedness == Utilities.Handedness.Left ? ControllerModel.Left : ControllerModel.Right;
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
         }
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
         private static readonly Dictionary<ulong, GameObject> ControllerModelDictionary = new Dictionary<ulong, GameObject>(2);
         private readonly ControllerModel controllerModelProvider;
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
         // Disables "This async method lacks 'await' operators and will run synchronously." when the correct OpenXR package isn't installed
 #pragma warning disable CS1998
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             GameObject gltfGameObject = null;
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
             if (!controllerModelProvider.TryGetControllerModelKey(out ulong modelKey))
             {
                 Debug.LogError("Failed to obtain controller model key from platform.");
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     ControllerModelDictionary.Add(modelKey, gltfGameObject);
                 }
             }
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
             return gltfGameObject;
         }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftMotionController.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftMotionController.cs
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             }
         }
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER
+#if MSFT_OPENXR
         private MicrosoftControllerModelProvider controllerModelProvider;
 
         /// <inheritdoc />
@@ -118,6 +118,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 controllerModel.SetActive(false);
             }
         }
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER
+#endif // MSFT_OPENXR
     }
 }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -13,10 +13,10 @@ using UnityEngine.XR;
 using UnityEngine.XR.OpenXR;
 #endif // UNITY_OPENXR
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#if MSFT_OPENXR && WINDOWS_UWP
 using Microsoft.MixedReality.OpenXR;
 using Microsoft.MixedReality.Toolkit.Windows.Input;
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#endif // MSFT_OPENXR && WINDOWS_UWP
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 {
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             false;
 #endif // UNITY_OPENXR
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#if MSFT_OPENXR && WINDOWS_UWP
         private GestureRecognizer gestureRecognizer;
         private GestureRecognizer navigationGestureRecognizer;
         private GestureEventData eventData;
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         private MixedRealityInputAction navigationAction = MixedRealityInputAction.None;
         private MixedRealityInputAction manipulationAction = MixedRealityInputAction.None;
         private MixedRealityInputAction selectAction = MixedRealityInputAction.None;
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#endif // MSFT_OPENXR && WINDOWS_UWP
 
         /// <inheritdoc />
         public override void Enable()
@@ -78,9 +78,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 return;
             }
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#if MSFT_OPENXR && WINDOWS_UWP
             CreateGestureRecognizers();
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#endif // MSFT_OPENXR && WINDOWS_UWP
 
             base.Enable();
         }
@@ -94,7 +94,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             }
         }
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#if MSFT_OPENXR && WINDOWS_UWP
         /// <inheritdoc />
         public override void Initialize()
         {
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
             base.Disable();
         }
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#endif // MSFT_OPENXR && WINDOWS_UWP
 
         #region Controller Utilities
 
@@ -262,7 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
         #region Gesture implementation
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#if MSFT_OPENXR && WINDOWS_UWP
         private void ReadProfile()
         {
             if (InputSystemProfile.GesturesProfile != null)
@@ -503,7 +503,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
             return null;
         }
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && WINDOWS_UWP
+#endif // MSFT_OPENXR && WINDOWS_UWP
 
         #endregion Gesture implementation
     }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandMeshProvider.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 using Microsoft.MixedReality.OpenXR;
 using System.Collections.Generic;
 using UnityEngine;
-#endif // MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Unity.Profiling;
@@ -21,23 +21,23 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// The user's left hand.
         /// </summary>
         public static OpenXRHandMeshProvider Left { get; } =
-#if MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
             new OpenXRHandMeshProvider(HandMeshTracker.Left, Utilities.Handedness.Left);
 #else
             null;
-#endif // MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
         /// <summary>
         /// The user's right hand.
         /// </summary>
         public static OpenXRHandMeshProvider Right { get; } =
-#if MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
             new OpenXRHandMeshProvider(HandMeshTracker.Right, Utilities.Handedness.Right);
 #else
             null;
-#endif // MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
-#if MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
         private OpenXRHandMeshProvider(HandMeshTracker handMeshTracker, Utilities.Handedness handedness)
         {
             this.handMeshTracker = handMeshTracker;
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         private readonly List<int> triangles = new List<int>();
 
         private Vector2[] handMeshUVs = null;
-#endif // MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
         private IMixedRealityInputSource inputSource = null;
 
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// </summary>
         public void UpdateHandMesh()
         {
-#if MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
             using (UpdateHandMeshPerfMarker.Auto())
             {
                 MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
@@ -155,7 +155,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             }
 
             return uvs;
-#endif // MSFT_OPENXR_0_2_0_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
         }
     }
 }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRReprojectionUpdater.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRReprojectionUpdater.cs
@@ -3,10 +3,10 @@
 
 using UnityEngine;
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 using Microsoft.MixedReality.OpenXR;
 using System.Linq;
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 {
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// </summary>
         public HolographicReprojectionMethod ReprojectionMethod { get; set; }
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
         private ReprojectionSettings reprojectionSettings = default;
 
         private void OnPostRender()
@@ -54,6 +54,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     return ReprojectionMode.NoReprojection;
             }
         }
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
     }
 }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
@@ -5,11 +5,11 @@ using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 using Microsoft.MixedReality.OpenXR;
 using Unity.Profiling;
 using UnityEngine.XR.OpenXR;
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 {
@@ -40,13 +40,13 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         { }
 
         protected override bool? IsActiveLoader =>
-#if MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
             LoaderHelpers.IsLoaderActive<OpenXRLoaderBase>();
 #else
             false;
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
-#if MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
         private static readonly ProfilerMarker ApplyUpdatedMeshDisplayOptionPerfMarker = new ProfilerMarker($"[MRTK] {nameof(OpenXRSpatialAwarenessMeshObserver)}.ApplyUpdatedMeshDisplayOption");
 
         /// <inheritdoc/>
@@ -107,6 +107,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     return VisualMeshLevelOfDetail.Coarse;
             }
         }
-#endif // MSFT_OPENXR_0_9_4_OR_NEWER && (UNITY_STANDALONE_WIN || UNITY_WSA)
+#endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
     }
 }


### PR DESCRIPTION
## Overview

Now that 1.0.0 is out, we should only support that and newer. This is a breaking change, but one that I think is worth taking as:

1. It reduces the matrix of versions we're trying to support at once
2. Only removes pre-1.0 preview versions, which we want users to update to a stable release anyway
3. Is an easy fix: update any preview MROpenXR package to 1.0.0 or newer