### PR TITLE
Fixed log spam that is coming from HandConstraintPalmUp.cs

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -197,10 +197,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
                     return palmFacingThresholdMet;
                 }
-                else
-                {
-                    Debug.LogWarning($"HandConstraintPalmUp requires a palm joint, but none was provided by {controller.InputSource.SourceName}.");
-                }
 
                 return palmFacingThresholdMet;
             }


### PR DESCRIPTION

## Overview

The HandConstraintPalmUp.cs script is logging a warning whenever it cannot find the palm joint. However this scenario happens quite often when the HL detects a partial hand with palm joint missing. In that scenario, the hand input is considered invalid which causes no harm at all.

## Changes

The solution is to remove the debug log for this legitimate and common scenario to not flood our logs with unnecessary warnings.