### PR TITLE
Add option to move grasp point to fingertip

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -8,15 +8,15 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    public enum GraspPointPlacement
-    {
-        BetweenFingerAndThumb,
-        Fingertip,
-    }
-
     [AddComponentMenu("Scripts/MRTK/SDK/SpherePointer")]
     public class SpherePointer : BaseControllerPointer, IMixedRealityNearPointer
     {
+        private enum GraspPointPlacement
+        {
+            BetweenIndexFingerAndThumb,
+            IndexFingertip,
+        }
+
         private SceneQueryType raycastMode = SceneQueryType.SphereOverlap;
 
         /// <inheritdoc />
@@ -163,12 +163,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("Location on the hand where a grasp is triggered (apllies to IMixedRealityHand only)")]
-        private GraspPointPlacement graspPointPlacement = GraspPointPlacement.BetweenFingerAndThumb;
-
-        /// <summary>
-        /// Location on the hand where a grasp is triggered (apllies to IMixedRealityHand only)
-        /// </summary>
-        public GraspPointPlacement GraspPointPlacement => graspPointPlacement;
+        private GraspPointPlacement graspPointPlacement = GraspPointPlacement.BetweenIndexFingerAndThumb;
 
         /// <summary>
         /// Whether to ignore colliders that may be near the pointer, but not actually in the visual FOV.
@@ -280,7 +275,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <summary>
         /// Gets the position of where grasp happens
-        /// For IMixedRealityHand it's determined by <see cref="GraspPointPlacement"/> (either the average of index and thumb or the fingertip).
+        /// For IMixedRealityHand it's determined by <see cref="graspPointPlacement"/> (either the average of index and thumb or the fingertip).
         /// For any other IMixedRealityController, return just the pointer origin
         /// </summary>
         public bool TryGetNearGraspPoint(out Vector3 result)
@@ -294,9 +289,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     {
                         if (hand.TryGetJoint(TrackedHandJoint.IndexTip, out MixedRealityPose index) && index != null)
                         {
-                            switch (GraspPointPlacement)
+                            switch (graspPointPlacement)
                             {
-                                case GraspPointPlacement.BetweenFingerAndThumb:
+                                case GraspPointPlacement.BetweenIndexFingerAndThumb:
                                     if (hand.TryGetJoint(TrackedHandJoint.ThumbTip, out MixedRealityPose thumb) && thumb != null)
                                     {
                                         result = 0.5f * (index.Position + thumb.Position);
@@ -304,7 +299,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                     }
                                     break;
 
-                                case GraspPointPlacement.Fingertip:
+                                case GraspPointPlacement.IndexFingertip:
                                     result = index.Position;
                                     return true;
                             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -409,7 +409,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private class SpherePointerQueryInfo
         {
             /// <summary>
-            /// How many colliders are near the point from the latest call to TryUpdateQueryBufferForLayerMask
+            /// How many colliders are near the point from the latest call to TryUpdateQueryBufferForLayerMask.
             /// </summary>
             private int numColliders;
 


### PR DESCRIPTION
The grasp pointer by default is positioned between the thumb and index finger. However this is confusing if a fingertip cursor is rendered (either because one is added to the grasp pointer or because grabbable elements are near pokable ones). This adds an option to move the grasp point to the fingertip if desired.

## Changes
- Fixes: # .


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
