### PR TITLE
[2.8.1] perf pass

### DIFF
--- a/Assets/MRTK/Core/Providers/Hands/HandPoseUtils.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandPoseUtils.cs
@@ -105,8 +105,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public static float IndexFingerCurl(Handedness handedness)
         {
             if (HandJointUtils.TryGetJointPose(TrackedHandJoint.Wrist, handedness, out var wristPose) &&
-                           HandJointUtils.TryGetJointPose(TrackedHandJoint.IndexTip, handedness, out var fingerTipPose) &&
-                           HandJointUtils.TryGetJointPose(TrackedHandJoint.IndexKnuckle, handedness, out var fingerKnucklePose))
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.IndexTip, handedness, out var fingerTipPose) &&
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.IndexKnuckle, handedness, out var fingerKnucklePose))
             {
 
                 return CalculateCurl(wristPose.Position, fingerKnucklePose.Position, fingerTipPose.Position);
@@ -122,8 +122,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public static float MiddleFingerCurl(Handedness handedness)
         {
             if (HandJointUtils.TryGetJointPose(TrackedHandJoint.Wrist, handedness, out var wristPose) &&
-                           HandJointUtils.TryGetJointPose(TrackedHandJoint.MiddleTip, handedness, out var fingerTipPose) &&
-                           HandJointUtils.TryGetJointPose(TrackedHandJoint.MiddleKnuckle, handedness, out var fingerKnucklePose))
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.MiddleTip, handedness, out var fingerTipPose) &&
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.MiddleKnuckle, handedness, out var fingerKnucklePose))
             {
                 return CalculateCurl(wristPose.Position, fingerKnucklePose.Position, fingerTipPose.Position);
             }
@@ -138,8 +138,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public static float RingFingerCurl(Handedness handedness)
         {
             if (HandJointUtils.TryGetJointPose(TrackedHandJoint.Wrist, handedness, out var wristPose) &&
-                           HandJointUtils.TryGetJointPose(TrackedHandJoint.RingTip, handedness, out var fingerTipPose) &&
-                           HandJointUtils.TryGetJointPose(TrackedHandJoint.RingKnuckle, handedness, out var fingerKnucklePose))
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.RingTip, handedness, out var fingerTipPose) &&
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.RingKnuckle, handedness, out var fingerKnucklePose))
             {
                 return CalculateCurl(wristPose.Position, fingerKnucklePose.Position, fingerTipPose.Position);
             }
@@ -154,8 +154,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public static float PinkyFingerCurl(Handedness handedness)
         {
             if (HandJointUtils.TryGetJointPose(TrackedHandJoint.Wrist, handedness, out var wristPose) &&
-                           HandJointUtils.TryGetJointPose(TrackedHandJoint.PinkyTip, handedness, out var fingerTipPose) &&
-                           HandJointUtils.TryGetJointPose(TrackedHandJoint.PinkyKnuckle, handedness, out var fingerKnucklePose))
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.PinkyTip, handedness, out var fingerTipPose) &&
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.PinkyKnuckle, handedness, out var fingerKnucklePose))
             {
                 return CalculateCurl(wristPose.Position, fingerKnucklePose.Position, fingerTipPose.Position);
             }
@@ -194,7 +194,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         /// <summary>
         /// Pinch calculation of the index finger with the thumb based on the distance between the finger tip and the thumb tip.
-        /// 4 cm (0.04 unity units) is the treshold for fingers being far apart and pinch being read as 0.
+        /// 4 cm (0.04 unity units) is the threshold for fingers being far apart and pinch being read as 0.
         /// </summary>
         /// <param name="handedness">Handedness to query joint pose against.</param>
         /// <returns> Float ranging from 0 to 1. 0 if the thumb and finger are not pinched together, 1 if thumb finger are pinched together</returns>

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -1119,6 +1119,14 @@ namespace Microsoft.MixedReality.Toolkit
                 {
                     UnregisterService<IMixedRealitySpatialAwarenessSystem>();
                 }
+                else if (typeof(IMixedRealitySceneSystem).IsAssignableFrom(type))
+                {
+                    UnregisterService<IMixedRealitySceneSystem>();
+                }
+                else if (typeof(IMixedRealityRaycastProvider).IsAssignableFrom(type))
+                {
+                    UnregisterService<IMixedRealityRaycastProvider>();
+                }
                 else if (typeof(IMixedRealityTeleportSystem).IsAssignableFrom(type))
                 {
                     UnregisterService<IMixedRealityTeleportSystem>();

--- a/Assets/MRTK/Core/Utilities/CameraFOVChecker.cs
+++ b/Assets/MRTK/Core/Utilities/CameraFOVChecker.cs
@@ -16,14 +16,14 @@ namespace Microsoft.MixedReality.Toolkit
         // Help to clear caches when new frame runs
         private static int inFOVLastCalculatedFrame = -1;
         // Map from grabbable => is the grabbable in FOV for this frame. Cleared every frame
-        private static Dictionary<Tuple<Collider, Camera>, bool> inFOVColliderCache = new Dictionary<Tuple<Collider, Camera>, bool>();
+        private static Dictionary<ValueTuple<Collider, Camera>, bool> inFOVColliderCache = new Dictionary<ValueTuple<Collider, Camera>, bool>();
         // List of corners shared across all sphere pointer query instances --
         // used to store list of corners for a bounds. Shared and static
         // to avoid allocating memory each frame
         private static List<Vector3> inFOVBoundsCornerPoints = new List<Vector3>();
 
         /// <summary>
-        /// Returns true if a collider's bounds is within the camera FOV. 
+        /// Returns true if a collider's bounds is within the camera FOV.
         /// Utilizes a cache to test if this collider has been seen before and returns current frame's calculated result.
         /// NOTE: This is a 'loose' FOV check -- it can return true in cases when the collider is actually not in the FOV
         /// because it does an axis-aligned check when testing for large colliders. So, if the axis aligned bounds are in the bounds of the camera, it will return true.
@@ -37,7 +37,7 @@ namespace Microsoft.MixedReality.Toolkit
                 return false;
             }
 
-            Tuple<Collider, Camera> cameraColliderPair = new Tuple<Collider, Camera>(myCollider, cam);
+            ValueTuple<Collider, Camera> cameraColliderPair = ValueTuple.Create(myCollider, cam);
             bool result;
             if (inFOVLastCalculatedFrame != Time.frameCount)
             {
@@ -95,6 +95,5 @@ namespace Microsoft.MixedReality.Toolkit
 
             return result;
         }
