### PR TITLE
[2.8] Fix pointer profile layer mask syncing with prefabs

### DIFF
--- a/Assets/MRTK/Core/Definitions/InputSystem/PointerOption.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/PointerOption.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// Defines a pointer option to assign to a controller.
     /// </summary>
     [Serializable]
-    public struct PointerOption
+    public struct PointerOption : ISerializationCallbackReceiver
     {
         /// <summary>
         /// Constructor.
@@ -61,5 +61,27 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// The LayerMasks, in prioritized order, which are used to determine the target
         /// </summary>
         public LayerMask[] PrioritizedLayerMasks => prioritizedLayerMasks;
+
+        void ISerializationCallbackReceiver.OnBeforeSerialize()
+        {
+            if (pointerPrefab == null)
+            {
+                prioritizedLayerMasks = Array.Empty<LayerMask>();
+                return;
+            }
+
+            IMixedRealityPointer pointer = pointerPrefab.GetComponent<IMixedRealityPointer>();
+            if (pointer.IsNull()
+                || pointer.PrioritizedLayerMasksOverride == prioritizedLayerMasks
+                || pointer.PrioritizedLayerMasksOverride == null
+                || pointer.PrioritizedLayerMasksOverride.Length == 0)
+            {
+                return;
+            }
+
+            prioritizedLayerMasks = pointer.PrioritizedLayerMasksOverride;
+        }
+
+        void ISerializationCallbackReceiver.OnAfterDeserialize() { }
     }
 }

--- a/Assets/MRTK/Core/Definitions/InputSystem/PointerOption.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/PointerOption.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
+using System.Linq;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -60,26 +61,34 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// The LayerMasks, in prioritized order, which are used to determine the target
         /// </summary>
-        public LayerMask[] PrioritizedLayerMasks => prioritizedLayerMasks;
+        public LayerMask[] PrioritizedLayerMasks
+        {
+            get => prioritizedLayerMasks;
+            internal set => prioritizedLayerMasks = value;
+        }
 
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
             if (pointerPrefab == null)
             {
-                prioritizedLayerMasks = Array.Empty<LayerMask>();
                 return;
             }
 
             IMixedRealityPointer pointer = pointerPrefab.GetComponent<IMixedRealityPointer>();
             if (pointer.IsNull()
-                || pointer.PrioritizedLayerMasksOverride == prioritizedLayerMasks
                 || pointer.PrioritizedLayerMasksOverride == null
-                || pointer.PrioritizedLayerMasksOverride.Length == 0)
+                || pointer.PrioritizedLayerMasksOverride.Length == 0
+                || (prioritizedLayerMasks != null && pointer.PrioritizedLayerMasksOverride.SequenceEqual(prioritizedLayerMasks)))
             {
                 return;
             }
 
-            prioritizedLayerMasks = pointer.PrioritizedLayerMasksOverride;
+            int pointerPrioritizedLayerMasksOverrideCount = pointer.PrioritizedLayerMasksOverride.Length;
+            if (prioritizedLayerMasks?.Length != pointerPrioritizedLayerMasksOverrideCount)
+            {
+                prioritizedLayerMasks = new LayerMask[pointerPrioritizedLayerMasksOverrideCount];
+            }
+            Array.Copy(pointer.PrioritizedLayerMasksOverride, prioritizedLayerMasks, pointerPrioritizedLayerMasksOverrideCount);
         }
 
         void ISerializationCallbackReceiver.OnAfterDeserialize() { }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -182,6 +182,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 return;
             }
 
+            bool anyPrefabChanged = false;
+
             for (int i = 0; i < list.arraySize; i++)
             {
                 using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
@@ -237,11 +239,17 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
                         PrefabUtility.RecordPrefabInstancePropertyModifications(pointerPrefab);
                         EditorUtility.SetDirty(pointerPrefab);
+                        anyPrefabChanged = true;
                     }
 
                     GUI.color = prevColor;
                 }
                 EditorGUILayout.Space();
+            }
+
+            if (anyPrefabChanged)
+            {
+                AssetDatabase.SaveAssets();
             }
         }
     }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -18,6 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private static readonly GUIContent GazeCursorPrefabContent = new GUIContent("Gaze Cursor Prefab");
         private static readonly GUIContent UseEyeTrackingDataContent = new GUIContent("Use Eye Tracking Data");
         private static readonly GUIContent RaycastLayerMaskContent = new GUIContent("Default Raycast LayerMasks");
+        private static readonly GUIContent PointerRaycastLayerMaskContent = new GUIContent("Pointer Raycast LayerMasks");
 
 #if UNITY_2019_3_OR_NEWER
         private const string EnableGazeCapabilityContent = "To use eye tracking with UWP, the GazeInput capability needs to be set in the manifest." +
