### PR TITLE
Fixing difference in hand ray pointing math between left and right hands

### DIFF
--- a/Assets/MRTK/Core/Providers/Hands/HandRay/HandRay.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandRay/HandRay.cs
@@ -87,17 +87,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             float relativePivotY = DynamicPivotBaseY + Mathf.Min(DynamicPivotMultiplierY * handPositionHeadSpace.y, 0);
             relativePivotY = Mathf.Clamp(relativePivotY, DynamicPivotMinY, DynamicPivotMaxY);
 
-            float xBase = DynamicPivotBaseX;
+            float xBase = sourceHandedness == Handedness.Right ? DynamicPivotBaseX : -DynamicPivotBaseX;
             float xMultiplier = DynamicPivotMultiplierX;
-            float xMin = DynamicPivotMinX;
-            float xMax = DynamicPivotMaxX;
-            if (sourceHandedness == Handedness.Left)
-            {
-                xBase = -xBase;
-                float tmp = xMin;
-                xMin = -xMax;
-                xMax = tmp;
-            }
+            float xMin = sourceHandedness == Handedness.Right ? DynamicPivotMinX : -DynamicPivotMaxX;
+            float xMax = sourceHandedness == Handedness.Right ? DynamicPivotMaxX : -DynamicPivotMinX;
+
             float relativePivotX = xBase + xMultiplier * handPositionHeadSpace.x;
             relativePivotX = Mathf.Clamp(relativePivotX, xMin, xMax);
 

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -993,11 +993,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(endPosition);
 
             // make sure translation is as expected and no other transform values have been modified through this
-            Vector3 expectedPosition = new Vector3(1f, 0f, 1.5f);
+            Vector3 expectedPosition = new Vector3(1.1126f, 0f, 1.5f);
             Vector3 expectedSize = Vector3.one * 0.5f;
+            Debug.Log(boundsControl.transform.position.ToString("F4"));
             TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube didn't move as expected");
             TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube scaled while translating");
