### PR TITLE
Assorted perf improvements in hot code paths

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private readonly float cursorBeamBackwardTolerance = 0.5f;
         private readonly float cursorBeamUpTolerance = 0.8f;
 
-        private Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoseDictionary = new Dictionary<TrackedHandJoint, MixedRealityPose>();
+        private IDictionary<TrackedHandJoint, MixedRealityPose> unityJointPoseDictionary = new Dictionary<TrackedHandJoint, MixedRealityPose>();
         private MixedRealityPose[] unityJointPoses = null;
         private MixedRealityPose currentIndexPose = MixedRealityPose.ZeroIdentity;
         private Vector3 currentPalmNormal = Vector3.zero;
@@ -42,10 +42,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private const int IndexTipIndex = (int)TrackedHandJoint.IndexTip;
 
         // Minimum distance between the index and the thumb tip required to enter a pinch
-        private readonly float minimumPinchDistance = 0.015f;
+        private const float MinimumPinchDistance = 0.015f;
 
         // Maximum distance between the index and thumb tip required to exit the pinch gesture
-        private readonly float maximumPinchDistance = 0.1f;
+        private const float MaximumPinchDistance = 0.1f;
 
         // Default enterPinchDistance value
         private float enterPinchDistance = 0.02f;
@@ -59,13 +59,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             get => enterPinchDistance;
             set
             {
-                if (value >= minimumPinchDistance && value <= maximumPinchDistance)
+                if (value >= MinimumPinchDistance && value <= MaximumPinchDistance)
                 {
                     enterPinchDistance = value;
                 }
                 else
                 {
-                    Debug.LogError("EnterPinchDistance must be between 0.015 and 0.1, please change Enter Pinch Distance in the Leap Motion Device Manager Profile");
+                    Debug.LogError($"EnterPinchDistance must be between {MinimumPinchDistance} and {MaximumPinchDistance}.");
                 }
             }
         }
@@ -82,13 +82,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             get => exitPinchDistance;
             set
             {
-                if (value >= minimumPinchDistance && value <= maximumPinchDistance)
+                if (value >= MinimumPinchDistance && value <= MaximumPinchDistance)
                 {
                     exitPinchDistance = value;
                 }
                 else
                 {
-                    Debug.LogError("ExitPinchDistance must be between 0.015 and 0.1, please change Exit Pinch Distance in the Leap Motion Device Manager Profile");
+                    Debug.LogError($"ExitPinchDistance must be between {MinimumPinchDistance} and {MaximumPinchDistance}.");
                 }
             }
         }
@@ -326,7 +326,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private static readonly ProfilerMarker UpdateCurrentTeleportPosePerfMarker = new ProfilerMarker("[MRTK] ArticulatedHandDefinition.UpdateCurrentTeleportPose");
 
         /// <summary>
-        /// Updates the MixedRealityInteractionMapping with the lastest teleport pose status and fires an event when appropriate
+        /// Updates the MixedRealityInteractionMapping with the latest teleport pose status and fires an event when appropriate
         /// </summary>
         /// <param name="interactionMapping">The teleport action's interaction mapping.</param>
         public void UpdateCurrentTeleportPose(MixedRealityInteractionMapping interactionMapping)
@@ -385,7 +385,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Updates the MixedRealityInteractionMapping with the lastest pointer pose status and fires a corresponding pose event.
+        /// Updates the MixedRealityInteractionMapping with the latest pointer pose status and fires a corresponding pose event.
         /// </summary>
         /// <param name="interactionMapping">The pointer pose's interaction mapping.</param>
         public void UpdatePointerPose(MixedRealityInteractionMapping interactionMapping)

--- a/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ArticulatedHandDefinition.cs
@@ -164,7 +164,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             get
             {
-                if (unityJointPoses == null) return false;
+                if (unityJointPoses == null)
+                {
+                    return false;
+                }
 
                 Camera mainCamera = CameraCache.Main;
 
@@ -279,7 +282,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 unityJointPoses = jointPoses;
 
-                if (unityJointPoses == null) return;
+                if (unityJointPoses == null)
+                {
+                    return;
+                }
 
                 currentIndexPose = unityJointPoses[IndexTipIndex];
                 currentPalmNormal = unityJointPoses[PalmIndex].Rotation * Vector3.down;

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -27,6 +27,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         // handMeshFilter.mesh.vertices, which does a copy of the vertices.
         private int lastHandMeshVerticesCount = 0;
 
+        private IDictionary<TrackedHandJoint, MixedRealityPose> cachedJointsDictionary = null;
+        private HandMeshInfo lastHandMeshInfo = null;
+
         private void OnEnable()
         {
             CoreServices.InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
@@ -40,6 +43,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Handedness = Controller.ControllerHandedness;
             }
+        }
+
+        protected virtual void Update()
+        {
+            UpdateHandJoints();
+            UpdateHandMesh();
         }
 
         private void OnDisable()
@@ -100,81 +109,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnHandJointsUpdatedPerfMarker.Auto())
             {
-                if (eventData.InputSource.SourceId != Controller.InputSource.SourceId)
+                if (eventData.InputSource.SourceId != Controller.InputSource.SourceId
+                    || eventData.Handedness != Controller.ControllerHandedness)
                 {
                     return;
                 }
-                Debug.Assert(eventData.Handedness == Controller.ControllerHandedness);
 
-                IMixedRealityInputSystem inputSystem = CoreServices.InputSystem;
-                MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile != null ? inputSystem.InputSystemProfile.HandTrackingProfile : null;
-                if (handTrackingProfile != null && !handTrackingProfile.EnableHandJointVisualization)
-                {
-                    // clear existing joint GameObjects / meshes
-                    foreach (Transform joint in jointsArray)
-                    {
-                        if (joint != null)
-                        {
-                            Destroy(joint.gameObject);
-                        }
-                    }
-
-                    return;
-                }
-
-                // This starts at 1 to skip over TrackedHandJoint.None.
-                for (int i = 1; i < ArticulatedHandPose.JointCount; i++)
-                {
-                    TrackedHandJoint handJoint = (TrackedHandJoint)i;
-                    // Skip this hand joint if the event data doesn't have an entry for it
-                    if (!eventData.InputData.TryGetValue(handJoint, out MixedRealityPose handJointPose))
-                    {
-                        continue;
-                    }
-                    Transform jointTransform = jointsArray[i];
-
-                    if (jointTransform != null)
-                    {
-                        jointTransform.SetPositionAndRotation(handJointPose.Position, handJointPose.Rotation);
-                    }
-                    else
-                    {
-                        GameObject prefab;
-                        if (handJoint == TrackedHandJoint.None || handTrackingProfile == null)
-                        {
-                            // No visible mesh for the "None" joint
-                            prefab = null;
-                        }
-                        else if (handJoint == TrackedHandJoint.Palm)
-                        {
-                            prefab = handTrackingProfile.PalmJointPrefab;
-                        }
-                        else if (handJoint == TrackedHandJoint.IndexTip)
-                        {
-                            prefab = handTrackingProfile.FingerTipPrefab;
-                        }
-                        else
-                        {
-                            prefab = handTrackingProfile.JointPrefab;
-                        }
-
-                        GameObject jointObject;
-                        if (prefab != null)
-                        {
-                            jointObject = Instantiate(prefab);
-                        }
-                        else
-                        {
-                            jointObject = new GameObject();
-                        }
-
-                        jointObject.name = handJoint.ToString() + " Proxy Transform";
-                        jointObject.transform.SetPositionAndRotation(handJointPose.Position, handJointPose.Rotation);
-                        jointObject.transform.parent = transform;
-
-                        jointsArray[i] = jointObject.transform;
-                    }
-                }
+                cachedJointsDictionary = eventData.InputData;
+                eventData.Use();
             }
         }
 
