### PR TITLE
Remove Unused Variable

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -111,8 +111,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private Vector3 closestNormal = Vector3.forward;
 
-        private Vector3 endPoint;
-
         // previous frame pointer position
         public Vector3 PreviousPosition { get; private set; } = Vector3.zero;
 

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/ConeCastTrackingTargetTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/ConeCastTrackingTargetTest.cs
@@ -27,8 +27,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
         private static readonly string eyeTrackingConfigurationProfilePath = AssetDatabase.GUIDToAssetPath(eyeTrackingConfigurationProfileGuid);
 
-        private GameObject target;
-
         // This method is called once before we enter play mode and execute any of the tests
         // do any kind of setup here that can't be done in playmode
         public override IEnumerator Setup()

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/EyeTrackingTargetTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/EyeTrackingTargetTest.cs
@@ -27,8 +27,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
         private static readonly string eyeTrackingConfigurationProfilePath = AssetDatabase.GUIDToAssetPath(eyeTrackingConfigurationProfileGuid);
 
-        private GameObject target;
-
         // This method is called once before we enter play mode and execute any of the tests
         // do any kind of setup here that can't be done in playmode
         public override IEnumerator Setup()


### PR DESCRIPTION
## Overview
Remove unused variable in some file ```PokePointer.cs```, ```ConeCastTrackingTargetTest.cs``` & ```EyeTrackingTargetTest.cs```

## Changes
- Remove unused variable ```private Vector3 endPoint```.
- Remove unused variable ```private GameObject target```.