### PR TITLE
Fix issue where WMR controllers weren't reporting spatial data in "controller" mode when hand joints were enabled

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -273,9 +273,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             return base.GetCurrentControllerType(inputDevice);
         }
 
-#endregion Controller Utilities
+        #endregion Controller Utilities
 
-#region Gesture implementation
+        #region Gesture implementation
 
 #if MSFT_OPENXR && WINDOWS_UWP
         private void ReadProfile()
@@ -520,6 +520,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         }
 #endif // MSFT_OPENXR && WINDOWS_UWP
 
-#endregion Gesture implementation
+        #endregion Gesture implementation
     }
 }


### PR DESCRIPTION
## Overview

On OpenXR, there's a bit of an unusual state where we're reconciling two different `InputDevice`s together in order to get the full picture of hand joints, button data, positional data, etc.

This was hitting a weird case where, when controllers were reporting hand joint data, the hand joint `InputDevice` was inadvertently being used to read the pose data, even though it doesn't provide any. This change ensures we only report real pose data.

## Changes
- Fixes: I couldn't find the exact issues, but I've seen this come up in a couple places