@@ -185,58 +127,149 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnHandMeshUpdatedPerfMarker.Auto())
             {
-                if (eventData.InputSource.SourceId != Controller.InputSource.SourceId)
+                if (eventData.InputSource.SourceId != Controller.InputSource.SourceId
+                    || eventData.Handedness != Controller.ControllerHandedness)
                 {
                     return;
                 }
 
-                bool newMesh = handMeshFilter == null;
+                lastHandMeshInfo = eventData.InputData;
+                eventData.Use();
+            }
+        }
 
-                if (newMesh &&
-                    CoreServices.InputSystem?.InputSystemProfile != null &&
-                    CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile != null &&
-                    CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab != null)
+        private void UpdateHandJoints()
+        {
+            if (cachedJointsDictionary == null)
+            {
+                return;
+            }
+
+            IMixedRealityInputSystem inputSystem = CoreServices.InputSystem;
+            MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile != null ? inputSystem.InputSystemProfile.HandTrackingProfile : null;
+            if (handTrackingProfile != null && !handTrackingProfile.EnableHandJointVisualization)
+            {
+                // clear existing joint GameObjects / meshes
+                foreach (Transform joint in jointsArray)
                 {
-                    handMeshFilter = Instantiate(CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab).GetComponent<MeshFilter>();
-                    lastHandMeshVerticesCount = handMeshFilter.mesh.vertices.Length;
+                    if (joint != null)
+                    {
+                        Destroy(joint.gameObject);
+                    }
                 }
 
-                if (handMeshFilter != null)
+                return;
+            }
+
+            // This starts at 1 to skip over TrackedHandJoint.None.
+            for (int i = 1; i < ArticulatedHandPose.JointCount; i++)
+            {
+                TrackedHandJoint handJoint = (TrackedHandJoint)i;
+
+                // Skip this hand joint if the event data doesn't have an entry for it
+                if (!cachedJointsDictionary.TryGetValue(handJoint, out MixedRealityPose handJointPose))
                 {
-                    Mesh mesh = handMeshFilter.mesh;
-
-                    bool meshChanged = false;
-                    // On some platforms, mesh length counts may change as the hand mesh is updated.
-                    // In order to update the vertices when the array sizes change, the mesh
-                    // must be cleared per instructions here:
-                    // https://docs.unity3d.com/ScriptReference/Mesh.html
-                    if (lastHandMeshVerticesCount != eventData.InputData.vertices?.Length)
-                    {
-                        meshChanged = true;
-                        mesh.Clear();
-                    }
-
-                    mesh.vertices = eventData.InputData.vertices;
-                    mesh.normals = eventData.InputData.normals;
-                    lastHandMeshVerticesCount = eventData.InputData.vertices != null ? eventData.InputData.vertices.Length : 0;
-
-                    if (newMesh || meshChanged)
-                    {
-                        mesh.triangles = eventData.InputData.triangles;
-
-                        if (eventData.InputData.uvs?.Length > 0)
-                        {
-                            mesh.uv = eventData.InputData.uvs;
-                        }
-                    }
-
-                    if (meshChanged)
-                    {
-                        mesh.RecalculateBounds();
-                    }
-
-                    handMeshFilter.transform.SetPositionAndRotation(eventData.InputData.position, eventData.InputData.rotation);
+                    continue;
                 }
+
+                Transform jointTransform = jointsArray[i];
+                if (jointTransform != null)
+                {
+                    jointTransform.SetPositionAndRotation(handJointPose.Position, handJointPose.Rotation);
+                }
+                else
+                {
+                    GameObject prefab;
+                    if (handJoint == TrackedHandJoint.None || handTrackingProfile == null)
+                    {
+                        // No visible mesh for the "None" joint
+                        prefab = null;
+                    }
+                    else if (handJoint == TrackedHandJoint.Palm)
+                    {
+                        prefab = handTrackingProfile.PalmJointPrefab;
+                    }
+                    else if (handJoint == TrackedHandJoint.IndexTip)
+                    {
+                        prefab = handTrackingProfile.FingerTipPrefab;
+                    }
+                    else
+                    {
+                        prefab = handTrackingProfile.JointPrefab;
+                    }
+
+                    GameObject jointObject;
+                    if (prefab != null)
+                    {
+                        jointObject = Instantiate(prefab);
+                    }
+                    else
+                    {
+                        jointObject = new GameObject();
+                    }
+
+                    jointObject.name = handJoint.ToString() + " Proxy Transform";
+                    jointObject.transform.SetPositionAndRotation(handJointPose.Position, handJointPose.Rotation);
+                    jointObject.transform.parent = transform;
+
+                    jointsArray[i] = jointObject.transform;
+                }
+            }
+        }
+
+        private void UpdateHandMesh()
+        {
+            if (lastHandMeshInfo == null)
+            {
+                return;
+            }
+
+            bool newMesh = handMeshFilter == null;
+
+            if (newMesh &&
+                CoreServices.InputSystem?.InputSystemProfile != null &&
+                CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile != null &&
+                CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab != null)
+            {
+                handMeshFilter = Instantiate(CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab).GetComponent<MeshFilter>();
+                lastHandMeshVerticesCount = handMeshFilter.mesh.vertices.Length;
+            }
+
+            if (handMeshFilter != null)
+            {
+                Mesh mesh = handMeshFilter.mesh;
+
+                bool meshChanged = false;
+                // On some platforms, mesh length counts may change as the hand mesh is updated.
+                // In order to update the vertices when the array sizes change, the mesh
+                // must be cleared per instructions here:
+                // https://docs.unity3d.com/ScriptReference/Mesh.html
+                if (lastHandMeshVerticesCount != lastHandMeshInfo.vertices?.Length)
+                {
+                    meshChanged = true;
+                    mesh.Clear();
+                }
+
+                mesh.vertices = lastHandMeshInfo.vertices;
+                mesh.normals = lastHandMeshInfo.normals;
+                lastHandMeshVerticesCount = lastHandMeshInfo.vertices != null ? lastHandMeshInfo.vertices.Length : 0;
+
+                if (newMesh || meshChanged)
+                {
+                    mesh.triangles = lastHandMeshInfo.triangles;
+
+                    if (lastHandMeshInfo.uvs?.Length > 0)
+                    {
+                        mesh.uv = lastHandMeshInfo.uvs;
+                    }
+                }
+
+                if (meshChanged)
+                {
+                    mesh.RecalculateBounds();
+                }
+
+                handMeshFilter.transform.SetPositionAndRotation(lastHandMeshInfo.position, lastHandMeshInfo.rotation);
             }
         }
     }

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected readonly Dictionary<TrackedHandJoint, Transform> joints = new Dictionary<TrackedHandJoint, Transform>();
 
         protected IMixedRealityHand MixedRealityHand { get; private set; } = null;
