### PR TITLE
Add support for "select" voice command with Windows XR Plugin

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -768,6 +768,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             {
                 detectedController = new WindowsMixedRealityGGVHand(TrackingState.NotTracked, controllingHand, inputSource);
             }
+
             if (!detectedController.Enabled)
             {
                 // Controller failed to be setup correctly.

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKGGVHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKGGVHand.cs
@@ -22,5 +22,42 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions, new SimpleHandDefinition(controllerHandedness))
         { }
+
+        internal void UpdateVoiceState(bool isPressed)
+        {
+            MixedRealityInteractionMapping interactionMapping = null;
+
+            for (int i = 0; i < Interactions?.Length; i++)
+            {
+                MixedRealityInteractionMapping currentInteractionMapping = Interactions[i];
+
+                if (currentInteractionMapping.AxisType == AxisType.Digital && currentInteractionMapping.InputType == DeviceInputType.Select)
+                {
+                    interactionMapping = currentInteractionMapping;
+                    break;
+                }
+            }
+
+            if (interactionMapping == null)
+            {
+                return;
+            }
+
+            interactionMapping.BoolData = isPressed;
+
+            // If our value changed raise it.
+            if (interactionMapping.Changed)
+            {
+                // Raise input system event if it's enabled
+                if (interactionMapping.BoolData)
+                {
+                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                }
+                else
+                {
+                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                }
+            }
+        }
     }
 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -85,6 +85,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             mixedRealityGazeProviderHeadOverride = Service?.GazeProvider as IMixedRealityGazeProviderHeadOverride;
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
+#if WINDOWS_UWP
+            WindowsMixedRealityUtilities.SpatialInteractionManager.SourcePressed += SpatialInteractionManager_SourcePressed;
+            WindowsMixedRealityUtilities.SpatialInteractionManager.SourceReleased += SpatialInteractionManager_SourceReleased;
+#endif // WINDOWS_UWP
+
 #if HP_CONTROLLER_ENABLED
             // Listens to events to track the HP Motion Controller
             motionControllerWatcher = new MotionControllerWatcher();
@@ -133,6 +138,23 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             base.Update();
         }
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+
+#if WINDOWS_UWP
+        /// <inheritdoc/>
+        public override void Disable()
+        {
+            WindowsMixedRealityUtilities.SpatialInteractionManager.SourcePressed -= SpatialInteractionManager_SourcePressed;
+            WindowsMixedRealityUtilities.SpatialInteractionManager.SourceReleased -= SpatialInteractionManager_SourceReleased;
+
+            if (voiceController != null)
+            {
+                RemoveControllerFromScene(voiceController);
+                voiceController = null;
+            }
+
+            base.Disable();
+        }
+#endif // WINDOWS_UWP
 
         #endregion IMixedRealityDeviceManager Interface
 
@@ -332,5 +354,74 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         }
 
         #endregion Controller Utilities
+
+        #region SpatialInteractionManager events
+
+#if WINDOWS_UWP
+        /// <summary>
+        /// SDK Interaction Source Released Event handler. Used only for voice.
+        /// </summary>
+        /// <param name="args">SDK source released event arguments</param>
+        private void SpatialInteractionManager_SourcePressed(SpatialInteractionManager sender, SpatialInteractionSourceEventArgs args)
+        {
+            if (args.State.Source.Kind == SpatialInteractionSourceKind.Voice)
+            {
+                GetOrAddVoiceController()?.UpdateVoiceState(true);
+            }
+        }
+
+        /// <summary>
+        /// SDK Interaction Source Pressed Event handler. Used only for voice.
+        /// </summary>
+        /// <param name="args">SDK source pressed event arguments</param>
+        private void SpatialInteractionManager_SourceReleased(SpatialInteractionManager sender, SpatialInteractionSourceEventArgs args)
+        {
+            if (args.State.Source.Kind == SpatialInteractionSourceKind.Voice)
+            {
+                WindowsMixedRealityXRSDKGGVHand controller = GetOrAddVoiceController();
+                if (controller != null)
+                {
+                    controller.UpdateVoiceState(false);
+                    // On WMR, the voice recognizer does not actually register the phrase 'select'
+                    // when you add it to the speech commands profile. Therefore, simulate
+                    // the "select" voice command running to ensure that we get a select voice command
+                    // registered. This is used by FocusProvider to detect when the select pointer is active
+                    Service?.RaiseSpeechCommandRecognized(controller.InputSource, RecognitionConfidenceLevel.High, TimeSpan.MinValue, DateTime.Now, new SpeechCommands("select", KeyCode.Alpha1, MixedRealityInputAction.None));
+                }
+            }
+        }
+
+        private WindowsMixedRealityXRSDKGGVHand voiceController = null;
+
+        private WindowsMixedRealityXRSDKGGVHand GetOrAddVoiceController()
+        {
+            if (voiceController != null)
+            {
+                return voiceController;
+            }
+
+            IMixedRealityInputSource inputSource = Service?.RequestNewGenericInputSource("Mixed Reality Voice", sourceType: InputSourceType.Voice);
+            WindowsMixedRealityXRSDKGGVHand detectedController = new WindowsMixedRealityXRSDKGGVHand(TrackingState.NotTracked, Handedness.None, inputSource);
+
+            if (!detectedController.Enabled)
+            {
+                // Controller failed to be setup correctly.
+                // Return null so we don't raise the source detected.
+                return null;
+            }
+
+            for (int i = 0; i < detectedController.InputSource?.Pointers?.Length; i++)
+            {
+                detectedController.InputSource.Pointers[i].Controller = detectedController;
+            }
+
+            Service?.RaiseSourceDetected(detectedController.InputSource, detectedController);
+
+            voiceController = detectedController;
+            return voiceController;
+        }
+#endif // WINDOWS_UWP
+
+        #endregion SpatialInteractionManager events
     }
 }


### PR DESCRIPTION
## Overview

Adds explicit support for the `SpatialInteractionManager`s source pressed/released with voice.
This will _not_ work over remoting, but the normal keyword recognition should catch this case in that scenario.

## Changes
- Fixes: #8582
