### PR TITLE
[BuildAndDeploy] perceptionSensorsExperimental should be first

### DIFF
--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -522,8 +522,9 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             var uwpBuildInfo = buildInfo as UwpBuildInfo;
 
             Debug.Assert(uwpBuildInfo != null);
+
             // Here, ResearchModeCapability must come first, in order to avoid schema errors
-            // See https://docs.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations#restricted-capabilities
+            // See https://docs.microsoft.com/windows/uwp/packaging/app-capability-declarations#restricted-capabilities
             if (uwpBuildInfo.ResearchModeCapabilityEnabled
 #if !UNITY_2021_2_OR_NEWER
                 && EditorUserBuildSettings.wsaSubtarget == WSASubtarget.HoloLens
@@ -532,6 +533,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             {
                 AddResearchModeCapability(rootElement);
             }
+
             if (uwpBuildInfo.DeviceCapabilities != null)
             {
                 AddCapabilities(rootElement, uwpBuildInfo.DeviceCapabilities);

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -522,6 +522,16 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             var uwpBuildInfo = buildInfo as UwpBuildInfo;
 
             Debug.Assert(uwpBuildInfo != null);
+            // Here, ResearchModeCapability must come first, in order to avoid schema errors
+            // See https://docs.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations#restricted-capabilities
+            if (uwpBuildInfo.ResearchModeCapabilityEnabled
+#if !UNITY_2021_2_OR_NEWER
+                && EditorUserBuildSettings.wsaSubtarget == WSASubtarget.HoloLens
+#endif // !UNITY_2021_2_OR_NEWER
+            )
+            {
+                AddResearchModeCapability(rootElement);
+            }
             if (uwpBuildInfo.DeviceCapabilities != null)
             {
                 AddCapabilities(rootElement, uwpBuildInfo.DeviceCapabilities);
@@ -529,15 +539,6 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             if (uwpBuildInfo.GazeInputCapabilityEnabled)
             {
                 AddGazeInputCapability(rootElement);
-            }
-
-            if (uwpBuildInfo.ResearchModeCapabilityEnabled
-#if !UNITY_2021_2_OR_NEWER
-                && EditorUserBuildSettings.wsaSubtarget == WSASubtarget.HoloLens
-#endif // !UNITY_2021_2_OR_NEWER
-                )
-            {
-                AddResearchModeCapability(rootElement);
             }
 
             rootElement.Save(manifestFilePath);


### PR DESCRIPTION


## Overview
Force the perceptionSensorsExperimental element to come first.
According to https://docs.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations#restricted-capabilities , it's necessary.

## Changes
- Prioritize ResearchMode capability first in BuildAppx 


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
