### PR TITLE
Stateviz animator fix

### DIFF
--- a/com.microsoft.mrtk.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/com.microsoft.mrtk.uxcore/StateVisualizer/StateVisualizer.cs
@@ -18,6 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
     /// Requires <see cref="StatefulInteractable"/> and an <see cref="Animator"/>.
     /// </summary>
     [AddComponentMenu("MRTK/UX/State Visualizer")]
+    [RequireComponent(typeof(Animator))]
     public class StateVisualizer : MonoBehaviour
     {
         // How long to wait after effects report they're done

--- a/com.microsoft.mrtk.uxcore/Tests/Runtime/StateVisualizerTests.cs
+++ b/com.microsoft.mrtk.uxcore/Tests/Runtime/StateVisualizerTests.cs
@@ -301,5 +301,20 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
 
             Assert.IsFalse(sv.Animator.enabled, "StateVisualizer did not go back to sleep!");
         }
+
+        [UnityTest]
+        /// <summary>
+        /// Makes sure an Animator component is added when necessary.
+        /// </summary>
+        public IEnumerator TestAnimatorMissing()
+        {
+            GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.AddComponent<StatefulInteractable>();
+            cube.AddComponent<StateVisualizer>();
+
+            yield return null;
+
+            Assert.IsTrue(cube.GetComponent<Animator>() != null, "An animator wasn't automatically added when it was missing!");
+        }
     }
 }


### PR DESCRIPTION
## Overview
Makes `StateVisualizer` explicitly require an `Animator`. A test is included to verify.

## Changes
- Fixes: #10693