### PR TITLE
Porting over Robert Sonnino's optimizations

### DIFF
--- a/Assets/MRTK/Core/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 491deae18ae79c84ab21bde71dacbf48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Attributes/SystemTypeAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/SystemTypeAttribute.cs
@@ -39,7 +39,10 @@ namespace Microsoft.MixedReality.Toolkit
 #else
             bool isValid = type.IsClass || type.IsInterface || type.IsValueType && !type.IsEnum;
 #endif // WINDOWS_UWP && !ENABLE_IL2CPP
-            Debug.Assert(isValid, $"Invalid Type {type} in attribute.");
+            if (!isValid)
+            {
+                Debug.Assert(isValid, $"Invalid Type {type} in attribute.");
+            }
             Grouping = grouping;
         }
 

--- a/Assets/MRTK/Core/Extensions/EditorClassExtensions/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Extensions/EditorClassExtensions/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Extensions/EditorClassExtensions/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Extensions/EditorClassExtensions/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e535186b4d3cca94ba22fe0a30229e61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Inspectors/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Inspectors/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Inspectors/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Inspectors/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b6fc939c93d8424fb9eb0b4cae4da59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -114,6 +114,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// </summary>
         public void OnProcessScene(Scene scene, BuildReport report)
         {
+            if (!MixedRealityToolkit.IsSceneSystemEnabled)
+            {
+                return;
+            }
+
             RefreshSceneInfoFieldsInScene(scene);
         }
 