-        protected Transform[] JointsArray { get; } = new Transform[ArticulatedHandPose.JointCount];
+        protected Transform[] JointsArray { get; private set; } = new Transform[ArticulatedHandPose.JointCount];
         protected MeshFilter handMeshFilter;
 
         // This member stores the last count of hand mesh vertices, to avoid using
@@ -68,6 +68,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     Destroy(joint.gameObject);
                 }
+
+                JointsArray = System.Array.Empty<Transform>();
             }
 
             if (handMeshFilter != null)
@@ -165,7 +167,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         }
                     }
 
-                    return false;
+                    JointsArray = System.Array.Empty<Transform>();
+
+                    // Even though the base class isn't handling joint visualization, we still received new joints.
+                    // Return true here in case any derived classes want to update.
+                    return true;
+                }
+
+                if (JointsArray.Length != ArticulatedHandPose.JointCount)
+                {
+                    JointsArray = new Transform[ArticulatedHandPose.JointCount];
                 }
 
                 // This starts at 1 to skip over TrackedHandJoint.None.

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             if (unityJointPoses != null)
             {
                 pose = unityJointPoses[(int)joint];
-                return true;
+                return pose != default(MixedRealityPose);
             }
 
             pose = MixedRealityPose.ZeroIdentity;

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         private readonly OpenXRHandMeshProvider handMeshProvider;
         private readonly OpenXRHandJointProvider handJointProvider;
 
-        protected readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
+        protected MixedRealityPose[] unityJointPoses = null;
 
         private Vector3 currentPointerPosition = Vector3.zero;
         private Quaternion currentPointerRotation = Quaternion.identity;
@@ -52,7 +52,17 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         #region IMixedRealityHand Implementation
 
         /// <inheritdoc/>
-        public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose) => unityJointPoses.TryGetValue(joint, out pose);
+        public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose)
+        {
+            if (unityJointPoses != null)
+            {
+                pose = unityJointPoses[(int)joint];
+                return true;
+            }
+
+            pose = MixedRealityPose.ZeroIdentity;
+            return false;
+        }
 
         #endregion IMixedRealityHand Implementation
 
@@ -306,7 +316,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
             using (UpdateHandDataPerfMarker.Auto())
             {
                 handMeshProvider?.UpdateHandMesh();
-                handJointProvider?.UpdateHandJoints(inputDevice, unityJointPoses);
+                handJointProvider?.UpdateHandJoints(inputDevice, ref unityJointPoses);
                 handDefinition?.UpdateHandJoints(unityJointPoses);
             }
         }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.XRSDK.Input;
-using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR;
@@ -77,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
         private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] MicrosoftArticulatedHand.UpdateController");
 
-        // This bool is used to track whether or not we are recieving device data from the platform itself
+        // This bool is used to track whether or not we are receiving device data from the platform itself
         // If we aren't we will attempt to infer some common input actions from the hand joint data (i.e. the pinch gesture, pointer positions etc)
         private bool receivingDeviceInputs = false;
 
