### PR TITLE
Added missing license headers

### DIFF
--- a/Assets/MRTK/Core/Utilities/Physics/ConeCastUtility.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/ConeCastUtility.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Assets/MRTK/Services/InputSystem/ConeCastGazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/ConeCastGazeProvider.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.MixedReality.Toolkit.Physics;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections;
 using System.Collections.Generic;


### PR DESCRIPTION
## Overview
License headers were missing on some of the cone cast files, this PR adds them in
