### PR TITLE
Convert incorrect usages of enumValueIndex to intValue

### DIFF
--- a/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
@@ -502,7 +502,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         {
                             var inputAction = actionId.intValue == 0 ? MixedRealityInputAction.None : MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
                             actionDescription.stringValue = inputAction.Description;
-                            actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
+                            actionConstraint.intValue = (int)inputAction.AxisConstraint;
                         }
 
                         if ((AxisType)axisType.intValue == AxisType.Digital)
@@ -730,7 +730,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
                             actionId.intValue = (int)inputAction.Id;
                             actionDescription.stringValue = inputAction.Description;
-                            actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
+                            actionConstraint.intValue = (int)inputAction.AxisConstraint;
                             interactionList.serializedObject.ApplyModifiedProperties();
                         }
                     }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
@@ -224,7 +224,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                                 }
 
                                 actionDescription.stringValue = inputAction.Description;
-                                actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
+                                actionConstraint.intValue = (int)inputAction.AxisConstraint;
                                 serializedObject.ApplyModifiedProperties();
                             }
 

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
@@ -166,7 +166,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                             {
                                 MixedRealityInputAction inputAction = actionId.intValue == 0 ? MixedRealityInputAction.None : MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
                                 actionDescription.stringValue = inputAction.Description;
-                                actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
+                                actionConstraint.intValue = (int)inputAction.AxisConstraint;
                             }
                         }
                         EditorGUILayout.Space();

--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorFieldsUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorFieldsUtility.cs
@@ -89,7 +89,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 SerializedProperty options = settingItem.FindPropertyRelative("Options");
                 SerializedProperty name = settingItem.FindPropertyRelative("Name");
 
-                type.enumValueIndex = (int)data[i].Attributes.Type;
+                type.intValue = (int)data[i].Attributes.Type;
                 tooltip.stringValue = data[i].Attributes.Tooltip;
                 label.stringValue = data[i].Attributes.Label;
                 name.stringValue = data[i].Name;

--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -535,7 +535,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             EditorGUI.BeginProperty(position, label, prop);
             {
                 result = EditorGUI.EnumPopup(position, label, propValue);
-                prop.enumValueIndex = Convert.ToInt32(result);
+                prop.intValue = Convert.ToInt32(result);
             }
             EditorGUI.EndProperty();
 

--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionDeviceManagerProfileInspector.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionDeviceManagerProfileInspector.cs
@@ -102,14 +102,14 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Inspectors
                         // Allow selection of the LeapVRDeviceOffsetMode if the LeapControllerOrientation is Headset
                         EditorGUILayout.PropertyField(leapVRDeviceOffsetMode);
 
-                        if (leapVRDeviceOffsetMode.enumValueIndex == (int)LeapVRDeviceOffsetMode.ManualHeadOffset)
+                        if (leapVRDeviceOffsetMode.intValue == (int)LeapVRDeviceOffsetMode.ManualHeadOffset)
                         {
                             // Display the properties for editing the head offset 
                             EditorGUILayout.PropertyField(leapVRDeviceOffsetY);
                             EditorGUILayout.PropertyField(leapVRDeviceOffsetZ);
                             EditorGUILayout.PropertyField(leapVRDeviceOffsetTiltX);
                         }