-
     }
 }

--- a/Assets/MRTK/Core/Utilities/CoreServices.cs
+++ b/Assets/MRTK/Core/Utilities/CoreServices.cs
@@ -139,35 +139,35 @@ namespace Microsoft.MixedReality.Toolkit
             {
                 boundarySystem = null;
             }
-            if (typeof(IMixedRealityCameraSystem).IsAssignableFrom(serviceType))
+            else if (typeof(IMixedRealityCameraSystem).IsAssignableFrom(serviceType))
             {
                 cameraSystem = null;
             }
-            if (typeof(IMixedRealityDiagnosticsSystem).IsAssignableFrom(serviceType))
+            else if (typeof(IMixedRealityDiagnosticsSystem).IsAssignableFrom(serviceType))
             {
                 diagnosticsSystem = null;
             }
-            if (typeof(IMixedRealityFocusProvider).IsAssignableFrom(serviceType))
+            else if (typeof(IMixedRealityFocusProvider).IsAssignableFrom(serviceType))
             {
                 focusProvider = null;
             }
-            if (typeof(IMixedRealityInputSystem).IsAssignableFrom(serviceType))
+            else if (typeof(IMixedRealityInputSystem).IsAssignableFrom(serviceType))
             {
                 inputSystem = null;
             }
-            if (typeof(IMixedRealityRaycastProvider).IsAssignableFrom(serviceType))
+            else if (typeof(IMixedRealityRaycastProvider).IsAssignableFrom(serviceType))
             {
                 raycastProvider = null;
             }
-            if (typeof(IMixedRealitySceneSystem).IsAssignableFrom(serviceType))
+            else if (typeof(IMixedRealitySceneSystem).IsAssignableFrom(serviceType))
             {
                 sceneSystem = null;
             }
-            if (typeof(IMixedRealitySpatialAwarenessSystem).IsAssignableFrom(serviceType))
+            else if (typeof(IMixedRealitySpatialAwarenessSystem).IsAssignableFrom(serviceType))
             {
                 sceneSystem = null;
             }
-            if (typeof(IMixedRealityTeleportSystem).IsAssignableFrom(serviceType))
+            else if (typeof(IMixedRealityTeleportSystem).IsAssignableFrom(serviceType))
             {
                 teleportSystem = null;
             }

--- a/Assets/MRTK/Core/Utilities/MixedRealityServiceRegistry.cs
+++ b/Assets/MRTK/Core/Utilities/MixedRealityServiceRegistry.cs
@@ -80,13 +80,12 @@ namespace Microsoft.MixedReality.Toolkit
                 return false;
             }
 
-            Type interfaceType = typeof(T);
-            T existingService;
-
-            if (TryGetService<T>(out existingService, serviceInstance.Name))
+            if (TryGetService<T>(out _, serviceInstance.Name))
             {
                 return false;
             }
+
+            Type interfaceType = typeof(T);
 
             // Ensure we have a place to put our newly registered service.
             if (!registry.ContainsKey(interfaceType))
@@ -269,8 +268,7 @@ namespace Microsoft.MixedReality.Toolkit
         {
             Type interfaceType = typeof(T);
 
-            IMixedRealityService tempService;
-            if (TryGetServiceInternal(interfaceType, out tempService, out registrar, name))
+            if (TryGetServiceInternal(interfaceType, out IMixedRealityService tempService, out registrar, name))
             {
                 Debug.Assert(tempService is T, "The service in the registry does not match the expected type.");
                 serviceInstance = (T)tempService;

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -298,6 +298,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                             CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.PoseData);
                         }
                         break;
+                    // IndexFinger is handled in ArticulatedHandDefinition, so we can safely skip this case.
+                    case DeviceInputType.IndexFinger:
+                        break;
                     default:
                         base.UpdatePoseData(interactionMapping, inputDevice);
                         break;

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRDeviceManager.cs
@@ -156,15 +156,19 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             using (GetOrAddControllerPerfMarker.Auto())
             {
+                InputDeviceCharacteristics inputDeviceCharacteristics = inputDevice.characteristics;
+
                 // If this is a new input device, search if an existing input device has matching characteristics
                 if (!ActiveControllers.ContainsKey(inputDevice))
                 {
                     foreach (InputDevice device in ActiveControllers.Keys)
                     {
-                        if (((device.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
-                            || (device.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking)))
-                            && ((device.characteristics.IsMaskSet(InputDeviceCharacteristics.Left) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Left))
-                            || (device.characteristics.IsMaskSet(InputDeviceCharacteristics.Right) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Right))))
+                        InputDeviceCharacteristics deviceCharacteristics = device.characteristics;
+
+                        if (((deviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Controller) && inputDeviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
+                            || (deviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking) && inputDeviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking)))
+                            && ((deviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Left) && inputDeviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Left))
+                            || (deviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Right) && inputDeviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Right))))
                         {
                             ActiveControllers.Add(inputDevice, ActiveControllers[device]);
                             break;
@@ -172,7 +176,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     }
                 }
 
-                if (inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking)
+                if (inputDeviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking)
                     && inputDevice.TryGetFeatureValue(CommonUsages.isTracked, out bool isTracked)
                     && !isTracked)
                 {
@@ -194,13 +198,17 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         {
             using (RemoveControllerPerfMarker.Auto())
             {
+                InputDeviceCharacteristics inputDeviceCharacteristics = inputDevice.characteristics;
+
                 foreach (InputDevice device in ActiveControllers.Keys)
                 {
+                    InputDeviceCharacteristics deviceCharacteristics = device.characteristics;
+
                     if (device != inputDevice
-                        && ((device.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
-                        || (device.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking)))
-                        && ((device.characteristics.IsMaskSet(InputDeviceCharacteristics.Left) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Left))
-                        || (device.characteristics.IsMaskSet(InputDeviceCharacteristics.Right) && inputDevice.characteristics.IsMaskSet(InputDeviceCharacteristics.Right))))
+                        && ((deviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Controller) && inputDeviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Controller))
+                        || (deviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking) && inputDeviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.HandTracking)))
+                        && ((deviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Left) && inputDeviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Left))
+                        || (deviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Right) && inputDeviceCharacteristics.IsMaskSet(InputDeviceCharacteristics.Right))))
                     {
                         ActiveControllers.Remove(inputDevice);
                         // Since an additional device exists, return so a lost source isn't reported

--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -73,6 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                 {
                     Debug.LogError($"No interaction configuration for {GetType().Name}");
                     Enabled = false;
+                    return;
                 }
 
                 UpdateSixDofData(inputDevice);

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -77,6 +77,27 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
 
         private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] XRSDKDeviceManager.Update");
 