-            TestUtilities.AssertAboutEqual(boundsControl.transform.rotation, Quaternion.identity, "cube rotated while translating");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.rotation, Quaternion.identity, "cube rotated while translating"); ;
 
             GameObject.Destroy(boundsControl.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -382,7 +382,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return VerifyInitialBoundsCorrect(boundsControl);
 
             Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where hand ray points on center of the test cube
-            Vector3 rightFrontRotationHandlePoint = new Vector3(0.121f, -0.127f, 0.499f); // position of hand for far interacting with front right rotation sphere 
+            Vector3 rightFrontRotationHandlePoint = new Vector3(0.034f, -0.1266f, 0.499f); // position of hand for far interacting with front right rotation sphere 
             Vector3 endRotation = new Vector3(-0.18f, -0.109f, 0.504f); // end position for far interaction scaling
 
             TestHand hand = new TestHand(Handedness.Left);
@@ -399,7 +399,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             float angle;
             Vector3 axis = new Vector3();
             boundsControl.transform.rotation.ToAngleAxis(out angle, out axis);
-            float expectedAngle = 85f;
+            float expectedAngle = 87f;
             float angleDiff = Mathf.Abs(expectedAngle - angle);
             Vector3 expectedAxis = new Vector3(0f, 1f, 0f);
             TestUtilities.AssertAboutEqual(axis, expectedAxis, "Rotated around wrong axis");
@@ -476,7 +476,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return VerifyInitialBoundsCorrect(boundsControl);
 
             Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where hand ray points on center of the test cube
-            Vector3 rightFrontRotationHandlePoint = new Vector3(0.121f, -0.127f, 0.499f); // position of hand for far interacting with front right rotation sphere 
+            Vector3 rightFrontRotationHandlePoint = new Vector3(0.034f, -0.1266f, 0.499f); // position of hand for far interacting with front right rotation sphere 
             Vector3 endRotation = new Vector3(-0.18f, -0.109f, 0.504f); // end position for far interaction scaling
 
             TestHand hand = new TestHand(Handedness.Left);
@@ -503,7 +503,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             float angle;
             Vector3 axis = new Vector3();
             boundsControl.transform.rotation.ToAngleAxis(out angle, out axis);
-            float expectedAngle = 85f;
+            float expectedAngle = 87f;
             float angleDiff = Mathf.Abs(expectedAngle - angle);
             Vector3 expectedAxis = new Vector3(0f, 1f, 0f);
             TestUtilities.AssertAboutEqual(axis, expectedAxis, "Rotated around wrong axis");
@@ -768,7 +768,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
 
-            Vector3 rightCornerInteractionPoint = new Vector3(0.184f, 0.078f, 0.79f); // position of hand for far interacting with front right corner 
+            Vector3 rightCornerInteractionPoint = new Vector3(0.115f, 0.07f, 0.79f); // position of hand for far interacting with front right corner 
             Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where hand ray points on center of the test cube
             Vector3 scalePoint = new Vector3(0.165f, 0.267f, 0.794f); // end position for far interaction scaling
 
@@ -778,8 +778,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return hand.MoveTo(scalePoint);
             var endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
-            Vector3 expectedCenter = new Vector3(0.0453f, 0.0453f, 1.455f);
-            Vector3 expectedSize = Vector3.one * 0.59f;
+            Vector3 expectedCenter = new Vector3(0.0668f, 0.0668f, 1.4332f);
+            Vector3 expectedSize = Vector3.one * 0.6336f;
             TestUtilities.AssertAboutEqual(endBounds.center, expectedCenter, "endBounds incorrect center");
             TestUtilities.AssertAboutEqual(endBounds.size, expectedSize, "endBounds incorrect size");
 
@@ -2447,16 +2447,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             appBarGameObject.SetActive(true);
 
             // manipulation coords
-            Vector3 rightCornerInteractionPoint = new Vector3(0.184f, 0.078f, 0.79f); // position of hand for far interacting with front right corner 
+            Vector3 rightCornerInteractionPoint = new Vector3(0.115f, 0.07f, 0.79f); // position of hand for far interacting with front right corner 
             Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where hand ray points on center of the test cube
             Vector3 scalePoint = new Vector3(0.165f, 0.267f, 0.794f); // end position for far interaction scaling
             Vector3 appBarButtonStart = new Vector3(-0.028f, -0.263f, 0.499f); // location of hand for interaction with the app bar manipulation button after scene setup
-            Vector3 appBarButtonAfterScale = new Vector3(0.009f, -0.255f, 0.499f); // location of the hand for interaction with the app bar manipulation button after scaling
+            Vector3 appBarButtonAfterScale = new Vector3(-0.009f, -0.255f, 0.499f); // location of the hand for interaction with the app bar manipulation button after scaling
 
             // first test to interact with the cube without activating the app bar
             // this shouldn't scale the cube
             TestHand hand = new TestHand(Handedness.Left);
-            yield return hand.Show(pointOnCube); // Initially make sure that hand ray is pointed on cube surface so we won't go behind the cube with our ray
+            yield return hand.Show(pointOnCube); // Initially make sure that hand ray is pointed on cube surface so we won't go behind the cube with our ray\
             yield return hand.MoveTo(rightCornerInteractionPoint);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return hand.MoveTo(scalePoint);
@@ -2476,8 +2476,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.MoveTo(scalePoint);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
             endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
-            Vector3 expectedScaleCenter = new Vector3(0.0453f, 0.0453f, 1.455f);
-            Vector3 expectedScaleSize = Vector3.one * 0.59f;
+            Vector3 expectedScaleCenter = new Vector3(0.0668f, 0.0668f, 1.4332f);
+            Vector3 expectedScaleSize = Vector3.one * 0.6336f;
             TestUtilities.AssertAboutEqual(endBounds.center, expectedScaleCenter, "endBounds incorrect center");
             TestUtilities.AssertAboutEqual(endBounds.size, expectedScaleSize, "endBounds incorrect size");
 
@@ -2486,8 +2486,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.Click();
 
             // check if we can scale the box - box shouldn't scale
-            Vector3 startLocationScaleToOriginal = new Vector3(0.181f, 0.013f, 0.499f);
-            Vector3 endLocationScaleToOriginal = new Vector3(0.121f, -0.052f, 0.499f);
+            Vector3 startLocationScaleToOriginal = new Vector3(0.1059f, 0.034f, 0.499f);
+            Vector3 endLocationScaleToOriginal = new Vector3(0.0145f, -0.0267f, 0.499f);
             yield return hand.MoveTo(pointOnCube); // make sure our hand ray is on the cube again before moving to the scale corner
             yield return hand.MoveTo(startLocationScaleToOriginal); // move to scale corner
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);

