### PR TITLE
Update a property name in button config helper

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -186,7 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                                     if (interactableProp.objectReferenceValue != null)
                                     {
                                         SerializedObject interactableObject = new SerializedObject(interactableProp.objectReferenceValue);
-                                        SerializedProperty voiceCommandProperty = interactableObject.FindProperty("VoiceCommand");
+                                        SerializedProperty voiceCommandProperty = interactableObject.FindProperty("voiceCommand");
 
                                         if(string.IsNullOrEmpty(voiceCommandProperty.stringValue))
                                         {


### PR DESCRIPTION
## Overview
Update the voiceCommand property name in the editor script to fix a null pointer problem caused by the case change introduced in #10197.