### PR TITLE
Update OpenXR settings

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
@@ -261,7 +261,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: feeef8d85de8db242bdda70cc7ff5acd, type: 3}
   m_Name: OculusTouchControllerProfile Standalone
   m_EditorClassIdentifier: 
-  m_enabled: 0
+  m_enabled: 1
   nameUi: Oculus Touch Controller Profile
   version: 0.0.1
   featureIdInternal: com.unity.openxr.feature.input.oculustouch

--- a/UnityProjects/MRTKDevTemplate/Assets/XR/XRGeneralSettings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/XR/XRGeneralSettings.asset
@@ -78,7 +78,7 @@ MonoBehaviour:
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
   m_Loaders:
-  - {fileID: 11400000, guid: ec1db0b36e875074baa415e142f75b29, type: 2}
+  - {fileID: 11400000, guid: 1aff1d0a357cadb42b05e6d26e0d5f63, type: 2}
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Overview

1. Enables Oculus Touch controllers on Standalone for Oculus Link
2. Assign the correct OpenXR loader for UWP