### PR TITLE
OpenXR general hand interaction support

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -285,6 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private IMixedRealityTeleportPointer teleportPointer;
 
         private static readonly ProfilerMarker UpdateCurrentTeleportPosePerfMarker = new ProfilerMarker("[MRTK] ArticulatedHandDefinition.UpdateCurrentTeleportPose");
+
         /// <summary>
         /// Updates the MixedRealityInteractionMapping with the lastest teleport pose status and fires an event when appropriate
         /// </summary>

--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -86,8 +86,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private bool isPinching = false;
-
         /// <summary>
         /// The articulated hands default interactions.
         /// </summary>
@@ -120,8 +118,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
             new MixedRealityInputActionMapping("Teleport Pose", AxisType.DualAxis, DeviceInputType.ThumbStick),
         };
 
+
+        // Internal calculation of what the HandRay should be
+        // Useful as a fallback for hand ray data
+        protected virtual IHandRay HandRay { get; } = new HandRay();
+
         /// <summary>
         /// Calculates whether the current pose allows for pointing/distant interactions.
+        /// Equivalent to the HandRay's ShouldShowRay implementation (how do I hotlink the code reference in here Kurtis)
         /// </summary>
         public bool IsInPointingPose
         {
@@ -168,12 +172,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 Transform cameraTransform = mainCamera.transform;
 
+                Vector3 palmNormal = -palmPose.Up;
                 // We check if the palm up is roughly in line with the camera up
-                return Vector3.Dot(-palmPose.Up, cameraTransform.up) > 0.6f
+                return Vector3.Dot(palmNormal, cameraTransform.up) > 0.6f
                        // Thumb must be extended, and middle must be grabbing
                        && !isThumbGrabbing && isMiddleGrabbing;
             }
         }
+
+        /// <summary>
+        /// A bool tracking whether the hand definition is pinch or not
+        /// </summary>
+        private bool isPinching = false;
 
         /// <summary>
         /// Calculates whether the current the current joint pose is selecting (air tap gesture).
@@ -206,11 +216,30 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        public bool IsGrabbing => isIndexGrabbing && isMiddleGrabbing;
+
         private bool isIndexGrabbing;
         private bool isMiddleGrabbing;
         private bool isThumbGrabbing;
 
+        // Velocity internal states
+        private float deltaTimeStart;
+        private const int velocityUpdateInterval = 6;
+        private int frameOn = 0;
+
+        private readonly Vector3[] velocityPositionsCache = new Vector3[velocityUpdateInterval];
+        private readonly Vector3[] velocityNormalsCache = new Vector3[velocityUpdateInterval];
+        private Vector3 velocityPositionsSum = Vector3.zero;
+        private Vector3 velocityNormalsSum = Vector3.zero;
+
+        public Vector3 AngularVelocity { get; protected set; }
+
+        public Vector3 Velocity { get; protected set; }
+
+
         private static readonly ProfilerMarker UpdateHandJointsPerfMarker = new ProfilerMarker("[MRTK] ArticulatedHandDefinition.UpdateHandJoints");
+
+        #region Hand Definition Update functions
 
         /// <summary>
         /// Updates the current hand joints with new data.
@@ -256,7 +285,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private IMixedRealityTeleportPointer teleportPointer;
 
         private static readonly ProfilerMarker UpdateCurrentTeleportPosePerfMarker = new ProfilerMarker("[MRTK] ArticulatedHandDefinition.UpdateCurrentTeleportPose");
-
+        /// <summary>
+        /// Updates the MixedRealityInteractionMapping with the lastest teleport pose status and fires an event when appropriate
+        /// </summary>
+        /// <param name="interactionMapping">The teleport action's interaction mapping.</param>
         public void UpdateCurrentTeleportPose(MixedRealityInteractionMapping interactionMapping)
         {
             using (UpdateCurrentTeleportPosePerfMarker.Auto())
@@ -311,5 +343,80 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 previousReadyToTeleport = isReadyForTeleport;
             }
         }
