### PR TITLE
Backport recent v3 update to reduce debug log spam

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -263,7 +263,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             if (SolverHandler.TrackedTargetType != TrackedObjectType.HandJoint &&
                 SolverHandler.TrackedTargetType != TrackedObjectType.ControllerRay)
             {
-                Debug.LogWarning("Solver HandConstraint requires TrackedObjectType of type HandJoint or ControllerRay");
+                // Requires HandJoint or ControllerRay target type.
                 return;
             }
 
@@ -705,6 +705,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             trackedController = null;
             OnLastHandLost.Invoke();
             OnHandDeactivate.Invoke();
+
+            if (SolverHandler.TrackedTargetType != TrackedObjectType.HandJoint &&
+                SolverHandler.TrackedTargetType != TrackedObjectType.ControllerRay)
+            {
+                Debug.LogWarning("Solver HandConstraint requires TrackedObjectType of type HandJoint or ControllerRay.");
+            }
         }
 
         #endregion MonoBehaviour Implementation


### PR DESCRIPTION
This change brings to 2.x a recent change made to v3 that reduces the number of Debug.LogWarning events originating in the HandConstraint solver.