### PR TITLE
Introduce alternative to .HasFlag

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
@@ -248,7 +248,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             return setting.ControllerType != null &&
                 setting.ControllerType.Type == controllerType &&
-                setting.Handedness.HasFlag(hand) && setting.Handedness != Handedness.None;
+                setting.Handedness.IsMaskSet(hand) && setting.Handedness != Handedness.None;
         }
     }
 }

--- a/Assets/MRTK/Core/Definitions/Devices/SupportedControllerType.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/SupportedControllerType.cs
@@ -28,4 +28,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
         GGVHand = 1 << 11,
         HPMotionController = 1 << 12
     }
+
+    /// <summary>
+    /// Extension methods specific to the <see cref="SupportedControllerType"/> enum.
+    /// </summary>
+    public static class SupportedControllerTypeExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="SupportedControllerType"/> value.</param>
+        /// <param name="b"><see cref="SupportedControllerType"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this SupportedControllerType a, SupportedControllerType b)
+        {
+            return (a & b) == b;
+        }
+    }
 }

--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs
@@ -63,4 +63,23 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// </summary>
         Inferred = 1 << 7
     }
+
+    /// <summary>
+    /// Extension methods specific to the <see cref="SpatialAwarenessSurfaceTypes"/> enum.
+    /// </summary>
+    public static class SpatialAwarenessSurfaceTypesExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="SpatialAwarenessSurfaceTypes"/> value.</param>
+        /// <param name="b"><see cref="SpatialAwarenessSurfaceTypes"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this SpatialAwarenessSurfaceTypes a, SpatialAwarenessSurfaceTypes b)
+        {
+            return (a & b) == b;
+        }
+    }
 }

--- a/Assets/MRTK/Core/Definitions/Utilities/AxisFlags.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/AxisFlags.cs
@@ -13,4 +13,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         YAxis = 1 << 1,
         ZAxis = 1 << 2
     }
+
+    /// <summary>
+    /// Extension methods specific to the <see cref="AxisFlags"/> enum.
+    /// </summary>
+    public static class AxisFlagsExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="AxisFlags"/> value.</param>
+        /// <param name="b"><see cref="AxisFlags"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this AxisFlags a, AxisFlags b)
+        {
+            return (a & b) == b;
+        }
+    }
 }

--- a/Assets/MRTK/Core/Definitions/Utilities/Handedness.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/Handedness.cs
@@ -39,4 +39,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <remarks>Note, by default the specific hand actions will override settings mapped as both</remarks>
         Any = Other | Left | Right,
     }
+
+    /// <summary>
+    /// Extension methods specific to the <see cref="Handedness"/> enum.
+    /// </summary>
+    public static class HandednessExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="Handedness"/> value.</param>
+        /// <param name="b"><see cref="Handedness"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this Handedness a, Handedness b)
+        {
+            return (a & b) == b;
+        }
+    }
 }

--- a/Assets/MRTK/Core/Definitions/Utilities/ManipulationHandFlags.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/ManipulationHandFlags.cs
@@ -12,4 +12,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         OneHanded = 1 << 0,
         TwoHanded = 1 << 1,
     }
+
+    /// <summary>
+    /// Extension methods specific to the <see cref="ManipulationHandFlags"/> enum.
+    /// </summary>
+    public static class ManipulationHandFlagsExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="ManipulationHandFlags"/> value.</param>
+        /// <param name="b"><see cref="ManipulationHandFlags"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this ManipulationHandFlags a, ManipulationHandFlags b)
+        {
+            return (a & b) == b;
+        }
+    }
 }

--- a/Assets/MRTK/Core/Definitions/Utilities/ManipulationProximityFlags.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/ManipulationProximityFlags.cs
@@ -12,4 +12,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         Near = 1 << 0,
         Far = 1 << 1,
     }
+
+    /// <summary>
+    /// Extension methods specific to the <see cref="ManipulationProximityFlags"/> enum.
+    /// </summary>
+    public static class ManipulationProximityFlagsExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="ManipulationProximityFlags"/> value.</param>
+        /// <param name="b"><see cref="ManipulationProximityFlags"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this ManipulationProximityFlags a, ManipulationProximityFlags b)
+        {
+            return (a & b) == b;
+        }
+    }
 }

--- a/Assets/MRTK/Core/Definitions/Utilities/SupportedPlatforms.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/SupportedPlatforms.cs
@@ -36,4 +36,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         LegacyXR = 1 << 0,
         XRSDK = 1 << 1,
     }
+
+    /// <summary>
+    /// Extension methods specific to the <see cref="SupportedUnityXRPipelines"/> enum.
+    /// </summary>
+    public static class SupportedUnityXRPipelinesExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="SupportedUnityXRPipelines"/> value.</param>
+        /// <param name="b"><see cref="SupportedUnityXRPipelines"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this SupportedUnityXRPipelines a, SupportedUnityXRPipelines b)
+        {
+            return (a & b) == b;
+        }
+    }
 }

