### PR TITLE
Skip Scriptable object reflection if scene system isn't enabled

### DIFF
--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -114,6 +114,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// </summary>
         public void OnProcessScene(Scene scene, BuildReport report)
         {
+            if (!MixedRealityToolkit.IsSceneSystemEnabled)
+            {
+                return;
+            }
+
             RefreshSceneInfoFieldsInScene(scene);
         }
 
@@ -214,12 +219,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [PostProcessSceneAttribute]
         public static void OnPostProcessScene()
         {
+            if (!MixedRealityToolkit.IsSceneSystemEnabled)
+            {
+                return;
+            }
+
             RefreshSceneInfoFieldsInOpenScenes();
         }
 
         [InitializeOnLoadMethod]
         private static void InitializeOnLoad()
         {
+            if (!MixedRealityToolkit.IsSceneSystemEnabled)
+            {
+                return;
+            }
+
             EditorBuildSettings.sceneListChanged += SceneListChanged;
             EditorSceneManager.sceneOpened += SceneOpened;
 
@@ -279,6 +294,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// </summary>
         private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
         {
+            if (!MixedRealityToolkit.IsSceneSystemEnabled)
+            {
+                return;
+            }
+
             RefreshSceneInfoFieldsInScriptableObjects();
             RefreshSceneInfoFieldsInOpenScenes();
         }


### PR DESCRIPTION
## Overview
We found that this was causing intermittent pauses when entering/exiting PlayMode.  Upwards of 5 seconds.  
(This is a slice of an earlier PR that was too big)

## Changes
- Fixes: # .


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
