### PR TITLE
Add support for "select" voice command with OpenXR

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftOpenXRGGVHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftOpenXRGGVHand.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
     [MixedRealityController(
         SupportedControllerType.GGVHand,
         new[] { Handedness.Left, Handedness.Right, Handedness.None })]
-    public class MicrosoftOpenXRGGVHand : GenericXRSDKController
+    internal class MicrosoftOpenXRGGVHand : GenericXRSDKController
     {
         public MicrosoftOpenXRGGVHand(
             TrackingState trackingState,

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftOpenXRGGVHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftOpenXRGGVHand.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.XRSDK.Input;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
+{
+    /// <summary>
+    /// A GGV (Gaze, Gesture, and Voice) hand instance for OpenXR.
+    /// Used only for the purposes of acting on the select keyword detected by HoloLens 2.
+    /// </summary>
+    [MixedRealityController(
+        SupportedControllerType.GGVHand,
+        new[] { Handedness.Left, Handedness.Right, Handedness.None })]
+    public class MicrosoftOpenXRGGVHand : GenericXRSDKController
+    {
+        public MicrosoftOpenXRGGVHand(
+            TrackingState trackingState,
+            Handedness controllerHandedness,
+            IMixedRealityInputSource inputSource = null,
+            MixedRealityInteractionMapping[] interactions = null)
+            : base(trackingState, controllerHandedness, inputSource, interactions, new SimpleHandDefinition(controllerHandedness))
+        { }
+
+        internal void UpdateVoiceState(bool isPressed)
+        {
+            MixedRealityInteractionMapping interactionMapping = null;
+
+            for (int i = 0; i < Interactions?.Length; i++)
+            {
+                MixedRealityInteractionMapping currentInteractionMapping = Interactions[i];
+
+                if (currentInteractionMapping.AxisType == AxisType.Digital && currentInteractionMapping.InputType == DeviceInputType.Select)
+                {
+                    interactionMapping = currentInteractionMapping;
+                    break;
+                }
+            }
+
+            if (interactionMapping == null)
+            {
+                return;
+            }
+
+            interactionMapping.BoolData = isPressed;
+
+            // If our value changed raise it.
+            if (interactionMapping.Changed)
+            {
+                // Raise input system event if it's enabled
+                if (interactionMapping.BoolData)
+                {
+                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                }
+                else
+                {
+                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                }
+            }
+        }
+    }
+}

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftOpenXRGGVHand.cs.meta
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftOpenXRGGVHand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5a8da3ddac5dc245989c9515ccec423
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Allow HoloLens 2 to act on the "select" keyword in OpenXR by subscribing to `SpatialInteractionManager.SourcePressed`. Follow up & very similar to #10533.

## Changes
- Fixes: #10604, #10154.