### PR TITLE
Fix single-frame cursor flickering

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/PokePointer.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/PokePointer.prefab
@@ -182,7 +182,7 @@ MonoBehaviour:
   handedness: 1
   cursorPrefab: {fileID: 3455979907861255611, guid: 27155818b2006c74497a3f244aacc92a,
     type: 3}
-  disableCursorOnStart: 0
+  disableCursorOnStart: 1
   setCursorVisibilityOnSourceDetected: 0
   raycastOrigin: {fileID: 0}
   activeHoldAction:

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ShellHandRayPointer.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ShellHandRayPointer.prefab
@@ -334,7 +334,7 @@ MonoBehaviour:
   handedness: 1
   cursorPrefab: {fileID: 1000012072213228, guid: 5b3e2856904e43c680f84f326861032a,
     type: 3}
-  disableCursorOnStart: 0
+  disableCursorOnStart: 1
   setCursorVisibilityOnSourceDetected: 0
   raycastOrigin: {fileID: 0}
   activeHoldAction:

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
@@ -139,6 +139,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="visible">Should the ring be visible?</param>
         protected virtual void UpdateVisuals(Renderer ringRenderer, float distance, bool visible)
         {
+            base.SetVisibility(visible);
             ringRenderer.GetPropertyBlock(materialPropertyBlock);
             materialPropertyBlock.SetFloat(proximityDistanceID, visible ? distance : 1.0f);
             ringRenderer.SetPropertyBlock(materialPropertyBlock);


### PR DESCRIPTION
## Overview

The offending cursor prefabs have by default their visuals enabled. When handtracking starts and the cursors are spawned, it takes the system a frame to figure out they're not needed and to disable them. This results in the cursors flashing.

The solution is to simply check `disableCursorOnStart` for the offending cursors and have the visuals properly disabled for the poke pointer (properly as in not only a transparent material, but disabling the visuals GameObject).

The latter change also fixes a cutout on your index finger when using the handmesh visualization:

_After - Before:_
![image](https://user-images.githubusercontent.com/4631548/151381684-14c42ccc-1cbe-474d-9744-d3f3a42e3161.png)

## Changes
- Fixes: #10270
- Fixes: #10236