### PR TITLE
Quick fix for start streaming

### DIFF
--- a/Assets/MRTK/Examples/Demos/Audio/Scripts/MicrophoneAmplitudeDemo.cs
+++ b/Assets/MRTK/Examples/Demos/Audio/Scripts/MicrophoneAmplitudeDemo.cs
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
             if (result != WindowsMicrophoneStreamErrorCode.Success)
             {
                 Debug.Log($"Failed to initialize the microphone stream. {result}");
-                return;
+                if (result != WindowsMicrophoneStreamErrorCode.ALREADY_RUNNING) return;
             }
 
             // Start the microphone stream.


### PR DESCRIPTION
## Overview
MicStreamSelector doesn't work in this example

However the link below says "No need to start if it's already running." when the status for `initialize` is `ALREADY_RUNNING`, I tried many times and when it doesn't call `StartStream` (like the example of MicrophoneAmplitudeDemo) it doesn't work. Otherwise, it works perfectly.

Link to the external source code: https://github.com/microsoft/MixedRealityToolkit/blob/main/Input/MicStreamSelector/Source/MicStreamSelector.cpp

I'll post an issue on the MRTK repository as well.

## Changes
- Fixes: Streaming works even the status of `initialize` is `ALREADY_RUNNING`, by removing a single return statement in this case
