### PR TITLE
Allow custom TTS voices

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/Audio.meta
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 829d3e9da92118c44b5c8bf6b3939bce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Editor/Inspectors/Audio/TextToSpeechInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Audio/TextToSpeechInspector.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Audio.Editor
+{
+    [CustomEditor(typeof(TextToSpeech))]
+    public class TextToSpeechInspector : UnityEditor.Editor
+    {
+        private SerializedProperty voiceProperty;
+
+        private void OnEnable()
+        {
+            voiceProperty = serializedObject.FindProperty("voice");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            if (voiceProperty.enumValueIndex == (int)TextToSpeechVoice.Other)
+            {
+                DrawDefaultInspector();
+                EditorGUILayout.HelpBox("Use the links below to find more available voices (for non en-US languages):", MessageType.Info);
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    if (GUILayout.Button("Voices for HoloLens 2", EditorStyles.miniButton))
+                    {
+                        Application.OpenURL("https://docs.microsoft.com/hololens/hololens2-language-support");
+                    }
+                    if (GUILayout.Button("Voices for desktop Windows", EditorStyles.miniButton))
+                    {
+                        Application.OpenURL("https://support.microsoft.com/windows/appendix-a-supported-languages-and-voices-4486e345-7730-53da-fcfe-55cc64300f01#WindowsVersion=Windows_11");
+                    }
+                }
+            }
+            else
+            {
+                DrawPropertiesExcluding(serializedObject, "customVoice");
+            }
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Editor/Inspectors/Audio/TextToSpeechInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Audio/TextToSpeechInspector.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio.Editor
 
         public override void OnInspectorGUI()
         {
-            if (voiceProperty.enumValueIndex == (int)TextToSpeechVoice.Other)
+            if (voiceProperty.intValue == (int)TextToSpeechVoice.Other)
             {
                 DrawDefaultInspector();
                 EditorGUILayout.HelpBox("Use the links below to find more available voices (for non en-US languages):", MessageType.Info);

--- a/Assets/MRTK/SDK/Editor/Inspectors/Audio/TextToSpeechInspector.cs.meta
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Audio/TextToSpeechInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b222cbab2f1aa7a4a82734bed784b113
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/Audio/TextToSpeech.cs
+++ b/Assets/MRTK/SDK/Features/Audio/TextToSpeech.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 namespace Microsoft.MixedReality.Toolkit.Audio
 {
     /// <summary>
-    /// The well-known voices that can be used by <see cref="TextToSpeech"/>.
+    /// The en-US voices that can be used by <see cref="TextToSpeech"/>. Voices for all other locale are categorized as Other.
     /// </summary>
     public enum TextToSpeechVoice
     {
@@ -25,19 +25,24 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         Default,
 
         /// <summary>
-        /// Microsoft David Mobile
+        /// Microsoft David voice
         /// </summary>
         David,
 
         /// <summary>
-        /// Microsoft Mark Mobile
+        /// Microsoft Mark voice
         /// </summary>
         Mark,
 
         /// <summary>
-        /// Microsoft Zira Mobile
+        /// Microsoft Zira voice
         /// </summary>
         Zira,
+
+        /// <summary>
+        /// Voice not listed above (for non en-US languages)
+        /// </summary>
+        Other
     }
 
     /// <summary>
@@ -65,13 +70,46 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         public AudioSource AudioSource { get { return audioSource; } set { audioSource = value; } }
 
         /// <summary>
-        /// Gets or sets the voice that will be used to generate speech.
+        /// Gets or sets the voice that will be used to generate speech. To use a non en-US voice, set this to Other.
         /// </summary>
+        /// <remarks>
+        /// If a custom voice is desired (i.e. this enum is being set to Other) make sure to set the <see cref="VoiceName"/> property.
+        /// </remarks>
         public TextToSpeechVoice Voice { get { return voice; } set { voice = value; } }
 
-        [Tooltip("The voice that will be used to generate speech.")]
+        [Tooltip("The voice that will be used to generate speech. To use a non en-US voice, set this to Other.")]
         [SerializeField]
         private TextToSpeechVoice voice;
+
+        /// <summary>
+        /// Gets or sets the voice that will be used to generate speech.
+        /// </summary>
+        /// <remarks>
+        /// It is required to set the voice through this property when using a custom voice.
+        /// </remarks>
+        public string VoiceName
+        {
+            get
+            {
+                return Voice != TextToSpeechVoice.Other ? Voice.ToString() : customVoice;
+            }
+            set
+            {
+                if (Enum.TryParse(value, out TextToSpeechVoice parsedVoice))
+                {
+                    Voice = parsedVoice;
+                }
+                else
+                {
+                    Voice = TextToSpeechVoice.Other;
+                    customVoice = value;
+                }
+            }
+        }
+
+        [Tooltip("The custom voice that will be used to generate speech. See below for the list of available voices.")]
+        [SerializeField]
+        private string customVoice = string.Empty;
 
 #if WINDOWS_UWP
         private SpeechSynthesizer synthesizer;
@@ -202,14 +240,11 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                         // Change voice?
                         if (voice != TextToSpeechVoice.Default)
                         {
-                            // Get name
-                            var voiceName = Enum.GetName(typeof(TextToSpeechVoice), voice);
-
                             // See if it's never been found or is changing
-                            if ((voiceInfo == null) || (!voiceInfo.DisplayName.Contains(voiceName)))
+                            if ((voiceInfo == null) || (!voiceInfo.DisplayName.Contains(VoiceName)))
                             {
                                 // Search for voice info
-                                voiceInfo = SpeechSynthesizer.AllVoices.Where(v => v.DisplayName.Contains(voiceName)).FirstOrDefault();
+                                voiceInfo = SpeechSynthesizer.AllVoices.Where(v => v.DisplayName.Contains(VoiceName)).FirstOrDefault();
 
                                 // If found, select
                                 if (voiceInfo != null)
@@ -218,9 +253,13 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                                 }
                                 else
                                 {
-                                    Debug.LogErrorFormat("TTS voice {0} could not be found.", voiceName);
+                                    Debug.LogErrorFormat("TTS voice {0} could not be found.", VoiceName);
                                 }
                             }
+                        }
+                        else
+                        {
+                            synthesizer.Voice = SpeechSynthesizer.DefaultVoice;
                         }
 
                         // Speak and get stream

--- a/Assets/MRTK/SDK/Features/Audio/TextToSpeech.cs
+++ b/Assets/MRTK/SDK/Features/Audio/TextToSpeech.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 namespace Microsoft.MixedReality.Toolkit.Audio
 {
     /// <summary>
-    /// The en-US voices that can be used by <see cref="TextToSpeech"/>. Voices for all other locale are categorized as Other.
+    /// The en-US voices that can be used by <see cref="TextToSpeech"/>. Voices for all other locales are categorized as Other.
     /// </summary>
     public enum TextToSpeechVoice
     {


### PR DESCRIPTION
## Overview
Modified the TextToSpeech script so that it now supports user specified voices. This is useful when performing TTS in locale other than en-US.

![image](https://user-images.githubusercontent.com/68253937/158497912-a8e69883-a474-47ed-adbc-6558059225f8.png)

## Changes
- Fixes: #10395