--- a/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundsControlTests.cs
@@ -995,7 +995,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // make sure translation is as expected and no other transform values have been modified through this
             Vector3 expectedPosition = new Vector3(1.1126f, 0f, 1.5f);
             Vector3 expectedSize = Vector3.one * 0.5f;
-            Debug.Log(boundsControl.transform.position.ToString("F4"));
             TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube didn't move as expected");
             TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube scaled while translating");
             TestUtilities.AssertAboutEqual(boundsControl.transform.rotation, Quaternion.identity, "cube rotated while translating"); ;

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -679,7 +679,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
 
             // Set hand position 
-            Vector3 handStartPosition = new Vector3(0, -0.1f, 0.6f);
+            Vector3 handStartPosition = new Vector3(-0.055f, -0.1f, 0.5f);
             var leftHand = new TestHand(Handedness.Left);
             yield return leftHand.Show(handStartPosition);
 
@@ -742,14 +742,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             tapToPlaceSolverHandler.TrackedTargetType = TrackedObjectType.ControllerRay;
 
             // Set hand position
-            Vector3 handStartPosition = new Vector3(0, -0.1f, 0.6f);
+            Vector3 handStartPosition = new Vector3(-0.055f, -0.1f, 0.5f);
             var leftHand = new TestHand(Handedness.Left);
             yield return leftHand.Show(handStartPosition);
 
             Vector3 initialObjPosition = tapToPlaceObj.target.transform.position;
 
             yield return leftHand.Click();
-
             // Make sure the object is being placed after selection
             Assert.True(tapToPlace.IsBeingPlaced);
 
@@ -861,7 +860,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             SolverHandler tapToPlaceSolverHandler = tapToPlaceObj.handler;
             tapToPlaceSolverHandler.TrackedTargetType = TrackedObjectType.ControllerRay;
 
-            Vector3 handStartPosition = new Vector3(0, -0.15f, 0.5f);
+            Vector3 handStartPosition = new Vector3(-0.04f, -0.15f, 0.5f);
             var leftHand = new TestHand(Handedness.Left);
             yield return leftHand.Show(handStartPosition);
 
@@ -871,14 +870,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.True(tapToPlace.IsBeingPlaced);
 
+            
             // Move hand, object should follow
-            yield return leftHand.Move(new Vector3(-0.15f, 0, 0), 30);
+            yield return leftHand.Move(new Vector3(-0.20f, 0, 0), 30);
             Assert.True(tapToPlaceObj.target.transform.position.z < colliderObj1.transform.position.z);
 
-            yield return leftHand.Move(new Vector3(0.15f, 0, 0), 30);
+            yield return leftHand.Move(new Vector3(0.20f, 0, 0), 30);
             Assert.True(tapToPlaceObj.target.transform.position.z > colliderObj1.transform.position.z);
 
-            yield return leftHand.Move(new Vector3(0.15f, 0, 0), 30);
+            yield return leftHand.Move(new Vector3(0.05f, 0, 0), 30);
             Assert.True(tapToPlaceObj.target.transform.position.z < colliderObj1.transform.position.z);
 
             // Stop the placement via code instead of click from the hand
@@ -916,7 +916,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             SolverHandler tapToPlaceSolverHandler = tapToPlaceObj.handler;
             tapToPlaceSolverHandler.TrackedTargetType = TrackedObjectType.ControllerRay;
 
