### PR TITLE
[2.7.3] Improve raycast hit to prevent log spam on Unity 2021 and prevent a crash when using assetbundles

### DIFF
--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
@@ -34,7 +34,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 triangleIndex = hitInfo.triangleIndex;
 
                 MeshCollider meshCollider = hitInfo.collider as MeshCollider;
-                if (meshCollider == null || meshCollider.sharedMesh.isReadable)
+                if (meshCollider == null)
+                {
+                    textureCoord = hitInfo.textureCoord;
+                    textureCoord2 = hitInfo.textureCoord2;
+                    lightmapCoord = hitInfo.lightmapCoord;
+                }
+                else if (meshCollider.sharedMesh.isReadable)
                 {
 #if UNITY_2019_4_OR_NEWER
                     if (meshCollider.sharedMesh.HasVertexAttribute(UnityEngine.Rendering.VertexAttribute.TexCoord0))

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
@@ -52,6 +52,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         textureCoord = Vector2.zero;
                     }
 
+                    // This checks for TexCoord1, since textureCoord2 and lightmapCoord both query that index
+                    // via CalculateRaycastTexCoord(collider, m_UV, m_Point, m_FaceID, 1); (the last parameter is the index)
                     if (meshCollider.sharedMesh.HasVertexAttribute(UnityEngine.Rendering.VertexAttribute.TexCoord1))
                     {
                         textureCoord2 = hitInfo.textureCoord2;

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
@@ -40,41 +40,45 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     textureCoord2 = hitInfo.textureCoord2;
                     lightmapCoord = hitInfo.lightmapCoord;
                 }
-                else if (meshCollider.sharedMesh.isReadable)
+                else
                 {
-#if UNITY_2019_4_OR_NEWER
-                    if (meshCollider.sharedMesh.HasVertexAttribute(UnityEngine.Rendering.VertexAttribute.TexCoord0))
+                    Mesh sharedMesh = meshCollider.sharedMesh;
+                    if (sharedMesh != null && sharedMesh.isReadable)
                     {
+#if UNITY_2019_4_OR_NEWER
+                        if (sharedMesh.HasVertexAttribute(UnityEngine.Rendering.VertexAttribute.TexCoord0))
+                        {
+                            textureCoord = hitInfo.textureCoord;
+                        }
+                        else
+                        {
+                            textureCoord = Vector2.zero;
+                        }
+
+                        // This checks for TexCoord1, since textureCoord2 and lightmapCoord both query that index
+                        // via CalculateRaycastTexCoord(collider, m_UV, m_Point, m_FaceID, 1); (the last parameter is the index)
+                        if (sharedMesh.HasVertexAttribute(UnityEngine.Rendering.VertexAttribute.TexCoord1))
+                        {
+                            textureCoord2 = hitInfo.textureCoord2;
+                            lightmapCoord = hitInfo.lightmapCoord;
+                        }
+                        else
+                        {
+                            textureCoord2 = Vector2.zero;
+                            lightmapCoord = Vector2.zero;
+                        }
+#else
                         textureCoord = hitInfo.textureCoord;
+                        textureCoord2 = hitInfo.textureCoord2;
+                        lightmapCoord = hitInfo.lightmapCoord;
+#endif
                     }
                     else
                     {
                         textureCoord = Vector2.zero;
-                    }
-
-                    // This checks for TexCoord1, since textureCoord2 and lightmapCoord both query that index
-                    // via CalculateRaycastTexCoord(collider, m_UV, m_Point, m_FaceID, 1); (the last parameter is the index)
-                    if (meshCollider.sharedMesh.HasVertexAttribute(UnityEngine.Rendering.VertexAttribute.TexCoord1))
-                    {
-                        textureCoord2 = hitInfo.textureCoord2;
-                        lightmapCoord = hitInfo.lightmapCoord;
-                    }
-                    else
-                    {
                         textureCoord2 = Vector2.zero;
                         lightmapCoord = Vector2.zero;
                     }
-#else
-                    textureCoord = hitInfo.textureCoord;
-                    textureCoord2 = hitInfo.textureCoord2;
-                    lightmapCoord = hitInfo.lightmapCoord;
-#endif
-                }
-                else
-                {
-                    textureCoord = Vector2.zero;
-                    textureCoord2 = Vector2.zero;
-                    lightmapCoord = Vector2.zero;
                 }
 
                 transform = hitInfo.transform;

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
@@ -32,18 +32,44 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 barycentricCoordinate = hitInfo.barycentricCoordinate;
                 distance = hitInfo.distance;
                 triangleIndex = hitInfo.triangleIndex;
-                textureCoord = hitInfo.textureCoord;
+
                 MeshCollider meshCollider = hitInfo.collider as MeshCollider;
                 if (meshCollider == null || meshCollider.sharedMesh.isReadable)
                 {
+#if UNITY_2019_4_OR_NEWER
+                    if (meshCollider.sharedMesh.HasVertexAttribute(UnityEngine.Rendering.VertexAttribute.TexCoord0))
+                    {
+                        textureCoord = hitInfo.textureCoord;
+                    }
+                    else
+                    {
+                        textureCoord = Vector2.zero;
+                    }
+
+                    if (meshCollider.sharedMesh.HasVertexAttribute(UnityEngine.Rendering.VertexAttribute.TexCoord1))
+                    {
+                        textureCoord2 = hitInfo.textureCoord2;
+                        lightmapCoord = hitInfo.lightmapCoord;
+                    }
+                    else
+                    {
+                        textureCoord2 = Vector2.zero;
+                        lightmapCoord = Vector2.zero;
+                    }
+#else
+                    textureCoord = hitInfo.textureCoord;
                     textureCoord2 = hitInfo.textureCoord2;
+                    lightmapCoord = hitInfo.lightmapCoord;
+#endif
                 }
                 else
                 {
+                    textureCoord = Vector2.zero;
                     textureCoord2 = Vector2.zero;
+                    lightmapCoord = Vector2.zero;
                 }
+
                 transform = hitInfo.transform;
-                lightmapCoord = hitInfo.lightmapCoord;
                 collider = hitInfo.collider;
             }
             else


### PR DESCRIPTION
## Overview

This PR fixes two issues:

1. Similar to #7632, which we apparently fixed in too-targeted of a fashion, there are three other calls that we needed to gate behind the mesh being readable.
2. Starting in Unity 2021, there are error logs every time you try to read a texture coordinate that doesn't exist. Luckily, Unity added some helper methods in Unity 2019 to check if the mesh has specific texture coordinate attributes.

## Changes
- Fixes: #10233 and fixes #10339