+
+        /// <summary>
+        /// Updates the MixedRealityInteractionMapping with the lastest pointer pose status and fires a corresponding pose event.
+        /// </summary>
+        /// <param name="interactionMapping">The pointer pose's interaction mapping.</param>
+        public void UpdatePointerPose(MixedRealityInteractionMapping interactionMapping)
+        {
+            if (!unityJointPoses.TryGetValue(TrackedHandJoint.IndexKnuckle, out var knucklePose)) return;
+            if (!unityJointPoses.TryGetValue(TrackedHandJoint.Palm, out var palmPose)) return;
+
+            Vector3 rayPosition = knucklePose.Position;
+            Vector3 palmNormal = -palmPose.Up;
+
+            HandRay.Update(rayPosition, palmNormal, CameraCache.Main.transform, Handedness);
+            Ray ray = HandRay.Ray;
+
+            MixedRealityPose pointerPose = new MixedRealityPose();
+            pointerPose.Position = ray.origin;
+            pointerPose.Rotation = Quaternion.LookRotation(ray.direction);
+
+            // Update the interaction data source
+            interactionMapping.PoseData = pointerPose;
+
+            // If our value changed raise it
+            if (interactionMapping.Changed)
+            {
+                // Raise input system event if it's enabled
+                CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, Handedness, interactionMapping.MixedRealityInputAction, pointerPose);
+            }
+        }
+
+        /// <summary>
+        /// Updates the hand definition with it's velocity
+        /// </summary>
+        public void UpdateVelocity()
+        {
+            if (unityJointPoses.TryGetValue(TrackedHandJoint.Palm, out var currentPalmPose))
+            {
+                Vector3 palmPosition = currentPalmPose.Position;
+                Vector3 palmNormal = -currentPalmPose.Up;
+
+                if (frameOn < velocityUpdateInterval)
+                {
+                    velocityPositionsCache[frameOn] = palmPosition;
+                    velocityPositionsSum += velocityPositionsCache[frameOn];
+                    velocityNormalsCache[frameOn] = palmNormal;
+                    velocityNormalsSum += velocityNormalsCache[frameOn];
+                }
+                else
+                {
+                    int frameIndex = frameOn % velocityUpdateInterval;
+
+                    float deltaTime = Time.unscaledTime - deltaTimeStart;
+
+                    Vector3 newPositionsSum = velocityPositionsSum - velocityPositionsCache[frameIndex] + palmPosition;
+                    Vector3 newNormalsSum = velocityNormalsSum - velocityNormalsCache[frameIndex] + palmNormal;
+
+                    Velocity = (newPositionsSum - velocityPositionsSum) / deltaTime / velocityUpdateInterval;
+
+                    Quaternion rotation = Quaternion.FromToRotation(velocityNormalsSum / velocityUpdateInterval, newNormalsSum / velocityUpdateInterval);
+                    Vector3 rotationRate = rotation.eulerAngles * Mathf.Deg2Rad;
+                    AngularVelocity = rotationRate / deltaTime;
+
+                    velocityPositionsCache[frameIndex] = palmPosition;
+                    velocityNormalsCache[frameIndex] = palmNormal;
+                    velocityPositionsSum = newPositionsSum;
+                    velocityNormalsSum = newNormalsSum;
+                }
+
+                deltaTimeStart = Time.unscaledTime;
+                frameOn++;
+            }
+        }
+
+        #endregion
     }
 }

--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -125,7 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <summary>
         /// Calculates whether the current pose allows for pointing/distant interactions.
-        /// Equivalent to the HandRay's ShouldShowRay implementation (how do I hotlink the code reference in here Kurtis)
+        /// Equivalent to the HandRay's ShouldShowRay implementation <see cref="HandRay.ShouldShowRay"/>
         /// </summary>
         public bool IsInPointingPose
         {

--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -375,7 +375,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Updates the hand definition with it's velocity
+        /// Updates the hand definition with its velocity
         /// </summary>
         public void UpdateVelocity()
         {

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -135,8 +135,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
 
                 currentGripPose = jointPoses[TrackedHandJoint.Palm];
 
-                CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, currentGripPose);
-
                 UpdateVelocity();
             }
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -134,6 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
                 currentPointerPose.Rotation = Quaternion.LookRotation(pointerForward, pointerUp);
 
                 currentGripPose = jointPoses[TrackedHandJoint.Palm];
