### PR TITLE
Some minor reworks to use TryGetComponent in every-frame pointer code

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -671,8 +671,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 Transform contextCenter = null;
                 if (TargetedObject)
                 {
+#if UNITY_2019_4_OR_NEWER
+                    if (TargetedObject.TryGetComponent(out CursorContextInfo contextInfo) && contextInfo != null)
+#else
                     var contextInfo = TargetedObject.GetComponent<CursorContextInfo>();
                     if (contextInfo != null)
+#endif
                     {
                         cursorAction = contextInfo.CurrentCursorAction;
                         contextCenter = contextInfo.ObjectCenter;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -224,9 +224,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 Camera mainCam = CameraCache.Main;
                 for (int i = 0; i < numColliders; ++i)
                 {
-                    var collider = queryBuffer[i];
-                    var touchable = collider.GetComponent<BaseNearInteractionTouchable>();
-                    if (touchable)
+                    Collider collider = queryBuffer[i];
+#if UNITY_2019_4_OR_NEWER
+                    if (collider.TryGetComponent(out BaseNearInteractionTouchable touchable) && touchable != null)
+#else
+                    BaseNearInteractionTouchable touchable = collider.GetComponent<BaseNearInteractionTouchable>();
+                    if (touchable != null)
+#endif
                     {
                         if (IgnoreCollidersNotInFOV && !mainCam.IsInFOVCached(collider))
                         {


### PR DESCRIPTION
## Overview

While digging into https://github.com/microsoft/MixedRealityToolkit-Unity/pull/10310, I noticed a couple spots where `GetComponent` on objects _without_ the corresponding component were both costly and caused allocations. Unity 2019 introduced `TryGetComponent`, which helps reduce those side effects.

Before: 
![image](https://user-images.githubusercontent.com/3580640/141396469-84e4418a-772a-428e-8543-ad1263aeb4bf.png)
![image](https://user-images.githubusercontent.com/3580640/141400376-233cf6fb-896c-49e9-9ab3-e9285316470f.png)

After:
![image](https://user-images.githubusercontent.com/3580640/141396488-8fa355cd-5d2a-470c-ab0b-e79cb466555f.png)
