### PR TITLE
Always publish artifacts in docs pipeline

### DIFF
--- a/pipelines/docs-binaries.yml
+++ b/pipelines/docs-binaries.yml
@@ -26,6 +26,7 @@ jobs:
         -OutputDirectory $(Build.ArtifactStagingDirectory)
 
   - task: PublishPipelineArtifact@1
+    condition: always()
     displayName: Publish docs binaries
     inputs:
       targetPath: $(Build.ArtifactStagingDirectory)
@@ -51,6 +52,7 @@ jobs:
         -OutputDirectory $(Build.ArtifactStagingDirectory)
 
   - task: PublishPipelineArtifact@1
+    condition: always()
     displayName: Publish docs binaries
     inputs:
       targetPath: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
## Overview

These represent DLLs when successful and the log when unsuccessful.