+                CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, currentGripPose);
 
                 UpdateVelocity();
             }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -122,20 +122,22 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                             switch (interactionMapping.InputType)
                             {
                                 case DeviceInputType.SpatialGrip:
-                                    MixedRealityPose currentGripPose = unityJointPoses[TrackedHandJoint.Palm];
-                                    interactionMapping.PoseData = currentGripPose;
-
-                                    if (interactionMapping.Changed)
+                                    if (TryGetJoint(TrackedHandJoint.Palm, out MixedRealityPose currentGripPose))
                                     {
-                                        CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentGripPose);
+                                        interactionMapping.PoseData = currentGripPose;
 
-                                        // Spatial Grip is also used as the basis for the source pose when device data is not provided
-                                        // We need to rotate it by an offset to properly represent the source pose.
-                                        MixedRealityPose CurrentControllerPose = currentGripPose;
-                                        CurrentControllerPose.Rotation *= (ControllerHandedness == Handedness.Left ? leftPalmOffset : rightPalmOffset);
+                                        if (interactionMapping.Changed)
+                                        {
+                                            CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentGripPose);
 
-                                        CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, CurrentControllerPose);
-                                        IsPositionAvailable = IsRotationAvailable = true;
+                                            // Spatial Grip is also used as the basis for the source pose when device data is not provided
+                                            // We need to rotate it by an offset to properly represent the source pose.
+                                            MixedRealityPose CurrentControllerPose = currentGripPose;
+                                            CurrentControllerPose.Rotation *= (ControllerHandedness == Handedness.Left ? leftPalmOffset : rightPalmOffset);
+
+                                            CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, CurrentControllerPose);
+                                            IsPositionAvailable = IsRotationAvailable = true;
+                                        }
                                     }
                                     break;
                                 case DeviceInputType.Select:

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -103,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                         switch (interactionMapping.InputType)
                         {
                             case DeviceInputType.IndexFinger:
-                                handDefinition?.UpdateCurrentIndexPose(Interactions[i]);
+                                handDefinition?.UpdateCurrentIndexPose(interactionMapping);
                                 break;
                         }
                     }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -113,15 +113,16 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     {
                         for (int i = 0; i < Interactions?.Length; i++)
                         {
-                            switch (Interactions[i].InputType)
+                            var interactionMapping = Interactions[i];
+                            switch (interactionMapping.InputType)
                             {
                                 case DeviceInputType.SpatialGrip:
                                     MixedRealityPose currentGripPose = unityJointPoses[TrackedHandJoint.Palm];
-                                    Interactions[i].PoseData = currentGripPose;
+                                    interactionMapping.PoseData = currentGripPose;
 
-                                    if (Interactions[i].Changed)
+                                    if (interactionMapping.Changed)
                                     {
-                                        CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction, currentGripPose);
+                                        CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentGripPose);
 
                                         // Spatial Grip is also used as the source pose when device data is not provided
                                         CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, CurrentControllerPose);
@@ -131,26 +132,26 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                                 case DeviceInputType.Select:
                                 case DeviceInputType.TriggerPress:
                                 case DeviceInputType.GripPress:
-                                    Interactions[i].BoolData = IsPinching || IsGrabbing;
+                                    interactionMapping.BoolData = IsPinching || IsGrabbing;
 
-                                    if (Interactions[i].Changed)
+                                    if (interactionMapping.Changed)
                                     {
-                                        if (Interactions[i].BoolData)
+                                        if (interactionMapping.BoolData)
                                         {
-                                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction);
+                                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
                                         }
                                         else
                                         {
-                                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction);
+                                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
                                         }
                                     }
                                     break;
                                 case DeviceInputType.SpatialPointer:
-                                    handDefinition?.UpdatePointerPose(Interactions[i]);
+                                    handDefinition?.UpdatePointerPose(interactionMapping);
                                     break;
                                 // Gotta do this only for non-AR devices
                                 case DeviceInputType.ThumbStick:
