### PR TITLE
Fix null ref when stopping playmode with spatial mapping

### DIFF
--- a/Assets/MRTK/Examples/Common/Scripts/DemoSpatialMeshHandler.cs
+++ b/Assets/MRTK/Examples/Common/Scripts/DemoSpatialMeshHandler.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         protected void AddToData(int eventDataId)
         {
             // A new mesh has been added.
-            Debug.Log($"Tracking mesh {eventDataId}");
+            Debug.Log($"Started tracking mesh {eventDataId}");
             meshUpdateData.Add(eventDataId, 0);
         }
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -545,8 +545,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                     // Do not destroy the game object, destroy the meshes.
                     SpatialAwarenessMeshObject.Cleanup(availableMeshObject, false);
 
-                    availableMeshObject.GameObject.name = "Unused Spatial Mesh";
-                    availableMeshObject.GameObject.SetActive(false);
+                    if (availableMeshObject.GameObject != null)
+                    {
+                        availableMeshObject.GameObject.name = "Unused Spatial Mesh";
+                        availableMeshObject.GameObject.SetActive(false);
+                    }
 
                     spareMeshObject = availableMeshObject;
                 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -72,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// </summary>
         protected override void CreateObserver()
         {
-            if (SpatialAwarenessSystem == null) { return; }
+            if (Service == null) { return; }
 
 #if UNITY_WSA
             if (observer == null)
@@ -352,7 +352,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// </summary>
         private void UpdateObserver()
         {
-            if (SpatialAwarenessSystem == null || HolographicSettings.IsDisplayOpaque || !XRDevice.isPresent) { return; }
+            if (Service == null || HolographicSettings.IsDisplayOpaque || !XRDevice.isPresent) { return; }
 
             using (UpdateObserverPerfMarker.Auto())
             {
@@ -525,7 +525,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
 
                     // Send the mesh removed event
                     meshEventData.Initialize(this, id, null);
-                    SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshRemoved);
+                    Service?.HandleEvent(meshEventData, OnMeshRemoved);
                 }
             }
         }
@@ -716,11 +716,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                 meshEventData.Initialize(this, meshObject.Id, meshObject);
                 if (isMeshUpdate)
                 {
-                    SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshUpdated);
+                    Service?.HandleEvent(meshEventData, OnMeshUpdated);
                 }
                 else
                 {
-                    SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshAdded);
+                    Service?.HandleEvent(meshEventData, OnMeshAdded);
                 }
             }
         }

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKSpatialMeshObserver.cs
@@ -407,8 +407,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         {
             using (RemoveMeshObjectPerfMarker.Auto())
             {
-                SpatialAwarenessMeshObject mesh;
-                if (meshes.TryGetValue(id, out mesh))
+                if (meshes.TryGetValue(id, out SpatialAwarenessMeshObject mesh))
                 {
                     // Remove the mesh object from the collection.
                     meshes.Remove(id);
@@ -438,8 +437,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                     // Do not destroy the game object, destroy the meshes.
                     SpatialAwarenessMeshObject.Cleanup(availableMeshObject, false);
 
-                    availableMeshObject.GameObject.name = "Unused Spatial Mesh";
-                    availableMeshObject.GameObject.SetActive(false);
+                    if (availableMeshObject.GameObject != null)
+                    {
+                        availableMeshObject.GameObject.name = "Unused Spatial Mesh";
+                        availableMeshObject.GameObject.SetActive(false);
+                    }
 
                     spareMeshObject = availableMeshObject;
                 }


### PR DESCRIPTION
## Overview

Adds a null check, in case the GameObject was destroyed before the system is cleaned up.

## Changes
- Fixes: #10587
