### PR TITLE
Fixed inconsistent interaction behavior for overlapping objects

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -468,7 +468,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             /// <summary>
             /// Minimum differences in distance for one grabbable to be considered closer than the other
             /// </summary>
-            private const float MIN_DIST_DIFF = 1.0e-5f
+            private const float MIN_DIST_DIFF = 1.0e-5f;
 
             /// <param name="pointerPosition">The position of the pointer to query against.</param>
             /// <param name="ignoreCollidersNotInFOV">Whether to ignore colliders that are not visible.</param>
@@ -491,7 +491,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         float currentDistance = (pointerPosition - colliderHitPoint).sqrMagnitude;
                         float currentVolume = collider.bounds.Transform(collider.transform.localToWorldMatrix).Volume();
 
-                        float distanceDiff = closestDistance - distance;
+                        float distanceDiff = closestDistance - currentDistance;
                         // set current grabbable to be the closest grabbable if it is significantly closer than the previously recorded
                         // closest grabbable, or if it's volume is smaller than the previous closest grabbable's volume.
                         if (distanceDiff > MIN_DIST_DIFF || (Mathf.Abs(distanceDiff) < MIN_DIST_DIFF && currentVolume < closestVolume))

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -475,6 +475,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 NearInteractionGrabbable closestGrabbable = null;
                 Vector3 closestColliderHitPosition = pointerPosition;
                 float closestDistance = Mathf.Infinity;
+                float closestVolume = Mathf.Infinity;
 
                 for (int i = 0; i < numColliders; i++)
                 {
@@ -483,9 +484,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         && IsColliderPositionValid(collider, pointerPosition, pointerAxis, queryAngle, queryMinDistance, out colliderHitPoint))
                     {
                         float distance = (pointerPosition - colliderHitPoint).sqrMagnitude;
-                        if (distance < closestDistance)
+                        float volume = collider.bounds.Transform(collider.transform.localToWorldMatrix).Volume();
+
+                        float distanceDiff = distance - closestDistance;
+                        if (distance < closestDistance || (Mathf.Abs(distanceDiff) < 1.0e-5f && volume < closestVolume))
                         {
                             closestDistance = distance;
+                            closestVolume = volume;
                             closestGrabbable = currentGrabbable;
                             closestColliderHitPosition = colliderHitPoint;
                         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -487,7 +487,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         float volume = collider.bounds.Transform(collider.transform.localToWorldMatrix).Volume();
 
                         float distanceDiff = distance - closestDistance;
-                        if (distance < closestDistance || (Mathf.Abs(distanceDiff) < 1.0e-5f && volume < closestVolume))
+                        if (distanceDiff < -1.0e-5f || (Mathf.Abs(distanceDiff) < 1.0e-5f && volume < closestVolume))
                         {
                             closestDistance = distance;
                             closestVolume = volume;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -465,6 +465,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return false;
             }
 
+            /// <summary>
+            /// Minimum differences in distance for one grabbable to be considered closer than the other
+            /// </summary>
+            private const float MIN_DIST_DIFF = 1.0e-5f
+
             /// <param name="pointerPosition">The position of the pointer to query against.</param>
             /// <param name="ignoreCollidersNotInFOV">Whether to ignore colliders that are not visible.</param>
             public GameObject GetClosestValidGrabbable(Vector3 pointerPosition, Vector3 pointerAxis, bool ignoreCollidersNotInFOV, out Vector3 hitPosition)
@@ -483,14 +488,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     if (IsColliderValidGrabbable(collider, ignoreCollidersNotInFOV, out currentGrabbable)
                         && IsColliderPositionValid(collider, pointerPosition, pointerAxis, queryAngle, queryMinDistance, out colliderHitPoint))
                     {
-                        float distance = (pointerPosition - colliderHitPoint).sqrMagnitude;
-                        float volume = collider.bounds.Transform(collider.transform.localToWorldMatrix).Volume();
+                        float currentDistance = (pointerPosition - colliderHitPoint).sqrMagnitude;
+                        float currentVolume = collider.bounds.Transform(collider.transform.localToWorldMatrix).Volume();
 
-                        float distanceDiff = distance - closestDistance;
-                        if (distanceDiff < -1.0e-5f || (Mathf.Abs(distanceDiff) < 1.0e-5f && volume < closestVolume))
+                        float distanceDiff = closestDistance - distance;
+                        // set current grabbable to be the closest grabbable if it is significantly closer than the previously recorded
+                        // closest grabbable, or if it's volume is smaller than the previous closest grabbable's volume.
+                        if (distanceDiff > MIN_DIST_DIFF || (Mathf.Abs(distanceDiff) < MIN_DIST_DIFF && currentVolume < closestVolume))
                         {
-                            closestDistance = distance;
-                            closestVolume = volume;
+                            closestDistance = currentDistance;
+                            closestVolume = currentVolume;
                             closestGrabbable = currentGrabbable;
                             closestColliderHitPosition = colliderHitPoint;
                         }

--- a/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
@@ -173,6 +173,44 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Verifies that SpherePointer grabs the smaller of two overlapping objects
+        /// </summary>
+        [UnityTest]
+        public IEnumerator GrabVolumesWithOverlap()
+        {
+            // Initialize overlapRect and cube
+            overlapRect.SetActive(true);
+            overlapRect.transform.localScale = Vector3.one * 2;
+            overlapRect.transform.position = Vector3.zero;
+
+            cube.transform.localScale = Vector3.one;
+            cube.transform.position = Vector3.zero;
+
+            // Initialize hand
+            var rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(Vector3.zero);
+            yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+
+            var pointer = rightHand.GetPointer<SpherePointer>();
+            Assert.IsNotNull(pointer, "Expected to find SpherePointer in the hand controller");
+
+            Assert.True(CoreServices.InputSystem.FocusProvider.GetFocusedObject(pointer) == cube, " the cube was not in focus");
+            Assert.True(pointer.IsNearObject);
+            Assert.True(pointer.IsInteractionEnabled);
+
+            // Switch the scale of the cube and rect
+            overlapRect.transform.localScale = Vector3.one;
+            cube.transform.localScale = Vector3.one * 2;
+
+            // Wait for the input system to process the changes
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            Assert.True(CoreServices.InputSystem.FocusProvider.GetFocusedObject(pointer) == overlapRect, " the overlapping rectangle was not in focus");
+
+            // Reinitialize the overlapRect
+            overlapRect.SetActive(false);
+        }
+
+        /// <summary>
         /// Verifies that the IsNearObject and IsInteractionEnabled get set 
         /// at the correct times as a hand approaches a grabbable object
         /// </summary>


### PR DESCRIPTION
## Overview
This PR makes it so that the sphere pointer now prioritizes the object with less volume when determining which object to grab in overlapping cases. This is a sufficiently usable solution for our OverlapSphere based implementation of grab pointers, only failing in cases of corner overlap and convex colliders.

![Overlap](https://user-images.githubusercontent.com/39840334/131188511-a79938c8-7980-4005-9ffe-16d0e128f1a4.gif)

## Changes
- Fixes: #7629