@@ -214,12 +219,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [PostProcessSceneAttribute]
         public static void OnPostProcessScene()
         {
+            if (!MixedRealityToolkit.IsSceneSystemEnabled)
+            {
+                return;
+            }
+
             RefreshSceneInfoFieldsInOpenScenes();
         }
 
         [InitializeOnLoadMethod]
         private static void InitializeOnLoad()
         {
+            if (!MixedRealityToolkit.IsSceneSystemEnabled)
+            {
+                return;
+            }
+
             EditorBuildSettings.sceneListChanged += SceneListChanged;
             EditorSceneManager.sceneOpened += SceneOpened;
 

--- a/Assets/MRTK/Core/Inspectors/ServiceInspectors/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Inspectors/ServiceInspectors/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Inspectors/ServiceInspectors/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Inspectors/ServiceInspectors/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36e6f2ff8724e1b418059e00a71c60c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
@@ -90,6 +90,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
         IEnumerable<T> GetPointers<T>() where T : class, IMixedRealityPointer;
 
         /// <summary>
+        /// Gets the first registered pointer that satisfies a specific condition.
+        /// </summary>
+        /// <typeparam name="T">The type of pointers to request. Use IMixedRealityPointer to access all pointers.</typeparam>
+        /// <param name="predicate">A function that returns true when the parameter satisfies a condition.</param>
+        /// <returns>The first pointer in the collection that satisfies the specified condition.</returns>
+        T GetFirstPointerWhere<T>(System.Predicate<T> predicate) where T : class, IMixedRealityPointer;
+
+        /// <summary>
+        /// Gets the first registered pointer that matches a given handedness.
+        /// </summary>
+        /// <typeparam name="T">The type of pointers to request. Use IMixedRealityPointer to access all pointers.</typeparam>
+        /// <param name="handedness">The first pointer in the collection that matches the specified handedness.</param>
+        /// <returns></returns>
+        T GetFirstPointerWithHandedness<T>(Utilities.Handedness handedness) where T : class, IMixedRealityPointer;
+
+        /// <summary>
         /// Subscribes to primary pointer changes.
         /// </summary>
         /// <param name="handler">Handler to be called when the primary pointer changes</param>

--- a/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
@@ -160,16 +160,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var newGlobalBounds = new Bounds(palmPose.Position, Vector3.zero);
                 var newLocalBounds = new Bounds(Vector3.zero, Vector3.zero);
 
-                foreach (var kvp in eventData.InputData)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
                 {
-                    if (kvp.Key == TrackedHandJoint.None ||
-                        kvp.Key == TrackedHandJoint.Palm)
+                    if (i == (int)TrackedHandJoint.None || i == (int)TrackedHandJoint.Palm)
                     {
                         continue;
                     }
 
-                    newGlobalBounds.Encapsulate(kvp.Value.Position);
-                    newLocalBounds.Encapsulate(Quaternion.Inverse(palmPose.Rotation) * (kvp.Value.Position - palmPose.Position));
+                    if (eventData.InputData.TryGetValue((TrackedHandJoint)i, out var pose))
+                    {
+                        newGlobalBounds.Encapsulate(pose.Position);
+                        newLocalBounds.Encapsulate(Quaternion.Inverse(palmPose.Rotation) * (pose.Position - palmPose.Position));
+                    }
                 }
 
                 Bounds[eventData.Handedness] = newGlobalBounds;

--- a/Assets/MRTK/Core/Providers/InputAnimation/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Providers/InputAnimation/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Providers/InputAnimation/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Providers/InputAnimation/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef5f8cd50d19a354782164c570a9749c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Providers/InputSimulation/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Providers/InputSimulation/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Providers/InputSimulation/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0e40e51b17eeac4f8273e6e8e0db14b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Providers/InputSimulation/Editor/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/Editor/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Providers/InputSimulation/Editor/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Providers/InputSimulation/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f757783e1ba14604295c7ee35babbcef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Providers/ObjectMeshObserver/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Providers/ObjectMeshObserver/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1748e078c82619d4c93d7cae0d52e16e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Services/BaseEventSystem.cs
+++ b/Assets/MRTK/Core/Services/BaseEventSystem.cs
@@ -128,8 +128,9 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (eventExecutionDepth == 0 && (postponedActions.Count > 0 || postponedObjectActions.Count > 0))
             {
-                foreach (var handler in postponedActions)
+                for (var i = 0; i < postponedActions.Count; i++)
                 {
+                    var handler = postponedActions[i];
                     if (handler.Item1 == Action.Add)
                     {
                         AddHandlerToMap(handler.Item2, handler.Item3);
@@ -140,8 +141,9 @@ namespace Microsoft.MixedReality.Toolkit
                     }
                 }
 
-                foreach (var obj in postponedObjectActions)
+                for (var i = 0; i < postponedObjectActions.Count; i++)
                 {
+                    var obj = postponedObjectActions[i];
                     if (obj.Item1 == Action.Add)
                     {
                         // Can call it here, because guaranteed that eventExecutionDepth is 0

--- a/Assets/MRTK/Core/Services/BaseService.cs
+++ b/Assets/MRTK/Core/Services/BaseService.cs
@@ -13,6 +13,11 @@ namespace Microsoft.MixedReality.Toolkit
     {
         public const uint DefaultPriority = 10;
 
+        public BaseService()
+        {
+            typeName = GetType().ToString();
+        }
+
         #region IMixedRealityService Implementation
 
         /// <inheritdoc />
@@ -68,12 +73,19 @@ namespace Microsoft.MixedReality.Toolkit
 
         private bool? isInitialized = null;
 
+        private readonly string typeName = null;
+
         /// <inheritdoc />
         public virtual bool IsInitialized
         {
             get
             {
-                Debug.Assert(isInitialized.HasValue, $"{GetType()} has not set a value for IsInitialized, returning false.");
+                if (!isInitialized.HasValue)
+                {
+                    // Calling this allocates a string, so test the condition before
+                    Debug.AssertFormat(isInitialized.HasValue, "{0} has not set a value for IsInitialized, returning false.", typeName);
+                }
+
                 return isInitialized ?? false;
             }
 
@@ -87,9 +99,14 @@ namespace Microsoft.MixedReality.Toolkit
         {
             get
             {
-                Debug.Assert(isEnabled.HasValue, $"{GetType()} has not set a value for IsEnabled, returning false.");
+                if (!isEnabled.HasValue)
+                {
+                    // Calling this allocates a string, so test the condition before
+                    Debug.AssertFormat(isEnabled.HasValue, "{0} has not set a value for IsEnabled, returning false.", typeName);
+                }
                 return isEnabled ?? false;
             }
+
 
             protected set => isEnabled = value;
         }
@@ -101,7 +118,10 @@ namespace Microsoft.MixedReality.Toolkit
         {
             get
             {
-                Debug.Assert(isMarkedDestroyed.HasValue, $"{GetType()} has not set a value for IsMarkedDestroyed, returning false.");
+                if (!isMarkedDestroyed.HasValue)
+                {
+                    Debug.AssertFormat(isMarkedDestroyed.HasValue, "{0} has not set a value for IsMarkedDestroyed, returning false.", typeName);
+                }
                 return isMarkedDestroyed ?? false;
             }
 

--- a/Assets/MRTK/Core/Utilities/Async/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Utilities/Async/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Utilities/Async/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Utilities/Async/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8ab1015c4547bf42bdbfc7ae6d09064
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1173b19a6e0c0664b80574802581dce1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Utilities/DebugUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/DebugUtilities.cs
@@ -178,6 +178,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// Draws a point with a rotation in the Scene window.
         /// </summary>
+        [System.Diagnostics.Conditional("UNITY_EDITOR")]
         public static void DrawPoint(Vector3 point, Quaternion rotation, Color color, float size = 0.05f)
         {
             Vector3[] axes = { rotation * Vector3.up, rotation * Vector3.right, rotation * Vector3.forward };

--- a/Assets/MRTK/Core/Utilities/Editor/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Utilities/Editor/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Utilities/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6346cda0eb018f499002e0a1195479a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -10,10 +10,10 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Rendering;
 
-#if WINDOWS_UWP
+#if ENABLE_WINMD_SUPPORT
 using Windows.Storage;
 using Windows.Storage.Streams;
-#endif // WINDOWS_UWP
+#endif // ENABLE_WINMD_SUPPORT
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
 {
@@ -136,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
 
                     if (texture == null)
                     {
-#if WINDOWS_UWP
+#if ENABLE_WINMD_SUPPORT
                         if (gltfObject.UseBackgroundThread)
                         {
                             try

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/GltfUtility.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/GltfUtility.cs
@@ -10,7 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEngine;
 
-#if WINDOWS_UWP
+#if ENABLE_WINMD_SUPPORT
 using Windows.Storage;
 using Windows.Storage.Streams;
 #else
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
             {
                 byte[] glbData;
 
-#if WINDOWS_UWP
+#if ENABLE_WINMD_SUPPORT
 
                 if (useBackgroundThread)
                 {

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+[assembly: System.Reflection.AssemblyVersion("2.7.2.0")]
+[assembly: System.Reflection.AssemblyFileVersion("2.7.2.0")]
+
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/Importers/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e8bf5fbcff9c844d8e3294027baea43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MRTK/Core/Utilities/Rendering/MaterialInstance.cs
@@ -133,6 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private bool initialized = false;
         private bool materialsInstanced = false;
         private readonly HashSet<Object> materialOwners = new HashSet<Object>();
+        private readonly List<Material> sharedMaterials = new List<Material>();
 
         private const string instancePostfix = " (Instance)";
 
@@ -146,12 +147,12 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private void Update()
         {
             // If the materials get changed via outside of MaterialInstance.
-            var sharedMaterials = CachedRenderer.sharedMaterials;
+            CachedRenderer.GetSharedMaterials(sharedMaterials);
 
             if (!MaterialsMatch(sharedMaterials, instanceMaterials))
             {
                 // Re-create the material instances.
-                var newDefaultMaterials = new Material[sharedMaterials.Length];
+                var newDefaultMaterials = new Material[sharedMaterials.Count];
                 var min = Math.Min(newDefaultMaterials.Length, defaultMaterials.Length);
 
                 // Copy the old defaults.
@@ -222,7 +223,8 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         {
             if (CachedRenderer != null)
             {
-                if (!MaterialsMatch(CachedRenderer.sharedMaterials, instanceMaterials))
+                CachedRenderer.GetSharedMaterials(sharedMaterials);
+                if (!MaterialsMatch(sharedMaterials, instanceMaterials))
                 {
                     CreateInstances();
                 }
@@ -245,14 +247,14 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             materialsInstanced = true;
         }
 
-        private static bool MaterialsMatch(Material[] a, Material[] b)
+        private static bool MaterialsMatch(List<Material> a, Material[] b)
         {
-            if (a?.Length != b?.Length)
+            if (a?.Count != b?.Length)
             {
                 return false;
             }
 
-            for (int i = 0; i < a?.Length; ++i)
+            for (int i = 0; i < a?.Count; ++i)
             {
                 if (a[i] != b[i])
                 {

--- a/Assets/MRTK/Core/Version.txt
+++ b/Assets/MRTK/Core/Version.txt
@@ -1,0 +1,1 @@
+Microsoft Mixed Reality Toolkit 2.7.2

--- a/Assets/MRTK/Core/Version.txt.meta
+++ b/Assets/MRTK/Core/Version.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cafd93a41dc71ed488d540f69fdb685f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
@@ -186,6 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 switch (state)
                 {
                     case KeyboardState.Showing:
+                        if (TouchScreenKeyboard.visible == true)
                         {
                             UpdateText();
                         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
@@ -154,13 +154,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             var focusProvider = CoreServices.InputSystem?.FocusProvider;
             if (focusProvider != null)
             {
-                var spherePointers = focusProvider.GetPointers<SpherePointer>();
-                foreach (var spherePointer in spherePointers)
+                var spherePointer = focusProvider.GetFirstPointerWhere<SpherePointer>(p => p.Controller == Pointer.Controller);
+                if (spherePointer != null)
                 {
-                    if (spherePointer.Controller == Pointer.Controller)
-                    {
-                        return spherePointer.IsNearObject;
-                    }
+                    return spherePointer.IsNearObject;
                 }
             }
 

--- a/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
@@ -85,14 +85,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public static T GetPointer<T>(Handedness handedness) where T : class, IMixedRealityPointer
         {
-            foreach (var pointer in CoreServices.InputSystem.FocusProvider.GetPointers<T>())
+            if (handedness == Handedness.None)
             {
-                if (pointer.Controller?.ControllerHandedness.IsMatch(handedness) == true)
-                {
-                    return pointer;
-                }
+                return null;
             }
-            return null;
+
+            return CoreServices.InputSystem.FocusProvider.GetFirstPointerWithHandedness<T>(handedness);
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
Taken from: https://dev.azure.com/EDT/EDT/_git/lib.mrtk/pullrequest/4743?_a=files&path=/MRTK/Services/InputSystem/FocusProvider.cs
Greatly reduce allocations related to focus/cursors, and MaterialInstance, which was calling renderer.sharedMaterials every frame (which allocates).

Also brings in a keyboard change from the MRTK 2.6 branch into the 2.7 branch.

## Changes
- Fixes: # .


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
