### PR TITLE
Add four-param constructor to GenericXRSDKController for fallback

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -20,6 +20,14 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
             TrackingState trackingState,
             Handedness controllerHandedness,
             IMixedRealityInputSource inputSource = null,
+            MixedRealityInteractionMapping[] interactions = null)
+            : base(trackingState, controllerHandedness, inputSource, interactions)
+        { }
+
+        public GenericXRSDKController(
+            TrackingState trackingState,
+            Handedness controllerHandedness,
+            IMixedRealityInputSource inputSource = null,
             MixedRealityInteractionMapping[] interactions = null,
             IMixedRealityInputSourceDefinition definition = null)
             : base(trackingState, controllerHandedness, inputSource, interactions, definition)


### PR DESCRIPTION
## Overview

Adding a param to the constructor a while back broke the fallback case...

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/10200

