### PR TITLE
Fix for jittery near manipulation holding

### DIFF
--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -815,7 +815,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 wasGravity = rigidBody.useGravity;
                 wasKinematic = rigidBody.isKinematic;
                 rigidBody.useGravity = false;
-                rigidBody.isKinematic = false;
+                rigidBody.isKinematic = true;
             }
 
             if (EnableConstraints && constraintsManager != null)


### PR DESCRIPTION
## Overview
All objects affected by gravity will suffer jittery near-holding behaviour because the "isKinematic" flag was incorrectly set to false when objects are held, causing gravity to "pull" the objects away from the hand, and the grip to resolve it, causing jitter. MRTK correctly returns the rigidbody back to it's original state when dropped again with this fix.

"isKinematic" is a flag for letting scripts take over movement of a rigidbody, which MRTK does in this case.

Both of these videos were taken in an oculus 2 device using the native record functionality. The low frame rate may make it hard to see, but there is a serious jitter in the first video that is remedied in the second using this fix.

**Before:**

![JitterMRTK](https://user-images.githubusercontent.com/9042770/155219453-12e15e72-bc26-4fc9-8c9b-5995bd024f27.gif)

**After:**

![FixedMRTK](https://user-images.githubusercontent.com/9042770/155220555-c15df3bf-60c4-4d58-9bac-d27c1dbe8e3e.gif)



## Changes
- Fixes: #10478  .


## Verification

I have tested this extensively, and I have it live in my current projects. It does not seem to affect any other grabbing techniques or interfere with the normal workings of the MRTK grabbing systems. 