-                        else if (leapVRDeviceOffsetMode.enumValueIndex == (int)LeapVRDeviceOffsetMode.Transform)
+                        else if (leapVRDeviceOffsetMode.intValue == (int)LeapVRDeviceOffsetMode.Transform)
                         {
                             // Display the transform property 
                             // EditorGUILayout.PropertyField() did not allow the setting the transform property in editor 

--- a/Assets/MRTK/SDK/Editor/Inspectors/Exp/InteractiveEl/CompressableButtonInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Exp/InteractiveEl/CompressableButtonInspector.cs
@@ -329,7 +329,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.InteractiveElement.Editor
             {
                 // Changing the DistanceSpaceMode requires updating the plane distance values so they stay in the same relative ratio positions
                 Undo.RecordObject(target, string.Concat("Trigger Plane Distance Conversion of ", button.name));
-                button.DistanceSpaceMode = (CompressableButton.SpaceMode)distanceSpaceMode.enumValueIndex;
+                button.DistanceSpaceMode = (CompressableButton.SpaceMode)distanceSpaceMode.intValue;
                 serializedObject.Update();
             }
 

--- a/Assets/MRTK/SDK/Editor/Inspectors/Input/Handlers/ControllerPoseSynchronizerInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Input/Handlers/ControllerPoseSynchronizerInspector.cs
@@ -64,9 +64,9 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     var label = new GUIContent(handedness.displayName);
                     using (new EditorGUI.PropertyScope(position, label, handedness))
                     {
-                        var currentHandedness = (Handedness)handedness.enumValueIndex;
+                        var currentHandedness = (Handedness)handedness.intValue;
 
-                        handedness.enumValueIndex = (int)(Handedness)EditorGUI.EnumPopup(position, label, currentHandedness,
+                        handedness.intValue = (int)(Handedness)EditorGUI.EnumPopup(position, label, currentHandedness,
                             (value) => { return (Handedness)value == Handedness.Left || (Handedness)value == Handedness.Right; });
                     }
                 }

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
 
 
-            LayoutOrder layoutTypeIndex = (LayoutOrder)layout.enumValueIndex;
+            LayoutOrder layoutTypeIndex = (LayoutOrder)layout.intValue;
             if (layoutTypeIndex == LayoutOrder.ColumnThenRow)
             {
                 EditorGUILayout.HelpBox("ColumnThenRow will lay out content first horizontally (by column), then vertically (by row). NumColumns specifies number of columns per row.", MessageType.Info);
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 EditorGUILayout.PropertyField(cellHeight);
             }
 
-            ObjectOrientationSurfaceType surfaceTypeIndex = (ObjectOrientationSurfaceType)surfaceType.enumValueIndex;
+            ObjectOrientationSurfaceType surfaceTypeIndex = (ObjectOrientationSurfaceType)surfaceType.intValue;
             if (surfaceTypeIndex == ObjectOrientationSurfaceType.Plane)
             {
                 EditorGUILayout.PropertyField(distance, new GUIContent("Distance from parent", "Distance from parent object's origin"));
@@ -96,8 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 EditorGUILayout.PropertyField(anchor);
             }
 
-            LayoutAnchor layoutAnchor = (LayoutAnchor)anchor.enumValueIndex;
-            if (layoutAnchor != LayoutAnchor.MiddleCenter)
+            if ((LayoutAnchor)anchor.intValue != LayoutAnchor.MiddleCenter)
             {
                 EditorGUILayout.PropertyField(anchorAlongAxis);
             }

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -107,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
             showComponents = EditorGUILayout.Toggle("Show Component References", showComponents);
 
-            ButtonIconStyle oldStyle = (ButtonIconStyle)iconStyleProp.enumValueIndex;
+            ButtonIconStyle oldStyle = (ButtonIconStyle)iconStyleProp.intValue;
 
             using (new EditorGUI.IndentLevelScope(1))
             {
@@ -288,7 +288,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
             serializedObject.ApplyModifiedProperties();
 
-            if (oldStyle != (ButtonIconStyle)iconStyleProp.enumValueIndex)
+            if (oldStyle != (ButtonIconStyle)iconStyleProp.intValue)
             {
                 cb.ForceRefresh();
             }

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -331,7 +331,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 // Changing the DistanceSpaceMode requires updating the plane distance values so they stay in the same relative ratio positions
                 Undo.RecordObject(target, string.Concat("Trigger Plane Distance Conversion of ", button.name));
-                button.DistanceSpaceMode = (PressableButton.SpaceMode)distanceSpaceMode.enumValueIndex;
+                button.DistanceSpaceMode = (PressableButton.SpaceMode)distanceSpaceMode.intValue;
                 serializedObject.Update();
             }
 

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
@@ -146,7 +146,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                                         break;
                                 }
                                 ConnectorPivotDirection newPivotDirection = DrawPivotDirection(connector.PivotDirection);
