### PR TITLE
Fix speech command dropdown and update commands in ET example

### DIFF
--- a/Assets/MRTK/Core/Attributes/SpeechKeywordAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/SpeechKeywordAttribute.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit
+{
+    /// <summary>
+    /// Attribute used to display a dropdown of registered keywords from the speech profile.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public sealed class SpeechKeywordAttribute : PropertyAttribute { }
+}

--- a/Assets/MRTK/Core/Attributes/SpeechKeywordAttribute.cs.meta
+++ b/Assets/MRTK/Core/Attributes/SpeechKeywordAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f47425f809ae9f945ae63e6616771ba0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Definitions/InputSystem/KeywordAndResponse.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/KeywordAndResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("The keyword to listen for.")]
+        [SpeechKeyword]
         private string keyword;
 
         /// <summary>

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SpeechKeywordPropertyDrawer.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SpeechKeywordPropertyDrawer.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Input.Editor
+{
+    [CustomPropertyDrawer(typeof(SpeechKeywordAttribute))]
+    public class SpeechKeywordPropertyDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect rect, SerializedProperty property, GUIContent content) => SpeechKeywordUtility.RenderKeywords(property, rect, content);
+    }
+}

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SpeechKeywordPropertyDrawer.cs.meta
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SpeechKeywordPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3302e5771f764be4dbddbed7dcd0a483
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
-using UnityEditor.Experimental.SceneManagement;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor

--- a/Assets/MRTK/Core/Inspectors/Utilities/SpeechKeywordUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/SpeechKeywordUtility.cs
@@ -8,6 +8,9 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
+    /// <summary>
+    /// Provides helpers for rendering speech keyword dropdowns populated from the MRTK speech profile.
+    /// </summary>
     public static class SpeechKeywordUtility
     {
         private static readonly GUIContent SpeechCommandsLabel = new GUIContent("Speech Command", "Speech keyword to use, pulled from MRTK/Input/Speech Commands Profile");
@@ -29,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             if (keywordsInUse != null && availableKeywords != null)
             {
-                availableKeywords = availableKeywords.Except(keywordsInUse.Select(keyword => keyword)).ToArray();
+                availableKeywords = availableKeywords.Except(keywordsInUse.Select(keyword => keyword));
             }
 
             bool validSpeechKeywords = availableKeywords != null && availableKeywords.Count() > 0;

--- a/Assets/MRTK/Core/Inspectors/Utilities/SpeechKeywordUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/SpeechKeywordUtility.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
+{
+    public static class SpeechKeywordUtility
+    {
+        private static readonly GUIContent SpeechCommandsLabel = new GUIContent("Speech Command", "Speech keyword to use, pulled from MRTK/Input/Speech Commands Profile");
+
+        /// <summary>
+        /// Renders a dropdown with all keywords in the active <see cref="Input.MixedRealitySpeechCommandsProfile"/>.
+        /// </summary>
+        /// <param name="property">The string property representing the selected keyword.</param>
+        public static void RenderKeywords(SerializedProperty property, Rect rect = default(Rect), GUIContent content = null) => RenderKeywordsExcept(null, property, rect, content);
+
+        /// <summary>
+        /// Renders a dropdown with all keywords in the active <see cref="Input.MixedRealitySpeechCommandsProfile"/> except those passed in.
+        /// </summary>
+        /// <param name="keywordsInUse">The keywords the component is currently using.</param>
+        /// <param name="property">The string property representing the selected keyword.</param>
+        public static void RenderKeywordsExcept(string[] keywordsInUse, SerializedProperty property, Rect rect = default(Rect), GUIContent content = null)
+        {
+            IEnumerable<string> availableKeywords = GetDistinctRegisteredKeywords();
+
+            if (keywordsInUse != null && availableKeywords != null)
+            {
+                availableKeywords = availableKeywords.Except(keywordsInUse.Select(keyword => keyword)).ToArray();
+            }
+
+            bool validSpeechKeywords = availableKeywords != null;
+
+            if (rect == default(Rect))
+            {
+                rect = EditorGUILayout.GetControlRect();
+            }
+
+            if (content == null)
+            {
+                content = SpeechCommandsLabel;
+            }
+
+            using (new EditorGUI.DisabledScope(!validSpeechKeywords))
+            using (new EditorGUI.PropertyScope(rect, content, property))
+            {
+                string[] keywordOptions;
+                if (validSpeechKeywords)
+                {
+                    if (string.IsNullOrWhiteSpace(property.stringValue) || availableKeywords.Contains(property.stringValue))
+                    {
+                        keywordOptions = availableKeywords.OrderBy(keyword => keyword).ToArray();
+                    }
+                    else
+                    {
+                        // if the currently selected option is not whitespace, ensure it's included in the dropdown
+                        keywordOptions = availableKeywords.Concat(new[] { property.stringValue }).OrderBy(keyword => keyword).ToArray();
+                    }
+                }
+                else
+                {
+                    keywordOptions = new string[] { "Missing Speech Commands" };
+                }
+
+                int previousSelection = Mathf.Clamp(ArrayUtility.IndexOf(keywordOptions, property.stringValue), 0, int.MaxValue);
+                int currentSelection = EditorGUI.Popup(rect, content.text, previousSelection, keywordOptions);
+
+                if (validSpeechKeywords && currentSelection != previousSelection)
+                {
+                    property.stringValue = currentSelection > 0 ? keywordOptions[currentSelection] : string.Empty; // Don't serialize the "(No Selection)" entry
+                }
+            }
+        }
+
+        /// <summary>
+        /// Look for speech commands in the MRTK speech command profile.
+        /// Adds a "(No Selection)" value at index zero and filters out duplicate values.
+        /// </summary>
+        public static IEnumerable<string> GetDistinctRegisteredKeywords()
+        {
+            if (!MixedRealityToolkit.ConfirmInitialized() ||
+                !MixedRealityToolkit.Instance.HasActiveProfile ||
+                !MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled ||
+                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.SpeechCommandsProfile == null ||
+                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.SpeechCommandsProfile.SpeechCommands.Length == 0)
+            {
+                return null;
+            }
+
+            List<string> keywords = new List<string>
+            {
+                "(No Selection)"
+            };
+
+            Input.SpeechCommands[] speechCommands = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.SpeechCommandsProfile.SpeechCommands;
+            for (var i = 0; i < speechCommands.Length; i++)
+            {
+                keywords.Add(speechCommands[i].Keyword);
+            }
+
+            return keywords.Distinct();
+        }
+    }
+}

--- a/Assets/MRTK/Core/Inspectors/Utilities/SpeechKeywordUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/SpeechKeywordUtility.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 availableKeywords = availableKeywords.Except(keywordsInUse.Select(keyword => keyword)).ToArray();
             }
 
