### PR TITLE
Add a parameterless constructor to InteractableOnClickReceiver

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
@@ -21,6 +21,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public InteractableOnClickReceiver(UnityEvent ev) : base(ev, "OnClick") { }
 
+        /// <summary>
+        /// Creates receiver for raising OnClick events
+        /// </summary>
+        public InteractableOnClickReceiver() : this(new UnityEvent()) { }
+
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {


### PR DESCRIPTION
## Overview
Add a parameterless constructor to InteractableOnClickReceiver to allow lines like `var onClickReceiver = interactable.AddReceiver<InteractableOnClickReceiver>();`

## Changes
- Fixes: #10341. Thanks @iweinbau for spotting the issue and proposing a fix!