### PR TITLE
Fixed issue where hand joint lookup would throw dictionary exceptions for visualizers

### DIFF
--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -126,6 +126,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 for (int i = 1; i < ArticulatedHandPose.JointCount; i++)
                 {
                     TrackedHandJoint handJoint = (TrackedHandJoint)i;
+                    // Skip this hand joint if the event data doesn't have an entry for it
+                    if (!eventData.InputData.ContainsKey(handJoint))
+                    {
+                        continue;
+                    }
                     MixedRealityPose handJointPose = eventData.InputData[handJoint];
                     Transform jointTransform = jointsArray[i];
 
@@ -171,7 +176,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         jointsArray[i] = jointObject.transform;
                     }
                 }
-            }
+             }
         }
 
         private static readonly ProfilerMarker OnHandMeshUpdatedPerfMarker = new ProfilerMarker("[MRTK] BaseHandVisualizer.OnHandMeshUpdated");

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -176,7 +176,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         jointsArray[i] = jointObject.transform;
                     }
                 }
-             }
+            }
         }
 
         private static readonly ProfilerMarker OnHandMeshUpdatedPerfMarker = new ProfilerMarker("[MRTK] BaseHandVisualizer.OnHandMeshUpdated");

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
@@ -211,9 +211,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
         }
 
         /// <summary>
-        /// Adds warnings to the nowarn line in the csc.rsp file located at the root of assets.  Warning 618 and 649 are added to the nowarn line because if
+        /// Adds warnings to the nowarn line in the csc.rsp file located at the root of assets.  Warning 414, 618 and 649 are added to the nowarn line because if
         /// the MRTK source is from the repo, warnings are converted to errors. Warnings are not converted to errors if the MRTK source is from the unity packages.
-        /// Warning 618 and 649 are logged when Oculus Integration is imported into the project, 618 is the obsolete warning and 649 is a null on start warning.
+        /// Warning 414, 618 and 649 are logged when Oculus Integration is imported into the project, 414 is an unsued variable warning,
+        /// 618 is the obsolete warning and 649 is a null on start warning.
         /// </summary>
         static void UpdateCSC()
         {
@@ -229,6 +230,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
             // List of new warning numbers to add to the csc file
             List<string> warningNumbersToAdd = new List<string>()
             {
+                "414",
                 "618",
                 "649"
             };

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -268,7 +268,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
 
                 UpdatePalm();
             }
-            
+
             HandDefinition?.UpdateHandJoints(jointPoses);
 
             // Note: After some testing, it seems when moving your hand fast, Oculus's pinch estimation data gets frozen, which leads to stuck pinches.
@@ -371,8 +371,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
 
         protected void UpdateJointPose(TrackedHandJoint joint, Vector3 position, Quaternion rotation)
         {
-            Vector3 jointPosition = position;
-
             // TODO Figure out kalman filter coefficients to get good quality smoothing
 #if LATER
             if (joint == TrackedHandJoint.IndexTip)
@@ -385,7 +383,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             }
 #endif
 
-            MixedRealityPose pose = new MixedRealityPose(jointPosition, rotation);
+            MixedRealityPose pose = new MixedRealityPose(position, rotation);
             if (!jointPoses.ContainsKey(joint))
             {
                 jointPoses.Add(joint, pose);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -319,6 +319,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     for (int i = 1; i < ArticulatedHandPose.JointCount; i++)
                     {
                         TrackedHandJoint handJoint = (TrackedHandJoint)i;
+                        // Skip this hand joint if the event data doesn't have an entry for it
+                        if (!eventData.InputData.ContainsKey(handJoint))
+                        {
+                            continue;
+                        }
                         MixedRealityPose handJointPose = eventData.InputData[handJoint];
                         Transform jointTransform = riggedVisualJointsArray[i];
 


### PR DESCRIPTION
## Overview
If the event data did not contain entries for all joints, the hand visualizer would throw an exception as it does a lookup on a hand joint which doesn't exist. This PR fixes that, stabilizing Oculus Visuals for 39.0 and beyond for 2019.

