### PR TITLE
Fixed cases where bounds control would aggressively remove other components

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/BoundsControl/BoundsControlInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/BoundsControl/BoundsControlInspector.cs
@@ -116,12 +116,33 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 {
                     EditorGUI.BeginChangeCheck();
 
+                    // Initializes the target object of the bounds control to itself
                     EditorGUILayout.PropertyField(targetObject);
+                    if (targetObject.objectReferenceValue == null)
+                    {
+                        targetObject.objectReferenceValue = boundsControl.gameObject;
+                    }
+
+                    // Checks that the targetObject has a box collider that this bounds control can manage if bounds override was not supplied, otherwise, raises a warning and prompts the user to add one
+                    if (boundsOverride.objectReferenceValue == null)
+                    {
+                        GameObject boundsTargetObject = targetObject.objectReferenceValue as GameObject;
+                        if (boundsTargetObject != null && boundsTargetObject.GetComponent<BoxCollider>() == null)
+                        {
+                            EditorGUILayout.HelpBox("No Box Collider assigned to the TargetObject and no Bounds Override assigned, add a Box Collider to enable proper interaction with the Bounds Control", MessageType.Warning);
+
+                           if (GUILayout.Button("Add Box Collider to Target Object"))
+                           {
+                                boundsTargetObject.AddComponent<BoxCollider>();
+                           }
+                        }
+                    }
 
                     EditorGUILayout.Space();
                     EditorGUILayout.LabelField(new GUIContent("Behavior"), EditorStyles.boldLabel);
                     EditorGUILayout.PropertyField(activationType);
                     EditorGUILayout.PropertyField(boundsOverride);
+
                     EditorGUILayout.PropertyField(boundsCalculationMethod);
                     EditorGUILayout.PropertyField(controlPadding);
                     EditorGUILayout.PropertyField(flattenAxis);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -1090,6 +1090,14 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
 
         private void DestroyRig()
         {
+            // If we have previously logged an initial bounds size,
+            // reset the boundsOverride BoxCollider to the initial size.
+            // This is because the CalculateBoxPadding
+            if (initialBoundsOverrideSize.HasValue)
+            {
+                boundsOverride.size = initialBoundsOverrideSize.Value;
+            }
+
             // todo: move this out?
             DestroyVisuals();
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -856,8 +856,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             }
 
             TargetBounds.size += Vector3.Scale(boxPadding, scale);
-
-            TargetBounds.EnsureComponent<NearInteractionGrabbable>();
         }
 
         private readonly List<Transform> childTransforms = new List<Transform>();

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -836,13 +836,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
             }
             else
             {
-                // first remove old collider if there is any so we don't accumulate any 
-                // box padding on consecutive calls of this method
-                if (TargetBounds != null)
-                {
-                    Destroy(TargetBounds);
-                }
-                TargetBounds = Target.AddComponent<BoxCollider>();
+                TargetBounds = Target.EnsureComponent<BoxCollider>();
                 Bounds bounds = GetTargetBounds();
 
                 TargetBounds.center = bounds.center;
@@ -1096,29 +1090,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
 
         private void DestroyRig()
         {
-            if (boundsOverride == null)
-            {
-                Destroy(TargetBounds);
-            }
-            else
-            {
-                // If we have previously logged an initial bounds size,
-                // reset the boundsOverride BoxCollider to the initial size.
-                // This is because the CalculateBoxPadding
-                if (initialBoundsOverrideSize.HasValue)
-                {
-                    boundsOverride.size = initialBoundsOverrideSize.Value;
-                }
-
-                if (TargetBounds != null)
-                {
-                    if (TargetBounds.gameObject.GetComponent<NearInteractionGrabbable>())
-                    {
-                        Destroy(TargetBounds.gameObject.GetComponent<NearInteractionGrabbable>());
-                    }
-                }
-            }
-
             // todo: move this out?
             DestroyVisuals();
 
@@ -1127,7 +1098,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                 Destroy(rigRoot.gameObject);
                 rigRoot = null;
             }
-
         }
 
         private void UpdateRigVisibilityInInspector()


### PR DESCRIPTION
## Overview
Bounds control will no longer remove boxcollider and neargrabbable components on disable

## Changes
- Fixes: #10290
