### PR TITLE
Update assembly name to match MRTK standards

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/Editor/MRTK.OpenXR.Editor.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/Editor/MRTK.OpenXR.Editor.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "MRTK.OpenXR.Editor",
+    "name": "Microsoft.MixedReality.Toolkit.Providers.OpenXR.Editor",
     "rootNamespace": "Microsoft.MixedReality.Toolkit.XRSDK.OpenXR.Editor",
     "references": [
         "Microsoft.MixedReality.Toolkit",


### PR DESCRIPTION
## Overview

Looking through our assemblies, I accidentally created one that matched our asmdef filenames and not our assembly name standards.

![image](https://user-images.githubusercontent.com/3580640/127693267-52399812-8f29-4bc0-bfa3-7ae789ee4ac6.png)

This updates things to match. Since it's a small assembly with only one file, came out in our most recent release, and is editor-only, I don't think there should be any external assemblies with dependencies on this.