-            Vector3 handStartPosition = new Vector3(0, -0.15f, 0.5f);
+            Vector3 handStartPosition = new Vector3(-0.04f, -0.15f, 0.5f);
             var leftHand = new TestHand(Handedness.Left);
             yield return leftHand.Show(handStartPosition);
 
@@ -936,17 +936,17 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(tapToPlace.IsBeingPlaced);
 
             // Move hand in front of a collider for surface detection, the Tap to Place object should follow
-            yield return leftHand.Move(new Vector3(-0.15f, 0, 0), 30);
+            yield return leftHand.Move(new Vector3(-0.20f, 0, 0), 30);
 
             // Make sure the depth of the Tap to Place Object is very close to the depth of the wall because the SurfaceNormalOffset is 0
             Assert.AreEqual(tapToPlaceObj.target.transform.position.z, colliderObj1.transform.position.z, 0.05f);
 
             // Move hand between the colliders, the Tap to Place object should have a greater z position because the raycast did not detect a surface
-            yield return leftHand.Move(new Vector3(0.15f, 0, 0), 30);
+            yield return leftHand.Move(new Vector3(0.20f, 0, 0), 30);
             Assert.True(tapToPlaceObj.target.transform.position.z > colliderObj1.transform.position.z);
 
             // Move the hand in front of a collider for a surface detection
-            yield return leftHand.Move(new Vector3(0.15f, 0, 0), 30);
+            yield return leftHand.Move(new Vector3(0.05f, 0, 0), 30);
 
             // Set the UseDefaultSurfaceNormalOffset to true while still in the placing state
             tapToPlace.UseDefaultSurfaceNormalOffset = true;

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -336,25 +336,25 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public static void AssertAboutEqual(Vector3 actual, Vector3 expected, string message, float tolerance = 0.01f)
         {
             var dist = (actual - expected).magnitude;
-            Debug.Assert(dist < tolerance, $"{message}, expected {expected:0.000}, was {actual:0.000}");
+            Debug.Assert(dist < tolerance, $"{message}, expected {expected.ToString("F4")}, was {actual.ToString("F4")}");
         }
 
         public static void AssertAboutEqual(Quaternion actual, Quaternion expected, string message, float tolerance = 0.01f)
         {
             var angle = Quaternion.Angle(actual, expected);
-            Debug.Assert(angle < tolerance, $"{message}, expected {expected:0.000}, was {actual:0.000}");
+            Debug.Assert(angle < tolerance, $"{message}, expected {expected.ToString("F4")}, was {actual.ToString("F4")}");
         }
 
         public static void AssertNotAboutEqual(Vector3 val1, Vector3 val2, string message, float tolerance = 0.01f)
         {
             var dist = (val1 - val2).magnitude;
-            Debug.Assert(dist >= tolerance, $"{message}, val1 {val1:0.000} almost equals val2 {val2:0.000}");
+            Debug.Assert(dist >= tolerance, $"{message}, val1 {val1.ToString("F4")} almost equals val2 {val2.ToString("F4")}");
         }
 
         public static void AssertNotAboutEqual(Quaternion val1, Quaternion val2, string message, float tolerance = 0.01f)
         {
             var angle = Quaternion.Angle(val1, val2);
-            Debug.Assert(angle >= tolerance, $"{message}, val1 {val1:0.000} almost equals val2 {val2:0.000}");
+            Debug.Assert(angle >= tolerance, $"{message}, val1 {val1.ToString("F4")} almost equals val2 {val2.ToString("F4")}");
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
Hand rays had a slightly different update function based on handedness. This PR fixes the discrepancy

old:
![275119702_492113852506012_5273646645051996017_n](https://user-images.githubusercontent.com/39840334/157508760-e794f18f-5954-4e9b-9c0a-e4bc1947b144.png)


new:
![275200622_1893843437452649_4282125333137013771_n](https://user-images.githubusercontent.com/39840334/157508722-ef73305b-1227-43e6-b0b8-2bf93dac9e6a.png)
