### PR TITLE
Add null reference checks to callbacks

### DIFF
--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -58,6 +58,13 @@ namespace Microsoft.MixedReality.Toolkit
         public static bool IsNull<T>(this T @interface) where T : class => @interface == null || @interface.Equals(null);
 
         /// <summary>
+        /// Tests if an interface is null, taking potential UnityEngine.Object derived class implementers into account
+        /// which require their overridden operators to be called.
+        /// </summary>
+        /// <returns>Falseif either the managed or native object is null, true otherwise.</returns>
+        public static bool IsNotNull<T>(this T @interface) where T : class => !@interface.IsNull();
+
+        /// <summary>
         /// Properly checks an interface for null and returns the MonoBehaviour implementing it.
         /// </summary>
         /// <returns>True if the implementer of the interface is a MonoBehaviour and the MonoBehaviour is not null.</returns>

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -81,7 +81,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         void IMixedRealitySourceStateHandler.OnSourceLost(SourceStateEventData eventData)
         {
-            if (Controller?.InputSource.SourceId == eventData.SourceId)
+            // We must check if either this or gameObject equate to null because this callback may be triggered after
+            // the object has been destroyed. Although event handlers are unregistered in OnDisable(), this may in fact
+            // be postponed (see BaseEventSystem.UnregisterHandler()).
+            if (this.IsNotNull() && gameObject != null && Controller?.InputSource.SourceId == eventData.SourceId)
             {
                 Destroy(gameObject);
             }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/SpeechInputHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/SpeechInputHandler.cs
@@ -119,16 +119,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         void IMixedRealitySpeechHandler.OnSpeechKeywordRecognized(SpeechEventData eventData)
         {
-            UnityEvent keywordResponse;
+            // early return if the script is already heading for destruction
+            if (this.IsNull())
+            {
+                return;
+            }
 
             // Check to make sure the recognized keyword exists in the methods dictionary, then invoke the corresponding method.
-            if (enabled && responses.TryGetValue(eventData.Command.Keyword.ToLower(), out keywordResponse))
+            if (enabled && responses.TryGetValue(eventData.Command.Keyword.ToLower(), out UnityEvent keywordResponse))
             {
                 keywordResponse.Invoke();
-                eventData.Use();
+            eventData.Use();
 
                 // Instantiate the Speech Confirmation Tooltip prefab if assigned
-                // Ignore "Select" keyword since OS will display the tooltip. 
+                // Ignore "Select" keyword since OS will display the tooltip.
                 if (SpeechConfirmationTooltipPrefab != null
                     && speechConfirmationTooltipPrefabInstance == null
                     && !eventData.Command.Keyword.Equals("select", StringComparison.CurrentCultureIgnoreCase))
@@ -141,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // Trigger animation of the Speech Confirmation Tooltip prefab
                     speechConfirmationTooltipPrefabInstance.TriggerConfirmedAnimation();
 
-                    // Tooltip prefab instance will be destroyed on animation complete 
+                    // Tooltip prefab instance will be destroyed on animation complete
                     // by DestroyOnAnimationComplete.cs in the SpeechConfirmationTooltip.prefab
                 }
             }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/SpeechInputHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/SpeechInputHandler.cs
@@ -129,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (enabled && responses.TryGetValue(eventData.Command.Keyword.ToLower(), out UnityEvent keywordResponse))
             {
                 keywordResponse.Invoke();
-            eventData.Use();
+                eventData.Use();
 
                 // Instantiate the Speech Confirmation Tooltip prefab if assigned
                 // Ignore "Select" keyword since OS will display the tooltip.

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -169,7 +169,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             await EnsureInputSystemValid();
 
             // We've been destroyed during the await.
-            if (this == null)
+            if (this.IsNull())
             {
                 return;
             }
@@ -225,7 +225,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 base.Controller = value;
 
-                if (base.Controller != null && this != null)
+                if (base.Controller != null && this.IsNotNull())
                 {
                     // Ensures that the basePointerName is only initialized once
                     if (basePointerName == string.Empty)
@@ -265,7 +265,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             set
             {
                 pointerName = value;
-                if (this != null)
+                if (this.IsNotNull())
                 {
                     gameObject.name = value;
                 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 controller = value;
 
-                if (controller != null && this != null)
+                if (controller != null && this.IsNotNull())
                 {
                     gameObject.name = $"{Controller.ControllerHandedness}_GGVPointer";
                     pointerName = gameObject.name;
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             set
             {
                 pointerName = value;
-                if (this != null)
+                if (this.IsNotNull())
                 {
                     gameObject.name = value;
                 }
@@ -101,10 +101,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <inheritdoc />
         public bool IsInteractionEnabled => IsActive;
-        
+
         /// <inheritdoc />
         public bool IsActive { get; set; }
-        
+
         /// <inheritdoc />
         public bool IsFocusLocked { get; set; }
 
@@ -290,25 +290,33 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnInputUpPerfMarker.Auto())
             {
-                if (eventData.SourceId == InputSourceParent.SourceId)
+                if (InputSourceParent.IsNotNull() && eventData.SourceId == InputSourceParent.SourceId)
                 {
                     if (eventData.MixedRealityInputAction == selectAction)
                     {
                         isSelectPressed = false;
                         if (IsInteractionEnabled)
                         {
-                            BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                            BaseCursor c = null;
+                            if (gazeProvider.IsNotNull() && gazeProvider.GazePointer.IsNotNull())
+                            {
+                                c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                            }
+
                             if (c != null)
                             {
                                 c.SourceDownIds.Remove(eventData.SourceId);
                             }
 
-                            CoreServices.InputSystem.RaisePointerClicked(this, selectAction, 0, Controller.ControllerHandedness);
-                            CoreServices.InputSystem.RaisePointerUp(this, selectAction, Controller.ControllerHandedness);
+                            CoreServices.InputSystem?.RaisePointerClicked(this, selectAction, 0, Controller.ControllerHandedness);
+                            CoreServices.InputSystem?.RaisePointerUp(this, selectAction, Controller.ControllerHandedness);
 
-                            // For GGV, the gaze pointer does not set this value itself. 
+                            // For GGV, the gaze pointer does not set this value itself.
                             // See comment in OnInputDown for more details.
-                            gazeProvider.GazePointer.IsFocusLocked = false;
+                            if (gazeProvider.IsNotNull() && gazeProvider.GazePointer.IsNotNull())
+                            {
+                                gazeProvider.GazePointer.IsFocusLocked = false;
+                            }
                         }
                     }
                 }
@@ -322,7 +330,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnInputDownPerfMarker.Auto())
             {
-                if (eventData.SourceId == InputSourceParent.SourceId)
+                if (eventData.SourceId == InputSourceParent?.SourceId)
                 {
                     if (eventData.MixedRealityInputAction == selectAction)
                     {
@@ -330,18 +338,26 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         lastControllerHandedness = Controller.ControllerHandedness;
                         if (IsInteractionEnabled)
                         {
-                            BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                            BaseCursor c = null;
+                            if (gazeProvider.IsNotNull() && gazeProvider.GazePointer.IsNotNull())
+                            {
+                                c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                            }
+
                             if (c != null)
                             {
                                 c.SourceDownIds.Add(eventData.SourceId);
                             }
 
-                            CoreServices.InputSystem.RaisePointerDown(this, selectAction, Controller.ControllerHandedness);
+                            CoreServices.InputSystem?.RaisePointerDown(this, selectAction, Controller.ControllerHandedness);
 
-                            // For GGV, the gaze pointer does not set this value itself as it does not receive input 
-                            // events from the hands. Because this value is important for certain gaze behavior, 
+                            // For GGV, the gaze pointer does not set this value itself as it does not receive input
+                            // events from the hands. Because this value is important for certain gaze behavior,
                             // such as positioning the gaze cursor, it is necessary to set it here.
-                            gazeProvider.GazePointer.IsFocusLocked = (gazeProvider.GazePointer.Result?.Details.Object != null);
+                            if (gazeProvider.IsNotNull() && gazeProvider.GazePointer.IsNotNull())
+                            {
+                                gazeProvider.GazePointer.IsFocusLocked = (gazeProvider.GazePointer.Result?.Details.Object != null);
+                            }
                         }
                     }
                 }
@@ -357,26 +373,31 @@ namespace Microsoft.MixedReality.Toolkit.Input
             base.OnEnable();
 
             gazeProvider = CoreServices.InputSystem.GazeProvider;
-            BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
-            if (c != null)
+
+            if (gazeProvider.IsNotNull() && gazeProvider.GazePointer.IsNotNull())
             {
-                c.VisibleSourcesCount++;
+
+                BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                if (c.IsNotNull())
+                {
+                    c.VisibleSourcesCount++;
+                }
             }
         }
 
         protected override void OnDisable()
         {
             base.OnDisable();
-            if (gazeProvider != null)
+
+            if (gazeProvider.IsNotNull() && gazeProvider.GazePointer.IsNotNull())
             {
                 BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
-                if (c != null)
+                if (c.IsNotNull())
                 {
                     c.VisibleSourcesCount--;
                 }
             }
         }
-
         #endregion MonoBehaviour Implementation
 
         #region InputSystemGlobalHandlerListener Implementation
@@ -411,9 +432,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnSourceLostPerfMarker.Auto())
             {
-                if (eventData.SourceId == InputSourceParent.SourceId)
+                if (eventData.SourceId == InputSourceParent?.SourceId)
                 {
-                    BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                    BaseCursor c = null;
+                    if (gazeProvider.IsNotNull() && gazeProvider.GazePointer.IsNotNull())
+                    {
+                        c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                    }
+
                     if (c != null)
                     {
                         c.SourceDownIds.Remove(eventData.SourceId);
@@ -422,11 +448,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     if (isSelectPressed)
                     {
                         // Raise OnInputUp if pointer is lost while select is pressed
-                        CoreServices.InputSystem.RaisePointerUp(this, selectAction, lastControllerHandedness);
+                        CoreServices.InputSystem?.RaisePointerUp(this, selectAction, lastControllerHandedness);
 
-                        // For GGV, the gaze pointer does not set this value itself. 
+                        // For GGV, the gaze pointer does not set this value itself.
                         // See comment in OnInputDown for more details.
-                        gazeProvider.GazePointer.IsFocusLocked = false;
+                        if (gazeProvider.IsNotNull() && gazeProvider.GazePointer.IsNotNull())
+                        {
+                            gazeProvider.GazePointer.IsFocusLocked = false;
+                        }
                     }
 
                     // Destroy the pointer since nobody else is destroying us

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public override bool IsInteractionEnabled =>
                 // If IsTracked is not true, then we don't have position data yet (or have stale data),
                 // so remain disabled until we know where to appear (not just at the origin).
-                IsFocusLocked || (IsTracked && Controller != null && Controller.IsInPointingPose && base.IsInteractionEnabled);
+                IsFocusLocked || (IsTracked && Controller.IsNotNull() && Controller.IsInPointingPose && base.IsInteractionEnabled);
 
         private Vector3 lineStartPoint;
         private Vector3 lineEndPoint;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         [SerializeField]
         [Tooltip("The distance to move the camera when the strafe is activated")]
         internal float strafeAmount = 0.25f;
-        
+
         [SerializeField]
         [Tooltip("Whether or not a strafe checks that there is a floor beneath the user's origin on strafe")]
         internal bool checkForFloorOnStrafe = false;
@@ -195,7 +195,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                     await new WaitUntil(() => CoreServices.TeleportSystem != null);
 
                     // We've been destroyed during the await.
-                    if (this == null)
+                    if (this.IsNull())
                     {
                         return;
                     }

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private const float MovementThreshold = 0.01f;
 
         /// <summary>
-        /// Used on Gaze Pointer initialization. To make the object lock/not lock when focus locked during runtime, use the IsTargetPositionLockedOnFocusLock 
+        /// Used on Gaze Pointer initialization. To make the object lock/not lock when focus locked during runtime, use the IsTargetPositionLockedOnFocusLock
         /// attribute of <see cref="GazePointer.IsTargetPositionLockedOnFocusLock"/>
         /// </summary>
         [SerializeField]
@@ -345,7 +345,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             await EnsureInputSystemValid();
 
-            if (this == null)
+            if (this.IsNull())
             {
                 // We've been destroyed during the await.
                 return;
@@ -379,7 +379,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     GazeCursor.SetVisibility(!gazePointer.IsFocusLocked);
                 }
 
-                // Handle toggling the input source's SourceType based on the current eyetracking mode 
+                // Handle toggling the input source's SourceType based on the current eyetracking mode
                 if (IsEyeTrackingEnabledAndValid)
                 {
                     gazeInputSource.SourceType = InputSourceType.Eyes;
@@ -519,7 +519,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 Debug.Assert(gazeTransform != null, "No gaze transform to raycast from!");
 
                 gazePointer = new InternalGazePointer(this, "Gaze Pointer", null, raycastLayerMasks, maxGazeCollisionDistance, gazeTransform, stabilizer);
-                
+
                 if ((GazeCursor == null) &&
                     (GazeCursorPrefab != null))
                 {
@@ -542,7 +542,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 await EnsureInputSystemValid();
 
-                if (this == null)
+                if (this.IsNull())
                 {
                     // We've been destroyed during the await.
                     return;


### PR DESCRIPTION
## Overview
We've encountered a number of input callbacks that can cause `NullReferenceException` in rare circumstances. These incidents seem to occur most often when suspending the app by returning to the holographic shell and resuming while tapping repeatedly.

## Changes
I've added null checks in a variety of places where we've observed problems.

I've replaced `if (this == null)` with `if ((MonoBehaviour)this == null)` (as well as adding this check in a few places) to ensure that the correct overload of `==` is resolved.

## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
