### PR TITLE
Apply playspace awareness from the XR2018 observer to WinMR XRSDK and OpenXR observers

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
@@ -64,20 +64,23 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
             using (ConfigureObserverVolumePerfMarker.Auto())
             {
+                Vector3 observerOriginPlayspace = MixedRealityPlayspace.InverseTransformPoint(ObserverOrigin);
+
                 // Update the observer
                 switch (ObserverVolumeType)
                 {
                     case VolumeType.AxisAlignedCube:
-                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
+                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolume(observerOriginPlayspace, ObservationExtents);
                         break;
 #if WMR_ENABLED
                     case VolumeType.Sphere:
                         // We use the x value of the extents as the sphere radius
-                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolumeSphere(ObserverOrigin, ObservationExtents.x);
+                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolumeSphere(observerOriginPlayspace, ObservationExtents.x);
                         break;
 
                     case VolumeType.UserAlignedCube:
-                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolumeOrientedBox(ObserverOrigin, ObservationExtents, ObserverRotation);
+                        Quaternion observerRotationPlayspace = Quaternion.Inverse(MixedRealityPlayspace.Rotation) * ObserverRotation;
+                        XRSubsystemHelpers.MeshSubsystem.SetBoundingVolumeOrientedBox(observerOriginPlayspace, ObservationExtents, observerRotationPlayspace);
                         break;
 #endif // WMR_ENABLED
                     default:

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -473,11 +473,13 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
 
             using (ConfigureObserverVolumePerfMarker.Auto())
             {
+                Vector3 observerOriginPlayspace = MixedRealityPlayspace.InverseTransformPoint(ObserverOrigin);
+
                 // Update the observer
                 switch (ObserverVolumeType)
                 {
                     case VolumeType.AxisAlignedCube:
-                        MeshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
+                        MeshSubsystem.SetBoundingVolume(observerOriginPlayspace, ObservationExtents);
                         break;
 
                     default:


### PR DESCRIPTION
This change applies playspace awareness from the WinMR XR2018 spatial mesh observer to the WinMR XRSDK and OpenXR observers.

Caviat: The OpenXR observer supports only AxisAlignedCube per Unity's API specification ( https://docs.unity3d.com/ScriptReference/XR.XRMeshSubsystem.SetBoundingVolume.html )

Opening as a DRAFT PR so that impacted customers can get early access to the proposed fix while internal testing is underway.

@fast-slow-still @peterneil-bimholoview this _should_ fix #10343.