### PR TITLE
LastHoverExit fix

### DIFF
--- a/com.microsoft.mrtk.core/Editor/Inspectors/StatefulInteractableInspector.cs
+++ b/com.microsoft.mrtk.core/Editor/Inspectors/StatefulInteractableInspector.cs
@@ -28,8 +28,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializedProperty onDetoggled;
         private SerializedProperty onEnabled;
         private SerializedProperty onDisabled;
-        static bool advancedFoldout = false;
-        static bool enabledEventsFoldout = false;
+        private static bool advancedFoldout = false;
+        private static bool enabledEventsFoldout = false;
 
         protected override void OnEnable()
         {

--- a/com.microsoft.mrtk.core/Editor/Inspectors/StatefulInteractableInspector.cs
+++ b/com.microsoft.mrtk.core/Editor/Inspectors/StatefulInteractableInspector.cs
@@ -26,6 +26,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializedProperty onClicked;
         private SerializedProperty onToggled;
         private SerializedProperty onDetoggled;
+        private SerializedProperty onEnabled;
+        private SerializedProperty onDisabled;
+        static bool advancedFoldout = false;
+        static bool enabledEventsFoldout = false;
 
         protected override void OnEnable()
         {
@@ -51,12 +55,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             onClicked = SetUpProperty(nameof(onClicked));
 
+            onEnabled = SetUpProperty(nameof(onEnabled));
+            onDisabled = SetUpProperty(nameof(onDisabled));
+
             // OnToggle/Detoggle aliases to IsToggled.OnEntered/IsToggled.OnExited
             onToggled = isToggled.FindPropertyRelative("onEntered");
             onDetoggled = isToggled.FindPropertyRelative("onExited");
         }
-
-        static bool advancedFoldout = false;
 
         protected override void DrawProperties()
         {
@@ -171,6 +176,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 EditorGUILayout.Space();
 
                 DrawTimedFlag(isToggled, interactable.IsToggled, previousGUIColor, Color.cyan);
+                
+                enabledEventsFoldout = EditorGUILayout.Foldout(enabledEventsFoldout, "OnEnable/Disable", true);
+                
+                if (enabledEventsFoldout)
+                {
+                    EditorGUILayout.PropertyField(onEnabled);
+                    EditorGUILayout.PropertyField(onDisabled);
+                }
             }
 
             EditorGUILayout.Space();

--- a/com.microsoft.mrtk.uxcore/Button/PressableButton.cs
+++ b/com.microsoft.mrtk.uxcore/Button/PressableButton.cs
@@ -425,6 +425,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         protected override void OnHoverEntered(HoverEnterEventArgs args)
         {
             base.OnHoverEntered(args);
+
             // If we decide this interactor has begun its hover in a well-behaved way,
             // we add it to our hashset of valid pokes.
             if (args.interactorObject is IPokeInteractor pokeInteractor && !IsOutsideFootprint(pokeInteractor.PokeTrajectory.End, 0.0001f))
@@ -445,6 +446,8 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// <inheritdoc />
         protected override void OnHoverExited(HoverExitEventArgs args)
         {
+            base.OnHoverExited(args);
+
             if (args.interactorObject is IPokeInteractor pokeInteractor)
             {
                 // Remove from our valid poke hashset if it was registered there.


### PR DESCRIPTION
## Overview
`PressableButton` was squashing `LastHoverExit`s by not calling the base impl.

## Changes
- This fixes that.
- Also makes the OnEnable/OnDisable events in the inspector not ugly, which was bothering me for a while 🙃
