### PR TITLE
Add BaseMeshOutline inspector

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline.meta
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 424a795e86accb844a34a3a7caa82968
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
                 }
             }
 
-            //Draw other properties
+            // Draw other properties
             DrawPropertiesExcluding(serializedObject, nameof(m_Script), nameof(outlineMaterial));
 
             if (EditorGUI.EndChangeCheck())
@@ -137,7 +137,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
                             return !material.IsKeywordEnabled(x.Key);
                         }
                     default:
-                        //default return value
+                        // Default return value
                         return false;
                 }
             });

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+using static Microsoft.MixedReality.Toolkit.Utilities.StandardShaderUtility;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
 {
@@ -18,8 +19,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
         private BaseMeshOutline instance;
         private SerializedProperty m_Script;
         private SerializedProperty outlineMaterial;
-
-        private string MrtkStandardShaderName => StandardShaderUtility.MrtkStandardShaderName;
 
         private readonly Dictionary<string, object> defaultOutlineMaterialSettings = new Dictionary<string, object>()
         {
@@ -76,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
 
         private Material CreateNewMaterial()
         {
-            var material = new Material(Shader.Find(MrtkStandardShaderName));
+            var material = new Material(MrtkStandardShader);
             ForceUpdateToDefaultOutlineMaterial(ref material);
             AssetDatabase.CreateAsset(material, $"Assets/{Selection.activeGameObject.name}Mat.mat");
             return material;
@@ -84,9 +83,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
 
         private void ForceUpdateToDefaultOutlineMaterial(ref Material material)
         {
-            if (!IsCorrectShader(material))
+            if (!IsUsingMrtkStandardShader(material))
             {
-                material.shader = Shader.Find(MrtkStandardShaderName);
+                material.shader = MrtkStandardShader;
             }
 
             foreach (var pair in defaultOutlineMaterialSettings)
@@ -115,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
 
         private bool IsCorrectMaterial(Material material)
         {
-            if (!IsCorrectShader(material))
+            if (!IsUsingMrtkStandardShader(material))
             {
                 return false;
             }
@@ -143,10 +142,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
             });
         }
 
-        private bool IsCorrectShader(Material material)
-        {
-            return material.shader.name.Equals(MrtkStandardShaderName);
-        }
         private void DrawReadonlyPropertyField(SerializedProperty property, params GUILayoutOption[] options)
         {
             GUI.enabled = false;

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
+{
+    /// <summary>
+    /// A custom inspector for BaseMeshOutline.
+    /// Used for create && fix outline material
+    /// </summary>
+    [CustomEditor(typeof(BaseMeshOutline), true)]
+    public class BaseMeshOutlineInspector : UnityEditor.Editor
+    {
+        private BaseMeshOutline instance;
+        private SerializedProperty m_Script;
+        private SerializedProperty outlineMaterial;
+
+        private readonly string standardShaderName = "Mixed Reality Toolkit/Standard";
+
+        private readonly Dictionary<string, object> defaultOutlineMaterialSettings = new Dictionary<string, object>()
+        {
+            { "_Mode", 5f },
+            { "_CustomMode", 0f },
+            { "_ZWrite", 0f },
+            { "_VertexExtrusion", 1f },
+            { "_VertexExtrusionValue",  0.01f },
+            { "_VertexExtrusionSmoothNormals", 1f },
+            { "_VERTEX_EXTRUSION", true },
+            { "_VERTEX_EXTRUSION_SMOOTH_NORMALS", true },
+        };
+
+        private void OnEnable()
+        {
+            instance = target as BaseMeshOutline;
+            m_Script = serializedObject.FindProperty("m_Script");
+            outlineMaterial = serializedObject.FindProperty(nameof(outlineMaterial));
+        }
+
+        public override void OnInspectorGUI()
+        {
+            DrawReadonlyPropertyField(m_Script);
+
+            EditorGUI.BeginChangeCheck();
+            EditorGUILayout.PropertyField(outlineMaterial);
+
+            var currentMat = instance.OutlineMaterial;
+            if (currentMat == null)
+            {
+                EditorGUILayout.HelpBox($"Outline Material field is empty, please create or select material", MessageType.Warning);
+
+                if (GUILayout.Button("Create && set new material"))
+                {
+                    outlineMaterial.objectReferenceValue = CreateNewMaterial();
+                }
+            }
+            else if(!IsCorrectMaterial(currentMat))
+            {
+                EditorGUILayout.HelpBox($"Material may not be configured correctly, check or reset to default", MessageType.Info);
+
+                if (GUILayout.Button("Update material settings to default"))
+                {
+                    ForceUpdateToDefaultOutlineMaterial(ref currentMat);
+                }
+            }
+
+            //Draw other properties
+            DrawPropertiesExcluding(serializedObject, nameof(m_Script), nameof(outlineMaterial));
+
+            if (EditorGUI.EndChangeCheck())
+                serializedObject.ApplyModifiedProperties();
+        }
+
+        private Material CreateNewMaterial()
+        {
+            var material = new Material(Shader.Find(standardShaderName));
+            ForceUpdateToDefaultOutlineMaterial(ref material);
+            AssetDatabase.CreateAsset(material, $"Assets/{Selection.activeGameObject.name}Mat.mat");
+            return material;
+        }
+
+        private void ForceUpdateToDefaultOutlineMaterial(ref Material material)
+        {
+            if (!IsCorrectShader(material))
+            {
+                material.shader = Shader.Find(standardShaderName);
+            }
+
+            foreach (var pair in defaultOutlineMaterialSettings)
+            {
+                switch (pair.Value.GetType().Name)
+                {
+                    case nameof(System.Single):
+                        material.SetFloat(pair.Key, (float)pair.Value);
+                        break;
+                    case nameof(System.Boolean):
+                        var val = (bool)pair.Value;
+                        if (val) 
+                        {
+                            material.EnableKeyword(pair.Key);
+                        }
+                        else
+                        {
+                            material.DisableKeyword(pair.Key);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        private bool IsCorrectMaterial(Material material)
+        {
+            if (!IsCorrectShader(material))
+            {
+                return false;
+            }
+
+            return defaultOutlineMaterialSettings.All(x => 
+            {
+                switch (x.Value.GetType().Name)
+                {
+                    case nameof(System.Single):
+                        return material.GetFloat(x.Key) == (float)x.Value;
+                    case nameof(System.Boolean):
+                        var val = (bool)x.Value;
+                        if (val)
+                        {
+                            return material.IsKeywordEnabled(x.Key);
+                        }
+                        else
+                        {
+                            return !material.IsKeywordEnabled(x.Key);
+                        }
+                    default:
+                        //default return value
+                        return false;
+                }
+            });
+        }
+
+        private bool IsCorrectShader(Material material)
+        {
+            return material.shader.name.Equals(standardShaderName);
+        }
+        private void DrawReadonlyPropertyField(SerializedProperty property, params GUILayoutOption[] options)
+        {
+            GUI.enabled = false;
+            EditorGUILayout.PropertyField(property, options);
+            GUI.enabled = true;
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
 {
     /// <summary>
     /// A custom inspector for BaseMeshOutline.
-    /// Used for create && fix outline material
+    /// Used for create or fix outline material
     /// </summary>
     [CustomEditor(typeof(BaseMeshOutline), true)]
     public class BaseMeshOutlineInspector : UnityEditor.Editor

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
         private SerializedProperty m_Script;
         private SerializedProperty outlineMaterial;
 
-        private readonly string standardShaderName = "Mixed Reality Toolkit/Standard";
+        private string MrtkStandardShaderName => StandardShaderUtility.MrtkStandardShaderName;
 
         private readonly Dictionary<string, object> defaultOutlineMaterialSettings = new Dictionary<string, object>()
         {
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
 
         private Material CreateNewMaterial()
         {
-            var material = new Material(Shader.Find(standardShaderName));
+            var material = new Material(Shader.Find(MrtkStandardShaderName));
             ForceUpdateToDefaultOutlineMaterial(ref material);
             AssetDatabase.CreateAsset(material, $"Assets/{Selection.activeGameObject.name}Mat.mat");
             return material;
@@ -86,7 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
         {
             if (!IsCorrectShader(material))
             {
-                material.shader = Shader.Find(standardShaderName);
+                material.shader = Shader.Find(MrtkStandardShaderName);
             }
 
             foreach (var pair in defaultOutlineMaterialSettings)
@@ -145,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.MeshOutline
 
         private bool IsCorrectShader(Material material)
         {
-            return material.shader.name.Equals(standardShaderName);
+            return material.shader.name.Equals(MrtkStandardShaderName);
         }
         private void DrawReadonlyPropertyField(SerializedProperty property, params GUILayoutOption[] options)
         {

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs.meta
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/MeshOutline/BaseMeshOutlineInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53217051b596a2542b2dfdf392741419
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Changes
- Fixes: #10657 

## Overview
Added simple inspector helper for BaseMeshOutline abstract class, 
used in MeshOutline && MeshOutlineHierarchy, (mb in other custom classes)

## Includes
- check current material settings
- force update material settings to default outline mat settings
- add new correct material

## Added
- Inspector for BaseMeshOutline abstract class