+        public override void Enable()
+        {
+            base.Enable();
+
+            inputDevices.Clear();
+            foreach (InputDeviceCharacteristics inputDeviceCharacteristics in DesiredInputCharacteristics)
+            {
+                InputDevices.GetDevicesWithCharacteristics(inputDeviceCharacteristics, inputDevicesSubset);
+                foreach (InputDevice device in inputDevicesSubset)
+                {
+                    if (!inputDevices.Contains(device))
+                    {
+                        inputDevices.Add(device);
+                    }
+                }
+            }
+
+            InputDevices.deviceConnected += InputDevices_deviceConnected;
+            InputDevices.deviceDisconnected += InputDevices_deviceDisconnected;
+        }
+
         /// <inheritdoc/>
         public override void Update()
         {
@@ -92,19 +113,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                 if (XRSubsystemHelpers.InputSubsystem == null || !XRSubsystemHelpers.InputSubsystem.running)
                 {
                     return;
-                }
-
-                inputDevices.Clear();
-                foreach (InputDeviceCharacteristics inputDeviceCharacteristics in DesiredInputCharacteristics)
-                {
-                    InputDevices.GetDevicesWithCharacteristics(inputDeviceCharacteristics, inputDevicesSubset);
-                    foreach (InputDevice device in inputDevicesSubset)
-                    {
-                        if (!inputDevices.Contains(device))
-                        {
-                            inputDevices.Add(device);
-                        }
-                    }
                 }
 
                 foreach (InputDevice device in inputDevices)
@@ -137,6 +145,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// <inheritdoc/>
         public override void Disable()
         {
+            InputDevices.deviceConnected -= InputDevices_deviceConnected;
+            InputDevices.deviceDisconnected -= InputDevices_deviceDisconnected;
+
             var controllersCopy = ActiveControllers.ToReadOnlyCollection();
             foreach (var controller in controllersCopy)
             {
@@ -144,6 +155,20 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
             }
 
             base.Disable();
+        }
+
+        private void InputDevices_deviceConnected(InputDevice obj)
+        {
+            bool characteristicsMatch = (obj.characteristics & (InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.HandTracking)) > 0;
+            if (characteristicsMatch && !inputDevices.Contains(obj))
+            {
+                inputDevices.Add(obj);
+            }
+        }
+
+        private void InputDevices_deviceDisconnected(InputDevice obj)
+        {
+            inputDevices.Remove(obj);
         }
 
         #region Controller Utilities

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
@@ -185,8 +185,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (SourcePoseDataUsable(eventData))
             {
                 TrackingState = eventData.Controller.TrackingState;
-                transform.position = eventData.SourceData.Position;
-                transform.rotation = eventData.SourceData.Rotation;
+                transform.SetPositionAndRotation(eventData.SourceData.Position, eventData.SourceData.Rotation);
             }
         }
 
@@ -235,8 +234,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 poseActionDetected = true;
                 TrackingState = TrackingState.Tracked;
