### PR TITLE
Fix mesh when using app-based holographic remoting

### DIFF
--- a/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialMeshObserver.cs
@@ -239,7 +239,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             get { return levelOfDetail; }
             set
             {
-                if (value != SpatialAwarenessMeshLevelOfDetail.Custom)
+                if (Application.isPlaying && value != SpatialAwarenessMeshLevelOfDetail.Custom)
                 {
                     TrianglesPerCubicMeter = LookupTriangleDensity(value);
                 }

--- a/Assets/MRTK/Core/Providers/BaseSpatialObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialObserver.cs
@@ -79,8 +79,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// </summary>
         public override void Initialize()
         {
-            base.Initialize();
             CreateObserver();
+            base.Initialize();
         }
 
         /// <summary>

--- a/Assets/MRTK/Examples/Demos/PulseShader/Profile/PulseShaderSpatialAwarenessSystemProfile.asset
+++ b/Assets/MRTK/Examples/Demos/PulseShader/Profile/PulseShaderSpatialAwarenessSystemProfile.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
         Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
     componentName: XR SDK Windows Mixed Reality Spatial Mesh Observer
     priority: 0
-    runtimePlatform: 8
+    runtimePlatform: 9
     observerProfile: {fileID: 11400000, guid: 4f5009fa6e8234540be72702bb09d29a, type: 2}
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.XRSDK.GenericXRSDKSpatialMeshObserver,
@@ -40,5 +40,5 @@ MonoBehaviour:
         Microsoft.MixedReality.Toolkit.Providers.OpenXR
     componentName: OpenXR Spatial Mesh Observer
     priority: 0
-    runtimePlatform: 8
+    runtimePlatform: 9
     observerProfile: {fileID: 11400000, guid: 4f5009fa6e8234540be72702bb09d29a, type: 2}

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 {
     [MixedRealityDataProvider(
         typeof(IMixedRealitySpatialAwarenessSystem),
-        SupportedPlatforms.WindowsUniversal,
+        SupportedPlatforms.WindowsStandalone | SupportedPlatforms.WindowsUniversal,
         "OpenXR Spatial Mesh Observer",
         "Profiles/DefaultMixedRealitySpatialAwarenessMeshObserverProfile.asset",
         "MixedRealityToolkit.SDK",

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 {
     [MixedRealityDataProvider(
         typeof(IMixedRealitySpatialAwarenessSystem),
-        SupportedPlatforms.WindowsUniversal,
+        SupportedPlatforms.WindowsStandalone | SupportedPlatforms.WindowsUniversal,
         "XR SDK Windows Mixed Reality Spatial Mesh Observer",
         "Profiles/DefaultMixedRealitySpatialAwarenessMeshObserverProfile.asset",
         "MixedRealityToolkit.SDK",

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -52,6 +52,24 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                     && XRGeneralSettings.Instance.Manager != null
                     && XRGeneralSettings.Instance.Manager.activeLoader != null)
                 {
+                    if ((observersCache == null || observersCache.Count == 0)
+                        && Service is IMixedRealityDataProviderAccess spatialAwarenessDataProviderAccess
+                        && Service is IMixedRealityServiceState spatialAwarenessState
+                        && spatialAwarenessState.IsInitialized)
+                    {
+                        observersCache = spatialAwarenessDataProviderAccess.GetDataProviders<GenericXRSDKSpatialMeshObserver>();
+                    }
+
+                    // Don't report ourselves as active if another observer is handling this platform
+                    for (int i = 0; i < observersCache?.Count; i++)
+                    {
+                        GenericXRSDKSpatialMeshObserver observer = observersCache[i];
+                        if (observer != this && (observer.IsActiveLoader ?? false))
+                        {
+                            return false;
+                        }
+                    }
+
                     return true;
                 }
 

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -41,7 +41,26 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         { }
 
-        protected virtual bool? IsActiveLoader => true;
+        private IReadOnlyList<GenericXRSDKSpatialMeshObserver> observersCache;
+
+        protected virtual bool? IsActiveLoader
+        {
+            get
+            {
+#if XR_MANAGEMENT_ENABLED
+                if (XRGeneralSettings.Instance != null
+                    && XRGeneralSettings.Instance.Manager != null
+                    && XRGeneralSettings.Instance.Manager.activeLoader != null)
+                {
+                    return true;
+                }
+
+                return null;
+#else
+                return false;
+#endif
+            }
+        }
 
         /// <inheritdoc />
         public override void Enable()
@@ -58,6 +77,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                 return;
             }
 
+            ConfigureObserverVolume();
             base.Enable();
         }
 
@@ -73,29 +93,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         #region BaseSpatialObserver Implementation
 
         private XRMeshSubsystem meshSubsystem;
-
-        /// <summary>
-        /// Creates the XRMeshSubsystem and handles the desired startup behavior.
-        /// </summary>
-        protected override void CreateObserver()
-        {
-            if (Service == null
+        private XRMeshSubsystem MeshSubsystem => meshSubsystem != null && meshSubsystem.running
+            ? meshSubsystem :
 #if XR_MANAGEMENT_ENABLED
-                || XRGeneralSettings.Instance == null || XRGeneralSettings.Instance.Manager == null || XRGeneralSettings.Instance.Manager.activeLoader == null
-#endif // XR_MANAGEMENT_ENABLED
-                ) { return; }
-
-#if XR_MANAGEMENT_ENABLED
-            meshSubsystem = XRGeneralSettings.Instance.Manager.activeLoader.GetLoadedSubsystem<XRMeshSubsystem>();
+            meshSubsystem = IsActiveLoader ?? false
+                ? XRGeneralSettings.Instance.Manager.activeLoader.GetLoadedSubsystem<XRMeshSubsystem>()
+                : null;
 #else
             meshSubsystem = XRSubsystemHelpers.MeshSubsystem;
 #endif // XR_MANAGEMENT_ENABLED
-
-            if (meshSubsystem != null)
-            {
-                ConfigureObserverVolume();
-            }
-        }
 
         /// <summary>
         /// Implements proper cleanup of the SurfaceObserver.
@@ -119,15 +125,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             // For non-custom levels, the enum value is the appropriate triangles per cubic meter.
             int level = (int)levelOfDetail;
-            if (meshSubsystem != null)
+            if (MeshSubsystem != null)
             {
                 if (levelOfDetail == SpatialAwarenessMeshLevelOfDetail.Unlimited)
                 {
-                    meshSubsystem.meshDensity = 1;
+                    MeshSubsystem.meshDensity = 1;
                 }
                 else
                 {
-                    meshSubsystem.meshDensity = level / (float)SpatialAwarenessMeshLevelOfDetail.Fine; // For now, map Coarse to 0.0 and Fine to 1.0
+                    MeshSubsystem.meshDensity = level / (float)SpatialAwarenessMeshLevelOfDetail.Fine; // For now, map Coarse to 0.0 and Fine to 1.0
                 }
             }
             return level;
@@ -215,9 +221,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
 
             using (ResumePerfMarker.Auto())
             {
-                if (meshSubsystem != null && !meshSubsystem.running)
+                if (MeshSubsystem != null && !MeshSubsystem.running)
                 {
-                    meshSubsystem.Start();
+                    MeshSubsystem.Start();
                 }
 
                 // We want the first update immediately.
@@ -241,9 +247,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
 
             using (SuspendPerfMarker.Auto())
             {
-                if (meshSubsystem != null && meshSubsystem.running)
+                if (MeshSubsystem != null && MeshSubsystem.running)
                 {
-                    meshSubsystem.Stop();
+                    MeshSubsystem.Stop();
                 }
 
                 // UpdateObserver keys off of this value to stop observing.
@@ -293,7 +299,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         /// </summary>
         private void UpdateObserver()
         {
-            if (Service == null || meshSubsystem == null) { return; }
+            if (Service == null || MeshSubsystem == null) { return; }
 
             using (UpdateObserverPerfMarker.Auto())
             {
@@ -325,7 +331,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                         // The application can update the observer volume at any time, make sure we are using the latest.
                         ConfigureObserverVolume();
 
-                        if (meshSubsystem.TryGetMeshInfos(meshInfos))
+                        if (MeshSubsystem.TryGetMeshInfos(meshInfos))
                         {
                             UpdateMeshes(meshInfos);
                         }
@@ -368,7 +374,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                     newMesh.GameObject.SetActive(true);
                 }
 
-                meshSubsystem.GenerateMeshAsync(meshId, newMesh.Filter.mesh, newMesh.Collider, MeshVertexAttributes.Normals, (MeshGenerationResult meshGenerationResult) => MeshGenerationAction(meshGenerationResult));
+                MeshSubsystem.GenerateMeshAsync(meshId, newMesh.Filter.mesh, newMesh.Collider, MeshVertexAttributes.Normals, (MeshGenerationResult meshGenerationResult) => MeshGenerationAction(meshGenerationResult));
                 outstandingMeshObject = newMesh;
             }
         }
@@ -439,7 +445,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         /// </summary>
         protected virtual void ConfigureObserverVolume()
         {
-            if (meshSubsystem == null
+            if (MeshSubsystem == null
                 || (oldObserverOrigin == ObserverOrigin
                 && oldObservationExtents == ObservationExtents
                 && oldObserverVolumeType == ObserverVolumeType))
@@ -453,7 +459,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                 switch (ObserverVolumeType)
                 {
                     case VolumeType.AxisAlignedCube:
-                        meshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
+                        MeshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
                         break;
 
                     default:
@@ -590,7 +596,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             base.Initialize();
 
-            if (Service == null || meshSubsystem == null) { return; }
+            if (Service == null || MeshSubsystem == null) { return; }
 
             if (RuntimeSpatialMeshPrefab != null)
             {

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealitySpatialAwarenessSystemProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealitySpatialAwarenessSystemProfile.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
         Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
     componentName: XR SDK Windows Mixed Reality Spatial Mesh Observer
     priority: 0
-    runtimePlatform: 8
+    runtimePlatform: 9
     observerProfile: {fileID: 11400000, guid: 8be0bcd2117dd214da41ed98f0def2e3, type: 2}
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.XRSDK.GenericXRSDKSpatialMeshObserver,
@@ -40,5 +40,5 @@ MonoBehaviour:
         Microsoft.MixedReality.Toolkit.Providers.OpenXR
     componentName: OpenXR Spatial Mesh Observer
     priority: 0
-    runtimePlatform: 8
+    runtimePlatform: 9
     observerProfile: {fileID: 11400000, guid: 8be0bcd2117dd214da41ed98f0def2e3, type: 2}

--- a/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -68,6 +68,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <inheritdoc/>
         public override void Initialize()
         {
+            // Mark not initialized early so observers can use this state in their own initialization
+            IsInitialized = false;
             InitializeInternal();
             base.Initialize();
         }

--- a/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -65,12 +65,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 
         #region IMixedRealityToolkitService Implementation
 
-        private MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> meshEventData = null;
-
         /// <inheritdoc/>
         public override void Initialize()
         {
-            meshEventData = new MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>(EventSystem.current);
             InitializeInternal();
             base.Initialize();
         }

--- a/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -70,11 +70,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <inheritdoc/>
         public override void Initialize()
         {
-            base.Initialize();
-
             meshEventData = new MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>(EventSystem.current);
-
             InitializeInternal();
+            base.Initialize();
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

Updates our XRSDK-based mesh observers to:

1. Properly refresh their mesh subsystem when XR is initialized _after_ MRTK is initialized
2. Ensure that more than one observer is not running when the "generic" observer is used with a more specific observer (like the one specific to OpenXR)
3. Ensured that we don't try to use a mesh subsystem that isn't actively running. This was leading to 
3. Ensured that we don't try to set values on the mesh subsystem unless the app is running (the underlying bug here would probably also be solved by fix 3)

## Changes
- Fixes: #10293, fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/10244, might fix #10245 (but I couldn't get a repro)
