### PR TITLE
fixed issue where gaze provider gets forcibly reset on profile modification

### DIFF
--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -329,7 +329,7 @@ namespace Microsoft.MixedReality.Toolkit
             if (IsInitialized)
             {
                 DebugUtilities.LogVerboseFormat("Unregistered service of type {0} was an initialized service, disabling and destroying it", typeof(T));
-                if (Application.IsPlaying(activeProfile))
+                if (activeProfile != null && Application.IsPlaying(activeProfile))
                 {
                     serviceInstance.Disable();
                 }

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -326,10 +326,13 @@ namespace Microsoft.MixedReality.Toolkit
 
             Type interfaceType = typeof(T);
 
-            if (IsInitialized)
+            if (HasProfileAndIsInitialized)
             {
                 DebugUtilities.LogVerboseFormat("Unregistered service of type {0} was an initialized service, disabling and destroying it", typeof(T));
-                serviceInstance.Disable();
+                if (Application.IsPlaying(activeProfile))
+                {
+                    serviceInstance.Disable();
+                }
                 serviceInstance.Destroy();
             }
 

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -326,7 +326,7 @@ namespace Microsoft.MixedReality.Toolkit
 
             Type interfaceType = typeof(T);
 
-            if (HasProfileAndIsInitialized)
+            if (IsInitialized)
             {
                 DebugUtilities.LogVerboseFormat("Unregistered service of type {0} was an initialized service, disabling and destroying it", typeof(T));
                 if (Application.IsPlaying(activeProfile))


### PR DESCRIPTION
## Overview
The way we were reinitializing profiles called into a systems Disable() function, causing side effects. In particular, for the gaze provider, it would aggressively remove and repopulate the gaze provider.

This PR changes that.

## Changes
- Fixes: #10485 