-                                    handDefinition?.UpdateCurrentTeleportPose(Interactions[i]);
+                                    handDefinition?.UpdateCurrentTeleportPose(interactionMapping);
                                     break;
                             }
                         }
@@ -296,31 +297,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 handMeshProvider?.UpdateHandMesh();
                 handJointProvider?.UpdateHandJoints(inputDevice, unityJointPoses);
                 handDefinition?.UpdateHandJoints(unityJointPoses);
-
-                // Note: After some testing, it seems when moving your hand fast, Oculus's pinch estimation data gets frozen, which leads to stuck pinches.
-                // To counter this, we perform a distance check between thumb and index to determine if we should force the pinch to a false state.
-
-                // Need to realign the oculus hand to match the articulated hand definition lol
-                // ... or just ditch it
-                // We can probably use index pinch strength somewhere... just maybe not here?
-                //float pinchStrength = HandPoseUtils.CalculateIndexPinch(ControllerHandedness);
-                //if (pinchStrength == 0.0f)
-                //{
-                //    IsPinching = false;
-                //}
-                //else
-                //{
-                //    if (IsPinching)
-                //    {
-                //        // If we are already pinching, we make the pinch a bit sticky
-                //        IsPinching = pinchStrength > 0.5f;
-                //    }
-                //    else
-                //    {
-                //        // If not yet pinching, only consider pinching if we've exceeded the redesignated threshold
-                //        IsPinching = pinchStrength > 0.85f;
-                //    }
-                //}
             }
         }
     }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OculusController.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OculusController.cs
