### PR TITLE
Integrate support of Leap Plugin V5.3.0

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionConfigurationChecker.cs
@@ -167,6 +167,9 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             }
         }
 
+        /// <summary>
+        /// Adds scripting definitions that are required when using the Ultraleap Unity Plugin (i.e. >= V5.0)
+        /// </summary>
         private static void AddScriptingDefinitionsForUnityPlugin()
         {
             ScriptUtilities.AppendScriptingDefinitions(BuildTargetGroup.Standalone, UnityPluginDefinitions);
@@ -233,7 +236,11 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             }
         }
 
-
+        /// <summary>
+        /// Gets the filepath to the Unity Modules / Unity Plugin version text file. This contains the version string
+        /// of the Ultraleap plugin
+        /// </summary>
+        /// <returns>The path to the Unity Modules / Unity Plugin version text file</returns>
         private static string GetVersionPath()
         {
             string versionPath = Path.Combine(Application.dataPath, pathDifference, "LeapMotion", "Core", "Version.txt");
@@ -247,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             if (File.Exists(versionPath))
                 return versionPath;
 
-            throw new FileNotFoundException("Unable to locate version.txt file for Ultraleap/Leap Motion Unity plugin");
+            return String.Empty;
         }
 
         /// <summary>
@@ -295,8 +302,6 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         /// </summary>
         private static void AddAndUpdateAsmDefs()
         {
-            string leapCoreAsmDefPath = Path.Combine(Application.dataPath, pathDifference, "LeapMotion", "LeapMotion.asmdef");
-
             // If the Leap Unity Modules version is 4.7.1 or newer, the LeapMotion.asmdef file does not need to be created
             // NB V5.0 - V5.2 are not supported by MRTK so are not expected here.
             if (currentLeapCoreAssetsVersion == "4.7.1" ||
@@ -306,6 +311,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                 return;
             }
 
+            string leapCoreAsmDefPath = Path.Combine(Application.dataPath, pathDifference, "LeapMotion", "LeapMotion.asmdef");
             // If the asmdef has already been created then do not create another one
             if (!File.Exists(leapCoreAsmDefPath))
             {
@@ -346,6 +352,11 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             }
         }
 
+        /// <summary>
+        /// Identifes whether the hand tracking Unity components are known as
+        /// the Unity Plugin (>=V5.0) or the Unity Modules (<V5.0)
+        /// </summary>
+        /// <returns>True if the version string indicates that the plugin in installed in the project, otherwise false</returns>
         private static bool UsingUnityPlugin()
         {
             if (String.IsNullOrEmpty(currentLeapCoreAssetsVersion))
@@ -357,6 +368,9 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             return currentLeapCoreAssetsVersion == "5.3.0";
         }
 