-            bool validSpeechKeywords = availableKeywords != null;
+            bool validSpeechKeywords = availableKeywords != null && availableKeywords.Count() > 0;
 
             if (rect == default(Rect))
             {

--- a/Assets/MRTK/Core/Inspectors/Utilities/SpeechKeywordUtility.cs.meta
+++ b/Assets/MRTK/Core/Inspectors/Utilities/SpeechKeywordUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 893db7bbe33c8d849b376885d3246f8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Prefabs/RecordButton.prefab
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Prefabs/RecordButton.prefab
@@ -914,9 +914,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_text: Start Recording
+  m_text: Record Eye Gaze
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -952,7 +950,6 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_textAlignment: 514
-  m_isAlignmentEnumConverted: 1
   m_characterSpacing: 3
   m_wordSpacing: 0
   m_lineSpacing: 0
@@ -979,26 +976,24 @@ MonoBehaviour:
   m_verticalMapping: 0
   m_uvLineOffset: 0
   m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
   m_firstVisibleCharacter: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
-    textComponent: {fileID: 0}
+    textComponent: {fileID: 4533479808247404460}
     characterCount: 15
     spriteCount: 0
-    spaceCount: 1
-    wordCount: 2
+    spaceCount: 2
+    wordCount: 3
     linkCount: 0
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 0
-  m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 4533479808247404465}
   m_subTextObjects:
@@ -1307,7 +1302,7 @@ MonoBehaviour:
   startDimensionIndex: 0
   CanSelect: 1
   CanDeselect: 1
-  VoiceCommand: Select
+  voiceCommand: Select
   voiceRequiresFocus: 1
   profiles:
   - Target: {fileID: 4533479809219024895}
@@ -1352,8 +1347,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Events: []
   resetOnDestroy: 0
   enabledOnStart: 1
@@ -1378,8 +1371,6 @@ MonoBehaviour:
   onLookAtStart:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   whileLookingAtTarget:
     m_PersistentCalls:
       m_Calls:
@@ -1394,8 +1385,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   onLookAway:
     m_PersistentCalls:
       m_Calls:
@@ -1410,18 +1399,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   onDwell:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   onSelected:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
+  onTapDown:
+    m_PersistentCalls:
+      m_Calls: []
+  onTapUp:
+    m_PersistentCalls:
+      m_Calls: []
   eyeCursorSnapToTargetCenter: 0
 --- !u!82 &4533479808906774274
 AudioSource:

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoSpeechCommandsProfile.asset
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoSpeechCommandsProfile.asset
@@ -87,14 +87,14 @@ MonoBehaviour:
       description: ZoomOut
       axisConstraint: 0
   - localizationKey: 
-    keyword: Start recording
+    keyword: Record eye gaze
     keyCode: 107
     action:
       id: 20
       description: StartRecordingData
       axisConstraint: 0
   - localizationKey: 
-    keyword: Stop recording
+    keyword: End recording
     keyCode: 108
     action:
       id: 21

--- a/Assets/MRTK/Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-05-Visualizer.unity
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-05-Visualizer.unity
@@ -161,6 +161,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   alignmentType: 0
+  containerObject: {fileID: 0}
 --- !u!1 &59515335
 GameObject:
   m_ObjectHideFlags: 0
@@ -206,7 +207,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isFocusRequired: 0
   keywords:
-  - keyword: Start recording
+  - keyword: Record eye gaze
     response:
       m_PersistentCalls:
         m_Calls:
@@ -243,7 +244,7 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-  - keyword: Stop recording
+  - keyword: End recording
     response:
       m_PersistentCalls:
         m_Calls:
@@ -1541,6 +1542,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
+      propertyPath: whileLookingAtTarget.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: onLookAway.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
       propertyPath: WhileLookingAtTarget.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 92775347}
@@ -2405,6 +2416,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   handType: 3
   proximityType: 3
+  executionOrder: 0
   constraintOnRotation: 5
   useLocalSpaceForConstraint: 0
 --- !u!114 &914966067
@@ -2427,6 +2439,9 @@ MonoBehaviour:
   oneHandRotationModeNear: 1
   oneHandRotationModeFar: 1
   releaseBehavior: 3
+  transformSmoothingLogicType:
+    reference: Microsoft.MixedReality.Toolkit.Utilities.DefaultTransformSmoothingLogic,
+      Microsoft.MixedReality.Toolkit.SDK
   smoothingFar: 1
   smoothingNear: 1
   moveLerpTime: 0.001
@@ -2723,6 +2738,16 @@ PrefabInstance:
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
       propertyPath: OnLookAway.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: whileLookingAtTarget.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: onLookAway.m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
@@ -3765,6 +3790,16 @@ PrefabInstance:
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
       propertyPath: OnLookAway.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: whileLookingAtTarget.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: onLookAway.m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
@@ -5232,7 +5267,7 @@ PrefabInstance:
     - target: {fileID: 4533479808247404460, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
       propertyPath: m_text
-      value: Stop Recording
+      value: End Recording
       objectReference: {fileID: 0}
     - target: {fileID: 4533479808247404460, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
@@ -5388,6 +5423,16 @@ PrefabInstance:
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
       propertyPath: OnLookAway.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: whileLookingAtTarget.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: onLookAway.m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
@@ -5666,6 +5711,16 @@ PrefabInstance:
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
       propertyPath: OnLookAway.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: whileLookingAtTarget.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: onLookAway.m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
@@ -6008,6 +6063,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
+      propertyPath: whileLookingAtTarget.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: onLookAway.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
       propertyPath: WhileLookingAtTarget.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 92775347}
@@ -6334,6 +6399,16 @@ PrefabInstance:
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
       propertyPath: OnLookAway.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: whileLookingAtTarget.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: onLookAway.m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
@@ -6832,6 +6907,16 @@ PrefabInstance:
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
         type: 3}
       propertyPath: OnLookAway.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: whileLookingAtTarget.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,
+        type: 3}
+      propertyPath: onLookAway.m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4533479808906774277, guid: 231a4253eb1a74d4e87393459447cc95,

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -229,16 +229,24 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public bool CanDeselect = true;
 
+        [SpeechKeyword]
+        [SerializeField, FormerlySerializedAs("VoiceCommand")]
+        [Tooltip("This string keyword is the voice command that will fire a click on this Interactable.")]
+        private string voiceCommand = "";
+
         /// <summary>
         /// This string keyword is the voice command that will fire a click on this Interactable.
         /// </summary>
-        [Tooltip("This string keyword is the voice command that will fire a click on this Interactable.")]
-        public string VoiceCommand = "";
+        public string VoiceCommand
+        {
+            get => voiceCommand;
+            set => voiceCommand = value;
+        }
 
-        [FormerlySerializedAs("RequiresFocus")]
-        [SerializeField]
+        [SerializeField, FormerlySerializedAs("RequiresFocus")]
         [Tooltip("If true, then the voice command will only respond to voice commands while this Interactable has focus.")]
         public bool voiceRequiresFocus = true;
+
         /// <summary>
         /// Does the voice command require this to have focus?
         /// Registers as a global listener for speech commands, ignores input events


### PR DESCRIPTION
## Overview

Updates the keywords and labels in the ET sample to no longer clash with [system keywords](https://docs.microsoft.com/en-us/hololens/hololens-cortana#general-speech-commands). The new keywords are "record eye gaze" and "end recording".

![image](https://user-images.githubusercontent.com/3580640/131905543-ffd99b1d-3f88-4259-9a8f-fbf793e49918.png)

While investigating this, I also noticed some general speech command issues that I fixed up, including

1. The KeywordAndResponse not filling the entire inspector

    ![image](https://user-images.githubusercontent.com/3580640/131905781-dd5b0fee-1e4f-4acf-b002-8013568f50da.png)

2. Voice command not being settable from a Unity event

    ![image](https://user-images.githubusercontent.com/3580640/131905908-f99bb654-f52f-41fd-8a3d-21ab2b4b8aff.png)

I unified the speech command dropdown behavior into a single utility class, which is now used across `Interactable` and `SpeechInputHandler`, which previously had their own distinct implementations.

Additionally, `SpeechInputHandler` had a bug from porting from HTK that was preventing the custom dropdown from showing up in the first place.

## Changes
- Fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9363, fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8122, and fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/10181