--- a/Assets/MRTK/Core/Definitions/Utilities/TransformFlags.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/TransformFlags.cs
@@ -13,4 +13,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         Rotate = 1 << 1,
         Scale = 1 << 2
     }
+
+    /// <summary>
+    /// Extension methods specific to the <see cref="TransformFlags"/> enum.
+    /// </summary>
+    public static class TransformFlagsExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="TransformFlags"/> value.</param>
+        /// <param name="b"><see cref="TransformFlags"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this TransformFlags a, TransformFlags b)
+        {
+            return (a & b) == b;
+        }
+    }
 }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
@@ -193,7 +193,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 if (hasValidType)
                 {
                     MixedRealityControllerAttribute controllerAttribute = MixedRealityControllerAttribute.Find(controllerType.Type);
-                    if (controllerAttribute != null && !controllerAttribute.SupportedUnityXRPipelines.HasFlag(xrPipelineUtility.SelectedPipeline))
+                    if (controllerAttribute != null && !controllerAttribute.SupportedUnityXRPipelines.IsMaskSet(xrPipelineUtility.SelectedPipeline))
                     {
                         continue;
                     }

--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -193,7 +193,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 for (int i = 0; i < pointerConfigurations.Length; i++)
                 {
                     var option = pointerConfigurations[i].profile;
-                    if (option.ControllerType.HasFlag(controllerType) && option.Handedness.HasFlag(controllingHand))
+                    if (option.ControllerType.IsMaskSet(controllerType) && option.Handedness.IsMaskSet(controllingHand))
                     {
                         IMixedRealityPointer requestedPointer = null;
 

--- a/Assets/MRTK/Core/Services/BaseDataProviderAccessCoreSystem.cs
+++ b/Assets/MRTK/Core/Services/BaseDataProviderAccessCoreSystem.cs
@@ -221,13 +221,11 @@ namespace Microsoft.MixedReality.Toolkit
                 SupportedUnityXRPipelines.LegacyXR;
 #endif
 
-            if (MixedRealityExtensionServiceAttribute.Find(concreteType) is MixedRealityDataProviderAttribute providerAttribute)
+            if (MixedRealityExtensionServiceAttribute.Find(concreteType) is MixedRealityDataProviderAttribute providerAttribute
+                && !providerAttribute.SupportedUnityXRPipelines.IsMaskSet(selectedPipeline))
             {
-                if (!providerAttribute.SupportedUnityXRPipelines.HasFlag(selectedPipeline))
-                {
-                    DebugUtilities.LogVerboseFormat("{0} not suitable for the current XR pipeline ({1})", concreteType.Name, selectedPipeline);
-                    return false;
-                }
+                DebugUtilities.LogVerboseFormat("{0} not suitable for the current XR pipeline ({1})", concreteType.Name, selectedPipeline);
+                return false;
             }
 
             if (!typeof(IMixedRealityDataProvider).IsAssignableFrom(concreteType))

--- a/Assets/MRTK/Examples/Experimental/SceneUnderstanding/Scripts/DemoSceneUnderstandingController.cs
+++ b/Assets/MRTK/Examples/Experimental/SceneUnderstanding/Scripts/DemoSceneUnderstandingController.cs
@@ -179,7 +179,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.SceneUnderstanding
         /// <returns>A dictionary with the scene objects of the requested type being the values and their ids being the keys.</returns>
         public IReadOnlyDictionary<int, SpatialAwarenessSceneObject> GetSceneObjectsOfType(SpatialAwarenessSurfaceTypes type)
         {
-            if (!observer.SurfaceTypes.HasFlag(type))
+            if (!observer.SurfaceTypes.IsMaskSet(type))
             {
                 Debug.LogErrorFormat("The Scene Objects of type {0} are not being observed. You should add {0} to the SurfaceTypes property of the observer in advance.", type);
             }
@@ -341,7 +341,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.SceneUnderstanding
         {
             ToggleObservedSurfaceType(SpatialAwarenessSurfaceTypes.World);
 
-            if (observer.SurfaceTypes.HasFlag(SpatialAwarenessSurfaceTypes.World))
+            if (observer.SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceTypes.World))
             {
                 // Ensure we requesting meshes
                 observer.RequestMeshData = true;
@@ -386,13 +386,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.SceneUnderstanding
             inferRegionsToggle.IsToggled = observer.InferRegions;
 
             // Filter display
-            platformToggle.IsToggled = observer.SurfaceTypes.HasFlag(SpatialAwarenessSurfaceTypes.Platform);
-            wallToggle.IsToggled = observer.SurfaceTypes.HasFlag(SpatialAwarenessSurfaceTypes.Wall);
-            floorToggle.IsToggled = observer.SurfaceTypes.HasFlag(SpatialAwarenessSurfaceTypes.Floor);
-            ceilingToggle.IsToggled = observer.SurfaceTypes.HasFlag(SpatialAwarenessSurfaceTypes.Ceiling);
-            worldToggle.IsToggled = observer.SurfaceTypes.HasFlag(SpatialAwarenessSurfaceTypes.World);
-            completelyInferred.IsToggled = observer.SurfaceTypes.HasFlag(SpatialAwarenessSurfaceTypes.Inferred);
-            backgroundToggle.IsToggled = observer.SurfaceTypes.HasFlag(SpatialAwarenessSurfaceTypes.Background);
+            platformToggle.IsToggled = observer.SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceTypes.Platform);
+            wallToggle.IsToggled = observer.SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceTypes.Wall);
+            floorToggle.IsToggled = observer.SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceTypes.Floor);
+            ceilingToggle.IsToggled = observer.SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceTypes.Ceiling);
+            worldToggle.IsToggled = observer.SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceTypes.World);
+            completelyInferred.IsToggled = observer.SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceTypes.Inferred);
+            backgroundToggle.IsToggled = observer.SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceTypes.Background);
         }
 
         /// <summary>
