### PR TITLE
Clarified eye tracking settings wording and added links to documentation

### DIFF
--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
@@ -82,11 +82,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public bool UseHeadGazeOverride => useHeadGazeOverride;
 
         [SerializeField]
-        [Tooltip("If true, eye-based tracking will be used as gaze input when available. Requires the 'Gaze Input' permission and device eye calibration to have been run.")]
+        [Tooltip("If true, eye-based tracking will be used as gaze input when available. This field does not control whether eye tracking data is provided.")]
         private bool isEyeTrackingEnabled = false;
 
         /// <summary>
-        /// If true, eye-based tracking will be used as gaze input when available.
+        /// If true, eye-based tracking will be used as gaze input when available. This field does not control whether eye tracking data is provided.
         /// </summary>
         public bool IsEyeTrackingEnabled
         {

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -86,7 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     EditorGUILayout.BeginHorizontal();
                     EditorGUILayout.PropertyField(useEyeTrackingDataWhenAvailable, new GUIContent("Use Eye Tracking Data"));
                     // Render a help link for getting started with eyetracking documentation
-                    string helpURL = "https://docs.microsoft.com/en-us/windows/mixed-reality/mrtk-unity/features/input/eye-tracking/eye-tracking-basic-setup";
+                    string helpURL = "https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/eye-tracking/eye-tracking-basic-setup";
                     InspectorUIUtility.RenderDocumentationButton(helpURL);
                     EditorGUILayout.EndHorizontal();
 

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -16,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private static readonly GUIContent MinusButtonContent = new GUIContent("-", "Remove Pointer Option");
         private static readonly GUIContent AddButtonContent = new GUIContent("+ Add a New Pointer Option", "Add Pointer Option");
         private static readonly GUIContent GazeCursorPrefabContent = new GUIContent("Gaze Cursor Prefab");
+        private static readonly GUIContent UseEyeTrackingDataContent = new GUIContent("Use Eye Tracking Data");
         private static readonly GUIContent RaycastLayerMaskContent = new GUIContent("Default Raycast LayerMasks");
 
         private const string ProfileTitle = "Pointer Settings";
@@ -84,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     EditorGUILayout.PropertyField(useHeadGazeOverride);
 
                     EditorGUILayout.BeginHorizontal();
-                    EditorGUILayout.PropertyField(useEyeTrackingDataWhenAvailable, new GUIContent("Use Eye Tracking Data"));
+                    EditorGUILayout.PropertyField(useEyeTrackingDataWhenAvailable, UseEyeTrackingDataContent);
                     // Render a help link for getting started with eyetracking documentation
                     string helpURL = "https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/input/eye-tracking/eye-tracking-basic-setup";
                     InspectorUIUtility.RenderDocumentationButton(helpURL);

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private SerializedProperty gazeCursorPrefab;
         private SerializedProperty gazeProviderType;
         private SerializedProperty useHeadGazeOverride;
-        private SerializedProperty isEyeTrackingEnabled;
+        private SerializedProperty useEyeTrackingDataWhenAvailable;
 
         private static bool showGazeProviderProperties = true;
         private UnityEditor.Editor gazeProviderEditor;
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             gazeCursorPrefab = serializedObject.FindProperty("gazeCursorPrefab");
             gazeProviderType = serializedObject.FindProperty("gazeProviderType");
             useHeadGazeOverride = serializedObject.FindProperty("useHeadGazeOverride");
-            isEyeTrackingEnabled = serializedObject.FindProperty("isEyeTrackingEnabled");
+            useEyeTrackingDataWhenAvailable = serializedObject.FindProperty("isEyeTrackingEnabled");
             pointerMediator = serializedObject.FindProperty("pointerMediator");
             primaryPointerSelector = serializedObject.FindProperty("primaryPointerSelector");
         }
@@ -82,7 +82,14 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     EditorGUILayout.PropertyField(gazeCursorPrefab, GazeCursorPrefabContent);
                     EditorGUILayout.PropertyField(gazeProviderType);
                     EditorGUILayout.PropertyField(useHeadGazeOverride);
-                    EditorGUILayout.PropertyField(isEyeTrackingEnabled);
+
+                    EditorGUILayout.BeginHorizontal();
+                    EditorGUILayout.PropertyField(useEyeTrackingDataWhenAvailable, new GUIContent("Use Eye Tracking Data"));
+                    // Render a help link for getting started with eyetracking documentation
+                    string helpURL = "https://docs.microsoft.com/en-us/windows/mixed-reality/mrtk-unity/features/input/eye-tracking/eye-tracking-basic-setup";
+                    InspectorUIUtility.RenderDocumentationButton(helpURL);
+                    EditorGUILayout.EndHorizontal();
+
                     EditorGUILayout.Space();
 
                     var gazeProvider = CameraCache.Main.GetComponent<IMixedRealityGazeProvider>();

--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs
@@ -33,6 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <summary>
         /// If true, eye-based tracking will be used when available.
+        /// This field does not control whether eye tracking data is provided.
         /// </summary>
         /// <remarks>
         /// <para>The usage of eye-based tracking depends on having the Gaze Input permission set


### PR DESCRIPTION
## Overview
Reworded the profile inspector settings to reflect their actual usage, and added a button directly in the inspector to bring users to our Eye Gaze setup documentation.

![image](https://user-images.githubusercontent.com/39840334/162833019-02c6ceec-26a5-4163-b49f-8c26261ca7a9.png)


## Changes
- Fixes: #8390

