### PR TITLE
Fix Leap hand not reporting position and rotation availability correctly

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
@@ -106,6 +106,8 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
             {
                 if (attachmentHand != null && attachmentHand.isTracked)
                 {
+                    IsPositionAvailable = IsRotationAvailable = true;
+
                     // Is the current joint a metacarpal
                     bool isMetacarpal = metacarpals.Contains(joint);
 
@@ -131,6 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
                 }
                 else
                 {
+                    IsPositionAvailable = IsRotationAvailable = false;
                     jointPoses[joint] = MixedRealityPose.ZeroIdentity;
                 }
             }


### PR DESCRIPTION
## Overview
Fix to ensure that LeapMotionArticulatedHand, which implements IMixedRealityController, correctly sets the IsPositionAvailable and IsRotationAvailable properties.

Before the fix, they defaulted to and stayed false. This manifested as an issue in the HandMenuExamples scene where, while using LeapMotionDeviceManager as an Input Data Provider, the hand menu would not appear when the palm was turned towards the camera. This was due to a check of IsPositionAvailable in HandConstraintPalmUp.cs returning false thus preventing the menu becoming active.

## Changes
- LeapMotionArticulatedHand: set _IsPositionAvailable_ and _IsRotationAvailable_ correctly after checking whether a Leap hand is being tracked.

## Verification
I have tested the following set up to ensure the fix took effect.

- MRTK 2.7.3
- Unity 2019.4.34
- Ultraleap Leap Motion Unity Modules 4.9.1
- Ultraleap Gemini Hand Tracking 5.2
- Ultraleap SIR170 camera

Verification steps:
1. Follow the [Using Leap Motion](https://docs.microsoft.com/en-us/windows/mixed-reality/mrtk-unity/supported-devices/leap-motion-mrtk?view=mrtkunity-2021-05#using-leap-motion-by-ultraleap-hand-tracking-in-mrtk) MRTK guide, import and set up the necessary files for Leap Motion in MRTK.
2. Grab the MRTK Examples, specifically Hand Tracking.
3. Open the HandMenuExamples scene, set up the Leap Motion as an Input Data Provider.
4. Press play and turn hands towards the camera.