### PR TITLE
Define Build Tool C# version based on Unity version

### DIFF
--- a/Assets/MRTK/Tools/MSBuild/Scripts/MSBuildTools.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/MSBuildTools.cs
@@ -25,7 +25,13 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             BuildTarget.WSAPlayer
         };
 
-        public const string CSharpVersion = "7.3";
+        public const string CSharpVersion =
+#if UNITY_2020_2_OR_NEWER
+            "8.0";
+#else
+            "7.3";
+#endif
+
         public readonly static Version DefaultMinUWPSDK = new Version("10.0.14393.0");
 
         private static readonly string uwpMinPlatformVersion = EditorUserBuildSettings.wsaMinUWPSDK;


### PR DESCRIPTION
## Overview
Use a newer C# version for 2020.2+ C# project generation to resolve a docs pipeline failure caused by #10561.