@@ -435,7 +435,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.SceneUnderstanding
 
         private void ToggleObservedSurfaceType(SpatialAwarenessSurfaceTypes surfaceType)
         {
-            if (observer.SurfaceTypes.HasFlag(surfaceType))
+            if (observer.SurfaceTypes.IsMaskSet(surfaceType))
             {
                 observer.SurfaceTypes &= ~surfaceType;
             }

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
@@ -859,7 +859,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
                     EnableSceneObjectQuads = RequestPlaneData,
                     EnableSceneObjectMeshes = RequestMeshData,
                     EnableOnlyObservedSceneObjects = !InferRegions,
-                    EnableWorldMesh = SurfaceTypes.HasFlag(SpatialAwarenessSurfaceTypes.World),
+                    EnableWorldMesh = SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceTypes.World),
                     RequestedMeshLevelOfDetail = LevelOfDetailToMeshLOD(WorldMeshLevelOfDetail)
                 };
 
@@ -1009,7 +1009,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
 
             for (int i = 0; i < count; ++i)
             {
-                if (!SurfaceTypes.HasFlag(SpatialAwarenessSurfaceType(newObjects[i].Kind)))
+                if (!SurfaceTypes.IsMaskSet(SpatialAwarenessSurfaceType(newObjects[i].Kind)))
                 {
                     continue;
                 }

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -150,17 +150,17 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
         /// <inheritdoc />
         protected override SupportedControllerType GetCurrentControllerType(InputDevice inputDevice)
         {
-            if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.HandTracking))
+            if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking))
             {
-                if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Left) ||
-                    inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Right))
+                if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Left) ||
+                    inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Right))
                 {
                     // If it's a hand with a reported handedness, assume articulated hand
                     return SupportedControllerType.ArticulatedHand;
                 }
             }
 
-            if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Controller))
+            if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
             {
                 return SupportedControllerType.OculusTouch;
             }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -153,10 +153,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 {
                     foreach (InputDevice device in ActiveControllers.Keys)
                     {
-                        if (((device.characteristics.HasFlag(InputDeviceCharacteristics.Controller) && inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Controller))
-                            || (device.characteristics.HasFlag(InputDeviceCharacteristics.HandTracking) && inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.HandTracking)))
-                            && ((device.characteristics.HasFlag(InputDeviceCharacteristics.Left) && inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Left))
-                            || (device.characteristics.HasFlag(InputDeviceCharacteristics.Right) && inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Right))))
+                        if (((device.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
+                            || (device.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking)))
+                            && ((device.characteristics.IsMaskSet(InputDeviceCharacteristics.Left) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Left))
+                            || (device.characteristics.IsMaskSet(InputDeviceCharacteristics.Right) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Right))))
                         {
                             ActiveControllers.Add(inputDevice, ActiveControllers[device]);
                             break;
@@ -164,7 +164,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     }
                 }
 
-                if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.HandTracking)
+                if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking)
                     && inputDevice.TryGetFeatureValue(CommonUsages.isTracked, out bool isTracked)
                     && !isTracked)
                 {
@@ -189,10 +189,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 foreach (InputDevice device in ActiveControllers.Keys)
                 {
                     if (device != inputDevice
-                        && ((device.characteristics.HasFlag(InputDeviceCharacteristics.Controller) && inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Controller))
-                        || (device.characteristics.HasFlag(InputDeviceCharacteristics.HandTracking) && inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.HandTracking)))
-                        && ((device.characteristics.HasFlag(InputDeviceCharacteristics.Left) && inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Left))
-                        || (device.characteristics.HasFlag(InputDeviceCharacteristics.Right) && inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Right))))
+                        && ((device.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
+                        || (device.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking)))
+                        && ((device.characteristics.IsMaskSet(InputDeviceCharacteristics.Left) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Left))
+                        || (device.characteristics.IsMaskSet(InputDeviceCharacteristics.Right) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Right))))
                     {
                         ActiveControllers.Remove(inputDevice);
                         // Since an additional device exists, return so a lost source isn't reported
@@ -238,12 +238,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// <inheritdoc />
         protected override SupportedControllerType GetCurrentControllerType(InputDevice inputDevice)
         {
-            if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.HandTracking))
+            if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking))
             {
                 return SupportedControllerType.ArticulatedHand;
             }
 
