### PR TITLE
Fix FollowMeToggle's auto-follow breaking if the component is disabled

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
@@ -184,7 +184,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             AutoFollowAtDistance = autoFollowAtDistance;
         }
         
-        private void OnDisable() {
+        private void OnDisable()
+        {
             autoFollowDistanceCheck = null;
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
@@ -183,6 +183,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // Begin the follow coroutine when enabled.
             AutoFollowAtDistance = autoFollowAtDistance;
         }
+        
+        private void OnDisable() {
+            autoFollowDistanceCheck = null;
+        }
 
         #endregion MonoBehaviour Implementation
 


### PR DESCRIPTION
## Overview

`FollowMeToggle` has an `AutoFollowAtDistance` feature which breaks if the `FollowMeToggle` component is ever disabled and re-enabled. This is because the `AutoFollowAtDistance` property setter checks if the `autoFollowDistanceCheck` coroutine is null before starting the coroutine. If the component is disabled, the coroutine will _stop_ but not become null. When the component is re-enabled, the coroutine does not start again because the previous instance is non-null, even though it is no longer running.

This is fixed by simply setting `autoFollowDistanceCheck` to null in `OnDisable()`.

## Changes
- Fixes: #10619.