### PR TITLE
Fix gltf object appears black

### DIFF
--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -360,7 +360,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 material.mainTexture = gltfObject.images[gltfMaterial.pbrMetallicRoughness.baseColorTexture.index].Texture;
             }
 
-            material.color = gltfMaterial.pbrMetallicRoughness.baseColorFactor.GetColorValue();
+            if (gltfMaterial.pbrMetallicRoughness?.baseColorFactor != null)
+            {
+                material.color = gltfMaterial.pbrMetallicRoughness.baseColorFactor.GetColorValue();
+            }
 
             if (gltfMaterial.alphaMode == "MASK")
             {


### PR DESCRIPTION
## Overview
GLTF object appears black if it is loaded with Unity's Standard shader.

When loading gltf, and if there's no MixedRealityStandard shader, ConstructGLTF creates materials using Unity's Standard shader.
And if the main color data is null, CreateStandardShaderMaterial() assigns the null data to the main color of the material so the gltf object appears black.
This can be avoided by checking the color data is null as like the same as CreateMRTKShaderMaterial() does.

## Changes
- Fixes: #10195
Assign main color only if the gltf material has color value.
