### PR TITLE
Add fallback case for articulated hand select on OpenXR

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -184,6 +184,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                         {
                             interactionMapping.BoolData = buttonPressed;
                         }
+                        else
+                        {
+                            base.UpdateButtonData(interactionMapping, inputDevice);
+                            return;
+                        }
                         break;
                     default:
                         base.UpdateButtonData(interactionMapping, inputDevice);


### PR DESCRIPTION
## Overview

To fix #10304, we'll likely need a change on the Unity side. To account for this change, we'll need to add a new fallback for the articulated hand on OpenXR. This will allow us to both be compatible with existing versions and future versions (assuming the change is made on the Unity side).

## Changes
- Part of fixing #10304 
