### PR TITLE
Update MR OpenXR to 1.4.2

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
@@ -108,6 +108,7 @@ MonoBehaviour:
   priority: 0
   required: 1
   disableFirstPersonObserver: 0
+  enablePoseUpdateOnBeforeRender: 0
 --- !u!114 &-7232978043429515688
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -164,6 +165,7 @@ MonoBehaviour:
   priority: 0
   required: 1
   disableFirstPersonObserver: 0
+  enablePoseUpdateOnBeforeRender: 0
 --- !u!114 &-6481664739586093490
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProjects/MRTKDevTemplate/Packages/manifest.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.microsoft.mixedreality.openxr": "file:../../../ExternalDependencies/com.microsoft.mixedreality.openxr-1.4.1.tgz",
+    "com.microsoft.mixedreality.openxr": "file:../../../ExternalDependencies/com.microsoft.mixedreality.openxr-1.4.2.tgz",
     "com.microsoft.mixedreality.visualprofiler": "https://github.com/microsoft/VisualProfiler-Unity.git",
     "com.microsoft.mrtk.accessibility": "file:../../../com.microsoft.mrtk.accessibility",
     "com.microsoft.mrtk.audio": "file:../../../com.microsoft.mrtk.audio",

--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.microsoft.mixedreality.openxr": {
-      "version": "file:../../../ExternalDependencies/com.microsoft.mixedreality.openxr-1.4.1.tgz",
+      "version": "file:../../../ExternalDependencies/com.microsoft.mixedreality.openxr-1.4.2.tgz",
       "depth": 0,
       "source": "local-tarball",
       "dependencies": {


### PR DESCRIPTION
## Overview

Update MR OpenXR to 1.4.2

## [1.4.2] - Current Release

* Fixed a bug where the anchors are located incorrectly after user clear all holograms in user's settings page.
* Fixed a bug where rendering framerate might be dropped due to hand and controller tracking cost.
* Fixed a bug where ARPlanes might be incorrectly reported as updated or removed before they are reported as added.
* Added feature validation to warn developer about missing internet capabilities in appxmanifest for remoting apps.