### PR TITLE
Simplify InternalsVisibleTo in Core

### DIFF
--- a/Assets/MRTK/Core/AssemblyInfo.cs
+++ b/Assets/MRTK/Core/AssemblyInfo.cs
@@ -3,5 +3,5 @@
 
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.EditModeTests")]
 [assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.PlayModeTests")]
-[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.Utilities")]

--- a/Assets/MRTK/Core/AssemblyInfo.cs.meta
+++ b/Assets/MRTK/Core/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26cee117733e84e409a3020951c8cfb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -4,11 +4,8 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 
-[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.EditModeTests")]
-[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.PlayModeTests")]
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>

--- a/Assets/MRTK/Core/Definitions/MixedRealityExperienceSettingsProfile.cs
+++ b/Assets/MRTK/Core/Definitions/MixedRealityExperienceSettingsProfile.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 
-[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.EditModeTests")]
-[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.PlayModeTests")]
 namespace Microsoft.MixedReality.Toolkit
 {
     /// <summary>

--- a/Assets/MRTK/Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
@@ -10,12 +10,9 @@ using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Teleport;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Serialization;
 
-[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.EditModeTests")]
-[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.PlayModeTests")]
 namespace Microsoft.MixedReality.Toolkit
 {
     /// <summary>

--- a/Assets/MRTK/Core/Utilities/Async/Internal/AsyncCoroutineRunner.cs
+++ b/Assets/MRTK/Core/Utilities/Async/Internal/AsyncCoroutineRunner.cs
@@ -22,10 +22,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 
-[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.PlayModeTests")]
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     /// <summary>


### PR DESCRIPTION
## Overview

We mark multiple classes with `[assembly: InternalsVisibleTo(` in the core, so it seems reasonable to refactor that out into a single AssemblyInfo.cs.