### PR TITLE
Fix cursors spawning at the root on initial source detection

### DIFF
--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -302,9 +302,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (CreatePointerPerfMarker.Auto())
             {
-                var pointerObject = Object.Instantiate(option.PointerPrefab);
-                MixedRealityPlayspace.AddChild(pointerObject.transform);
-                var pointer = pointerObject.GetComponent<IMixedRealityPointer>();
+                GameObject pointerObject = Object.Instantiate(option.PointerPrefab, MixedRealityPlayspace.Transform);
+                IMixedRealityPointer pointer = pointerObject.GetComponent<IMixedRealityPointer>();
                 if (pointer == null)
                 {
                     Debug.LogError($"Ensure that the prefab '{option.PointerPrefab.name}' listed under Input -> Pointers -> Pointer Options has an {typeof(IMixedRealityPointer).Name} component.\nThis prefab can't be used as a pointer as configured and won't be instantiated.");


### PR DESCRIPTION
## Overview

Currently, the pointer uses its parent to spawn its cursor. During the initial creation flow, that logic is hit _before_ we actually put the pointer under the playspace. With this change, the pointer is now put under the playspace immediately at creation, before the cursor is spawned.