-            if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Controller))
+            if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
             {
                 if (inputDevice.manufacturer == "HP")
                 {

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -257,7 +257,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
         private uint GetControllerId(InputDevice inputDevice)
         {
-            var handedness = (uint)(inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Right) ? 2 : (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Left) ? 1 : 0));
+            var handedness = (uint)(inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Right) ? 2 : (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Left) ? 1 : 0));
             return GetControllerId(handedness);
         }
 #endif // HP_CONTROLLER_ENABLED
@@ -299,10 +299,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         protected override SupportedControllerType GetCurrentControllerType(InputDevice inputDevice)
         {
-            if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.HandTracking))
+            if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking))
             {
-                if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Left) ||
-                    inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Right))
+                if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Left) ||
+                    inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Right))
                 {
                     // If it's a hand with a reported handedness, assume HL2 articulated hand
                     return SupportedControllerType.ArticulatedHand;
@@ -314,7 +314,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 }
             }
 
-            if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Controller))
+            if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
             {
                 // primary2DAxis represents the touchpad in Windows XR Plugin.
                 // The HP motion controller doesn't have a touchpad, so we check for its existence in the feature usages.

--- a/Assets/MRTK/Providers/XRSDK/FlagsExtensions.cs
+++ b/Assets/MRTK/Providers/XRSDK/FlagsExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine.XR;
+
+namespace Microsoft.MixedReality.Toolkit.XRSDK
+{
+    public static class FlagsExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="InputDeviceCharacteristics"/> value.</param>
+        /// <param name="b"><see cref="InputDeviceCharacteristics"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this InputDeviceCharacteristics a, InputDeviceCharacteristics b)
+        {
+            return (a & b) == b;
+        }
+
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="TrackingOriginModeFlags"/> value.</param>
+        /// <param name="b"><see cref="TrackingOriginModeFlags"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this TrackingOriginModeFlags a, TrackingOriginModeFlags b)
+        {
+            return (a & b) == b;
+        }
+    }
+}

--- a/Assets/MRTK/Providers/XRSDK/FlagsExtensions.cs.meta
+++ b/Assets/MRTK/Providers/XRSDK/FlagsExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bad6ee50ff9f3864aa94a5724cc71cb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -169,11 +169,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
 
                 Handedness controllingHand;
 
-                if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Left))
+                if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Left))
                 {
                     controllingHand = Handedness.Left;
                 }
-                else if (inputDevice.characteristics.HasFlag(InputDeviceCharacteristics.Right))
+                else if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Right))
                 {
                     controllingHand = Handedness.Right;
                 }

