### PR TITLE
Correctly handling IOSMinOSVersion in different cultures

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Editor;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEditor;
 using UnityEngine;
 
@@ -147,7 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.AndroidMinSdkVersion, new ConfigGetter(() =>  PlayerSettings.Android.minSdkVersion >= MinAndroidSdk, BuildTarget.Android) },
 
             // iOS Settings
-            { Configurations.IOSMinOSVersion, new ConfigGetter(() => float.TryParse(PlayerSettings.iOS.targetOSVersionString, out float version) && version >= iOSMinOsVersion, BuildTarget.iOS) },
+            { Configurations.IOSMinOSVersion, new ConfigGetter(() => float.TryParse(PlayerSettings.iOS.targetOSVersionString, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out float version) && version >= iOSMinOsVersion, BuildTarget.iOS) },
             { Configurations.IOSArchitecture, new ConfigGetter(() => PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequirediOSArchitecture, BuildTarget.iOS) },
             { Configurations.IOSCameraUsageDescription, new ConfigGetter(() => !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription), BuildTarget.iOS) },
 
@@ -204,7 +205,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.AndroidMinSdkVersion, () => PlayerSettings.Android.minSdkVersion = MinAndroidSdk },
 
             // iOS Settings
-            { Configurations.IOSMinOSVersion, () => PlayerSettings.iOS.targetOSVersionString = iOSMinOsVersion.ToString("n1") },
+            { Configurations.IOSMinOSVersion, () => PlayerSettings.iOS.targetOSVersionString = iOSMinOsVersion.ToString("n1", CultureInfo.InvariantCulture) },
             { Configurations.IOSArchitecture, () => PlayerSettings.SetArchitecture(BuildTargetGroup.iOS, RequirediOSArchitecture) },
             { Configurations.IOSCameraUsageDescription, () => PlayerSettings.iOS.cameraUsageDescription = iOSCameraUsageDescription },
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public override bool IsInteractionEnabled =>
                 // If IsTracked is not true, then we don't have position data yet (or have stale data),
                 // so remain disabled until we know where to appear (not just at the origin).
-                IsFocusLocked || (IsTracked && Controller.IsInPointingPose && base.IsInteractionEnabled);
+                IsFocusLocked || (IsTracked && Controller != null && Controller.IsInPointingPose && base.IsInteractionEnabled);
 
         private Vector3 lineStartPoint;
         private Vector3 lineEndPoint;


### PR DESCRIPTION
## Overview

Using CultureInfo.InvariantCulture for Configurations.IOSMinOSVersion because some cultures use other decimal separators than a dot ('.'). For example, in pl-PL it is a comma (',').