+        /// <summary>
+        /// Adds assembly definition files for the Unity Modules
+        /// </summary>
         private static void AddLeapEditorAsmDefsForUnityModules()
         {
             if (FileUtilities.FindFilesInAssets("LeapMotion.Core.Editor.asmdef").Length == 0)
@@ -429,6 +443,8 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
 
             // The Ultraleap Unity Plugin (i.e. V5.0 onwards) has been renamed to Ultraleap. Use this to determine if we are dealing with
             // the Unity Modules or Unity Plugin
+            List<string> unityDataPath = Application.dataPath.Split('/').ToList();
+
             if (leapPath.Contains("Ultraleap"))
             {
                 // Account fot the extra folder level used by the plugin
@@ -438,10 +454,8 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
             {
                 // Remove the last 3 elements of leap path (/Core/Scripts/LeapXRService.cs) from the list to get the root of the leap core assets
                 leapPath.RemoveRange(leapPath.Count - 3, 3);
+                unityDataPath.Add("LeapMotion");
             }
-
-            List<string> unityDataPath = Application.dataPath.Split('/').ToList();
-            unityDataPath.Add("LeapMotion");
 
             // Get the difference between the root of assets and the root of leap core assets
             IEnumerable<string> difference = leapPath.Except(unityDataPath);

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManager.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManager.cs
@@ -126,10 +126,12 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
             if (leapControllerOrientation == LeapControllerOrientation.Headset)
             {
                 // If the leap controller is mounted on a headset then add the LeapXRServiceProvider to the scene
-                // The LeapXRServiceProvider can only be attached to a camera 
-                LeapMotionServiceProvider = CameraCache.Main.gameObject.AddComponent<LeapXRServiceProvider>();
-
-                LeapXRServiceProvider leapXRServiceProvider = LeapMotionServiceProvider as LeapXRServiceProvider;
+				
+                // The leap service provider needs to know what is the main camera, it will pick this up from the MainCameraProvider
+                // which is used because camera.Main is not supported across all XR platforms
+                MainCameraProvider.mainCamera = CameraCache.Main;
+                var leapXRServiceProvider = CameraCache.Main.gameObject.AddComponent<LeapXRServiceProvider>();
+                LeapMotionServiceProvider = leapXRServiceProvider;
 
                 // Allow modification of VR specific offset modes if the leapControllerOrientation is Headset
                 // These settings mirror the modification of the properties exposed in the inspector within the LeapXRServiceProvider attached

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManager.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManager.cs
@@ -125,11 +125,14 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
 
             if (leapControllerOrientation == LeapControllerOrientation.Headset)
             {
-                // If the leap controller is mounted on a headset then add the LeapXRServiceProvider to the scene
-				
-                // The leap service provider needs to know what is the main camera, it will pick this up from the MainCameraProvider
-                // which is used because camera.Main is not supported across all XR platforms
+                // As of the Unity Plugin (>V5.0.0), the leap service provider needs to know what is the main camera,
+                // it will pick this up from the MainCameraProvider which is used because camera.Main is not supported
+                // across all XR platforms. This needs to be done before the LeapXRServiceProvider is created
+
+#if LEAPMOTIONPLUGIN_PRESENT
                 MainCameraProvider.mainCamera = CameraCache.Main;
+#endif
+                // If the leap controller is mounted on a headset then add the LeapXRServiceProvider to the scene
                 var leapXRServiceProvider = CameraCache.Main.gameObject.AddComponent<LeapXRServiceProvider>();
                 LeapMotionServiceProvider = leapXRServiceProvider;
 
@@ -331,7 +334,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
             }
         }
 #endif
-    }
+            }
 
-}
+        }
 

--- a/Assets/MRTK/Providers/LeapMotion/MRTK.LeapMotion.asmdef
+++ b/Assets/MRTK/Providers/LeapMotion/MRTK.LeapMotion.asmdef
@@ -3,7 +3,8 @@
     "references": [
         "Microsoft.MixedReality.Toolkit",
         "LeapMotion",
-        "LeapMotion.LeapCSharp"
+        "LeapMotion.LeapCSharp",
+        "Ultraleap.Tracking.Core"
     ],
     "includePlatforms": [
         "Editor",


### PR DESCRIPTION
## Overview
Adds support for 5.3 of the Ultraleap Unity plugin. 

This is the first time support is included in MRTK for version 5 and above of the Ultraleap Unity Plugin. Significant changes were made to the Ultraleap Tracking Plugin from V4 -> V5, the most notable of which from the MRTK perspective is:

- a name change from 'Unity Modules' to 'Unity Plugin'
- plugin path/folder name changes 
- changes to the way the main camera is set on the LeapXRServiceProvider

Fixes have had to be made in 5.3 of the plugin to support MRTK, specifically around how the main camera is set on the LeapXRServiceProvider and fixing some compiler warnings. This means it is the first version of the Unity Plugin to be supported by MTRK. **5.0.0 through to 5.2.0 are not supported and will be reported as such in the console window if an attempt is made to integrate them.**

## Changes
- Fixes: # .
Adds support for 5.3 of the Ultraleap Unity hand tracking plugin. This is the first release of version 5 to be supported by MRTK.

## Verification
Needs to be verified with V5.3 of the Ultraleap Unity plugin, which is currently undergoing testing prior to release. Note, testing identified that the 'Check Integration Status' feature (Mixed Reality > Toolkit > Utilities > Leap Motion >)  often reports that the plugin has not been integrated when it has. This is a bug and does **not** appear to be a regression from previous releases. It will be raised separately.

Only import of the tracking.**unitypackage** is supported, due to potential installation path changes with alternatives (e.g. the package manager).

A potential further improvement may be to rename the menu items 'Integrate Leap Motion Unity Modules' and 'Separate Leap Motion Unity Modules' to  'Integrate Leap Motion Unity Modules / Unity Plugin ' and 'Separate Leap Motion Unity Modules / Unity Plugin'.

Finally, Ultraleap and the MRTK team have decided not to force a full branding update (from Leap Motion to Ultraleap) in MRTK V2. References to Ultraleap have only been added in a restricted set of places where it may add clarity.
