### PR TITLE
UnityTouchDeviceManager now respects its IsEnabled property

### DIFF
--- a/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
@@ -61,6 +61,11 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         {
             using (UpdatePerfMarker.Auto())
             {
+                if (!IsEnabled)
+                {
+                    return;
+                }
+                
                 base.Update();
 
                 // Ensure that touch up and source lost events are at least one frame apart.


### PR DESCRIPTION
## Overview
UnityTouchDeviceManager, as other data providers (eg. XRSDKDeviceManager), should not Update itself if its IsEnabled property is false.

## Changes
- Fixes: # .


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
