### PR TITLE
Enable Scene Understanding in remoting via OpenXR

### DIFF
--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
@@ -133,7 +133,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
 #if MSFT_OPENXR
             isOpenXRLoaderActive = LoaderHelpers.IsLoaderActive<OpenXRLoaderBase>() ?? false;
             isOpenXRRemotingConnected = AppRemoting.TryGetConnectionState(out ConnectionState state, out _) && state == ConnectionState.Connected;
-            Debug.LogWarning(isOpenXRRemotingConnected);
 #elif WINDOWS_UWP
             isOpenXRLoaderActive = false;
 #endif // MSFT_OPENXR

--- a/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
+++ b/Assets/MRTK/Providers/Experimental/WindowsSceneUnderstanding/WindowsSceneUnderstandingObserver.cs
@@ -14,14 +14,15 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.MixedReality.SceneUnderstanding;
-#if WINDOWS_UWP
-using Windows.Perception.Spatial;
-using Windows.Perception.Spatial.Preview;
 #if MSFT_OPENXR
 using Microsoft.MixedReality.OpenXR;
+using Microsoft.MixedReality.OpenXR.Remoting;
 using Microsoft.MixedReality.Toolkit.XRSDK;
 using UnityEngine.XR.OpenXR;
 #endif // MSFT_OPENXR
+#if WINDOWS_UWP
+using Windows.Perception.Spatial;
+using Windows.Perception.Spatial.Preview;
 #endif // WINDOWS_UWP
 using UnityEngine.Assertions;
 using UnityEngine.EventSystems;
@@ -129,13 +130,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
             }
 #else
             base.Initialize();
-#if WINDOWS_UWP
 #if MSFT_OPENXR
             isOpenXRLoaderActive = LoaderHelpers.IsLoaderActive<OpenXRLoaderBase>() ?? false;
-#else
+            isOpenXRRemotingConnected = AppRemoting.TryGetConnectionState(out ConnectionState state, out _) && state == ConnectionState.Connected;
+            Debug.LogWarning(isOpenXRRemotingConnected);
+#elif WINDOWS_UWP
             isOpenXRLoaderActive = false;
 #endif // MSFT_OPENXR
-#endif // WINDOWS_UWP
             sceneEventData = new MixedRealitySpatialAwarenessEventData<SpatialAwarenessSceneObject>(EventSystem.current);
             CreateQuadFromExtents(normalizedQuadMesh, 1, 1);
 
@@ -414,9 +415,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
         private System.Numerics.Matrix4x4 sceneToWorldTransformMatrix;
         private List<SceneObject> filteredSelectedSurfaceTypesResult = new List<SceneObject>(128);
         private Texture defaultTexture;
-#if WINDOWS_UWP
+#if WINDOWS_UWP || MSFT_OPENXR
         private bool isOpenXRLoaderActive;
-#endif // WINDOWS_UWP
+#endif // WINDOWS_UWP || MSFT_OPENXR
+#if MSFT_OPENXR
+        private bool isOpenXRRemotingConnected;
+#endif // MSFT_OPENXR
 
         #endregion Private Fields
 
@@ -789,8 +793,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
         private System.Numerics.Matrix4x4? GetSceneToWorldTransform()
         {
             var result = System.Numerics.Matrix4x4.Identity;
-#if WINDOWS_UWP
+#if WINDOWS_UWP // On HoloLens 2 device
             if (isOpenXRLoaderActive)
+#elif MSFT_OPENXR // In editor and using OpenXR
+            if (isOpenXRLoaderActive && isOpenXRRemotingConnected && !ShouldLoadFromFile)
+#else // All other cases
+            if (false)
+#endif // WINDOWS_UWP
             {
 #if MSFT_OPENXR
                 SpatialGraphNode node = SpatialGraphNode.FromStaticNodeId(sceneOriginId);
@@ -806,6 +815,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
             }
             else
             {
+#if WINDOWS_UWP
                 SpatialCoordinateSystem sceneOrigin = SpatialGraphInteropPreview.CreateCoordinateSystemForNode(sceneOriginId);
                 SpatialCoordinateSystem worldOrigin = WindowsMixedReality.WindowsMixedRealityUtilities.SpatialCoordinateSystem;
 
@@ -819,8 +829,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsSceneUnderstanding.Experimental
                 {
                     return null;
                 }
-            }
 #endif // WINDOWS_UWP
+            }
             return result;
         }
 


### PR DESCRIPTION
## Overview
This PR adds support for Scene Understanding in remoting via the OpenXR pipeline, which is made possible by the recent improvements made to the Microsoft Mixed Reality OpenXR plugin.

## Changes
- Fixes: #10307.