@@ -12,7 +12,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 {
     [MixedRealityController(
         SupportedControllerType.OculusTouch,
-        new[] { Handedness.Left, Handedness.Right })]
+        new[] { Handedness.Left, Handedness.Right },
+        "Textures/OculusControllersTouch",
+        supportedUnityXRPipelines: SupportedUnityXRPipelines.XRSDK)]
     public class OculusController : GenericXRSDKController
     {
         /// <summary>

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OculusController.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OculusController.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.XRSDK.Input;
+using Unity.Profiling;
+using UnityEngine;
+using UnityEngine.XR;
+
+namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
+{
+    [MixedRealityController(
+        SupportedControllerType.OculusTouch,
+        new[] { Handedness.Left, Handedness.Right })]
+    public class OculusController : GenericXRSDKController
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public OculusController(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
+            : base(trackingState, controllerHandedness, inputSource, interactions, new OculusTouchControllerDefinition(controllerHandedness))
+        { }
+
+        private Vector3 currentPointerPosition = Vector3.zero;
+        private Quaternion currentPointerRotation = Quaternion.identity;
+        private MixedRealityPose currentPointerPose = MixedRealityPose.ZeroIdentity;
+
+        private static readonly ProfilerMarker UpdatePoseDataPerfMarker = new ProfilerMarker("[MRTK] OculusController.UpdatePoseData");
+
+        /// <summary>
+        /// Update spatial pointer and spatial grip data.
+        /// </summary>
+        protected override void UpdatePoseData(MixedRealityInteractionMapping interactionMapping, InputDevice inputDevice)
+        {
+            using (UpdatePoseDataPerfMarker.Auto())
+            {
+                Debug.Assert(interactionMapping.AxisType == AxisType.SixDof);
+
+                // Update the interaction data source
+                switch (interactionMapping.InputType)
+                {
+                    case DeviceInputType.SpatialPointer:
+                        if (inputDevice.TryGetFeatureValue(CustomUsages.PointerPosition, out currentPointerPosition))
+                        {
+                            currentPointerPose.Position = MixedRealityPlayspace.TransformPoint(currentPointerPosition);
+                        }
+
+                        if (inputDevice.TryGetFeatureValue(CustomUsages.PointerRotation, out currentPointerRotation))
+                        {
+                            currentPointerPose.Rotation = MixedRealityPlayspace.Rotation * currentPointerRotation;
+                        }
+
+                        interactionMapping.PoseData = currentPointerPose;
+
+                        // If our value changed raise it.
+                        if (interactionMapping.Changed)
+                        {
+                            // Raise input system event if it's enabled
+                            CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.PoseData);
+                        }
+                        break;
+                    default:
+                        base.UpdatePoseData(interactionMapping, inputDevice);
+                        break;
+                }
+            }
+        }
+
+#if MSFT_OPENXR
+        private MicrosoftControllerModelProvider controllerModelProvider;
+
+        /// <inheritdoc />
+        protected override bool TryRenderControllerModel(System.Type controllerType, InputSourceType inputSourceType)
+        {
+            if (GetControllerVisualizationProfile() == null ||
+                !GetControllerVisualizationProfile().GetUsePlatformModelsOverride(GetType(), ControllerHandedness))
+            {
+                return base.TryRenderControllerModel(controllerType, inputSourceType);
+            }
+            else
+            {
+                TryRenderControllerModelWithModelProvider();
+                return true;
+            }
+        }
+
+        private async void TryRenderControllerModelWithModelProvider()
+        {
+            if (controllerModelProvider == null)
+            {
+                controllerModelProvider = new MicrosoftControllerModelProvider(ControllerHandedness);
+            }
+
+            GameObject controllerModel = await controllerModelProvider.TryGenerateControllerModelFromPlatformSDK();
+
+            if (this != null)
+            {
+                if (controllerModel != null
+                    && MixedRealityControllerModelHelpers.TryAddVisualizationScript(controllerModel, GetType(), ControllerHandedness)
+                    && TryAddControllerModelToSceneHierarchy(controllerModel))
+                {
+                    controllerModel.SetActive(true);
+                    return;
+                }
+
+                Debug.LogWarning("Failed to create controller model from driver; defaulting to BaseController behavior.");
+                base.TryRenderControllerModel(GetType(), InputSource.SourceType);
+            }
+
+            if (controllerModel != null)
+            {
+                // If we didn't successfully set up the model and add it to the hierarchy (which returns early), set it inactive.
+                controllerModel.SetActive(false);
+            }
+        }
+#endif // MSFT_OPENXR
+    }
+}

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OculusController.cs.meta
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OculusController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 805c81fce82939e489fcaf965ad2a2dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -237,6 +237,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             {
                 case SupportedControllerType.WindowsMixedReality:
                 case SupportedControllerType.HPMotionController:
+                case SupportedControllerType.OculusTouch:
                     return InputSourceType.Controller;
                 case SupportedControllerType.ArticulatedHand:
                     return InputSourceType.Hand;
@@ -255,6 +256,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
             if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
             {
+#if UNITY_ANDROID
+                return SupportedControllerType.OculusTouch;
+#else
                 if (inputDevice.manufacturer == "HP")
                 {
                     return SupportedControllerType.HPMotionController;
@@ -263,14 +267,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                 {
                     return SupportedControllerType.WindowsMixedReality;
                 }
+#endif
             }
 
             return base.GetCurrentControllerType(inputDevice);
         }
 
-        #endregion Controller Utilities
+#endregion Controller Utilities
 
-        #region Gesture implementation
+#region Gesture implementation
 
 #if MSFT_OPENXR && WINDOWS_UWP
         private void ReadProfile()
@@ -515,6 +520,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         }
 #endif // MSFT_OPENXR && WINDOWS_UWP
 
-        #endregion Gesture implementation
+#endregion Gesture implementation
     }
 }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -221,6 +221,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     return typeof(MicrosoftMotionController);
                 case SupportedControllerType.HPMotionController:
                     return typeof(HPReverbG2Controller);
+                case SupportedControllerType.OculusTouch:
+                    return typeof(OculusController);
                 case SupportedControllerType.ArticulatedHand:
                     return typeof(MicrosoftArticulatedHand);
                 default:


### PR DESCRIPTION
## Overview
This PR adds several fallbacks for input actions for when hand joint data is available but not raw device data. This makes our OpenXR deployment story much more complete on non-Hololens platforms, and will greatly help drive cross-platform development.

Video sooooooon

## Changes
- Fixes: Several issues and is a big step towards removing our dependencies on Leap Motion and Oculus Packages.
#10477 