### PR TITLE
Fixed issue where Controller Visuals weren't initialized before OnSourceDetected

### DIFF
--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -117,7 +117,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             {
                 platformVisualization = deviceManager.leftControllerHelper.gameObject;
             }
-            if (ControllerHandedness == Handedness.Right)
+            else if (ControllerHandedness == Handedness.Right)
             {
                 platformVisualization = deviceManager.rightControllerHelper.gameObject;
             }

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -112,16 +112,19 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         {
             OculusXRSDKDeviceManager deviceManager = CoreServices.GetInputSystemDataProvider<OculusXRSDKDeviceManager>();
 
-            GameObject platformVisualization = null;
-            if (ControllerHandedness == Handedness.Left)
+            if(deviceManager.IsNotNull())
             {
-                platformVisualization = deviceManager.leftControllerHelper.gameObject;
+                GameObject platformVisualization = null;
+                if (ControllerHandedness == Handedness.Left)
+                {
+                    platformVisualization = deviceManager.leftControllerHelper.gameObject;
+                }
+                else if (ControllerHandedness == Handedness.Right)
+                {
+                    platformVisualization = deviceManager.rightControllerHelper.gameObject;
+                }
+                RegisterControllerVisualization(platformVisualization);
             }
-            else if (ControllerHandedness == Handedness.Right)
-            {
-                platformVisualization = deviceManager.rightControllerHelper.gameObject;
-            }
-            RegisterControllerVisualization(platformVisualization);
 
             if (this != null)
             {

--- a/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/Controllers/OculusXRSDKTouchController.cs
@@ -108,9 +108,20 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             }
         }
 
-        private async void TryRenderControllerModelFromOculus()
+        private void TryRenderControllerModelFromOculus()
         {
-            await WaitForOculusVisuals();
+            OculusXRSDKDeviceManager deviceManager = CoreServices.GetInputSystemDataProvider<OculusXRSDKDeviceManager>();
+
+            GameObject platformVisualization = null;
+            if (ControllerHandedness == Handedness.Left)
+            {
+                platformVisualization = deviceManager.leftControllerHelper.gameObject;
+            }
+            if (ControllerHandedness == Handedness.Right)
+            {
+                platformVisualization = deviceManager.rightControllerHelper.gameObject;
+            }
+            RegisterControllerVisualization(platformVisualization);
 
             if (this != null)
             {
@@ -127,18 +138,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
             }
         }
 
-        private const int ControllerInitializationTimeout = 1000;
-        private async Task WaitForOculusVisuals()
-        {
-            int timeWaited = 0;
-            while (OculusControllerVisualization == null || timeWaited > ControllerInitializationTimeout)
-            {
-                await Task.Delay(100);
-                timeWaited += 100;
-            }
-        }
-
-        internal void RegisterControllerVisualization(GameObject visualization)
+        private void RegisterControllerVisualization(GameObject visualization)
         {
             OculusControllerVisualization = visualization;
             if (GetControllerVisualizationProfile() != null &&

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -59,8 +59,8 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
         private readonly Dictionary<Handedness, OculusHand> trackedHands = new Dictionary<Handedness, OculusHand>();
 
         private OVRCameraRig cameraRig;
-        private OVRControllerHelper leftControllerHelper;
-        private OVRControllerHelper rightControllerHelper;
+        internal OVRControllerHelper leftControllerHelper;
+        internal OVRControllerHelper rightControllerHelper;
 
         private OVRHand rightHand;
         private OVRSkeleton rightSkeleton;
@@ -92,34 +92,6 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
         #endregion IMixedRealityCapabilityCheck Implementation
 
         #region Controller Utilities
-
-#if OCULUSINTEGRATION_PRESENT
-        /// <inheritdoc />
-        protected override GenericXRSDKController GetOrAddController(InputDevice inputDevice)
-        {
-            GenericXRSDKController controller = base.GetOrAddController(inputDevice);
-
-            if (!cameraRig.IsNull() && controller is OculusXRSDKTouchController oculusTouchController && oculusTouchController.OculusControllerVisualization == null)
-            {
-                GameObject platformVisualization = null; 
-                if (oculusTouchController.ControllerHandedness == Handedness.Left)
-                {
-                    platformVisualization = leftControllerHelper.gameObject;
-                }
-                if (oculusTouchController.ControllerHandedness == Handedness.Right)
-                {
-                    platformVisualization = rightControllerHelper.gameObject;
-                }
-
-                if(platformVisualization != null)
-                {
-                    oculusTouchController.RegisterControllerVisualization(platformVisualization);
-                }
-            }
-
-            return controller;
-        }
-#endif
 
         /// <inheritdoc />
         protected override Type GetControllerType(SupportedControllerType supportedControllerType)


### PR DESCRIPTION
## Overview
The Oculus Controller's Visuals property would not be initialized prior to OnSourceDetected getting raised, despite it behaving differently on other platforms. This change realigns the behavior to match other platforms

## Changes
- Fixes: #10002
