### PR TITLE
Gltf nodeId-gameObject dictionary

### DIFF
--- a/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfObject.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfObject.cs
@@ -117,6 +117,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         public GameObject GameObjectReference { get; internal set; }
 
         /// <summary>
+        /// the Node Id and corresponding GameObject pairs.
+        /// </summary>
+        public Dictionary<int, GameObject> NodeGameObjectPairs { get; internal set; }
+
+        /// <summary>
         /// The list of registered glTF extensions found for this object.
         /// </summary>
         public List<GltfExtension> RegisteredExtensions { get; internal set; } = new List<GltfExtension>();

--- a/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfObject.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfObject.cs
@@ -119,7 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <summary>
         /// the Node Id and corresponding GameObject pairs.
         /// </summary>
-        public Dictionary<int, GameObject> NodeGameObjectPairs { get; internal set; }
+        public Dictionary<int, GameObject> NodeGameObjectPairs { get; internal set; } = new Dictionary<int, GameObject>();
 
         /// <summary>
         /// The list of registered glTF extensions found for this object.

--- a/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfObject.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfObject.cs
@@ -117,7 +117,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         public GameObject GameObjectReference { get; internal set; }
 
         /// <summary>
-        /// the Node Id and corresponding GameObject pairs.
+        /// The Node Id and corresponding GameObject pairs.
         /// </summary>
         public Dictionary<int, GameObject> NodeGameObjectPairs { get; internal set; } = new Dictionary<int, GameObject>();
 

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -458,6 +458,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
             var nodeName = string.IsNullOrEmpty(node.name) ? $"glTF Node {nodeId}" : node.name;
             var nodeGameObject = new GameObject(nodeName);
 
+            gltfObject.NodeGameObjectPairs.Add(nodeId, nodeGameObject);
+
             // If we're creating a really large node, we need it to not be visible in partial stages. So we hide it while we create it
             nodeGameObject.SetActive(false);
 


### PR DESCRIPTION
## Overview
added NodeGameObjectPairs to easily get gameobject from GltfNode id

## Changes
- Fixes: #10399.
