### PR TITLE
Adding nullchecks to tintables

### DIFF
--- a/com.microsoft.mrtk.uxcore/StateVisualizer/Effects/GraphicTintEffect.cs
+++ b/com.microsoft.mrtk.uxcore/StateVisualizer/Effects/GraphicTintEffect.cs
@@ -23,15 +23,22 @@ namespace Microsoft.MixedReality.Toolkit.UX
             /// <inheritdoc />
             protected override void ApplyColor(Color color)
             {
+                if (Tintables == null) { return; }
+
                 foreach (Graphic graphic in Tintables)
                 {
-                    graphic.color = color;
+                    if (graphic != null)
+                    {
+                        graphic.color = color;
+                    }
                 }
             }
 
             /// <inheritdoc />
             protected override Color GetColor()
             {
+                if (Tintables == null) { return default; }
+
                 if (Tintables.Count > 0 && Tintables[0] != null)
                 {
                     return Tintables[0].color;

--- a/com.microsoft.mrtk.uxcore/StateVisualizer/Effects/SpriteTintEffect.cs
+++ b/com.microsoft.mrtk.uxcore/StateVisualizer/Effects/SpriteTintEffect.cs
@@ -22,15 +22,22 @@ namespace Microsoft.MixedReality.Toolkit.UX
             /// <inheritdoc />
             protected override void ApplyColor(Color color)
             {
+                if (Tintables == null) { return; }
+
                 foreach (SpriteRenderer sprite in Tintables)
                 {
-                    sprite.color = color;
+                    if (sprite != null)
+                    {
+                        sprite.color = color;
+                    }
                 }
             }
 
             /// <inheritdoc />
             protected override Color GetColor()
             {
+                if (Tintables == null) { return default; }
+
                 if (Tintables.Count > 0 && Tintables[0] != null)
                 {
                     return Tintables[0].color;


### PR DESCRIPTION
## Overview
Adds nullchecks to tintables. Null tintables and uninitialized tintables list will no longer NRE and break StateViz effects.

For @katie-msft :) 

## Changes
- Fixes: #10685 