@@ -28,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private const string ProfileDescription = "Pointers attach themselves onto controllers as they are initialized.";
 
         private SerializedProperty pointingExtent;
-        private SerializedProperty pointingRaycastLayerMasks;
+        private SerializedProperty defaultRaycastLayerMasks;
         private static bool showPointerOptionProperties = true;
         private SerializedProperty pointerOptions;
 
@@ -50,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             base.OnEnable();
 
             pointingExtent = serializedObject.FindProperty("pointingExtent");
-            pointingRaycastLayerMasks = serializedObject.FindProperty("pointingRaycastLayerMasks");
+            defaultRaycastLayerMasks = serializedObject.FindProperty("pointingRaycastLayerMasks");
             pointerOptions = serializedObject.FindProperty("pointerOptions");
             debugDrawPointingRays = serializedObject.FindProperty("debugDrawPointingRays");
             debugDrawPointingRayColors = serializedObject.FindProperty("debugDrawPointingRayColors");
@@ -75,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
                 EditorGUILayout.Space();
                 EditorGUILayout.PropertyField(pointingExtent);
-                EditorGUILayout.PropertyField(pointingRaycastLayerMasks, RaycastLayerMaskContent, true);
+                EditorGUILayout.PropertyField(defaultRaycastLayerMasks, RaycastLayerMaskContent, true);
                 EditorGUILayout.PropertyField(pointerMediator);
                 EditorGUILayout.PropertyField(primaryPointerSelector);
 
@@ -136,7 +137,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     }
                 }
 
