### PR TITLE
Clarifying raycast layermask descriptions and fixed teleport pointer overloading definitions

### DIFF
--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
@@ -23,11 +23,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public float PointingExtent => pointingExtent;
 
         [SerializeField]
-        [Tooltip("The LayerMasks, in prioritized order, that are used to determine the GazeTarget when raycasting.")]
+        [Tooltip("The default LayerMasks, in prioritized order, that are used to determine pointer's target. These layer masks are used if " +
+            "the pointer doesn't specify its own override")]
         private LayerMask[] pointingRaycastLayerMasks = { UnityEngine.Physics.DefaultRaycastLayers };
 
         /// <summary>
-        /// The LayerMasks, in prioritized order, that are used to determine the GazeTarget when raycasting.
+        /// The default layerMasks, in prioritized order, that are used to determine the target when raycasting.
         /// </summary>
         public LayerMask[] PointingRaycastLayerMasks => pointingRaycastLayerMasks;
 

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -82,7 +82,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 EditorGUILayout.LabelField("Pointer Settings", EditorStyles.boldLabel);
                 {
                     EditorGUILayout.PropertyField(pointingExtent);
-                    EditorGUILayout.PropertyField(pointingRaycastLayerMasks, true);
+                    EditorGUILayout.PropertyField(pointingRaycastLayerMasks, new GUIContent("Default Raycast LayerMasks"), true);
                     EditorGUILayout.PropertyField(pointerMediator);
                     EditorGUILayout.PropertyField(primaryPointerSelector);
 

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/TeleportPointerInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/TeleportPointerInspector.cs
@@ -50,8 +50,8 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
             maxHeightChangeOnStrafe = serializedObject.FindProperty("maxHeightChangeOnStrafe");
             upDirectionThreshold = serializedObject.FindProperty("upDirectionThreshold");
             lineColorHotSpot = serializedObject.FindProperty("LineColorHotSpot");
-            validLayers = serializedObject.FindProperty("ValidLayers");
-            invalidLayers = serializedObject.FindProperty("InvalidLayers");
+            validLayers = serializedObject.FindProperty("ValidTeleportationLayers");
+            invalidLayers = serializedObject.FindProperty("InvalidTeleportationLayers");
             pointerAudioSource = serializedObject.FindProperty("pointerAudioSource");
             teleportRequestedClip = serializedObject.FindProperty("teleportRequestedClip");
             teleportCompletedClip = serializedObject.FindProperty("teleportCompletedClip");

--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/TeleportPointerInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/Pointers/TeleportPointerInspector.cs
@@ -23,6 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
         private SerializedProperty maxHeightChangeOnStrafe;
         private SerializedProperty upDirectionThreshold;
         private SerializedProperty lineColorHotSpot;
+        private SerializedProperty teleportLayerMasks;
         private SerializedProperty validLayers;
         private SerializedProperty invalidLayers;
         private SerializedProperty pointerAudioSource;
@@ -50,6 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
             maxHeightChangeOnStrafe = serializedObject.FindProperty("maxHeightChangeOnStrafe");
             upDirectionThreshold = serializedObject.FindProperty("upDirectionThreshold");
             lineColorHotSpot = serializedObject.FindProperty("LineColorHotSpot");
+            teleportLayerMasks = serializedObject.FindProperty("teleportLayerMasks");
             validLayers = serializedObject.FindProperty("ValidTeleportationLayers");
             invalidLayers = serializedObject.FindProperty("InvalidTeleportationLayers");
             pointerAudioSource = serializedObject.FindProperty("pointerAudioSource");
@@ -84,6 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport.Editor
                 }
                 EditorGUILayout.PropertyField(upDirectionThreshold);
                 EditorGUILayout.PropertyField(lineColorHotSpot);
+                EditorGUILayout.PropertyField(teleportLayerMasks);
                 EditorGUILayout.PropertyField(validLayers);
                 EditorGUILayout.PropertyField(invalidLayers);
                 EditorGUILayout.PropertyField(pointerAudioSource);

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ParabolicTeleportPointer.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ParabolicTeleportPointer.prefab
@@ -115,6 +115,7 @@ LineRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -429,6 +430,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   destroyOnSourceLost: 0
   useSourcePoseData: 0
+  useSourcePoseAsFallback: 1
   poseAction:
     id: 4
     description: Pointer Pose
@@ -618,6 +620,9 @@ MonoBehaviour:
   rotationAmount: 90
   backStrafeActivationAngle: 45
   strafeAmount: 0.25
+  checkForFloorOnStrafe: 0
+  adjustHeightOnStrafe: 0
+  maxHeightChangeOnStrafe: 0.5
   upDirectionThreshold: 0.2
   LineColorHotSpot:
     serializedVersion: 2
@@ -648,10 +653,10 @@ MonoBehaviour:
     m_Mode: 0
     m_NumColorKeys: 2
     m_NumAlphaKeys: 4
-  ValidLayers:
+  ValidTeleportationLayers:
     serializedVersion: 2
     m_Bits: 1
-  InvalidLayers:
+  InvalidTeleportationLayers:
     serializedVersion: 2
     m_Bits: 4
   gravityDistorter: {fileID: 114225980339285346}

--- a/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerBehaviorTests.cs
@@ -413,6 +413,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return new WaitForSeconds(1.0f / iss.InputSimulationProfile.HandGestureAnimationSpeed + 0.1f);
 
             TeleportPointer teleportPointer = rightHand.GetPointer<TeleportPointer>();
+            teleportPointer.PrioritizedLayerMasksOverride = new LayerMask[1] { UnityEngine.Physics.AllLayers };
 
             floor.layer = LayerMask.NameToLayer("Default");
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();


### PR DESCRIPTION
## Overview
The raycast layermask path is pretty confusing between the pointer profile and the individual pointer settings. This PR does some work in clarifying these, and makes the teleport pointer more in line with the other pointers (poke, grab)

Potentially a breaking change, as the PrioritizedRaycastLayerMask returned by the interface is no longer a union of the Valid and Invalid layers.

![image](https://user-images.githubusercontent.com/39840334/158872744-c5ea0f0e-cd73-4449-b348-28186c1b6471.png)


## Changes
- Fixes: #10387 and others

