### PR TITLE
Update to new internal pool for CI

### DIFF
--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -13,15 +13,11 @@ jobs:
 - job: UnityValidation
   timeoutInMinutes: 90
   pool:
-    name: Analog On-Prem
-    demands:
-    - ${{ variables.Unity2018VersionInternal }}
-    - COG-UnityCache-WUS2-01
-    - SDK_18362 -equals TRUE
+    name: Analog-Unity
   workspace:
     clean: resources
   steps:
   - template: templates/ci-common.yml
     parameters:
       publishPackagesToFeed: true
-      UnityVersion: $(Unity2018VersionInternal)
+      UnityVersion: $(Unity2019VersionInternal)

--- a/pipelines/ci-weekly-internal.yml
+++ b/pipelines/ci-weekly-internal.yml
@@ -19,11 +19,7 @@ jobs:
 - job: Compliance
   timeoutInMinutes: 90
   pool:
-    name: Analog On-Prem
-    demands:
-    - ${{ variables.Unity2018VersionInternal }}
-    - COG-UnityCache-WUS2-01
-    - SDK_18362 -equals TRUE
+    name: Analog-Unity
   workspace:
     clean: resources
   steps:
@@ -59,7 +55,7 @@ jobs:
 
   - template: templates/compilemsbuild.yml
     parameters:
-      UnityVersion: $(Unity2018VersionInternal)
+      UnityVersion: $(Unity2019VersionInternal)
 
   - task: BinSkim@3
     inputs:

--- a/pipelines/config/settings.yml
+++ b/pipelines/config/settings.yml
@@ -4,9 +4,8 @@ variables:
   Unity2019Version: Unity2019.4.8f1
   Unity2020Version: Unity2020.3.5f1
   # Unity version on internal build agents (release builds)
-  Unity2018VersionInternal: Unity2018.4.26f1
-  Unity2019VersionInternal: Unity2019.4.17f1
-  Unity2020VersionInternal: Unity2020.3.12f1
+  Unity2019VersionInternal: Unity2019.4.31f1
+  Unity2020VersionInternal: Unity2020.3.21f1
 
   # Note that when updating this value also ensure that you update the
   # following locations to match. There will be a CI failure if they don't

--- a/pipelines/docs-binaries.yml
+++ b/pipelines/docs-binaries.yml
@@ -8,10 +8,7 @@ pr: none
 jobs:
 - job: BuildUnity2020
   pool:
-    name: Analog On-Prem
-    demands:
-    - ${{ variables.Unity2020VersionInternal }}
-    - COG-UnityCache-WUS2-01
+    name: Analog-Unity
 
   steps:
   - checkout: self
@@ -36,10 +33,7 @@ jobs:
 
 - job: BuildUnity2019
   pool:
-    name: Analog On-Prem
-    demands:
-    - ${{ variables.Unity2019VersionInternal }}
-    - COG-UnityCache-WUS2-01
+    name: Analog-Unity
 
   steps:
   - checkout: self
@@ -61,33 +55,3 @@ jobs:
     inputs:
       targetPath: $(Build.ArtifactStagingDirectory)
       artifactName: DocsBinariesForUnity2019
-
-- job: BuildUnity2018
-  pool:
-    name: Analog On-Prem
-    demands:
-    - ${{ variables.Unity2018VersionInternal }}
-    - COG-UnityCache-WUS2-01
-  workspace:
-    clean: resources
-
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 1
-
-  - task: PowerShell@2
-    displayName: 'Create binaries for docs generation'
-    inputs:
-      targetType: filePath
-      filePath: ./scripts/packaging/createbinariesfordocs.ps1
-      arguments: >
-        -Version $(MRTKVersion)
-        -UnityDirectory ${Env:$(Unity2018VersionInternal)}/Editor
-        -OutputDirectory $(Build.ArtifactStagingDirectory)
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish docs binaries
-    inputs:
-      targetPath: $(Build.ArtifactStagingDirectory)
-      artifactName: DocsBinariesForUnity2018


### PR DESCRIPTION
The new pool doesn't have a Unity 2018 installation, but we'll continue validating that on the public pools.