### PR TITLE
Fix for: "EyeTrackingTarget not triggering OnLookAway when passing from collider with EyeTrackingTarget to collider without"

### DIFF
--- a/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
@@ -261,10 +261,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     if (isHit)
                     {
                         LookedAtEyeTarget = hitInfo.collider.transform.GetComponent<EyeTrackingTarget>();
-                        if(LookedAtEyeTarget != null)
-                        {
-                            LookedAtTarget = LookedAtEyeTarget.gameObject;
-                        }
+                        LookedAtTarget = hitInfo.collider.transform.gameObject;
                         LookedAtPoint = hitInfo.point;
                     }
                     else


### PR DESCRIPTION
## Overview
Fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/10106

Changed assignmnet in accordance to variable documentation:
"GameObject eye gaze is currently targeting, updated once per frame. null if no object with collider is currently being looked at."
Previous behaviour only changed variable if gameobject that was hit had an EyeTrackingTarget attached, if no collider was hit it was set to null and if a collider was hit on a gameobject that did not have any eyetrackingtarget then it was not updated.
Documentation specifies it should be the "GameObject eye gaze is currently targeting", and not anything relating to if it has eyetrackingtarget or not. Not sure if intention is/was for it to be null if the gameobject does not have eyetrackingtarget, but then documentation as well as code should be updated for this.

## Changes
Added on line 264 of EyeTrackingTarget.cs
` LookedAtTarget = hitInfo.collider.transform.gameObject;`

Removed from line 264 of EyeTrackingTarget.cs
```
if(LookedAtEyeTarget != null)
{
    LookedAtTarget = LookedAtEyeTarget.gameObject;
}
```
