### PR TITLE
Fixing Oculus Deployment Issue, whitespace error

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
@@ -211,10 +211,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
         }
 
         /// <summary>
-        /// Adds warnings to the nowarn line in the csc.rsp file located at the root of assets.  Warning 414, 618 and 649 are added to the nowarn line because if
+        /// Adds warnings to the nowarn line in the csc.rsp file located at the root of assets.  Warning 618 is added to the nowarn line because if
         /// the MRTK source is from the repo, warnings are converted to errors. Warnings are not converted to errors if the MRTK source is from the unity packages.
-        /// Warning 414, 618 and 649 are logged when Oculus Integration is imported into the project, 414 is an unsued variable warning,
-        /// 618 is the obsolete warning and 649 is a null on start warning.
+        /// Warning 618 is logged when building the project as of Oculus Integration 39.0 https://developer.oculus.com/downloads/package/unity-integration/39.0
+        /// 618 is the obsolete property/function warning
         /// </summary>
         static void UpdateCSC()
         {
@@ -228,7 +228,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
             List<string> warningNumbers = new List<string>();
 
             // List of new warning numbers to add to the csc file
-            // Empty as of Oculus Integration 39.0 https://developer.oculus.com/downloads/package/unity-integration/39.0
             List<string> warningNumbersToAdd = new List<string>()
             {
                 "618"

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Editor/OculusXRSDKHandtrackingConfigurationChecker.cs
@@ -231,6 +231,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Editor
             // Empty as of Oculus Integration 39.0 https://developer.oculus.com/downloads/package/unity-integration/39.0
             List<string> warningNumbersToAdd = new List<string>()
             {
+                "618"
             };
 
             if (!File.Exists(cscFilePath))

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -51,7 +51,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
 #if !UNITY_2020_1_OR_NEWER
             UnityEngine.Debug.Log(@"Detected a potential deployment issue for the Oculus Quest. In order to use hand tracking with the Oculus Quest, download the Oculus Integration Package from the Unity Asset Store and run the Integration tool before deploying.
 The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > Integrate Oculus Integration Unity Modules</i>");
-            // Add a note about abandoning Oculus XRSDK if on 2020+, use open xr instead please
 #endif
         }
 #endif

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -510,7 +510,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
 #endregion IMixedRealityPointer Implementation
 
-        #region IEquality Implementation
+#region IEquality Implementation
 
         private static bool Equals(IMixedRealityPointer left, IMixedRealityPointer right)
         {
@@ -558,7 +558,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
 #endregion IEquality Implementation
 
-        #region IMixedRealitySourcePoseHandler Implementation
+#region IMixedRealitySourcePoseHandler Implementation
 
         private static readonly ProfilerMarker OnSourceLostPerfMarker = new ProfilerMarker("[MRTK] BaseControllerPointer.OnSourceLost");
 
@@ -594,7 +594,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
 #endregion IMixedRealitySourcePoseHandler Implementation
 
-        #region IMixedRealityInputHandler Implementation
+#region IMixedRealityInputHandler Implementation
 
         private static readonly ProfilerMarker OnInputUpPerfMarker = new ProfilerMarker("[MRTK] BaseControllerPointer.OnInputUp");
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -508,9 +508,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IsFocusLocked = false;
         }
 
-#endregion IMixedRealityPointer Implementation
+        #endregion IMixedRealityPointer Implementation
 
-#region IEquality Implementation
+        #region IEquality Implementation
 
         private static bool Equals(IMixedRealityPointer left, IMixedRealityPointer right)
         {
@@ -556,9 +556,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-#endregion IEquality Implementation
+        #endregion IEquality Implementation
 
-#region IMixedRealitySourcePoseHandler Implementation
+        #region IMixedRealitySourcePoseHandler Implementation
 
         private static readonly ProfilerMarker OnSourceLostPerfMarker = new ProfilerMarker("[MRTK] BaseControllerPointer.OnSourceLost");
 
@@ -592,9 +592,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-#endregion IMixedRealitySourcePoseHandler Implementation
+        #endregion IMixedRealitySourcePoseHandler Implementation
 
-#region IMixedRealityInputHandler Implementation
+        #region IMixedRealityInputHandler Implementation
 
         private static readonly ProfilerMarker OnInputUpPerfMarker = new ProfilerMarker("[MRTK] BaseControllerPointer.OnInputUp");
 
@@ -679,6 +679,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-#endregion  IMixedRealityInputHandler Implementation
+        #endregion  IMixedRealityInputHandler Implementation
     }
 }


### PR DESCRIPTION
## Overview
When deploying to Oculus the 618 error will still pop up, this adds that code to the csc to fix that issue.

Fixed some whitespace that was introduced accidentally.