-                                pivotDirection.enumValueIndex = (int)newPivotDirection;
+                                pivotDirection.intValue = (int)newPivotDirection;
                                 switch (connector.PivotDirection)
                                 {
                                     case ConnectorPivotDirection.Manual:

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/VisualThemes/ThemeInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/VisualThemes/ThemeInspector.cs
@@ -270,7 +270,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                 SerializedProperty stateProperty = stateProperties.GetArrayElementAtIndex(i);
                 SerializedProperty type = stateProperty.FindPropertyRelative("type");
 
-                if (ThemeStateProperty.IsShaderPropertyType((ThemePropertyTypes)type.enumValueIndex))
+                if (ThemeStateProperty.IsShaderPropertyType((ThemePropertyTypes)type.intValue))
                 {
                     SerializedProperty statePropertyName = stateProperty.FindPropertyRelative("name");
                     SerializedProperty shader = stateProperty.FindPropertyRelative("targetShader");
@@ -281,7 +281,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
 
                     EditorGUILayout.PropertyField(shader, new GUIContent(statePropertyName.stringValue + " Shader"), false);
 
-                    var propertyList = GetShaderPropertyList(shader.objectReferenceValue as Shader, GetShaderPropertyFilter((ThemePropertyTypes)type.enumValueIndex));
+                    var propertyList = GetShaderPropertyList(shader.objectReferenceValue as Shader, GetShaderPropertyFilter((ThemePropertyTypes)type.intValue));
                     int selectedIndex = propertyList.IndexOf(shaderPropertyname.stringValue);
 
                     Rect pos = EditorGUILayout.GetControlRect();
@@ -326,11 +326,11 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                     shader.objectReferenceValue = StandardShaderUtility.MrtkStandardShader;
 
                     SerializedProperty type = stateProperty.FindPropertyRelative("type");
-                    if (type.enumValueIndex == (int)ThemePropertyTypes.Color)
+                    if (type.intValue == (int)ThemePropertyTypes.Color)
                     {
                         shaderPropertyname.stringValue = "_Color";
                     }
-                    else if (type.enumValueIndex == (int)ThemePropertyTypes.Texture)
+                    else if (type.intValue == (int)ThemePropertyTypes.Texture)
                     {
                         shaderPropertyname.stringValue = "_MainTex";
                     }

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/FollowInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/FollowInspector.cs
@@ -142,7 +142,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
 
                     EditorGUILayout.PropertyField(angularClampMode);
 
-                    switch ((Follow.AngularClampType)angularClampMode.enumValueIndex)
+                    switch ((Follow.AngularClampType)angularClampMode.intValue)
                     {
                         case Follow.AngularClampType.AngleStepping:
                             {

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/InBetweenInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/InBetweenInspector.cs
@@ -34,18 +34,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
 
             serializedObject.Update();
 
-            bool objectChanged = false;
-
-            EditorGUI.BeginChangeCheck();
-
             InspectorUIUtility.DrawEnumSerializedProperty(secondTrackedTargetTypeProperty, SecondTrackedTypeLabel, solverInBetween.SecondTrackedObjectType);
 
-            if (secondTrackedTargetTypeProperty.enumValueIndex == (int)TrackedObjectType.CustomOverride)
+            if (secondTrackedTargetTypeProperty.intValue == (int)TrackedObjectType.CustomOverride)
             {
                 EditorGUILayout.PropertyField(secondTransformOverrideProperty);
             }
-
-            objectChanged = EditorGUI.EndChangeCheck();
 
             EditorGUILayout.PropertyField(partwayOffsetProperty);
 

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/SolverHandlerInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/SolverHandlerInspector.cs
@@ -56,21 +56,21 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
                     + "\" is obsolete. Select MotionController or HandJoint values instead");
             }
 
-            if (trackedTargetProperty.enumValueIndex == (int)TrackedObjectType.HandJoint ||
-                trackedTargetProperty.enumValueIndex == (int)TrackedObjectType.ControllerRay)
+            if (trackedTargetProperty.intValue == (int)TrackedObjectType.HandJoint ||
+                trackedTargetProperty.intValue == (int)TrackedObjectType.ControllerRay)
             {
                 EditorGUILayout.PropertyField(trackedHandednessProperty);
-                if (trackedHandednessProperty.enumValueIndex > (int)Handedness.Both)
+                if (trackedHandednessProperty.intValue > (int)Handedness.Both)
                 {
                     InspectorUIUtility.DrawWarning("Only Handedness values of None, Left, Right, and Both are valid");
                 }
             }
 
-            if (trackedTargetProperty.enumValueIndex == (int)TrackedObjectType.HandJoint)
+            if (trackedTargetProperty.intValue == (int)TrackedObjectType.HandJoint)
             {
                 EditorGUILayout.PropertyField(trackedHandJointProperty);
             }
-            else if (trackedTargetProperty.enumValueIndex == (int)TrackedObjectType.CustomOverride)
+            else if (trackedTargetProperty.intValue == (int)TrackedObjectType.CustomOverride)
             {
                 EditorGUILayout.PropertyField(transformOverrideProperty);
             }

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/SurfaceMagnetismInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/SurfaceMagnetismInspector.cs
@@ -105,7 +105,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
             EditorGUILayout.PropertyField(raycastModeProperty);
 
             // Draw properties dependent on type of raycast direction mode selected
-            switch (raycastModeProperty.enumValueIndex)
+            switch (raycastModeProperty.intValue)
             {
                 case (int)SceneQueryType.BoxRaycast:
                     EditorGUILayout.PropertyField(boxRaysPerEdgeProperty);
@@ -120,8 +120,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
                     break;
             }
 
-            if (raycastModeProperty.enumValueIndex != (int)SceneQueryType.SimpleRaycast &&
-                raycastModeProperty.enumValueIndex != (int)SceneQueryType.SphereOverlap)
+            if (raycastModeProperty.intValue != (int)SceneQueryType.SimpleRaycast &&
+                raycastModeProperty.intValue != (int)SceneQueryType.SphereOverlap)
             {
                 EditorGUILayout.PropertyField(volumeCastSizeOverrideProperty);
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
@@ -494,7 +494,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (!iconQuadRenderer.gameObject.activeSelf && !iconSpriteRenderer.gameObject.activeSelf && !iconCharLabel.gameObject.activeSelf)
             {   // If all the icon objects are disabled, set the icon style to none and do nothing else.
-                iconStyleProp.enumValueIndex = (int)ButtonIconStyle.None;
+                iconStyleProp.intValue = (int)ButtonIconStyle.None;
                 configObject.ApplyModifiedProperties();
                 EditorUtility.SetDirty(gameObject);
                 return;


### PR DESCRIPTION
## Overview

In almost every case, we care about intValue over enumValueIndex in serialized properties.

I'm bad at explaining this, but here goes:

enumValueIndex represents the ordinal placement of the enum value in the enum definition. This will always increase by 1 as we go down the enum definition, regardless of if the enum entry is defined as some other number.

intValue is the actual underlying int representation of the enum, so any time a cast or comparison with an enum value is used, this int is represents what we're trying to compare.

In many cases, this won't be an issue, but if there are duplicately defined int values or gaps in the enum, these numbers will differ.