### PR TITLE
Fix: Update goes into endless Destroy/Start

### DIFF
--- a/com.microsoft.mrtk.windowsspeech/Subsystems/WindowsPhraseRecognitionSubsystem.cs
+++ b/com.microsoft.mrtk.windowsspeech/Subsystems/WindowsPhraseRecognitionSubsystem.cs
@@ -80,6 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Speech.Windows
                 {
                     if (keywordListChanged)
                     {
+                        keywordListChanged = false;
                         Destroy();
                         keywordRecognizer = new KeywordRecognizer(phraseDictionary.Keys.ToArray());
                         Start();


### PR DESCRIPTION
## Overview
Speech recognition does not work at all because at adding the first keyword, the Update method goes in to an endless Destroy/Start loop because keywordListChanged never gets set to false

## Changes
Set keywordListChanged to false before starting the Destroy/Start sequence