-                transform.position = eventData.InputData.Position;
-                transform.rotation = eventData.InputData.Rotation;
+                transform.SetPositionAndRotation(eventData.InputData.Position, eventData.InputData.Rotation);
             }
         }
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -462,8 +462,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private Vector3 GetPointersGrabPoint()
         {
             Vector3 sum = Vector3.zero;
-            foreach (PointerData pointerData in pointerDataList)
+            int pointerDataListCount = pointerDataList.Count;
+            for (int i = 0; i < pointerDataListCount; i++)
             {
+                PointerData pointerData = pointerDataList[i];
                 sum += pointerData.GrabPoint;
             }
             return sum / Math.Max(1, pointerDataList.Count);
@@ -484,8 +486,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Vector3 sumPos = Vector3.zero;
             Vector3 sumDir = Vector3.zero;
-            foreach (PointerData pointerData in pointerDataList)
+            int pointerDataListCount = pointerDataList.Count;
+            for (int i = 0; i < pointerDataListCount; i++)
             {
+                PointerData pointerData = pointerDataList[i];
                 sumPos += pointerData.Pointer.Position;
                 sumDir += pointerData.Pointer.Rotation * Vector3.forward;
             }
@@ -502,9 +506,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Vector3 sum = Vector3.zero;
             int numControllers = 0;
-            foreach (PointerData pointerData in pointerDataList)
+            int pointerDataListCount = pointerDataList.Count;
+            for (int i = 0; i < pointerDataListCount; i++)
             {
-                IMixedRealityController controller = pointerData.Pointer.Controller;
+                IMixedRealityController controller = pointerDataList[i].Pointer.Controller;
                 // Check pointer has a valid controller (e.g. gaze pointer doesn't)
                 if (controller != null)
                 {
@@ -519,9 +524,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Vector3 sum = Vector3.zero;
             int numControllers = 0;
-            foreach (PointerData pointerData in pointerDataList)
+            int pointerDataListCount = pointerDataList.Count;
+            for (int i = 0; i < pointerDataListCount; i++)
             {
-                IMixedRealityController controller = pointerData.Pointer.Controller;
+                IMixedRealityController controller = pointerDataList[i].Pointer.Controller;
                 // Check pointer has a valid controller (e.g. gaze pointer doesn't)
                 if (controller != null)
                 {
@@ -534,9 +540,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool IsNearManipulation()
         {
-            foreach (PointerData pointerData in pointerDataList)
+            int pointerDataListCount = pointerDataList.Count;
+            for (int i = 0; i < pointerDataListCount; i++)
             {
-                if (pointerData.IsNearPointer)
+                if (pointerDataList[i].IsNearPointer)
                 {
                     return true;
                 }
@@ -568,8 +575,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public Vector3 GetPointerGrabPoint(uint pointerId)
         {
-            foreach (PointerData pointerData in pointerDataList)
+            int pointerDataListCount = pointerDataList.Count;
+            for (int i = 0; i < pointerDataListCount; i++)
             {
+                PointerData pointerData = pointerDataList[i];
                 if (pointerData.Pointer.PointerId == pointerId)
                 {
                     return pointerData.GrabPoint;
@@ -598,8 +607,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 uint id = eventData.Pointer.PointerId;
                 bool pointerPresent = false;
-                foreach (PointerData pointerData in pointerDataList)
+                int pointerDataListCount = pointerDataList.Count;
+                for (int i = 0; i < pointerDataListCount; i++)
                 {
+                    PointerData pointerData = pointerDataList[i];
                     if (pointerData.Pointer.PointerId == id)
                     {
                         pointerPresent = true;
@@ -680,8 +691,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             uint id = eventData.Pointer.PointerId;
             PointerData pointerDataToRemove = default;
             bool removePointerData = false;
-            foreach (PointerData pointerData in pointerDataList)
+            int pointerDataListCount = pointerDataList.Count;
+            for (int i = 0; i < pointerDataListCount; i++)
             {
+                PointerData pointerData = pointerDataList[i];
                 if (pointerData.Pointer.PointerId == id)
                 {
                     pointerDataToRemove = pointerData;
@@ -979,9 +992,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             uint index = 0;
-            foreach (PointerData pointerData in pointerDataList)
+            int pointerDataListCount = pointerDataList.Count;
+            for (int i = 0; i < pointerDataListCount; i++)
             {
-                handPositionMap[index++] = pointerData.Pointer.Position;
+                handPositionMap[index++] = pointerDataList[i].Pointer.Position;
             }
             return handPositionMap;
         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -27,10 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Tooltip("The distance from the hit surface to place the cursor")]
         private float surfaceCursorDistance = 0.02f;
 
-        public float SurfaceCursorDistance
-        {
-            get { return surfaceCursorDistance; }
-        }
+        public float SurfaceCursorDistance => surfaceCursorDistance;
 
         /// <summary>
         /// When lerping, use unscaled time. This is useful for games that have a pause mechanism or otherwise adjust the game timescale.
@@ -142,23 +139,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Tooltip("Visual that is displayed when cursor is active normally")]
         protected Transform PrimaryCursorVisual = null;
 
-        protected bool IsSourceDetected => visibleSourcesCount > 0;
+        protected bool IsSourceDetected => VisibleSourcesCount > 0;
 
         public List<uint> SourceDownIds = new List<uint>();
         public bool IsPointerDown => SourceDownIds.Count > 0;
 
         protected GameObject TargetedObject = null;
 
-        private uint visibleSourcesCount = 0;
-        public uint VisibleSourcesCount
-        {
-            get { return visibleSourcesCount; }
-            set { visibleSourcesCount = value; }
-        }
+        public uint VisibleSourcesCount { get; set; } = 0;
 
         protected Vector3 targetPosition;
         protected Vector3 targetScale;
         protected Quaternion targetRotation;
+
+        private static IMixedRealityInputSystem inputSystem;
+        private static IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = CoreServices.InputSystem);
 
         #region IMixedRealityCursor Implementation
 
@@ -256,9 +251,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // If a source is detected that's using this cursor's pointer, we increment the count to set the cursor state properly.
                     if (eventData.InputSource.Pointers[i].PointerId == Pointer.PointerId)
                     {
-                        visibleSourcesCount++;
+                        VisibleSourcesCount++;
 
-                        if (SetVisibilityOnSourceDetected && visibleSourcesCount == 1)
+                        if (SetVisibilityOnSourceDetected && VisibleSourcesCount == 1)
                         {
                             SetVisibility(true);
                         }
@@ -279,7 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // If a source is lost that's using this cursor's pointer, we decrement the count to set the cursor state properly.
                     if (eventData.InputSource.Pointers[i].PointerId == Pointer.PointerId)
                     {
-                        visibleSourcesCount--;
+                        VisibleSourcesCount--;
                         break;
                     }
                 }
@@ -362,17 +357,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private void Update()
         {
             // Skip Update if the input system is missing during a runtime profile switch
-            if ((CoreServices.InputSystem == null) ||
-                (CoreServices.InputSystem.FocusProvider == null))
+            if (InputSystem == null || InputSystem.FocusProvider == null)
             {
                 return;
             }
-            if (!CoreServices.InputSystem.FocusProvider.TryGetFocusDetails(Pointer, out focusDetails))
+
+            if (!InputSystem.FocusProvider.TryGetFocusDetails(Pointer, out focusDetails)
+                && InputSystem.FocusProvider.IsPointerRegistered(Pointer))
             {
-                if (CoreServices.InputSystem.FocusProvider.IsPointerRegistered(Pointer))
-                {
-                    Debug.LogError($"{name}: Unable to get focus details for {pointer.GetType().Name}!");
-                }
+                Debug.LogError($"{name}: Unable to get focus details for {pointer.GetType().Name}!");
+                return;
             }
 
             UpdateCursorState();
@@ -388,7 +382,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected virtual void OnDisable()
         {
             TargetedObject = null;
-            visibleSourcesCount = 0;
+            VisibleSourcesCount = 0;
             OnCursorStateChange(CursorStateEnum.Contextual);
         }
 
@@ -399,12 +393,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         protected virtual void RegisterManagers()
         {
-            var inputSystem = CoreServices.InputSystem;
+            if (InputSystem == null)
+            {
+                return;
+            }
+
             // Register the cursor as a listener, so that it can always get input events it cares about
-            inputSystem.RegisterHandler<IMixedRealityCursor>(this);
+            InputSystem.RegisterHandler<IMixedRealityCursor>(this);
 
             // Setup the cursor to be able to respond to input being globally enabled / disabled
-            if (inputSystem.IsInputEnabled)
+            if (InputSystem.IsInputEnabled)
             {
                 OnInputEnabled();
             }
@@ -413,8 +411,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 OnInputDisabled();
             }
 
-            inputSystem.InputEnabled += OnInputEnabled;
-            inputSystem.InputDisabled += OnInputDisabled;
+            InputSystem.InputEnabled += OnInputEnabled;
+            InputSystem.InputDisabled += OnInputDisabled;
         }
 
         /// <summary>
@@ -422,13 +420,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         protected virtual void UnregisterManagers()
         {
-            var inputSystem = CoreServices.InputSystem;
-            if (inputSystem != null)
+            if (InputSystem == null)
             {
-                inputSystem.InputEnabled -= OnInputEnabled;
-                inputSystem.InputDisabled -= OnInputDisabled;
-                inputSystem.UnregisterHandler<IMixedRealityCursor>(this);
+                return;
             }
+
+            InputSystem.InputEnabled -= OnInputEnabled;
+            InputSystem.InputDisabled -= OnInputDisabled;
+            InputSystem.UnregisterHandler<IMixedRealityCursor>(this);
         }
 
         /// <summary>
@@ -442,7 +441,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            GameObject newTargetedObject = CoreServices.InputSystem.FocusProvider.GetFocusedObject(Pointer);
+            GameObject newTargetedObject = InputSystem?.FocusProvider.GetFocusedObject(Pointer);
             Vector3 lookForward;
 
             // If no game object is hit, put the cursor at the default distance
@@ -519,7 +518,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public virtual void OnInputDisabled()
         {
             // Reset visible hands on disable
-            visibleSourcesCount = 0;
+            VisibleSourcesCount = 0;
 
             OnCursorStateChange(CursorStateEnum.Contextual);
         }
@@ -545,11 +544,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private void ResetInputSourceState()
         {
             SourceDownIds.Clear();
-            visibleSourcesCount = 0;
-            if (IsPointerValid)
+            VisibleSourcesCount = 0;
+            if (IsPointerValid && InputSystem != null)
             {
                 uint cursorPointerId = Pointer.PointerId;
-                foreach (IMixedRealityInputSource inputSource in CoreServices.InputSystem.DetectedInputSources)
+                foreach (IMixedRealityInputSource inputSource in InputSystem.DetectedInputSources)
                 {
                     if (inputSource.SourceType != InputSourceType.Head && inputSource.SourceType != InputSourceType.Eyes)
                     {
@@ -557,7 +556,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         {
                             if (inputSourcePointer.PointerId == cursorPointerId)
                             {
-                                ++visibleSourcesCount;
+                                ++VisibleSourcesCount;
                                 break;
                             }
                         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Unity.Profiling;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -29,13 +30,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         protected Gradient LineColorLockFocus = new Gradient();
 
-        [SerializeField]
-        private BaseMixedRealityLineDataProvider lineBase;
+        [SerializeField, FormerlySerializedAs("lineBase")]
+        private BaseMixedRealityLineDataProvider lineDataProvider;
 
         /// <summary>
         /// The Line Data Provider driving this pointer.
         /// </summary>
-        public BaseMixedRealityLineDataProvider LineBase => lineBase;
+        public BaseMixedRealityLineDataProvider LineBase => lineDataProvider;
 
         [SerializeField]
         [Tooltip("If no line renderers are specified, this array will be auto-populated on startup.")]
@@ -60,19 +61,19 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void CheckInitialization()
         {
-            if (lineBase == null)
+            if (lineDataProvider == null)
             {
-                lineBase = GetComponent<BaseMixedRealityLineDataProvider>();
+                lineDataProvider = GetComponent<BaseMixedRealityLineDataProvider>();
             }
 
-            if (lineBase == null)
+            if (lineDataProvider == null)
             {
                 Debug.LogError($"No Mixed Reality Line Data Provider found on {gameObject.name}. Did you forget to add a Line Data provider?");
             }
 
-            if (lineBase != null && (lineRenderers == null || lineRenderers.Length == 0))
+            if (lineDataProvider != null && (lineRenderers == null || lineRenderers.Length == 0))
             {
-                lineRenderers = lineBase.GetComponentsInChildren<BaseMixedRealityLineRenderer>();
+                lineRenderers = lineDataProvider.GetComponentsInChildren<BaseMixedRealityLineRenderer>();
             }
 
             if (lineRenderers == null || lineRenderers.Length == 0)
@@ -135,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 base.OnPostSceneQuery();
 
                 bool isEnabled = IsInteractionEnabled;
-                LineBase.enabled = isEnabled;
+                lineDataProvider.enabled = isEnabled;
                 if (BaseCursor != null)
                 {
                     BaseCursor.SetVisibility(isEnabled);
@@ -151,9 +152,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (PreUpdateLineRenderersPerfMarker.Auto())
             {
-                Debug.Assert(lineBase != null);
+                Debug.Assert(lineDataProvider != null);
 
-                lineBase.UpdateMatrix();
+                lineDataProvider.UpdateMatrix();
 
                 // Set our first and last points on the Line Renderer
                 if (IsFocusLocked && IsTargetPositionLockedOnFocusLock && Result != null)
@@ -221,13 +222,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // So don't clamp the world length, the line data's end point is already set to the world cursor
                 if (IsFocusLocked && IsTargetPositionLockedOnFocusLock)
                 {
-                    LineBase.LineEndClamp = 1;
+                    lineDataProvider.LineEndClamp = 1;
                 }
                 else
                 {
                     // Otherwise clamp the line end by the clear distance
-                    float clearLocalLength = lineBase.GetNormalizedLengthFromWorldLength(clearWorldLength - cursorOffsetWorldLength, maxClampLineSteps);
-                    LineBase.LineEndClamp = clearLocalLength;
+                    float clearLocalLength = lineDataProvider.GetNormalizedLengthFromWorldLength(clearWorldLength - cursorOffsetWorldLength, maxClampLineSteps);
+                    lineDataProvider.LineEndClamp = clearLocalLength;
                 }
             }
         }
@@ -255,8 +256,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             lineStartPoint = startPoint;
             lineEndPoint = endPoint;
 
-            lineBase.FirstPoint = startPoint;
-            lineBase.LastPoint = endPoint;
+            lineDataProvider.FirstPoint = startPoint;
+            lineDataProvider.LastPoint = endPoint;
         }
 
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -117,11 +117,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 if (!IsInteractionEnabled)
                 {
-                    LineBase.enabled = false;
-                    if (BaseCursor != null)
-                    {
-                        BaseCursor.SetVisibility(false);
-                    }
                     return;
                 }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -117,6 +117,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 if (!IsInteractionEnabled)
                 {
+                    LineBase.enabled = false;
+                    if (BaseCursor != null)
+                    {
+                        BaseCursor.SetVisibility(false);
+                    }
                     return;
                 }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -597,7 +597,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     if (currentGrabbable == null)
                     {
-                        // Remove it from the cache if the grabbable is no longer valid for the object
+                        // Only remove the grabbable from the cache if it's gone null.
+                        // If we instead remove all invalid grabbables, we get stuck in a cycle of
+                        // calling GetComponent the next time this method is called, just to re-add
+                        // and immediately re-remove the invalid component from the cache, invalidating
+                        // any perf benefits of using the cache to avoid GetComponent.
                         _ = componentCache.Remove(instanceId);
                     }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -493,9 +493,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             /// <param name="ignoreCollidersNotInFOV">Whether to ignore colliders that are not visible.</param>
             public GameObject GetClosestValidGrabbable(Vector3 pointerPosition, Vector3 pointerAxis, bool ignoreCollidersNotInFOV, out Vector3 hitPosition, LRUCache<int, NearInteractionGrabbable> componentCache)
             {
-                Vector3 colliderHitPoint = pointerPosition; ;
-                NearInteractionGrabbable currentGrabbable = null;
-
                 NearInteractionGrabbable closestGrabbable = null;
                 Vector3 closestColliderHitPosition = pointerPosition;
                 float closestDistance = Mathf.Infinity;
@@ -504,8 +501,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 for (int i = 0; i < numColliders; i++)
                 {
                     Collider collider = queryBuffer[i];
-                    if (IsColliderValidGrabbable(collider, ignoreCollidersNotInFOV, out currentGrabbable, componentCache)
-                        && IsColliderPositionValid(collider, pointerPosition, pointerAxis, queryAngle, queryMinDistance, out colliderHitPoint))
+                    if (IsColliderValidGrabbable(collider, ignoreCollidersNotInFOV, out NearInteractionGrabbable currentGrabbable, componentCache)
+                        && IsColliderPositionValid(collider, pointerPosition, pointerAxis, queryAngle, queryMinDistance, out Vector3 colliderHitPoint))
                     {
                         float currentDistance = (pointerPosition - colliderHitPoint).sqrMagnitude;
                         float currentVolume = collider.bounds.Transform(collider.transform.localToWorldMatrix).Volume();
@@ -598,8 +595,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 if (!isValidGrabbable)
                 {
-                    // Remove it from the cache if the grabbable is no longer valid for the object
-                    componentCache.Remove(instanceId);
+                    if (currentGrabbable == null)
+                    {
+                        // Remove it from the cache if the grabbable is no longer valid for the object
+                        _ = componentCache.Remove(instanceId);
+                    }
+
                     return false;
                 }
 
@@ -610,11 +611,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     return false;
                 }
 
-                Camera mainCam = CameraCache.Main;
                 // Additional check: is grabbable in the camera frustum
                 // We do this so that if grabbable is not visible it is not accidentally grabbed
                 // Also to not turn off the hand ray if hand is near a grabbable that's not actually visible
-                if (ignoreCollidersNotInFOV && !mainCam.IsInFOVCached(collider))
+                if (ignoreCollidersNotInFOV && !CameraCache.Main.IsInFOVCached(collider))
                 {
                     return false;
                 }

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -1471,8 +1471,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 Debug.Assert(step.Direction != Vector3.zero, "RayStep Direction is Invalid.");
 
                 // Move the uiRaycast camera to the current pointer's position.
-                UIRaycastCamera.transform.position = step.Origin;
-                UIRaycastCamera.transform.rotation = Quaternion.LookRotation(step.Direction, Vector3.up);
+                UIRaycastCamera.transform.SetPositionAndRotation(step.Origin, Quaternion.LookRotation(step.Direction, Vector3.up));
 
                 // We always raycast from the center of the camera.
                 graphicEventData.position = new Vector2(UIRaycastCamera.pixelWidth * 0.5f, UIRaycastCamera.pixelHeight * 0.5f);

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -492,7 +492,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         private event PrimaryPointerChangedHandler PrimaryPointerChanged;
 
-        private IMixedRealityInputSystem InputSystem => inputSystem != null ? inputSystem : inputSystem = CoreServices.InputSystem;
+        private IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = CoreServices.InputSystem);
         private IMixedRealityInputSystem inputSystem = null;
 
         #region IMixedRealityService Implementation

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -800,7 +800,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             using (RegisterPointersPerfMarker.Auto())
             {
                 // If our input source does not have any pointers, then skip.
-                if (inputSource.Pointers == null)
+                if (inputSource.Pointers == null || inputSource.Pointers.Length == 0)
                 {
                     return;
                 }
@@ -845,9 +845,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     // Special Registration for Gaze
                     // Refreshes gazeProviderPointingData to a new reference to the current EventSystem 
-                    if (!gazeProvider.IsNull()
-                        && inputSource.SourceId == gazeProvider.GazeInputSource.SourceId
-                        && gazeProviderPointingData == null)
+                    if (gazeProviderPointingData == null
+                        && !gazeProvider.IsNull()
+                        && inputSource.SourceId == gazeProvider.GazeInputSource.SourceId)
                     {
                         gazeProviderPointingData = new PointerEventData(EventSystem.current);
                     }
@@ -967,7 +967,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 ReconcilePointers();
 
-                foreach (var pointerMediator in pointerMediators)
+                foreach (KeyValuePair<uint, IMixedRealityPointerMediator> pointerMediator in pointerMediators)
                 {
                     // This will be handled by the new pointer mediator ideally...
                     pointerMediator.Value.UpdatePointers();
@@ -976,7 +976,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 #if UNITY_EDITOR
                 int pointerCount = 0;
 #endif
-                foreach (var pointerData in pointersList)
+                foreach (PointerData pointerData in pointersList)
                 {
                     UpdatePointer(pointerData);
 
@@ -1433,25 +1433,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 float totalDistance = 0.0f;
                 for (int i = 0; i < pointer.Rays.Length; i++)
                 {
-                    if (RaycastGraphicsStep(graphicEventData, pointer.Rays[i], prioritizedLayerMasks, out raycastResult))
+                    if (RaycastGraphicsStep(graphicEventData, pointer.Rays[i], prioritizedLayerMasks, out raycastResult) &&
+                        raycastResult.isValid &&
+                        raycastResult.distance < pointer.Rays[i].Length &&
+                        raycastResult.module != null &&
+                        raycastResult.module.eventCamera == UIRaycastCamera)
                     {
-                        if (raycastResult.isValid &&
-                            raycastResult.distance < pointer.Rays[i].Length &&
-                            raycastResult.module != null &&
-                            raycastResult.module.eventCamera == UIRaycastCamera)
-                        {
-                            totalDistance += raycastResult.distance;
+                        totalDistance += raycastResult.distance;
 
-                            newUiRaycastPosition.x = raycastResult.screenPosition.x;
-                            newUiRaycastPosition.y = raycastResult.screenPosition.y;
-                            newUiRaycastPosition.z = raycastResult.distance;
+                        newUiRaycastPosition.x = raycastResult.screenPosition.x;
+                        newUiRaycastPosition.y = raycastResult.screenPosition.y;
+                        newUiRaycastPosition.z = raycastResult.distance;
 
-                            Vector3 worldPos = UIRaycastCamera.ScreenToWorldPoint(newUiRaycastPosition);
-                            Vector3 normal = -raycastResult.gameObject.transform.forward;
+                        Vector3 worldPos = UIRaycastCamera.ScreenToWorldPoint(newUiRaycastPosition);
+                        Vector3 normal = -raycastResult.gameObject.transform.forward;
 
-                            hit.Set(raycastResult, worldPos, normal, pointer.Rays[i], i, totalDistance);
-                            return;
-                        }
+                        hit.Set(raycastResult, worldPos, normal, pointer.Rays[i], i, totalDistance);
+                        return;
                     }
 
                     totalDistance += pointer.Rays[i].Length;
@@ -1655,14 +1653,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #endregion
 
         #region IPointerPreferences Implementation
+
         private List<PointerPreferences> customPointerBehaviors = new List<PointerPreferences>();
 
         /// <inheritdoc />
         public PointerBehavior GetPointerBehavior(IMixedRealityPointer pointer)
         {
+            IMixedRealityController controller = pointer.Controller;
+            IMixedRealityInputSource inputSourceParent = pointer.InputSourceParent;
+
             // Assumption: all pointers have controllers, input sources, except the gaze pointers
             // if the controller, input source is null, return the gaze pointer behavior here.
-            if (pointer.Controller == null || pointer.InputSourceParent == null)
+            if (controller == null || inputSourceParent == null)
             {
                 // gazepointer means input source is null
                 return GazePointerBehavior;
@@ -1670,8 +1672,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             return GetPointerBehavior(
                 pointer.GetType(),
-                pointer.Controller.ControllerHandedness,
-                pointer.InputSourceParent.SourceType);
+                controller.ControllerHandedness,
+                inputSourceParent.SourceType);
         }
 
         /// <summary>
@@ -1690,7 +1692,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private PointerBehavior GetPointerBehavior(Type type, Handedness handedness, InputSourceType sourceType)
         {
-            for (int i = 0; i < customPointerBehaviors.Count; i++)
+            int customPointerBehaviorsCount = customPointerBehaviors.Count;
+            for (int i = 0; i < customPointerBehaviorsCount; i++)
             {
                 if (customPointerBehaviors[i].Matches(type, sourceType))
                 {
@@ -1707,7 +1710,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public void SetPointerBehavior<T>(Handedness handedness, InputSourceType inputType, PointerBehavior pointerBehavior) where T : class, IMixedRealityPointer
         {
             PointerPreferences preference = null;
-            for (int i = 0; i < customPointerBehaviors.Count; i++)
+            int customPointerBehaviorsCount = customPointerBehaviors.Count;
+            for (int i = 0; i < customPointerBehaviorsCount; i++)
             {
                 if (customPointerBehaviors[i].Matches(typeof(T), inputType))
                 {
@@ -1724,22 +1728,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private class PointerPreferences
         {
-            public InputSourceType InputSourceType;
-            public Type PointerType;
+            public InputSourceType InputSourceType { get; }
+            public Type PointerType { get; }
 
             public bool Matches(Type queryType, InputSourceType queryInputType)
             {
-                return Matches(queryType) && queryInputType == InputSourceType;
+                return queryInputType == InputSourceType && queryType.IsAssignableFrom(PointerType);
             }
 
-            public bool Matches(Type queryType)
-            {
-                return queryType.IsAssignableFrom(PointerType);
-            }
+            public PointerBehavior Left { get; private set; }
+            public PointerBehavior Right { get; private set; }
+            public PointerBehavior Other { get; private set; }
 
-            public PointerBehavior Left;
-            public PointerBehavior Right;
-            public PointerBehavior Other;
             public PointerBehavior GetBehaviorForHandedness(Handedness h)
             {
                 if ((h & Handedness.Right) != 0)
@@ -1756,6 +1756,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
                 return PointerBehavior.Default;
             }
+
             public void SetBehaviorForHandedness(
                 Handedness h,
                 PointerBehavior b)
@@ -1773,6 +1774,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     Other = b;
                 }
             }
+
             public PointerPreferences(Type pointerType, InputSourceType inputType)
             {
                 Left = PointerBehavior.Default;
@@ -1782,6 +1784,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 PointerType = pointerType;
             }
         }
+
         #endregion
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/Core/Utilities/LRUCacheUnitTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Core/Utilities/LRUCacheUnitTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
             Assert.IsFalse(result, "Get operation should be unsuccessful.");
             Assert.Null(retrievedValue, "Retrieved value should be null.");
             Assert.IsTrue(didRemoveFirstItem, "First remove operation should be successful for in cache item.");
-            Assert.IsFalse(didRemoveSecondItem, "Second remove operations hould be unsuccessful for out of cache item.");
+            Assert.IsFalse(didRemoveSecondItem, "Second remove operations should be unsuccessful for out of cache item.");
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
             {
                 var result = cache.TryGetValue(i, out var retrievedValue);
                 Assert.IsFalse(result, "Get operation should be unsuccessful.");
-                Assert.Null(retrievedValue, "Retrieved value should be null after clearning cache.");
+                Assert.Null(retrievedValue, "Retrieved value should be null after clearing cache.");
             }
 
             Assert.AreEqual(cache.Count, 0, "Cache should be empty.");
@@ -163,7 +163,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
             var cache = new LRUCache<int, string>(capacity);
 
             // Act
-            // Fill cache with sequential from 0 - 5, then add another entry 10 to cause an eviction of least recent entry
+            // Fill cache with sequential from 0 - 4, then add another entry 10 to cause an eviction of least recent entry
             AddItems(cache, capacity);
             cache.Add(10, "10");
 
@@ -244,7 +244,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
             }
         }
 
-        private void VerifyEntrySequence(LRUCache<int, string> cache, params int[] entryKeySequence )
+        private void VerifyEntrySequence(LRUCache<int, string> cache, params int[] entryKeySequence)
         {
             var entryList = cache.ToList();
 

--- a/Assets/MRTK/Tests/PlayModeTests/Core/Utilities/LRUCacheUnitTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Core/Utilities/LRUCacheUnitTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
             var cache = new LRUCache<int, string>(capacity);
 
             // Assert
-            Assert.AreEqual(cache.Capacity, capacity, "Incorrect cache capacity");
+            Assert.AreEqual(capacity, cache.Capacity, "Incorrect cache capacity");
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
             AddItems(cache, capacity);
 
             // Assert
-            Assert.AreEqual(cache.Count, capacity, "Incorrect item count.");
+            Assert.AreEqual(capacity, cache.Count, "Incorrect item count.");
 
             for (var i = 0; i < capacity; i++)
             {
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
 
                 // Assert
                 Assert.IsTrue(result, "Get operation should be successful.");
-                Assert.AreEqual(retrievedValue, i.ToString(), "Incorrect item value retrieved.");
+                Assert.AreEqual(i.ToString(), retrievedValue, "Incorrect item value retrieved.");
             }
         }
 
@@ -59,13 +59,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
             }
 
             // Assert
-            Assert.AreEqual(cache.Count, capacity, "Incorrect item count.");
+            Assert.AreEqual(capacity, cache.Count, "Incorrect item count.");
 
             for (var i = 0; i < capacity; i++)
             {
                 string retrievedValue = string.Empty;
                 Assert.DoesNotThrow(() => retrievedValue = cache[i]);
-                Assert.AreEqual(retrievedValue, i.ToString(), "Incorrect item value retrieved.");
+                Assert.AreEqual(i.ToString(), retrievedValue, "Incorrect item value retrieved.");
             }
 
             Assert.Throws<KeyNotFoundException>(() => _ = cache[capacity]);
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
 
             // Assert
             Assert.IsTrue(result, "Get operation should be successful.");
-            Assert.AreEqual(retrievedValue, string1, "Incorrect cached value.");
+            Assert.AreEqual(string1, retrievedValue, "Incorrect cached value.");
 
             // Act
             var string2 = "test string 2";
@@ -107,8 +107,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
 
             // Assert
             Assert.IsTrue(result, "Get operation should be successful.");
-            Assert.AreEqual(cache.Count, 1, "There should only be one item in the cache.");
-            Assert.AreEqual(retrievedValue, string2, "Incorrect cached value.");
+            Assert.AreEqual(1, cache.Count, "There should only be one item in the cache.");
+            Assert.AreEqual(string2, retrievedValue, "Incorrect cached value.");
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
                 Assert.Null(retrievedValue, "Retrieved value should be null after clearing cache.");
             }
 
-            Assert.AreEqual(cache.Count, 0, "Cache should be empty.");
+            Assert.AreEqual(0, cache.Count, "Cache should be empty.");
         }
 
         [Test]
@@ -169,7 +169,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
 
             // Assert
             // Expected in cache item (Most recent -> least recent): 10, 4, 3, 2, 1
-            Assert.AreEqual(cache.Count, capacity, "Cache count should be full.");
+            Assert.AreEqual(capacity, cache.Count, "Cache count should be full.");
             VerifyEntrySequence(cache, 10, 4, 3, 2, 1);
         }
 
@@ -189,7 +189,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
 
             // Assert
             // Expected in cache items: 10, 0, 4, 3, 2
-            Assert.AreEqual(cache.Count, capacity, "Cache count should be full.");
+            Assert.AreEqual(capacity, cache.Capacity, "Cache capacity doesn't match the constructor.");
+            Assert.AreEqual(capacity, cache.Count, "Cache count should be full.");
             VerifyEntrySequence(cache, 10, 0, 4, 3, 2);
         }
 
@@ -208,7 +209,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
 
             // Assert
             // Expected in cache item (Most recent -> least recent): 10, 0, 4, 3, 2
-            Assert.AreEqual(cache.Count, cache.Capacity, "Cache should be at max capacity.");
+            Assert.AreEqual(capacity, cache.Capacity, "Cache capacity doesn't match the constructor.");
+            Assert.AreEqual(capacity, cache.Count, "Cache should be at max capacity.");
             VerifyEntrySequence(cache, 10, 0, 4, 3, 2);
         }
 
@@ -228,7 +230,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
 
                 // Assert
                 Assert.IsTrue(result, "Get operation should be successful.");
-                Assert.AreEqual(retrievedValue, i.ToString(), "Cache entry value mismatch.");
+                Assert.AreEqual(i.ToString(), retrievedValue, "Cache entry value mismatch.");
             }
 
             // Assert
@@ -253,7 +255,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Utilities
             var index = 0;
             foreach (var kvp in entryList)
             {
-                Assert.AreEqual(kvp.Key, entryKeySequence[index++], "Cached item sequence does not meet expected sequence.");
+                Assert.AreEqual(entryKeySequence[index++], kvp.Key, "Cached item sequence does not meet expected sequence.");
             }
         }
     }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "com.unity.package-manager-ui": "2.0.13",
+    "com.unity.performance.profile-analyzer": "1.1.1",
     "com.unity.textmeshpro": "1.4.1",
     "com.unity.xr.arfoundation": "1.5.0-preview.6",
     "com.unity.xr.openvr.standalone": "1.0.5",


### PR DESCRIPTION
## Overview

* Removes some allocations in `CameraFOVChecker`, `ObjectManipulator`, `ObjectManipulator`, and `LRUCache`
* Returns early in `MicrosoftArticulatedHand`, `GenericXRSDKController`, and `FocusProvider` at an earlier point where we know there's no work to be done
* Cache the result of some expensive (at least, when you call them as much as we do) calls in `OpenXRDeviceManager`, `XRSDKDeviceManager`, `BaseCursor`, and `FocusProvider`
* Migrate `XRSDKDeviceManager` to use the `InputDevices` events instead of polling every frame (which can be expensive for this method)
* Update `ControllerPoseSynchronizer` and `FocusProvider` to use `SetPositionAndRotation` in hot loops
* Update `ObjectManipulator` to not update twice per frame when doing two handed manipulation...
* Disable the `LinePointer`'s line data provider when the pointer isn't active, since there's no need to update a line for an inactive pointer
* Rewrite `ObjectManipulator` to no longer use a dictionary