-
                 EditorGUILayout.Space();
                 EditorGUILayout.LabelField("Debug Settings", EditorStyles.boldLabel);
                 {
@@ -159,8 +159,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         private void RenderPointerList(SerializedProperty list)
         {
-            var profile = target as MixedRealityPointerProfile;
-
             if (InspectorUIUtility.RenderIndentedButton(AddButtonContent, EditorStyles.miniButton))
             {
                 pointerOptions.arraySize += 1;
@@ -186,9 +184,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
             for (int i = 0; i < list.arraySize; i++)
             {
-                IMixedRealityPointer pointer = null;
-                Object pointerPrefab = null;
-
                 using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
                 {
                     Color prevColor = GUI.color;
@@ -199,46 +194,14 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     var prefab = pointerOption.FindPropertyRelative("pointerPrefab");
                     var prioritizedLayerMasks = pointerOption.FindPropertyRelative("prioritizedLayerMasks");
 
-                    pointerPrefab = prefab.objectReferenceValue;
-                    pointer = pointerPrefab.IsNull() ? null : ((GameObject)pointerPrefab).GetComponent<IMixedRealityPointer>();
+                    GameObject pointerPrefab = prefab.objectReferenceValue as GameObject;
+                    IMixedRealityPointer pointer = pointerPrefab != null ? pointerPrefab.GetComponent<IMixedRealityPointer>() : null;
 
                     // Display an error if the prefab doesn't have a IMixedRealityPointer Component
-                    if (pointer == null)
+                    if (pointer.IsNull())
                     {
                         InspectorUIUtility.DrawError($"The prefab associated with this pointer option needs an {typeof(IMixedRealityPointer).Name} component");
-
                         GUI.color = MixedRealityInspectorUtility.ErrorColor;
-                    }
-                    // if the prefab does have the component, provide a field to display and edit it's PrioritzedLayerMaskOverrides if it specifies a way to get it
-                    else
-                    {
-                        // sync the pointer option with the prefab
-                        if (pointer.PrioritizedLayerMasksOverride != null)
-                        {
-                            if (prioritizedLayerMasks.arraySize != pointer.PrioritizedLayerMasksOverride.Length)
-                            {
-                                prioritizedLayerMasks.arraySize = pointer.PrioritizedLayerMasksOverride.Length;
-                            }
-                            foreach (LayerMask mask in pointer.PrioritizedLayerMasksOverride)
-                            {
-                                SerializedProperty item = prioritizedLayerMasks.GetArrayElementAtIndex(prioritizedLayerMasks.arraySize - 1);
-                                item.intValue = mask;
-                            }
-                        }
-
-                        // if after syncing the the pointer option list is still empty, initialize with the global default
-                        // sync the pointer option with the prefab
-                        if (prioritizedLayerMasks.arraySize == 0)
-                        {
-                            for (int j = 0; j < pointingRaycastLayerMasks.arraySize; j++)
-                            {
-                                var mask = pointingRaycastLayerMasks.GetArrayElementAtIndex(j).intValue;
-
-                                prioritizedLayerMasks.InsertArrayElementAtIndex(prioritizedLayerMasks.arraySize);
-                                SerializedProperty item = prioritizedLayerMasks.GetArrayElementAtIndex(prioritizedLayerMasks.arraySize - 1);
-                                item.intValue = mask;
-                            }
-                        }
                     }
 
                     using (new EditorGUILayout.HorizontalScope())
@@ -256,17 +219,24 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
                     // Ultimately sync the pointer prefab's value with the pointer option's
                     EditorGUI.BeginChangeCheck();
-                    EditorGUILayout.PropertyField(prioritizedLayerMasks, new GUIContent("Pointer Raycast LayerMasks"), true);
-                    if (EditorGUI.EndChangeCheck() && pointer.PrioritizedLayerMasksOverride != null)
+                    EditorGUILayout.PropertyField(prioritizedLayerMasks, PointerRaycastLayerMaskContent, true);
+                    if (EditorGUI.EndChangeCheck() && pointer.IsNotNull())
                     {
                         Undo.RecordObject(pointerPrefab, "Sync Pointer Prefab");
-                        pointer.PrioritizedLayerMasksOverride = new LayerMask[prioritizedLayerMasks.arraySize];
-                        for (int j = 0; j < prioritizedLayerMasks.arraySize; j++)
+
+                        int prioritizedLayerMasksCount = prioritizedLayerMasks.arraySize;
+                        if (pointer.PrioritizedLayerMasksOverride?.Length != prioritizedLayerMasksCount)
+                        {
+                            pointer.PrioritizedLayerMasksOverride = new LayerMask[prioritizedLayerMasksCount];
+                        }
+
+                        for (int j = 0; j < prioritizedLayerMasksCount; j++)
                         {
                             pointer.PrioritizedLayerMasksOverride[j] = prioritizedLayerMasks.GetArrayElementAtIndex(j).intValue;
                         }
-                        
+
                         PrefabUtility.RecordPrefabInstancePropertyModifications(pointerPrefab);
+                        EditorUtility.SetDirty(pointerPrefab);
                     }
 
                     GUI.color = prevColor;

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -117,8 +117,11 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                         // Provide a convenient way to toggle the gaze provider as enabled/disabled via editor
                         gazeProvider.Enabled = EditorGUILayout.Toggle("Enable Gaze Provider", gazeProvider.Enabled);
 
-                        // Draw out the rest of the Gaze Provider's settings
-                        gazeProviderEditor.OnInspectorGUI();
+                        using (new EditorGUI.IndentLevelScope())
+                        {
+                            // Draw out the rest of the Gaze Provider's settings
+                            gazeProviderEditor.OnInspectorGUI();
+                        }
                     }
                 }
 

--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -312,8 +312,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     GameObjectExtensions.DestroyGameObject(pointerObject);
                 }
 
-                // make sure we init the pointer with the correct raycast LayerMasks
-                pointer.PrioritizedLayerMasksOverride = option.PrioritizedLayerMasks;
+                // Make sure we init the pointer with the correct raycast LayerMasks, if needed
+                if (pointer.PrioritizedLayerMasksOverride == null || pointer.PrioritizedLayerMasksOverride.Length == 0)
+                {
+                    pointer.PrioritizedLayerMasksOverride = option.PrioritizedLayerMasks;
+                }
 
                 return pointer;
             }

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoPointerProfile.asset
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoPointerProfile.asset
@@ -31,27 +31,37 @@ MonoBehaviour:
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 512
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 31d81f88cf3f71d4b8392ded50df3f05,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 38b548c6a2c270545a383296ad2bc4d5,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 526b854247016cf47bc5c58e01d82407,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 51
   - controllerType: 3072
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   pointerMediator:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator, Microsoft.MixedReality.Toolkit.SDK
   primaryPointerSelector:

--- a/Assets/MRTK/Examples/Demos/Input/Scenes/DisablePointers/DisablePointersExamplePointerProfile.asset
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/DisablePointers/DisablePointersExamplePointerProfile.asset
@@ -35,37 +35,51 @@ MonoBehaviour:
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: d5b94136462644c9873bb3347169ae7e,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 47
     handedness: 7
     pointerPrefab: {fileID: 1196247974088106, guid: c4fd3c6fc7ff484eb434775066e7f327,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 256
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 512
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 31d81f88cf3f71d4b8392ded50df3f05,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 38b548c6a2c270545a383296ad2bc4d5,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 526b854247016cf47bc5c58e01d82407,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 51
   - controllerType: 3072
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   pointerMediator:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator, Microsoft.MixedReality.Toolkit.SDK
   primaryPointerSelector:

--- a/Assets/MRTK/Examples/Demos/LookAndPinch/General/Profile/LookAndPinchDemoPointerProfile.asset
+++ b/Assets/MRTK/Examples/Demos/LookAndPinch/General/Profile/LookAndPinchDemoPointerProfile.asset
@@ -31,27 +31,37 @@ MonoBehaviour:
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 512
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 31d81f88cf3f71d4b8392ded50df3f05,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 38b548c6a2c270545a383296ad2bc4d5,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 526b854247016cf47bc5c58e01d82407,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 51
   - controllerType: 3072
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   pointerMediator:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator, Microsoft.MixedReality.Toolkit.SDK
   primaryPointerSelector:

--- a/Assets/MRTK/Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubPointerProfile.asset
+++ b/Assets/MRTK/Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubPointerProfile.asset
@@ -35,37 +35,51 @@ MonoBehaviour:
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: d5b94136462644c9873bb3347169ae7e,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 47
     handedness: 7
     pointerPrefab: {fileID: 1196247974088106, guid: c4fd3c6fc7ff484eb434775066e7f327,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 256
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 512
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 31d81f88cf3f71d4b8392ded50df3f05,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 38b548c6a2c270545a383296ad2bc4d5,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 526b854247016cf47bc5c58e01d82407,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 51
   - controllerType: 2048
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   pointerMediator:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator, Microsoft.MixedReality.Toolkit.SDK
   primaryPointerSelector:

--- a/Assets/MRTK/Examples/Experimental/NonNativeKeyboard/Profiles/NonNativeKeyboardMixedRealityInputPointerProfile.asset
+++ b/Assets/MRTK/Examples/Experimental/NonNativeKeyboard/Profiles/NonNativeKeyboardMixedRealityInputPointerProfile.asset
@@ -35,37 +35,51 @@ MonoBehaviour:
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: d5b94136462644c9873bb3347169ae7e,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 47
     handedness: 7
     pointerPrefab: {fileID: 1196247974088106, guid: c4fd3c6fc7ff484eb434775066e7f327,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 256
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 512
     handedness: 7
     pointerPrefab: {fileID: 8953170493194829522, guid: 840df22ff840d5540b58ca6088afde25,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 38b548c6a2c270545a383296ad2bc4d5,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1024
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 526b854247016cf47bc5c58e01d82407,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 51
   - controllerType: 2048
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   pointerMediator:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator, Microsoft.MixedReality.Toolkit.SDK
   primaryPointerSelector:

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ConicalGrabPointer.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/ConicalGrabPointer.prefab
@@ -83,11 +83,12 @@ MonoBehaviour:
   nearObjectSmoothingFactor: 0.4
   grabLayerMasks:
   - serializedVersion: 2
-    m_Bits: 563
+    m_Bits: 51
   triggerInteraction: 0
   sceneQueryBufferSize: 64
   ignoreCollidersNotInFOV: 1
   graspPointPlacement: 0
+  nearInteractableCacheCapacity: 50
 --- !u!114 &7376459786343609486
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/GrabPointer.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Prefabs/Pointers/GrabPointer.prefab
@@ -83,11 +83,12 @@ MonoBehaviour:
   nearObjectSmoothingFactor: 0.4
   grabLayerMasks:
   - serializedVersion: 2
-    m_Bits: 563
+    m_Bits: 51
   triggerInteraction: 0
   sceneQueryBufferSize: 64
   ignoreCollidersNotInFOV: 1
   graspPointPlacement: 0
+  nearInteractableCacheCapacity: 50
 --- !u!114 &7376459786343609486
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
@@ -72,7 +72,7 @@ MonoBehaviour:
       type: 3}
     prioritizedLayerMasks:
     - serializedVersion: 2
-      m_Bits: 563
+      m_Bits: 51
   - controllerType: 2048
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,

--- a/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1PointerProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1PointerProfile.asset
@@ -35,37 +35,51 @@ MonoBehaviour:
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: d5b94136462644c9873bb3347169ae7e,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 1071
     handedness: 7
     pointerPrefab: {fileID: 1196247974088106, guid: c4fd3c6fc7ff484eb434775066e7f327,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 256
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 512
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 31d81f88cf3f71d4b8392ded50df3f05,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 0
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: 38b548c6a2c270545a383296ad2bc4d5,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   - controllerType: 0
     handedness: 7
     pointerPrefab: {fileID: 1507865967819406, guid: c2fde7a8938065b459cff79b8ed89393,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 51
   - controllerType: 3119
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
       type: 3}
-    prioritizedLayerMasks: []
+    prioritizedLayerMasks:
+    - serializedVersion: 2
+      m_Bits: 4294967291
   pointerMediator:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator, Microsoft.MixedReality.Toolkit.SDK
   primaryPointerSelector:


### PR DESCRIPTION
## Overview

I found that the pointer profiles could go out of sync if they were reserialized without the inspector open. This change ensures that

1. The pointer itself is the source of truth if there's any serialization present
2. If no serialization is present in the pointer, default to either the global default (if initializing the field for the first time) or to whatever's in the profile serialization
3. If the profile is changed through the inspector, immediately sync the result back to the prefab and save