### PR TITLE
Fix for flickering Proximity Lighting

### DIFF
--- a/Assets/MRTK/Core/Utilities/StandardShader/ProximityLight.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/ProximityLight.cs
@@ -158,6 +158,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         private void OnEnable()
         {
             AddProximityLight(this);
+            UpdateProximityLights(true);
         }
 
         private void OnDisable()


### PR DESCRIPTION
## Overview

We notice a small but distracting flicker when moving from a poke to a grab pointer when pokable and grabbable objects are in close proximity. There's a single frame when there are no lights enabled.

## Changes
Adding a forced update to `OnEnable()` (similarly to the behaviour of `OnDisable()`) fixes the issue.