--- a/Assets/MRTK/SDK/Editor/Inspectors/Exp/Elastics/ElasticsManagerInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Exp/Elastics/ElasticsManagerInspector.cs
@@ -86,7 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
             TransformFlags requiredFlag,
             TransformFlags providedFlags) where T : ElasticConfiguration
         {
-            if (providedFlags.HasFlag(requiredFlag))
+            if (providedFlags.IsMaskSet(requiredFlag))
             {
                 bool result = false;
                 using (new EditorGUI.IndentLevelScope())

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -133,7 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             if (oneHandedFoldout)
             {
-                if (handedness.HasFlag(ManipulationHandFlags.OneHanded))
+                if (handedness.IsMaskSet(ManipulationHandFlags.OneHanded))
                 {
                     EditorGUILayout.PropertyField(oneHandRotationModeNear);
                     EditorGUILayout.PropertyField(oneHandRotationModeFar);
@@ -149,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             if (twoHandedFoldout)
             {
-                if (handedness.HasFlag(ManipulationHandFlags.TwoHanded))
+                if (handedness.IsMaskSet(ManipulationHandFlags.TwoHanded))
                 {
                     EditorGUILayout.PropertyField(twoHandedManipulationType);
                 }

--- a/Assets/MRTK/SDK/Editor/Migration/ObjectManipulatorMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Editor/Migration/ObjectManipulatorMigrationHandler.cs
@@ -183,11 +183,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     break;
             }
 
-            if (proximity.HasFlag(ManipulationProximityFlags.Near))
+            if (proximity.IsMaskSet(ManipulationProximityFlags.Near))
             {
                 objManip.OneHandRotationModeNear = newMode;
             }
-            if (proximity.HasFlag(ManipulationProximityFlags.Far))
+            if (proximity.IsMaskSet(ManipulationProximityFlags.Far))
             {
                 objManip.OneHandRotationModeFar = newMode;
             }

--- a/Assets/MRTK/SDK/Experimental/Elastic/Scripts/ElasticsManager.cs
+++ b/Assets/MRTK/SDK/Experimental/Elastic/Scripts/ElasticsManager.cs
@@ -143,17 +143,17 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Physics
             if (hostTransform != null)
             {
                 TransformFlags enabledTransformTypes = transformsToApply & elasticTypes;
-                if (enabledTransformTypes.HasFlag(TransformFlags.Move))
+                if (enabledTransformTypes.IsMaskSet(TransformFlags.Move))
                 {
                     hostTransform.position = translationElastic.ComputeIteration(targetTransform.Position, Time.deltaTime);
                 }
 
-                if (enabledTransformTypes.HasFlag(TransformFlags.Rotate))
+                if (enabledTransformTypes.IsMaskSet(TransformFlags.Rotate))
                 {
                     hostTransform.rotation = rotationElastic.ComputeIteration(targetTransform.Rotation, Time.deltaTime);
                 }
 
-                if (enabledTransformTypes.HasFlag(TransformFlags.Scale))
+                if (enabledTransformTypes.IsMaskSet(TransformFlags.Scale))
                 {
                     hostTransform.localScale = scaleElastic.ComputeIteration(targetTransform.Scale, Time.deltaTime);
                 }
@@ -175,21 +175,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Physics
         public void InitializeElastics(Transform elasticsTransform)
         {
             hostTransform = elasticsTransform;
-            if (elasticTypes.HasFlag(TransformFlags.Move))
+            if (elasticTypes.IsMaskSet(TransformFlags.Move))
             {
                 translationElastic = new VolumeElasticSystem(hostTransform.position,
                                                              translationElastic?.GetCurrentVelocity() ?? Vector3.zero,
                                                              translationElasticExtent,
                                                              translationElasticConfigurationObject.ElasticProperties);
             }
-            if (elasticTypes.HasFlag(TransformFlags.Rotate))
+            if (elasticTypes.IsMaskSet(TransformFlags.Rotate))
             {
                 rotationElastic = new QuaternionElasticSystem(hostTransform.rotation,
                                                               rotationElastic?.GetCurrentVelocity() ?? Quaternion.identity,
                                                               rotationElasticExtent,
                                                               rotationElasticConfigurationObject.ElasticProperties);
             }
-            if (elasticTypes.HasFlag(TransformFlags.Scale))
+            if (elasticTypes.IsMaskSet(TransformFlags.Scale))
             {
                 scaleElastic = new VolumeElasticSystem(hostTransform.localScale,
                                                        scaleElastic?.GetCurrentVelocity() ?? Vector3.zero,
@@ -229,8 +229,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Physics
 
         private bool ShouldUpdateElastics<T>(TransformFlags elasticType, IElasticSystem<T> elasticSystem)
         {
-            return (elasticTypes.HasFlag(elasticType) &&
-                elasticTypesSimulating.HasFlag(elasticType) &&
+            return (elasticTypes.IsMaskSet(elasticType) &&
+                elasticTypesSimulating.IsMaskSet(elasticType) &&
                 elasticSystem != null);
         }
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
@@ -156,8 +156,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 
                 if (constraint.isActiveAndEnabled &&
                     constraint.ConstraintType == transformType &&
-                    constraint.HandType.HasFlag(handMode) &&
-                    constraint.ProximityType.HasFlag(proximityMode))
+                    constraint.HandType.IsMaskSet(handMode) &&
+                    constraint.ProximityType.IsMaskSet(proximityMode))
                 {
                     constraint.ApplyConstraint(ref transform);
                 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/MoveAxisConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/MoveAxisConstraint.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Quaternion inverseRotation = Quaternion.Inverse(worldPoseOnManipulationStart.Rotation);
             Vector3 position = transform.Position;
-            if (constraintOnMovement.HasFlag(AxisFlags.XAxis))
+            if (constraintOnMovement.IsMaskSet(AxisFlags.XAxis))
             {
                 if (useLocalSpaceForConstraint)
                 {
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     position.x = worldPoseOnManipulationStart.Position.x;
                 }
             }
-            if (constraintOnMovement.HasFlag(AxisFlags.YAxis))
+            if (constraintOnMovement.IsMaskSet(AxisFlags.YAxis))
             {
                 if (useLocalSpaceForConstraint)
                 {
@@ -81,7 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     position.y = worldPoseOnManipulationStart.Position.y;
                 }
             }
-            if (constraintOnMovement.HasFlag(AxisFlags.ZAxis))
+            if (constraintOnMovement.IsMaskSet(AxisFlags.ZAxis))
             {
                 if (useLocalSpaceForConstraint)
                 {

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/RotationAxisConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/RotationAxisConstraint.cs
@@ -55,15 +55,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Quaternion rotation = transform.Rotation * Quaternion.Inverse(worldPoseOnManipulationStart.Rotation);
             Vector3 eulers = rotation.eulerAngles;
-            if (constraintOnRotation.HasFlag(AxisFlags.XAxis))
+            if (constraintOnRotation.IsMaskSet(AxisFlags.XAxis))
             {
                 eulers.x = 0;
             }
-            if (constraintOnRotation.HasFlag(AxisFlags.YAxis))
+            if (constraintOnRotation.IsMaskSet(AxisFlags.YAxis))
             {
                 eulers.y = 0;
             }
-            if (constraintOnRotation.HasFlag(AxisFlags.ZAxis))
+            if (constraintOnRotation.IsMaskSet(AxisFlags.ZAxis))
             {
                 eulers.z = 0;
             }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
@@ -23,12 +23,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class ManipulationHandler : MonoBehaviour, IMixedRealityPointerHandler, IMixedRealityFocusChangedHandler
     {
         #region Public Enums
+
         public enum HandMovementType
         {
             OneHandedOnly = 0,
             TwoHandedOnly,
             OneAndTwoHanded
         }
+
         public enum TwoHandedManipulation
         {
             Scale,
@@ -37,7 +39,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             MoveRotate,
             RotateScale,
             MoveRotateScale
-        };
+        }
+
         public enum RotateInOneHandType
         {
             MaintainRotationToUser,
@@ -47,13 +50,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
             MaintainOriginalRotation,
             RotateAboutObjectCenter,
             RotateAboutGrabPoint
-        };
-        [System.Flags]
+        }
+
+        [Flags]
         public enum ReleaseBehaviorType
         {
             KeepVelocity = 1 << 0,
             KeepAngularVelocity = 1 << 1
         }
+
         #endregion Public Enums
 
         #region Serialized Fields
@@ -954,12 +959,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 rigidBody.isKinematic = wasKinematic;
 
-                if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepVelocity))
+                if (releaseBehavior.IsMaskSet(ReleaseBehaviorType.KeepVelocity))
                 {
                     rigidBody.velocity = GetPointersVelocity();
                 }
 
-                if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepAngularVelocity))
+                if (releaseBehavior.IsMaskSet(ReleaseBehaviorType.KeepAngularVelocity))
                 {
                     rigidBody.angularVelocity = GetPointersAngularVelocity();
                 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -41,13 +41,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             RotateAboutObjectCenter,
             RotateAboutGrabPoint
-        };
-        [System.Flags]
+        }
+
+        [Flags]
         public enum ReleaseBehaviorType
         {
             KeepVelocity = 1 << 0,
             KeepAngularVelocity = 1 << 1
         }
+
         #endregion Public Enums
 
         #region Serialized Fields
@@ -399,8 +401,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private bool wasGravity = false;
         private bool wasKinematic = false;
 
-        private bool IsOneHandedManipulationEnabled => manipulationType.HasFlag(ManipulationHandFlags.OneHanded) && pointerIdToPointerMap.Count == 1;
-        private bool IsTwoHandedManipulationEnabled => manipulationType.HasFlag(ManipulationHandFlags.TwoHanded) && pointerIdToPointerMap.Count > 1;
+        private bool IsOneHandedManipulationEnabled => manipulationType.IsMaskSet(ManipulationHandFlags.OneHanded) && pointerIdToPointerMap.Count == 1;
+        private bool IsTwoHandedManipulationEnabled => manipulationType.IsMaskSet(ManipulationHandFlags.TwoHanded) && pointerIdToPointerMap.Count > 1;
 
         private Quaternion leftHandRotation;
         private Quaternion rightHandRotation;
@@ -654,9 +656,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             // Call manipulation ended handlers
             var handsPressedCount = pointerIdToPointerMap.Count;
-            if (manipulationType.HasFlag(ManipulationHandFlags.TwoHanded) && handsPressedCount == 1)
+            if (manipulationType.IsMaskSet(ManipulationHandFlags.TwoHanded) && handsPressedCount == 1)
             {
-                if (manipulationType.HasFlag(ManipulationHandFlags.OneHanded))
+                if (manipulationType.IsMaskSet(ManipulationHandFlags.OneHanded))
                 {
                     HandleOneHandMoveStarted();
                 }
@@ -680,11 +682,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             var handPositionArray = GetHandPositionArray();
 
-            if (twoHandedManipulationType.HasFlag(TransformFlags.Rotate))
+            if (twoHandedManipulationType.IsMaskSet(TransformFlags.Rotate))
             {
                 rotateLogic.Setup(handPositionArray, HostTransform);
             }
-            if (twoHandedManipulationType.HasFlag(TransformFlags.Move))
+            if (twoHandedManipulationType.IsMaskSet(TransformFlags.Move))
             {
                 // If near manipulation, a pure grabpoint centroid is used for
                 // the initial pointer pose; if far manipulation, a more complex
@@ -693,7 +695,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 MixedRealityPose hostPose = new MixedRealityPose(HostTransform.position, HostTransform.rotation);
                 moveLogic.Setup(pointerPose, GetPointersGrabPoint(), hostPose, HostTransform.localScale);
             }
-            if (twoHandedManipulationType.HasFlag(TransformFlags.Scale))
+            if (twoHandedManipulationType.IsMaskSet(TransformFlags.Scale))
             {
                 scaleLogic.Setup(handPositionArray, HostTransform);
             }
@@ -705,7 +707,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             var handPositionArray = GetHandPositionArray();
 
-            if (twoHandedManipulationType.HasFlag(TransformFlags.Scale))
+            if (twoHandedManipulationType.IsMaskSet(TransformFlags.Scale))
             {
                 targetTransform.Scale = scaleLogic.UpdateMap(handPositionArray);
                 if (EnableConstraints && constraintsManager != null)
@@ -713,7 +715,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     constraintsManager.ApplyScaleConstraints(ref targetTransform, false, IsNearManipulation());
                 }
             }
-            if (twoHandedManipulationType.HasFlag(TransformFlags.Rotate))
+            if (twoHandedManipulationType.IsMaskSet(TransformFlags.Rotate))
             {
                 targetTransform.Rotation = rotateLogic.Update(handPositionArray, targetTransform.Rotation);
                 if (EnableConstraints && constraintsManager != null)
@@ -721,7 +723,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     constraintsManager.ApplyRotationConstraints(ref targetTransform, false, IsNearManipulation());
                 }
             }
-            if (twoHandedManipulationType.HasFlag(TransformFlags.Move))
+            if (twoHandedManipulationType.IsMaskSet(TransformFlags.Move))
             {
                 // If near manipulation, a pure GrabPoint centroid is used for
                 // the pointer pose; if far manipulation, a more complex
@@ -744,8 +746,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             IMixedRealityPointer pointer = pointerData.pointer;
 
             // Calculate relative transform from object to grip.
-            Quaternion gripRotation;
-            TryGetGripRotation(pointer, out gripRotation);
+            TryGetGripRotation(pointer, out Quaternion gripRotation);
             Quaternion worldToGripRotation = Quaternion.Inverse(gripRotation);
             objectToGripRotation = worldToGripRotation * HostTransform.rotation;
 
@@ -873,15 +874,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 {
                     transformUpdated = elasticsManager.ApplyTargetTransform(targetTransform);
                 }
-                if (!transformUpdated.HasFlag(TransformFlags.Move))
+                if (!transformUpdated.IsMaskSet(TransformFlags.Move))
                 {
                     HostTransform.position = applySmoothing ? smoothingLogic.SmoothPosition(HostTransform.position, targetTransform.Position, moveLerpTime, Time.deltaTime) : targetTransform.Position;
                 }
-                if (!transformUpdated.HasFlag(TransformFlags.Rotate))
+                if (!transformUpdated.IsMaskSet(TransformFlags.Rotate))
                 {
                     HostTransform.rotation = applySmoothing ? smoothingLogic.SmoothRotation(HostTransform.rotation, targetTransform.Rotation, rotateLerpTime, Time.deltaTime) : targetTransform.Rotation;
                 }
-                if (!transformUpdated.HasFlag(TransformFlags.Scale))
+                if (!transformUpdated.IsMaskSet(TransformFlags.Scale))
                 {
                     HostTransform.localScale = applySmoothing ? smoothingLogic.SmoothScale(HostTransform.localScale, targetTransform.Scale, scaleLerpTime, Time.deltaTime) : targetTransform.Scale;
                 }
@@ -987,12 +988,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 // Otherwise keep the objects current velocity so that it's not dampened unnaturally
                 if (isNearManipulation)
                 {
-                    if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepVelocity))
+                    if (releaseBehavior.IsMaskSet(ReleaseBehaviorType.KeepVelocity))
                     {
                         rigidBody.velocity = velocity;
                     }
 
-                    if (releaseBehavior.HasFlag(ReleaseBehaviorType.KeepAngularVelocity))
+                    if (releaseBehavior.IsMaskSet(ReleaseBehaviorType.KeepAngularVelocity))
                     {
                         rigidBody.angularVelocity = angularVelocity;
                     }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundsControl/BoundsControl.cs
@@ -1198,7 +1198,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     {
                         transformUpdated = elasticsManager.ApplyTargetTransform(constraintRotation, TransformFlags.Rotate);
                     }
-                    if (!transformUpdated.HasFlag(TransformFlags.Rotate))
+                    if (!transformUpdated.IsMaskSet(TransformFlags.Rotate))
                     {
                         Target.transform.rotation = smoothingActive ?
                             Smoothing.SmoothTo(Target.transform.rotation, constraintRotation.Rotation, rotateLerpTime, Time.deltaTime) :
@@ -1253,7 +1253,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     {
                         transformUpdated = elasticsManager.ApplyTargetTransform(clampedTransform, TransformFlags.Scale);
                     }
-                    if (!transformUpdated.HasFlag(TransformFlags.Scale))
+                    if (!transformUpdated.IsMaskSet(TransformFlags.Scale))
                     {
                         Target.transform.localScale = smoothingActive ?
                             Smoothing.SmoothTo(Target.transform.localScale, clampedTransform.Scale, scaleLerpTime, Time.deltaTime) :
@@ -1278,7 +1278,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.BoundsControl
                     {
                         transformUpdated = elasticsManager.ApplyTargetTransform(constraintTranslate, TransformFlags.Move);
                     }
-                    if (!transformUpdated.HasFlag(TransformFlags.Move))
+                    if (!transformUpdated.IsMaskSet(TransformFlags.Move))
                     {
                         Target.transform.position = smoothingActive ?
                             Smoothing.SmoothTo(Target.transform.position, constraintTranslate.Position, translateLerpTime, Time.deltaTime) :

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/DialogButtonType.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/DialogButtonType.cs
@@ -20,4 +20,23 @@ namespace Microsoft.MixedReality.Toolkit.UI
         No = 1 << 5,
         OK = 1 << 6
     }
+
+    /// <summary>
+    /// Extension methods specific to the <see cref="DialogButtonType"/> enum.
+    /// </summary>
+    public static class DialogButtonTypeExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="DialogButtonType"/> value.</param>
+        /// <param name="b"><see cref="DialogButtonType"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this DialogButtonType a, DialogButtonType b)
+        {
+            return (a & b) == b;
+        }
+    }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/DialogShell.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Dialog/DialogShell.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             foreach (DialogButtonType buttonType in Enum.GetValues(typeof(DialogButtonType)))
             {
                 // If this button type flag is set
-                if (buttonType != DialogButtonType.None && result.Buttons.HasFlag(buttonType))
+                if (buttonType != DialogButtonType.None && result.Buttons.IsMaskSet(buttonType))
                 {
                     buttonTypes.Add(buttonType);
                 }

--- a/Assets/MRTK/SDK/Features/Utilities/ReleaseBehaviorTypeExtensions.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/ReleaseBehaviorTypeExtensions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.MixedReality.Toolkit.UI
+{
+    /// <summary>
+    /// Extension methods specific to the <see cref="ObjectManipulator.ReleaseBehaviorType"/> and <see cref="ManipulationHandler.ReleaseBehaviorType"/> enums.
+    /// </summary>
+    public static class ReleaseBehaviorTypeExtensions
+    {
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="ObjectManipulator.ReleaseBehaviorType"/> value.</param>
+        /// <param name="b"><see cref="ObjectManipulator.ReleaseBehaviorType"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this ObjectManipulator.ReleaseBehaviorType a, ObjectManipulator.ReleaseBehaviorType b)
+        {
+            return (a & b) == b;
+        }
+
+        /// <summary>
+        /// Checks to determine if all bits in a provided mask are set.
+        /// </summary>
+        /// <param name="a"><see cref="ManipulationHandler.ReleaseBehaviorType"/> value.</param>
+        /// <param name="b"><see cref="ManipulationHandler.ReleaseBehaviorType"/> mask.</param>
+        /// <returns>
+        /// True if all of the bits in the specified mask are set in the current value.
+        /// </returns>
+        public static bool IsMaskSet(this ManipulationHandler.ReleaseBehaviorType a, ManipulationHandler.ReleaseBehaviorType b)
+        {
+            return (a & b) == b;
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/Utilities/ReleaseBehaviorTypeExtensions.cs.meta
+++ b/Assets/MRTK/SDK/Features/Utilities/ReleaseBehaviorTypeExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d14c62b61e29094b82878b1a1f2e8bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/Follow.cs
@@ -634,15 +634,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             if (FaceUserDefinedTargetTransform)
             {
                 Vector3 directionToTarget = TargetToFace != null ? goalPosition - TargetToFace.position : Vector3.zero;
-                if (!PivotAxis.HasFlag(AxisFlags.XAxis))
+                if (!PivotAxis.IsMaskSet(AxisFlags.XAxis))
                 {
                     directionToTarget.x = 0;
                 }
-                if (!PivotAxis.HasFlag(AxisFlags.YAxis))
+                if (!PivotAxis.IsMaskSet(AxisFlags.YAxis))
                 {
                     directionToTarget.y = 0;
                 }
-                if (!PivotAxis.HasFlag(AxisFlags.ZAxis))
+                if (!PivotAxis.IsMaskSet(AxisFlags.ZAxis))
                 {
                     directionToTarget.z = 0;
                 }


### PR DESCRIPTION
## Overview

Turns out, `.HasFlag` boxes the enum which causes GC allocs! @davidkline-ms introduced this pattern in our v3 investigations, so I'm backporting it to v2 so we get the goodness here as well!

This cuts a specific hotspot in GetPointers by about half:
![image](https://user-images.githubusercontent.com/3580640/141600656-55bf0de1-e1af-4f85-b1a8-2b1c4ab5b32d.png)