@@ -98,7 +97,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
             using (UpdateControllerPerfMarker.Auto())
             {
-                if (inputDevice.TryGetFeatureValue(CommonUsages.devicePosition, out Vector3 _))
+                if (inputDevice.TryGetFeatureValue(CommonUsages.devicePosition, out _))
                 {
                     base.UpdateController(inputDevice);
 
@@ -106,9 +105,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     // from the hand joint data
                     receivingDeviceInputs = true;
                 }
-                else
+
+                if (inputDevice.TryGetFeatureValue(CommonUsages.handData, out Hand hand))
                 {
-                    UpdateHandData(inputDevice);
+                    UpdateHandData(hand);
 
                     // Updating the Index finger pose right after getting the hand data
                     // regardless of whether device data is present
@@ -311,12 +311,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// Update the hand data from the device.
         /// </summary>
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
-        private void UpdateHandData(InputDevice inputDevice)
+        private void UpdateHandData(Hand hand)
         {
             using (UpdateHandDataPerfMarker.Auto())
             {
                 handMeshProvider?.UpdateHandMesh();
-                handJointProvider?.UpdateHandJoints(inputDevice, ref unityJointPoses);
+                handJointProvider?.UpdateHandJoints(hand, ref unityJointPoses);
                 handDefinition?.UpdateHandJoints(unityJointPoses);
             }
         }

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandJointProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandJointProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
@@ -31,11 +32,16 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         private readonly List<Bone> fingerBones = new List<Bone>();
 #endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
 
-        public void UpdateHandJoints(InputDevice inputDevice, Dictionary<TrackedHandJoint, MixedRealityPose> jointPoses)
+        public void UpdateHandJoints(InputDevice inputDevice, ref MixedRealityPose[] jointPoses)
         {
 #if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
             if (handTracker != null && handTracker.TryLocateHandJoints(FrameTime.OnUpdate, locations))
             {
+                if (jointPoses == null)
+                {
+                    jointPoses = new MixedRealityPose[ArticulatedHandPose.JointCount];
+                }
+
                 foreach (HandJoint handJoint in HandJoints)
                 {
                     HandJointLocation handJointLocation = locations[(int)handJoint];
@@ -45,16 +51,21 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     Vector3 position = MixedRealityPlayspace.TransformPoint(handJointLocation.Pose.position);
                     Quaternion rotation = MixedRealityPlayspace.Rotation * handJointLocation.Pose.rotation;
 
-                    jointPoses[ConvertToTrackedHandJoint(handJoint)] = new MixedRealityPose(position, rotation);
+                    jointPoses[ConvertToArrayIndex(handJoint)] = new MixedRealityPose(position, rotation);
                 }
 #else
             if (inputDevice.TryGetFeatureValue(CommonUsages.handData, out Hand hand))
             {
+                if (jointPoses == null)
+                {
+                    jointPoses = new MixedRealityPose[ArticulatedHandPose.JointCount];
+                }
+
                 foreach (HandFinger finger in HandFingers)
                 {
                     if (hand.TryGetRootBone(out Bone rootBone) && TryReadHandJoint(rootBone, out MixedRealityPose rootPose))
                     {
-                        jointPoses[TrackedHandJoint.Palm] = rootPose;
+                        jointPoses[(int)TrackedHandJoint.Palm] = rootPose;
                     }
 
                     if (hand.TryGetFingerBones(finger, fingerBones))
@@ -63,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                         {
                             if (TryReadHandJoint(fingerBones[i], out MixedRealityPose pose))
                             {
-                                jointPoses[ConvertToTrackedHandJoint(finger, i)] = pose;
+                                jointPoses[ConvertToArrayIndex(finger, i)] = pose;
                             }
                         }
                     }
@@ -73,43 +84,43 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         }
 
 #if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
-        private TrackedHandJoint ConvertToTrackedHandJoint(HandJoint handJoint)
+        private int ConvertToArrayIndex(HandJoint handJoint)
         {
             switch (handJoint)
             {
-                case HandJoint.Palm: return TrackedHandJoint.Palm;
-                case HandJoint.Wrist: return TrackedHandJoint.Wrist;
+                case HandJoint.Palm: return (int)TrackedHandJoint.Palm;
+                case HandJoint.Wrist: return (int)TrackedHandJoint.Wrist;
 
-                case HandJoint.ThumbMetacarpal: return TrackedHandJoint.ThumbMetacarpalJoint;
-                case HandJoint.ThumbProximal: return TrackedHandJoint.ThumbProximalJoint;
-                case HandJoint.ThumbDistal: return TrackedHandJoint.ThumbDistalJoint;
-                case HandJoint.ThumbTip: return TrackedHandJoint.ThumbTip;
+                case HandJoint.ThumbMetacarpal: return (int)TrackedHandJoint.ThumbMetacarpalJoint;
+                case HandJoint.ThumbProximal: return (int)TrackedHandJoint.ThumbProximalJoint;
+                case HandJoint.ThumbDistal: return (int)TrackedHandJoint.ThumbDistalJoint;
+                case HandJoint.ThumbTip: return (int)TrackedHandJoint.ThumbTip;
 
-                case HandJoint.IndexMetacarpal: return TrackedHandJoint.IndexMetacarpal;
-                case HandJoint.IndexProximal: return TrackedHandJoint.IndexKnuckle;
-                case HandJoint.IndexIntermediate: return TrackedHandJoint.IndexMiddleJoint;
-                case HandJoint.IndexDistal: return TrackedHandJoint.IndexDistalJoint;
-                case HandJoint.IndexTip: return TrackedHandJoint.IndexTip;
+                case HandJoint.IndexMetacarpal: return (int)TrackedHandJoint.IndexMetacarpal;
+                case HandJoint.IndexProximal: return (int)TrackedHandJoint.IndexKnuckle;
+                case HandJoint.IndexIntermediate: return (int)TrackedHandJoint.IndexMiddleJoint;
+                case HandJoint.IndexDistal: return (int)TrackedHandJoint.IndexDistalJoint;
+                case HandJoint.IndexTip: return (int)TrackedHandJoint.IndexTip;
 
-                case HandJoint.MiddleMetacarpal: return TrackedHandJoint.MiddleMetacarpal;
-                case HandJoint.MiddleProximal: return TrackedHandJoint.MiddleKnuckle;
-                case HandJoint.MiddleIntermediate: return TrackedHandJoint.MiddleMiddleJoint;
-                case HandJoint.MiddleDistal: return TrackedHandJoint.MiddleDistalJoint;
-                case HandJoint.MiddleTip: return TrackedHandJoint.MiddleTip;
+                case HandJoint.MiddleMetacarpal: return (int)TrackedHandJoint.MiddleMetacarpal;
+                case HandJoint.MiddleProximal: return (int)TrackedHandJoint.MiddleKnuckle;
+                case HandJoint.MiddleIntermediate: return (int)TrackedHandJoint.MiddleMiddleJoint;
+                case HandJoint.MiddleDistal: return (int)TrackedHandJoint.MiddleDistalJoint;
+                case HandJoint.MiddleTip: return (int)TrackedHandJoint.MiddleTip;
 
-                case HandJoint.RingMetacarpal: return TrackedHandJoint.RingMetacarpal;
-                case HandJoint.RingProximal: return TrackedHandJoint.RingKnuckle;
-                case HandJoint.RingIntermediate: return TrackedHandJoint.RingMiddleJoint;
-                case HandJoint.RingDistal: return TrackedHandJoint.RingDistalJoint;
-                case HandJoint.RingTip: return TrackedHandJoint.RingTip;
+                case HandJoint.RingMetacarpal: return (int)TrackedHandJoint.RingMetacarpal;
+                case HandJoint.RingProximal: return (int)TrackedHandJoint.RingKnuckle;
+                case HandJoint.RingIntermediate: return (int)TrackedHandJoint.RingMiddleJoint;
+                case HandJoint.RingDistal: return (int)TrackedHandJoint.RingDistalJoint;
+                case HandJoint.RingTip: return (int)TrackedHandJoint.RingTip;
 
-                case HandJoint.LittleMetacarpal: return TrackedHandJoint.PinkyMetacarpal;
-                case HandJoint.LittleProximal: return TrackedHandJoint.PinkyKnuckle;
-                case HandJoint.LittleIntermediate: return TrackedHandJoint.PinkyMiddleJoint;
-                case HandJoint.LittleDistal: return TrackedHandJoint.PinkyDistalJoint;
-                case HandJoint.LittleTip: return TrackedHandJoint.PinkyTip;
+                case HandJoint.LittleMetacarpal: return (int)TrackedHandJoint.PinkyMetacarpal;
+                case HandJoint.LittleProximal: return (int)TrackedHandJoint.PinkyKnuckle;
+                case HandJoint.LittleIntermediate: return (int)TrackedHandJoint.PinkyMiddleJoint;
+                case HandJoint.LittleDistal: return (int)TrackedHandJoint.PinkyDistalJoint;
+                case HandJoint.LittleTip: return (int)TrackedHandJoint.PinkyTip;
 
-                default: return TrackedHandJoint.None;
+                default: return (int)TrackedHandJoint.None;
             }
         }
 #else
@@ -143,16 +154,16 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// <param name="finger">The Unity classification of the current finger.</param>
         /// <param name="index">The Unity index of the current finger bone.</param>
         /// <returns>The current Unity finger bone converted into an MRTK joint.</returns>
-        private TrackedHandJoint ConvertToTrackedHandJoint(HandFinger finger, int index)
+        private int ConvertToArrayIndex(HandFinger finger, int index)
         {
             switch (finger)
             {
-                case HandFinger.Thumb: return (index == 0) ? TrackedHandJoint.Wrist : TrackedHandJoint.ThumbMetacarpalJoint + index - 1;
-                case HandFinger.Index: return TrackedHandJoint.IndexMetacarpal + index;
-                case HandFinger.Middle: return TrackedHandJoint.MiddleMetacarpal + index;
-                case HandFinger.Ring: return TrackedHandJoint.RingMetacarpal + index;
-                case HandFinger.Pinky: return TrackedHandJoint.PinkyMetacarpal + index;
-                default: return TrackedHandJoint.None;
+                case HandFinger.Thumb: return (index == 0) ? (int)TrackedHandJoint.Wrist : (int)TrackedHandJoint.ThumbMetacarpalJoint + index - 1;
+                case HandFinger.Index: return (int)TrackedHandJoint.IndexMetacarpal + index;
+                case HandFinger.Middle: return (int)TrackedHandJoint.MiddleMetacarpal + index;
+                case HandFinger.Ring: return (int)TrackedHandJoint.RingMetacarpal + index;
+                case HandFinger.Pinky: return (int)TrackedHandJoint.PinkyMetacarpal + index;
+                default: return (int)TrackedHandJoint.None;
             }
         }
 #endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandJointProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRHandJointProvider.cs
@@ -83,42 +83,46 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 #if MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
         private int ConvertToArrayIndex(HandJoint handJoint)
         {
+            TrackedHandJoint trackedHandJoint;
+
             switch (handJoint)
             {
-                case HandJoint.Palm: return (int)TrackedHandJoint.Palm;
-                case HandJoint.Wrist: return (int)TrackedHandJoint.Wrist;
+                case HandJoint.Palm: trackedHandJoint = TrackedHandJoint.Palm; break;
+                case HandJoint.Wrist: trackedHandJoint = TrackedHandJoint.Wrist; break;
 
-                case HandJoint.ThumbMetacarpal: return (int)TrackedHandJoint.ThumbMetacarpalJoint;
-                case HandJoint.ThumbProximal: return (int)TrackedHandJoint.ThumbProximalJoint;
-                case HandJoint.ThumbDistal: return (int)TrackedHandJoint.ThumbDistalJoint;
-                case HandJoint.ThumbTip: return (int)TrackedHandJoint.ThumbTip;
+                case HandJoint.ThumbMetacarpal: trackedHandJoint = TrackedHandJoint.ThumbMetacarpalJoint; break;
+                case HandJoint.ThumbProximal: trackedHandJoint = TrackedHandJoint.ThumbProximalJoint; break;
+                case HandJoint.ThumbDistal: trackedHandJoint = TrackedHandJoint.ThumbDistalJoint; break;
+                case HandJoint.ThumbTip: trackedHandJoint = TrackedHandJoint.ThumbTip; break;
 
-                case HandJoint.IndexMetacarpal: return (int)TrackedHandJoint.IndexMetacarpal;
-                case HandJoint.IndexProximal: return (int)TrackedHandJoint.IndexKnuckle;
-                case HandJoint.IndexIntermediate: return (int)TrackedHandJoint.IndexMiddleJoint;
-                case HandJoint.IndexDistal: return (int)TrackedHandJoint.IndexDistalJoint;
-                case HandJoint.IndexTip: return (int)TrackedHandJoint.IndexTip;
+                case HandJoint.IndexMetacarpal: trackedHandJoint = TrackedHandJoint.IndexMetacarpal; break;
+                case HandJoint.IndexProximal: trackedHandJoint = TrackedHandJoint.IndexKnuckle; break;
+                case HandJoint.IndexIntermediate: trackedHandJoint = TrackedHandJoint.IndexMiddleJoint; break;
+                case HandJoint.IndexDistal: trackedHandJoint = TrackedHandJoint.IndexDistalJoint; break;
+                case HandJoint.IndexTip: trackedHandJoint = TrackedHandJoint.IndexTip; break;
 
-                case HandJoint.MiddleMetacarpal: return (int)TrackedHandJoint.MiddleMetacarpal;
-                case HandJoint.MiddleProximal: return (int)TrackedHandJoint.MiddleKnuckle;
-                case HandJoint.MiddleIntermediate: return (int)TrackedHandJoint.MiddleMiddleJoint;
-                case HandJoint.MiddleDistal: return (int)TrackedHandJoint.MiddleDistalJoint;
-                case HandJoint.MiddleTip: return (int)TrackedHandJoint.MiddleTip;
+                case HandJoint.MiddleMetacarpal: trackedHandJoint = TrackedHandJoint.MiddleMetacarpal; break;
+                case HandJoint.MiddleProximal: trackedHandJoint = TrackedHandJoint.MiddleKnuckle; break;
+                case HandJoint.MiddleIntermediate: trackedHandJoint = TrackedHandJoint.MiddleMiddleJoint; break;
+                case HandJoint.MiddleDistal: trackedHandJoint = TrackedHandJoint.MiddleDistalJoint; break;
+                case HandJoint.MiddleTip: trackedHandJoint = TrackedHandJoint.MiddleTip; break;
 
-                case HandJoint.RingMetacarpal: return (int)TrackedHandJoint.RingMetacarpal;
-                case HandJoint.RingProximal: return (int)TrackedHandJoint.RingKnuckle;
-                case HandJoint.RingIntermediate: return (int)TrackedHandJoint.RingMiddleJoint;
-                case HandJoint.RingDistal: return (int)TrackedHandJoint.RingDistalJoint;
-                case HandJoint.RingTip: return (int)TrackedHandJoint.RingTip;
+                case HandJoint.RingMetacarpal: trackedHandJoint = TrackedHandJoint.RingMetacarpal; break;
+                case HandJoint.RingProximal: trackedHandJoint = TrackedHandJoint.RingKnuckle; break;
+                case HandJoint.RingIntermediate: trackedHandJoint = TrackedHandJoint.RingMiddleJoint; break;
+                case HandJoint.RingDistal: trackedHandJoint = TrackedHandJoint.RingDistalJoint; break;
+                case HandJoint.RingTip: trackedHandJoint = TrackedHandJoint.RingTip; break;
 
-                case HandJoint.LittleMetacarpal: return (int)TrackedHandJoint.PinkyMetacarpal;
-                case HandJoint.LittleProximal: return (int)TrackedHandJoint.PinkyKnuckle;
-                case HandJoint.LittleIntermediate: return (int)TrackedHandJoint.PinkyMiddleJoint;
-                case HandJoint.LittleDistal: return (int)TrackedHandJoint.PinkyDistalJoint;
-                case HandJoint.LittleTip: return (int)TrackedHandJoint.PinkyTip;
+                case HandJoint.LittleMetacarpal: trackedHandJoint = TrackedHandJoint.PinkyMetacarpal; break;
+                case HandJoint.LittleProximal: trackedHandJoint = TrackedHandJoint.PinkyKnuckle; break;
+                case HandJoint.LittleIntermediate: trackedHandJoint = TrackedHandJoint.PinkyMiddleJoint; break;
+                case HandJoint.LittleDistal: trackedHandJoint = TrackedHandJoint.PinkyDistalJoint; break;
+                case HandJoint.LittleTip: trackedHandJoint = TrackedHandJoint.PinkyTip; break;
 
-                default: return (int)TrackedHandJoint.None;
+                default: trackedHandJoint = TrackedHandJoint.None; break;
             }
+
+            return (int)trackedHandJoint;
         }
 #else
         private bool TryReadHandJoint(Bone bone, out MixedRealityPose pose)
@@ -153,15 +157,19 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         /// <returns>The current Unity finger bone converted into an MRTK joint.</returns>
         private int ConvertToArrayIndex(HandFinger finger, int index)
         {
+            TrackedHandJoint trackedHandJoint;
+
             switch (finger)
             {
-                case HandFinger.Thumb: return (index == 0) ? (int)TrackedHandJoint.Wrist : (int)TrackedHandJoint.ThumbMetacarpalJoint + index - 1;
-                case HandFinger.Index: return (int)TrackedHandJoint.IndexMetacarpal + index;
-                case HandFinger.Middle: return (int)TrackedHandJoint.MiddleMetacarpal + index;
-                case HandFinger.Ring: return (int)TrackedHandJoint.RingMetacarpal + index;
-                case HandFinger.Pinky: return (int)TrackedHandJoint.PinkyMetacarpal + index;
-                default: return (int)TrackedHandJoint.None;
+                case HandFinger.Thumb: trackedHandJoint = (index == 0) ? TrackedHandJoint.Wrist : TrackedHandJoint.ThumbMetacarpalJoint + index - 1; break;
+                case HandFinger.Index: trackedHandJoint = TrackedHandJoint.IndexMetacarpal + index; break;
+                case HandFinger.Middle: trackedHandJoint = TrackedHandJoint.MiddleMetacarpal + index; break;
+                case HandFinger.Ring: trackedHandJoint = TrackedHandJoint.RingMetacarpal + index; break;
+                case HandFinger.Pinky: trackedHandJoint = TrackedHandJoint.PinkyMetacarpal + index; break;
+                default: trackedHandJoint = TrackedHandJoint.None; break;
             }
+
+            return (int)trackedHandJoint;
         }
 #endif // MSFT_OPENXR && (UNITY_STANDALONE_WIN || UNITY_WSA)
     }

--- a/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
+++ b/Assets/MRTK/Providers/Windows/WindowsSpeechInputProvider.cs
@@ -148,22 +148,27 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         private void InitializeKeywordRecognizer()
         {
             if (!Application.isPlaying ||
-                (Commands == null) ||
-                (Commands.Length == 0) ||
                 InputSystemProfile == null ||
-                keywordRecognizer != null
-                )
+                keywordRecognizer != null)
+            {
+                return;
+            }
+
+            SpeechCommands[] commands = Commands;
+            int commandsCount = commands?.Length ?? 0;
+
+            if (commandsCount == 0)
             {
                 return;
             }
 
             globalInputSource = Service?.RequestNewGlobalInputSource("Windows Speech Input Source", sourceType: InputSourceType.Voice);
 
-            var newKeywords = new string[Commands.Length];
+            var newKeywords = new string[commandsCount];
 
-            for (int i = 0; i < Commands.Length; i++)
+            for (int i = 0; i < commandsCount; i++)
             {
-                newKeywords[i] = Commands[i].LocalizedKeyword;
+                newKeywords[i] = commands[i].LocalizedKeyword;
             }
 
             RecognitionConfidenceLevel = InputSystemProfile.SpeechCommandsProfile.SpeechRecognitionConfidenceLevel;
@@ -197,11 +202,14 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 
                 if (keywordRecognizer != null && keywordRecognizer.IsRunning)
                 {
-                    for (int i = 0; i < Commands.Length; i++)
+                    SpeechCommands[] commands = Commands;
+                    int commandsCount = commands?.Length ?? 0;
+                    for (int i = 0; i < commandsCount; i++)
                     {
-                        if (UInput.GetKeyDown(Commands[i].KeyCode))
+                        SpeechCommands command = commands[i];
+                        if (UInput.GetKeyDown(command.KeyCode))
                         {
-                            OnPhraseRecognized((ConfidenceLevel)RecognitionConfidenceLevel, TimeSpan.Zero, DateTime.UtcNow, Commands[i].LocalizedKeyword);
+                            OnPhraseRecognized((ConfidenceLevel)RecognitionConfidenceLevel, TimeSpan.Zero, DateTime.UtcNow, command.LocalizedKeyword);
                         }
                     }
                 }
@@ -244,13 +252,15 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         {
             using (OnPhraseRecognizedPerfMarker.Auto())
             {
-                for (int i = 0; i < Commands?.Length; i++)
+                SpeechCommands[] commands = Commands;
+                int commandsCount = commands?.Length ?? 0;
+                for (int i = 0; i < commandsCount; i++)
                 {
-                    if (Commands[i].LocalizedKeyword == text)
+                    SpeechCommands command = commands[i];
+                    if (command.LocalizedKeyword == text)
                     {
                         globalInputSource.UpdateActivePointers();
-
-                        Service?.RaiseSpeechCommandRecognized(InputSource, (RecognitionConfidenceLevel)confidence, phraseDuration, phraseStartTime, Commands[i]);
+                        Service?.RaiseSpeechCommandRecognized(InputSource, (RecognitionConfidenceLevel)confidence, phraseDuration, phraseStartTime, command);
                         break;
                     }
                 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -185,15 +185,19 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <returns>The current Unity finger bone converted into an MRTK joint.</returns>
         private int ConvertToArrayIndex(HandFinger finger, int index)
         {
+            TrackedHandJoint trackedHandJoint;
+
             switch (finger)
             {
-                case HandFinger.Thumb: return (index == 0) ? (int)TrackedHandJoint.Wrist : (int)TrackedHandJoint.ThumbMetacarpalJoint + index - 1;
-                case HandFinger.Index: return (int)TrackedHandJoint.IndexMetacarpal + index;
-                case HandFinger.Middle: return (int)TrackedHandJoint.MiddleMetacarpal + index;
-                case HandFinger.Ring: return (int)TrackedHandJoint.RingMetacarpal + index;
-                case HandFinger.Pinky: return (int)TrackedHandJoint.PinkyMetacarpal + index;
-                default: return (int)TrackedHandJoint.None;
+                case HandFinger.Thumb: trackedHandJoint = (index == 0) ? TrackedHandJoint.Wrist : TrackedHandJoint.ThumbMetacarpalJoint + index - 1; break;
+                case HandFinger.Index: trackedHandJoint = TrackedHandJoint.IndexMetacarpal + index; break;
+                case HandFinger.Middle: trackedHandJoint = TrackedHandJoint.MiddleMetacarpal + index; break;
+                case HandFinger.Ring: trackedHandJoint = TrackedHandJoint.RingMetacarpal + index; break;
+                case HandFinger.Pinky: trackedHandJoint = TrackedHandJoint.PinkyMetacarpal + index; break;
+                default: trackedHandJoint = TrackedHandJoint.None; break;
             }
+
+            return (int)trackedHandJoint;
         }
 
         #endregion Update data functions

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             if (unityJointPoses != null)
             {
                 pose = unityJointPoses[(int)joint];
-                return true;
+                return pose != default(MixedRealityPose);
             }
 
             pose = MixedRealityPose.ZeroIdentity;

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -699,29 +699,35 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
-            for (int i = 0; i < InteractableEvents.Count; i++)
+            int interactableEventsCount = InteractableEvents.Count;
+            for (int i = 0; i < interactableEventsCount; i++)
             {
-                if (InteractableEvents[i].Receiver != null)
+                InteractableEvent interactableEvent = InteractableEvents[i];
+                if (interactableEvent.Receiver != null)
                 {
-                    InteractableEvents[i].Receiver.OnUpdate(StateManager, this);
+                    interactableEvent.Receiver.OnUpdate(StateManager, this);
                 }
             }
 
-            for (int i = 0; i < activeThemes.Count; i++)
+            int activeThemesCount = activeThemes.Count;
+            for (int i = 0; i < activeThemesCount; i++)
             {
-                if (activeThemes[i].Loaded)
+                InteractableThemeBase interactableThemeBase = activeThemes[i];
+                if (interactableThemeBase.Loaded)
                 {
-                    activeThemes[i].OnUpdate(StateManager.CurrentState().ActiveIndex, forceUpdate);
+                    interactableThemeBase.OnUpdate(StateManager.CurrentState().ActiveIndex, forceUpdate);
                 }
             }
 
             if (lastState != StateManager.CurrentState())
             {
-                for (int i = 0; i < handlers.Count; i++)
+                int handlersCount = handlers.Count;
+                for (int i = 0; i < handlersCount; i++)
                 {
-                    if (handlers[i] != null)
+                    IInteractableHandler handler = handlers[i];
+                    if (handler != null)
                     {
-                        handlers[i].OnStateChange(StateManager, this);
+                        handler.OnStateChange(StateManager, this);
                     }
                 }
             }

--- a/Assets/MRTK/SDK/Features/UX/Materials/HandJoint.mat
+++ b/Assets/MRTK/SDK/Features/UX/Materials/HandJoint.mat
@@ -11,7 +11,7 @@ Material:
   m_Shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
   m_ShaderKeywords: _DIRECTIONAL_LIGHT _DISABLE_ALBEDO_MAP _SPECULAR_HIGHLIGHTS
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 2000
   stringTagMap:

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -115,7 +115,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnPreSceneQueryPerfMarker.Auto())
             {
-                if (!IsInteractionEnabled) return;
+                if (!IsInteractionEnabled)
+                {
+                    return;
+                }
 
                 PreUpdateLineRenderers();
                 UpdateRays();

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -115,6 +115,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnPreSceneQueryPerfMarker.Auto())
             {
+                if (!IsInteractionEnabled) return;
+
                 PreUpdateLineRenderers();
                 UpdateRays();
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ParabolicTeleportPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ParabolicTeleportPointer.cs
@@ -64,18 +64,19 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 
         private static readonly ProfilerMarker OnPreSceneQueryPerfMarker = new ProfilerMarker("[MRTK] ParabolicTeleportPointer.OnPreSceneQuery");
 
-
         private StabilizedRay stabilizedRay = new StabilizedRay(0.5f);
         private Ray stabilizationRay = new Ray();
+
         /// <inheritdoc />
         public override void OnPreSceneQuery()
         {
             using (OnPreSceneQueryPerfMarker.Auto())
             {
+                if (!IsInteractionEnabled) return;
+
                 stabilizationRay.origin = transform.position;
                 stabilizationRay.direction = transform.forward;
                 stabilizedRay.AddSample(stabilizationRay);
-
 
                 parabolicLineData.LineTransform.rotation = Quaternion.identity;
                 parabolicLineData.Direction = stabilizedRay.StabilizedDirection;
@@ -91,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 
                 // If we're pointing below the horizon, always use the minimum modifiers.
                 // We use square angle so that the velocity change is less noticeable the closer the teleport point
-                // is to the user            
+                // is to the user
                 if (sqr_angle > 0)
                 {
                     velocity = Mathf.Lerp(minParabolaVelocity, maxParabolaVelocity, sqr_angle);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ParabolicTeleportPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ParabolicTeleportPointer.cs
@@ -72,7 +72,10 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         {
             using (OnPreSceneQueryPerfMarker.Auto())
             {
-                if (!IsInteractionEnabled) return;
+                if (!IsInteractionEnabled)
+                {
+                    return;
+                }
 
                 stabilizationRay.origin = transform.position;
                 stabilizationRay.direction = transform.forward;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -138,10 +138,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <inheritdoc />
-        public virtual bool IsNearObject
-        {
-            get => closestProximityTouchable != null;
-        }
+        public virtual bool IsNearObject => closestProximityTouchable != null;
 
         /// <inheritdoc />
         public override bool IsInteractionEnabled => base.IsInteractionEnabled && IsNearObject;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -227,9 +227,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     Rays = new RayStep[1];
                 }
 
-                Vector3 pointerPosition;
-                Vector3 pointerAxis;
-                if (TryGetNearGraspPoint(out pointerPosition) && TryGetNearGraspAxis(out pointerAxis))
+                if (TryGetNearGraspPoint(out Vector3 pointerPosition) && TryGetNearGraspAxis(out Vector3 pointerAxis))
                 {
                     Vector3 endPoint = Vector3.forward * SphereCastRadius;
                     Rays[0].UpdateRayStep(ref pointerPosition, ref endPoint);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TouchPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TouchPointer.cs
@@ -43,6 +43,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnPreSceneQueryPerfMarker.Auto())
             {
+                if (!IsInteractionEnabled) return;
+
                 Rays[0].CopyRay(TouchRay, PointerExtent);
 
                 if (RayStabilizer != null)
@@ -63,22 +65,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <inheritdoc />
-        public override Vector3 Position
-        {
-            get
-            {
-                return TouchRay.origin;
-            }
-        }
+        public override Vector3 Position => TouchRay.origin;
 
         /// <inheritdoc />
-        public override Quaternion Rotation
-        {
-            get
-            {
-                return Quaternion.LookRotation(TouchRay.direction);
-            }
-        }
+        public override Quaternion Rotation => Quaternion.LookRotation(TouchRay.direction);
 
         private static readonly ProfilerMarker OnSourceDetectedPerfMarker = new ProfilerMarker("[MRTK] TouchPointer.OnSourceDetected");
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TouchPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TouchPointer.cs
@@ -43,7 +43,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (OnPreSceneQueryPerfMarker.Auto())
             {
-                if (!IsInteractionEnabled) return;
+                if (!IsInteractionEnabled)
+                {
+                    return;
+                }
 
                 Rays[0].CopyRay(TouchRay, PointerExtent);
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     public class RiggedHandVisualizer : BaseHandVisualizer
     {
-        // This bool is used to track whether or not we are recieving hand mesh data from the platform itself
+        // This bool is used to track whether or not we are receiving hand mesh data from the platform itself
         // If we aren't we will use our own rigged hand visualizer to render the hand mesh
         private bool ReceivingPlatformHandMesh => handMeshFilter != null;
 
@@ -287,15 +287,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
             using (UpdateHandJointsPerfMarker.Auto())
             {
                 // The base class takes care of updating all of the joint data
+                _ = base.UpdateHandJoints();
+
                 // Exit early and disable the rigged hand model if we've gotten a hand mesh from the underlying platform
-                if (!base.UpdateHandJoints() || ReceivingPlatformHandMesh)
+                if (ReceivingPlatformHandMesh || MixedRealityHand.IsNull())
                 {
                     HandRenderer.enabled = false;
                     return false;
                 }
 
                 IMixedRealityInputSystem inputSystem = CoreServices.InputSystem;
-                MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile.HandTrackingProfile;
+                MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile != null ? inputSystem.InputSystemProfile.HandTrackingProfile : null;
 
                 // Only runs if render hand mesh is true
                 bool renderHandmesh = handTrackingProfile != null && handTrackingProfile.EnableHandMeshVisualization;
@@ -314,8 +316,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         {
                             continue;
                         }
-                        Transform jointTransform = riggedVisualJointsArray[i];
 
+                        Transform jointTransform = riggedVisualJointsArray[i];
                         if (jointTransform != null)
                         {
                             if (handJoint == TrackedHandJoint.Palm)

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
@@ -240,8 +240,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 if (pointer.Controller != null && pointer.Controller.IsRotationAvailable)
                 {
-                    RaycastCamera.transform.position = pointer.Rays[0].Origin;
-                    RaycastCamera.transform.rotation = Quaternion.LookRotation(pointer.Rays[0].Direction);
+                    RaycastCamera.transform.SetPositionAndRotation(pointer.Rays[0].Origin, Quaternion.LookRotation(pointer.Rays[0].Direction));
                 }
                 else
                 {
@@ -249,8 +248,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // In this case pointer.Rays[0].Origin will be the head position, but we want the 
                     // hand to do drag operations, not the head.
                     // pointer.Position gives the position of the hand, use that to compute drag deltas.
-                    RaycastCamera.transform.position = pointer.Position;
-                    RaycastCamera.transform.rotation = Quaternion.LookRotation(pointer.Rays[0].Direction);
+                    RaycastCamera.transform.SetPositionAndRotation(pointer.Position, Quaternion.LookRotation(pointer.Rays[0].Direction));
                 }
 
                 // Populate eventDataLeft

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -71,10 +71,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <inheritdoc />
-        public IMixedRealityFocusProvider FocusProvider => CoreServices.FocusProvider;
+        public IMixedRealityFocusProvider FocusProvider => focusProvider != null ? focusProvider : focusProvider = CoreServices.FocusProvider;
+        private IMixedRealityFocusProvider focusProvider = null;
 
         /// <inheritdoc />
-        public IMixedRealityRaycastProvider RaycastProvider => CoreServices.RaycastProvider;
+        public IMixedRealityRaycastProvider RaycastProvider => raycastProvider != null ? raycastProvider : raycastProvider = CoreServices.RaycastProvider;
+        private IMixedRealityRaycastProvider raycastProvider = null;
 
         /// <inheritdoc />
         public IMixedRealityGazeProvider GazeProvider { get; private set; }

--- a/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
@@ -84,11 +84,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // input meshes and not crash (which is required on some platforms)
 
             GameObject baseHandVisualizerGameObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            var baseHandVisualizer = baseHandVisualizerGameObject.AddComponent<BaseHandVisualizer>();
+            BaseHandVisualizer baseHandVisualizer = baseHandVisualizerGameObject.AddComponent<BaseHandVisualizer>();
             baseHandVisualizer.Controller = new MockController();
 
-            baseHandVisualizer.OnHandMeshUpdated(CreateQuadInputEventData());
-            baseHandVisualizer.OnHandMeshUpdated(CreateTriangleInputEventData());
+            if (baseHandVisualizer is IMixedRealityHandMeshHandler handMeshHandler)
+            {
+                handMeshHandler.OnHandMeshUpdated(CreateQuadInputEventData());
+                handMeshHandler.OnHandMeshUpdated(CreateTriangleInputEventData());
+            }
+
             yield return null;
 
             Object.Destroy(baseHandVisualizer);


### PR DESCRIPTION
## Overview

These traces are using in-editor remoting.

Before:
<img width="887" alt="image" src="https://user-images.githubusercontent.com/3580640/169423924-c67aabbe-60d8-409a-8b0e-328bc63999e2.png">

After:
<img width="879" alt="image" src="https://user-images.githubusercontent.com/3580640/169423896-629cff63-e6c2-442e-bfa6-7f3b5e5457b6.png">

* Updated several hand joint code paths to prefer arrays over dictionaries
* Cached various `for` loop end conditions, so we don't continually query properties or `Length` or `Count` values
* Cached a handful of `CoreServices` calls in hot loops
* Updated several pointers to return early from `OnPreSceneQuery` if they aren't enabled and their enabled state doesn't depend on work in `OnPreSceneQuery`