### PR TITLE
Fix a reference issue in ClippingPrimitive

### DIFF
--- a/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
@@ -131,6 +131,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private Material[] AcquireMaterials(Renderer renderer, bool instance = true)
         {
+            if (renderer == null)
+            {
+                return null;
+            }
+
             if (applyToSharedMaterial)
             {
                 return renderer.sharedMaterials;


### PR DESCRIPTION
## Overview
Add a null check in `AcquireMaterials` to prevent a missing reference issue. Thanks @JakobAnarkyLabs for reporting the bug!

## Changes
- Fixes: #10626