### PR TITLE
Improvements to hand joint visualizer perf

### DIFF
--- a/Assets/MRTK/Core/Definitions/Utilities/ArticulatedHandPose.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/ArticulatedHandPose.cs
@@ -17,12 +17,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     /// </summary>
     public class ArticulatedHandPose
     {
-        private static readonly TrackedHandJoint[] Joints = Enum.GetValues(typeof(TrackedHandJoint)) as TrackedHandJoint[];
+        public static IReadOnlyList<TrackedHandJoint> HandJoints { get; } = Enum.GetValues(typeof(TrackedHandJoint)) as IReadOnlyList<TrackedHandJoint>;
 
         /// <summary>
         /// Represents the maximum number of tracked hand joints.
         /// </summary>
-        public static int JointCount { get; } = Joints.Length;
+        public static int JointCount { get; } = HandJoints.Count;
 
         /// <summary>
         /// Joint poses are stored as right-hand poses in camera space.
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             for (int i = 0; i < JointCount; i++)
             {
                 // Initialize from local offsets
-                MixedRealityPose pose = GetLocalJointPose(Joints[i], handedness);
+                MixedRealityPose pose = GetLocalJointPose(HandJoints[i], handedness);
                 Vector3 p = pose.Position;
                 Quaternion r = pose.Rotation;
 

--- a/Assets/MRTK/Core/Definitions/Utilities/ArticulatedHandPose.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/ArticulatedHandPose.cs
@@ -17,12 +17,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     /// </summary>
     public class ArticulatedHandPose
     {
-        public static IReadOnlyList<TrackedHandJoint> HandJoints { get; } = Enum.GetValues(typeof(TrackedHandJoint)) as IReadOnlyList<TrackedHandJoint>;
+        private static readonly TrackedHandJoint[] Joints = Enum.GetValues(typeof(TrackedHandJoint)) as TrackedHandJoint[];
 
         /// <summary>
         /// Represents the maximum number of tracked hand joints.
         /// </summary>
-        public static int JointCount { get; } = HandJoints.Count;
+        public static int JointCount { get; } = Joints.Length;
 
         /// <summary>
         /// Joint poses are stored as right-hand poses in camera space.
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             for (int i = 0; i < JointCount; i++)
             {
                 // Initialize from local offsets
-                MixedRealityPose pose = GetLocalJointPose(HandJoints[i], handedness);
+                MixedRealityPose pose = GetLocalJointPose(Joints[i], handedness);
                 Vector3 p = pose.Position;
                 Quaternion r = pose.Rotation;
 

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -120,7 +120,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 for (int i = 1; i < ArticulatedHandPose.JointCount; i++)
                 {
                     TrackedHandJoint handJoint = (TrackedHandJoint)i;
-
                     MixedRealityPose handJointPose = eventData.InputData[handJoint];
                     Transform jointTransform = jointsArray[i];
 

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
                 {
-                    TrackedHandJoint handJoint = ArticulatedHandPose.HandJoints[i];
+                    TrackedHandJoint handJoint = (TrackedHandJoint)i;
 
                     if (handJoint == TrackedHandJoint.None) { continue; }
 

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -125,8 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     if (jointTransform != null)
                     {
-                        jointTransform.position = handJointPose.Position;
-                        jointTransform.rotation = handJointPose.Rotation;
+                        jointTransform.SetPositionAndRotation(handJointPose.Position, handJointPose.Rotation);
                     }
                     else
                     {
@@ -160,8 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         }
 
                         jointObject.name = handJoint.ToString() + " Proxy Transform";
-                        jointObject.transform.position = handJointPose.Position;
-                        jointObject.transform.rotation = handJointPose.Rotation;
+                        jointObject.transform.SetPositionAndRotation(handJointPose.Position, handJointPose.Rotation);
                         jointObject.transform.parent = transform;
 
                         jointsArray[i] = jointObject.transform;
@@ -226,8 +224,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         mesh.RecalculateBounds();
                     }
 
-                    handMeshFilter.transform.position = eventData.InputData.position;
-                    handMeshFilter.transform.rotation = eventData.InputData.rotation;
+                    handMeshFilter.transform.SetPositionAndRotation(eventData.InputData.position, eventData.InputData.rotation);
                 }
             }
         }

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -119,10 +119,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     if (handJoint == TrackedHandJoint.None) { continue; }
 
+                    MixedRealityPose handJointPose = eventData.InputData[handJoint];
+
                     if (joints.TryGetValue(handJoint, out Transform jointTransform))
                     {
-                        jointTransform.position = eventData.InputData[handJoint].Position;
-                        jointTransform.rotation = eventData.InputData[handJoint].Rotation;
+                        jointTransform.position = handJointPose.Position;
+                        jointTransform.rotation = handJointPose.Rotation;
                     }
                     else
                     {
@@ -156,8 +158,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         }
 
                         jointObject.name = handJoint.ToString() + " Proxy Transform";
-                        jointObject.transform.position = eventData.InputData[handJoint].Position;
-                        jointObject.transform.rotation = eventData.InputData[handJoint].Rotation;
+                        jointObject.transform.position = handJointPose.Position;
+                        jointObject.transform.rotation = handJointPose.Rotation;
                         jointObject.transform.parent = transform;
 
                         joints.Add(handJoint, jointObject.transform);

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -116,11 +116,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     return;
                 }
 
-                for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
+                // This starts at 1 to skip over TrackedHandJoint.None.
+                for (int i = 1; i < ArticulatedHandPose.JointCount; i++)
                 {
                     TrackedHandJoint handJoint = (TrackedHandJoint)i;
-
-                    if (handJoint == TrackedHandJoint.None) { continue; }
 
                     MixedRealityPose handJointPose = eventData.InputData[handJoint];
                     Transform jointTransform = jointsArray[i];

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -113,10 +113,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     return;
                 }
 
-                foreach (TrackedHandJoint handJoint in eventData.InputData.Keys)
+                foreach (TrackedHandJoint handJoint in ArticulatedHandPose.HandJoints)
                 {
-                    Transform jointTransform;
-                    if (joints.TryGetValue(handJoint, out jointTransform))
+                    if (handJoint == TrackedHandJoint.None) { continue; }
+
+                    if (joints.TryGetValue(handJoint, out Transform jointTransform))
                     {
                         jointTransform.position = eventData.InputData[handJoint].Position;
                         jointTransform.rotation = eventData.InputData[handJoint].Rotation;

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -113,8 +113,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     return;
                 }
 
-                foreach (TrackedHandJoint handJoint in ArticulatedHandPose.HandJoints)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
                 {
+                    TrackedHandJoint handJoint = ArticulatedHandPose.HandJoints[i];
+
                     if (handJoint == TrackedHandJoint.None) { continue; }
 
                     if (joints.TryGetValue(handJoint, out Transform jointTransform))

--- a/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
@@ -155,7 +155,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
                 {
-                    TrackedHandJoint handJoint = ArticulatedHandPose.HandJoints[i];
+                    TrackedHandJoint handJoint = (TrackedHandJoint)i;
 
                     if (handJoint == TrackedHandJoint.None ||
                         handJoint == TrackedHandJoint.Palm)

--- a/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
@@ -97,38 +97,33 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public void OnSourceDetected(SourceStateEventData eventData)
         {
-            var hand = eventData.Controller;
+            IMixedRealityController hand = eventData.Controller;
 
-            if (hand != null)
+            // If a hand does not contain joints, OnHandJointsUpdated will not be called the bounds should
+            // be calculated based on the proxy visuals.
+            if (hand != null && !(hand is IMixedRealityHand))
             {
-                // If a hand does not contain joints, OnHandJointsUpdated will not be called the bounds should
-                // be calculated based on the proxy visuals.
-                bool handContainsJoints = (hand as IMixedRealityHand) != null;
+                var proxy = hand.Visualizer?.GameObjectProxy;
 
-                if (!handContainsJoints)
+                if (proxy != null)
                 {
-                    var proxy = hand.Visualizer?.GameObjectProxy;
+                    // Bounds calculated in proxy-space will have an origin of zero, but bounds
+                    // calculated in global space will have an origin centered on the proxy transform.
+                    var newGlobalBounds = new Bounds(proxy.transform.position, Vector3.zero);
+                    var newLocalBounds = new Bounds(Vector3.zero, Vector3.zero);
+                    var boundsPoints = new List<Vector3>();
+                    BoundsExtensions.GetRenderBoundsPoints(proxy, boundsPoints, 0);
 
-                    if (proxy != null)
+                    foreach (var point in boundsPoints)
                     {
-                        // Bounds calculated in proxy-space will have an origin of zero, but bounds
-                        // calculated in global space will have an origin centered on the proxy transform.
-                        var newGlobalBounds = new Bounds(proxy.transform.position, Vector3.zero);
-                        var newLocalBounds = new Bounds(Vector3.zero, Vector3.zero);
-                        var boundsPoints = new List<Vector3>();
-                        BoundsExtensions.GetRenderBoundsPoints(proxy, boundsPoints, 0);
-
-                        foreach (var point in boundsPoints)
-                        {
-                            newGlobalBounds.Encapsulate(point);
-                            // Local hand-space bounds are encapsulated using proxy-space point coordinates
-                            newLocalBounds.Encapsulate(proxy.transform.InverseTransformPoint(point));
-                        }
-
-                        Bounds[hand.ControllerHandedness] = newGlobalBounds;
-                        LocalBounds[hand.ControllerHandedness] = newLocalBounds;
-                        BoundsTransforms[hand.ControllerHandedness] = proxy.transform.localToWorldMatrix;
+                        newGlobalBounds.Encapsulate(point);
+                        // Local hand-space bounds are encapsulated using proxy-space point coordinates
+                        newLocalBounds.Encapsulate(proxy.transform.InverseTransformPoint(point));
                     }
+
+                    Bounds[hand.ControllerHandedness] = newGlobalBounds;
+                    LocalBounds[hand.ControllerHandedness] = newLocalBounds;
+                    BoundsTransforms[hand.ControllerHandedness] = proxy.transform.localToWorldMatrix;
                 }
             }
         }
@@ -153,23 +148,26 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public void OnHandJointsUpdated(InputEventData<IDictionary<TrackedHandJoint, MixedRealityPose>> eventData)
         {
-            MixedRealityPose palmPose;
-
-            if (eventData.InputData.TryGetValue(TrackedHandJoint.Palm, out palmPose))
+            if (eventData.InputData.TryGetValue(TrackedHandJoint.Palm, out MixedRealityPose palmPose))
             {
                 var newGlobalBounds = new Bounds(palmPose.Position, Vector3.zero);
                 var newLocalBounds = new Bounds(Vector3.zero, Vector3.zero);
 
-                foreach (var kvp in eventData.InputData)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
                 {
-                    if (kvp.Key == TrackedHandJoint.None ||
-                        kvp.Key == TrackedHandJoint.Palm)
+                    TrackedHandJoint handJoint = ArticulatedHandPose.HandJoints[i];
+
+                    if (handJoint == TrackedHandJoint.None ||
+                        handJoint == TrackedHandJoint.Palm)
                     {
                         continue;
                     }
 
-                    newGlobalBounds.Encapsulate(kvp.Value.Position);
-                    newLocalBounds.Encapsulate(Quaternion.Inverse(palmPose.Rotation) * (kvp.Value.Position - palmPose.Position));
+                    if (eventData.InputData.TryGetValue(handJoint, out MixedRealityPose pose))
+                    {
+                        newGlobalBounds.Encapsulate(pose.Position);
+                        newLocalBounds.Encapsulate(Quaternion.Inverse(palmPose.Rotation) * (pose.Position - palmPose.Position));
+                    }
                 }
 
                 Bounds[eventData.Handedness] = newGlobalBounds;

--- a/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
@@ -153,12 +153,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var newGlobalBounds = new Bounds(palmPose.Position, Vector3.zero);
                 var newLocalBounds = new Bounds(Vector3.zero, Vector3.zero);
 
-                for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
+                // This starts at 1 to skip over TrackedHandJoint.None.
+                for (int i = 1; i < ArticulatedHandPose.JointCount; i++)
                 {
                     TrackedHandJoint handJoint = (TrackedHandJoint)i;
 
-                    if (handJoint == TrackedHandJoint.None ||
-                        handJoint == TrackedHandJoint.Palm)
+                    if (handJoint == TrackedHandJoint.Palm)
                     {
                         continue;
                     }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -316,22 +316,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc/>
         void IMixedRealityHandJointHandler.OnHandJointsUpdated(InputEventData<IDictionary<TrackedHandJoint, MixedRealityPose>> eventData)
         {
-            var inputSystem = CoreServices.InputSystem;
-
             if (eventData.InputSource.SourceId != Controller.InputSource.SourceId)
             {
                 return;
             }
             Debug.Assert(eventData.Handedness == Controller.ControllerHandedness);
 
+            IMixedRealityInputSystem inputSystem = CoreServices.InputSystem;
+
             // Only runs if render skeleton joints is true
             MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile.HandTrackingProfile;
             if (handTrackingProfile != null && handTrackingProfile.EnableHandJointVisualization)
             {
-                foreach (TrackedHandJoint handJoint in eventData.InputData.Keys)
+                foreach (TrackedHandJoint handJoint in ArticulatedHandPose.HandJoints)
                 {
-                    Transform skeletonJointTransform;
-                    if (skeletonJoints.TryGetValue(handJoint, out skeletonJointTransform))
+                    if (handJoint == TrackedHandJoint.None) { continue; }
+
+                    if (skeletonJoints.TryGetValue(handJoint, out Transform skeletonJointTransform))
                     {
                         skeletonJointTransform.position = eventData.InputData[handJoint].Position;
                         skeletonJointTransform.rotation = eventData.InputData[handJoint].Rotation;
@@ -393,11 +394,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (renderHandmesh)
             {
                 // Render the rigged hand mesh itself
-                Transform jointTransform;
                 // Apply updated TrackedHandJoint pose data to the assigned transforms
-                foreach (TrackedHandJoint handJoint in eventData.InputData.Keys)
+                foreach (TrackedHandJoint handJoint in ArticulatedHandPose.HandJoints)
                 {
-                    if (joints.TryGetValue(handJoint, out jointTransform))
+                    if (handJoint == TrackedHandJoint.None) { continue; }
+
+                    if (joints.TryGetValue(handJoint, out Transform jointTransform))
                     {
                         if (jointTransform != null)
                         {
@@ -467,7 +469,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                     else
                     {
-                        throw new Exception(String.Format("The property {0} for reacting to pinch strength was not found please provide a valid material property name", pinchStrengthMaterialProperty));
+                        throw new Exception(string.Format("The property {0} for reacting to pinch strength was not found please provide a valid material property name", pinchStrengthMaterialProperty));
                     }
                 }
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -328,8 +328,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile.HandTrackingProfile;
             if (handTrackingProfile != null && handTrackingProfile.EnableHandJointVisualization)
             {
-                foreach (TrackedHandJoint handJoint in ArticulatedHandPose.HandJoints)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
                 {
+                    TrackedHandJoint handJoint = ArticulatedHandPose.HandJoints[i];
+
                     if (handJoint == TrackedHandJoint.None) { continue; }
 
                     if (skeletonJoints.TryGetValue(handJoint, out Transform skeletonJointTransform))
@@ -395,8 +397,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 // Render the rigged hand mesh itself
                 // Apply updated TrackedHandJoint pose data to the assigned transforms
-                foreach (TrackedHandJoint handJoint in ArticulatedHandPose.HandJoints)
+                for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
                 {
+                    TrackedHandJoint handJoint = ArticulatedHandPose.HandJoints[i];
+
                     if (handJoint == TrackedHandJoint.None) { continue; }
 
                     if (joints.TryGetValue(handJoint, out Transform jointTransform))

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -334,10 +334,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     if (handJoint == TrackedHandJoint.None) { continue; }
 
+                    MixedRealityPose handJointPose = eventData.InputData[handJoint];
+
                     if (skeletonJoints.TryGetValue(handJoint, out Transform skeletonJointTransform))
                     {
-                        skeletonJointTransform.position = eventData.InputData[handJoint].Position;
-                        skeletonJointTransform.rotation = eventData.InputData[handJoint].Rotation;
+                        skeletonJointTransform.position = handJointPose.Position;
+                        skeletonJointTransform.rotation = handJointPose.Rotation;
                     }
                     else
                     {
@@ -371,8 +373,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         }
 
                         jointObject.name = handJoint.ToString() + " Proxy Transform";
-                        jointObject.transform.position = eventData.InputData[handJoint].Position;
-                        jointObject.transform.rotation = eventData.InputData[handJoint].Rotation;
+                        jointObject.transform.position = handJointPose.Position;
+                        jointObject.transform.rotation = handJointPose.Rotation;
                         jointObject.transform.parent = transform;
 
                         skeletonJoints.Add(handJoint, jointObject.transform);
@@ -403,6 +405,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     if (handJoint == TrackedHandJoint.None) { continue; }
 
+                    MixedRealityPose handJointPose = eventData.InputData[handJoint];
+
                     if (joints.TryGetValue(handJoint, out Transform jointTransform))
                     {
                         if (jointTransform != null)
@@ -415,25 +419,25 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                 }
                                 else
                                 {
-                                    Palm.position = eventData.InputData[TrackedHandJoint.Palm].Position;
+                                    Palm.position = handJointPose.Position;
                                 }
-                                Palm.rotation = eventData.InputData[TrackedHandJoint.Palm].Rotation * userBoneRotation;
+                                Palm.rotation = handJointPose.Rotation * userBoneRotation;
                             }
                             else if (handJoint == TrackedHandJoint.Wrist)
                             {
                                 if (!ModelPalmAtLeapWrist)
                                 {
-                                    Wrist.position = eventData.InputData[TrackedHandJoint.Wrist].Position;
+                                    Wrist.position = handJointPose.Position;
                                 }
                             }
                             else
                             {
                                 // Finger joints
-                                jointTransform.rotation = eventData.InputData[handJoint].Rotation * Reorientation();
+                                jointTransform.rotation = handJointPose.Rotation * Reorientation();
 
                                 if (DeformPosition)
                                 {
-                                    jointTransform.position = eventData.InputData[handJoint].Position;
+                                    jointTransform.position = handJointPose.Position;
                                 }
 
                                 if (ScaleLastFingerBone &&

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -330,7 +330,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
                 {
-                    TrackedHandJoint handJoint = ArticulatedHandPose.HandJoints[i];
+                    TrackedHandJoint handJoint = (TrackedHandJoint)i;
 
                     if (handJoint == TrackedHandJoint.None) { continue; }
 
@@ -401,7 +401,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // Apply updated TrackedHandJoint pose data to the assigned transforms
                 for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
                 {
-                    TrackedHandJoint handJoint = ArticulatedHandPose.HandJoints[i];
+                    TrackedHandJoint handJoint = (TrackedHandJoint)i;
 
                     if (handJoint == TrackedHandJoint.None) { continue; }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -153,7 +153,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Rotation derived from the `modelFingerPointing` and
         /// `modelPalmFacing` vectors in the RiggedHand inspector.
         /// </summary>
-        private Quaternion userBoneRotation
+        private Quaternion UserBoneRotation
         {
             get
             {
@@ -336,8 +336,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     if (skeletonJoints.TryGetValue(handJoint, out Transform skeletonJointTransform))
                     {
-                        skeletonJointTransform.position = handJointPose.Position;
-                        skeletonJointTransform.rotation = handJointPose.Rotation;
+                        skeletonJointTransform.SetPositionAndRotation(handJointPose.Position, handJointPose.Rotation);
                     }
                     else
                     {
@@ -366,8 +365,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         }
 
                         jointObject.name = handJoint.ToString() + " Proxy Transform";
-                        jointObject.transform.position = handJointPose.Position;
-                        jointObject.transform.rotation = handJointPose.Rotation;
+                        jointObject.transform.SetPositionAndRotation(handJointPose.Position, handJointPose.Rotation);
                         jointObject.transform.parent = transform;
 
                         skeletonJoints.Add(handJoint, jointObject.transform);
@@ -399,48 +397,45 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     TrackedHandJoint handJoint = (TrackedHandJoint)i;
                     MixedRealityPose handJointPose = eventData.InputData[handJoint];
 
-                    if (joints.TryGetValue(handJoint, out Transform jointTransform))
+                    if (joints.TryGetValue(handJoint, out Transform jointTransform) && jointTransform != null)
                     {
-                        if (jointTransform != null)
+                        if (handJoint == TrackedHandJoint.Palm)
                         {
-                            if (handJoint == TrackedHandJoint.Palm)
+                            if (ModelPalmAtLeapWrist)
                             {
-                                if (ModelPalmAtLeapWrist)
-                                {
-                                    Palm.position = eventData.InputData[TrackedHandJoint.Wrist].Position;
-                                }
-                                else
-                                {
-                                    Palm.position = handJointPose.Position;
-                                }
-                                Palm.rotation = handJointPose.Rotation * userBoneRotation;
-                            }
-                            else if (handJoint == TrackedHandJoint.Wrist)
-                            {
-                                if (!ModelPalmAtLeapWrist)
-                                {
-                                    Wrist.position = handJointPose.Position;
-                                }
+                                Palm.position = eventData.InputData[TrackedHandJoint.Wrist].Position;
                             }
                             else
                             {
-                                // Finger joints
-                                jointTransform.rotation = handJointPose.Rotation * Reorientation();
+                                Palm.position = handJointPose.Position;
+                            }
+                            Palm.rotation = handJointPose.Rotation * UserBoneRotation;
+                        }
+                        else if (handJoint == TrackedHandJoint.Wrist)
+                        {
+                            if (!ModelPalmAtLeapWrist)
+                            {
+                                Wrist.position = handJointPose.Position;
+                            }
+                        }
+                        else
+                        {
+                            // Finger joints
+                            jointTransform.rotation = handJointPose.Rotation * Reorientation();
 
-                                if (DeformPosition)
-                                {
-                                    jointTransform.position = handJointPose.Position;
-                                }
+                            if (DeformPosition)
+                            {
+                                jointTransform.position = handJointPose.Position;
+                            }
 
-                                if (ScaleLastFingerBone &&
-                                        (handJoint == TrackedHandJoint.ThumbDistalJoint ||
-                                        handJoint == TrackedHandJoint.IndexDistalJoint ||
-                                        handJoint == TrackedHandJoint.MiddleDistalJoint ||
-                                        handJoint == TrackedHandJoint.RingDistalJoint ||
-                                        handJoint == TrackedHandJoint.PinkyDistalJoint))
-                                {
-                                    ScaleFingerTip(eventData, jointTransform, handJoint + 1, jointTransform.position);
-                                }
+                            if (ScaleLastFingerBone &&
+                                (handJoint == TrackedHandJoint.ThumbDistalJoint ||
+                                handJoint == TrackedHandJoint.IndexDistalJoint ||
+                                handJoint == TrackedHandJoint.MiddleDistalJoint ||
+                                handJoint == TrackedHandJoint.RingDistalJoint ||
+                                handJoint == TrackedHandJoint.PinkyDistalJoint))
+                            {
+                                ScaleFingerTip(eventData, jointTransform, handJoint + 1, jointTransform.position);
                             }
                         }
                     }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -328,12 +328,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile.HandTrackingProfile;
             if (handTrackingProfile != null && handTrackingProfile.EnableHandJointVisualization)
             {
-                for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
+                // This starts at 1 to skip over TrackedHandJoint.None.
+                for (int i = 1; i < ArticulatedHandPose.JointCount; i++)
                 {
                     TrackedHandJoint handJoint = (TrackedHandJoint)i;
-
-                    if (handJoint == TrackedHandJoint.None) { continue; }
-
                     MixedRealityPose handJointPose = eventData.InputData[handJoint];
 
                     if (skeletonJoints.TryGetValue(handJoint, out Transform skeletonJointTransform))
@@ -344,12 +342,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     else
                     {
                         GameObject prefab;
-                        if (handJoint == TrackedHandJoint.None)
-                        {
-                            // No visible mesh for the "None" joint
-                            prefab = null;
-                        }
-                        else if (handJoint == TrackedHandJoint.Palm)
+                        if (handJoint == TrackedHandJoint.Palm)
                         {
                             prefab = inputSystem.InputSystemProfile.HandTrackingProfile.PalmJointPrefab;
                         }
@@ -399,12 +392,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 // Render the rigged hand mesh itself
                 // Apply updated TrackedHandJoint pose data to the assigned transforms
-                for (int i = 0; i < ArticulatedHandPose.JointCount; i++)
+
+                // This starts at 1 to skip over TrackedHandJoint.None.
+                for (int i = 1; i < ArticulatedHandPose.JointCount; i++)
                 {
                     TrackedHandJoint handJoint = (TrackedHandJoint)i;
-
-                    if (handJoint == TrackedHandJoint.None) { continue; }
-
                     MixedRealityPose handJointPose = eventData.InputData[handJoint];
 
                     if (joints.TryGetValue(handJoint, out Transform jointTransform))

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -859,10 +859,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (UnregisterPointerPerfMarker.Auto())
             {
-                Debug.Assert(pointer.PointerId != 0, $"{pointer} does not have a valid pointer id!");
+                if (pointer.PointerId != 0)
+                {
+                    Debug.Assert(pointer.PointerId != 0, $"{pointer} does not have a valid pointer id!");
+                }
 
-                PointerData pointerData;
-                if (!TryGetPointerData(pointer, out pointerData)) { return false; }
+                if (!TryGetPointerData(pointer, out PointerData pointerData)) { return false; }
 
                 // Raise focus events if needed.
                 if (pointerData.CurrentPointerTarget != null)


### PR DESCRIPTION
## Overview

Removes everywhere we used to iterate through the dictionary, its keys, or its values with `foreach`, as all of these cause the enumerator to be allocated. Instead, we now use lists where possible and index into them instead of checking a dictionary.
Also optimizes some code paths where we were doing multiple dictionary calls for the same key.

Drops the per-frame allocs from 40B per-hand to 0.
Also feels like it drops the average time spent in this method, though it fluctuates a bit and is harder to measure.

![image](https://user-images.githubusercontent.com/3580640/141602741-ad03d8c8-baff-4005-a4b6-ab1701e66260.png)

## Changes

- Part of fixing #9400 
