### PR TITLE
Adapt obsolete method/property usage for compatibility with Mixed Reality OpenXR 1.4.0

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
@@ -26,6 +26,11 @@
             "define": "MSFT_OPENXR"
         },
         {
+            "name": "com.microsoft.mixedreality.openxr",
+            "expression": "1.4.0",
+            "define": "UNITY_OPENXR_1_4_0_OR_NEWER"
+        },
+        {
             "name": "com.unity.xr.openxr",
             "expression": "",
             "define": "UNITY_OPENXR"

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -125,11 +125,19 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             }
 
             gestureRecognizer?.Stop();
+#if UNITY_OPENXR_1_4_0_OR_NEWER
+            gestureRecognizer?.Destroy();
+#else
             gestureRecognizer?.Dispose();
+#endif // UNITY_OPENXR_1_4_0_OR_NEWER
             gestureRecognizer = null;
 
             navigationGestureRecognizer?.Stop();
+#if UNITY_OPENXR_1_4_0_OR_NEWER
+            navigationGestureRecognizer?.Destroy();
+#else
             navigationGestureRecognizer?.Dispose();
+#endif // UNITY_OPENXR_1_4_0_OR_NEWER
             navigationGestureRecognizer = null;
 
             base.Disable();

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             using (ApplyUpdatedMeshDisplayOptionPerfMarker.Auto())
             {
-                SetMeshComputeSettings(LevelOfDetail);
+                SetMeshComputeSettings(option, LevelOfDetail);
                 base.ApplyUpdatedMeshDisplayOption(option);
             }
         }
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             using (LookupTriangleDensityPerfMarker.Auto())
             {
-                if (Application.isPlaying && SetMeshComputeSettings(levelOfDetail))
+                if (Application.isPlaying && SetMeshComputeSettings(DisplayOption, levelOfDetail))
                 {
                     return (int)levelOfDetail;
                 }
@@ -77,10 +77,13 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             }
         }
 
-        private bool SetMeshComputeSettings(SpatialAwarenessMeshLevelOfDetail levelOfDetail)
+        private bool SetMeshComputeSettings(SpatialAwarenessMeshDisplayOptions option, SpatialAwarenessMeshLevelOfDetail levelOfDetail)
         {
             MeshComputeSettings settings = new MeshComputeSettings
             {
+#if !UNITY_OPENXR_1_4_0_OR_NEWER
+                MeshType = (option == SpatialAwarenessMeshDisplayOptions.Visible) ? MeshType.Visual : MeshType.Collider,
+#endif // !UNITY_OPENXR_1_4_0_OR_NEWER
                 VisualMeshLevelOfDetail = MapMRTKLevelOfDetailToOpenXR(levelOfDetail),
                 MeshComputeConsistency = MeshComputeConsistency.OcclusionOptimized,
             };

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRSpatialAwarenessMeshObserver.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             using (ApplyUpdatedMeshDisplayOptionPerfMarker.Auto())
             {
-                SetMeshComputeSettings(option, LevelOfDetail);
+                SetMeshComputeSettings(LevelOfDetail);
                 base.ApplyUpdatedMeshDisplayOption(option);
             }
         }
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             using (LookupTriangleDensityPerfMarker.Auto())
             {
-                if (Application.isPlaying && SetMeshComputeSettings(DisplayOption, levelOfDetail))
+                if (Application.isPlaying && SetMeshComputeSettings(levelOfDetail))
                 {
                     return (int)levelOfDetail;
                 }
@@ -77,11 +77,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             }
         }
 
-        private bool SetMeshComputeSettings(SpatialAwarenessMeshDisplayOptions option, SpatialAwarenessMeshLevelOfDetail levelOfDetail)
+        private bool SetMeshComputeSettings(SpatialAwarenessMeshLevelOfDetail levelOfDetail)
         {
             MeshComputeSettings settings = new MeshComputeSettings
             {
-                MeshType = (option == SpatialAwarenessMeshDisplayOptions.Visible) ? MeshType.Visual : MeshType.Collider,
                 VisualMeshLevelOfDetail = MapMRTKLevelOfDetailToOpenXR(levelOfDetail),
                 MeshComputeConsistency = MeshComputeConsistency.OcclusionOptimized,
             };


### PR DESCRIPTION
## Overview

The mesh visual/collider setting was never really hooked up on the OpenXR side and is being obsoleted in the upcoming 1.4.0 MR OpenXR package. The plugin returns visual meshes in all cases, like legacy XR did.

Also adjusted a usage of `Dispose()` vs `Destroy()` in the gesture recognizer.