### PR TITLE
Prefab/undo fixes for FontIconSelectorInspector

### DIFF
--- a/com.microsoft.mrtk.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
+++ b/com.microsoft.mrtk.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
@@ -95,7 +95,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     GUILayout.MaxHeight(buttonHeight),
                     GUILayout.MaxWidth(buttonWidth)))
                 {
+                    Undo.RecordObjects(new UnityEngine.Object[]{fontIconSelector, fontIconSelector.TextMeshProComponent}, "Changed icon");
                     fontIconSelector.CurrentIconName = iconName;
+                    PrefabUtility.RecordPrefabInstancePropertyModifications(fontIconSelector);
+                    PrefabUtility.RecordPrefabInstancePropertyModifications(fontIconSelector.TextMeshProComponent);
                 }
                 Rect textureRect = GUILayoutUtility.GetLastRect();
                 FontIconSetInspector.EditorDrawTMPGlyph(textureRect, unicodeValue, fontAsset, selected);

--- a/com.microsoft.mrtk.uxcore/FontIcons/FontIconSelector.cs
+++ b/com.microsoft.mrtk.uxcore/FontIcons/FontIconSelector.cs
@@ -8,26 +8,32 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.UX
 {
     /// <summary>
-    /// A Component that can be used to select a specific icon for display via a TextMeshPro component.
+    /// Allows the user to select a specific icon for display via a TextMeshPro component.
+    /// See <see cref="FontIconSelectorInspector"/> for the majority of the user-facing editor code.
     /// </summary>
-    [Serializable]
     [AddComponentMenu("MRTK/UX/Font Icon Selector")]
     public class FontIconSelector : MonoBehaviour
     {
         [Tooltip("The FontIconSet scriptable object that contains the icons available for use.")]
         [SerializeField]
         private FontIconSet fontIcons;
+
+        /// <summary>
+        /// The FontIconSet ScriptableObject that contains the icons
+        /// available for use, and their human-readable names.
+        /// </summary>
         public FontIconSet FontIcons => fontIcons;
 
-        [Tooltip("The currently selected icon by name.")]
+        [Tooltip("The currently selected icon's name, as defined by the FontIconSet ScriptableObject.")]
         [SerializeField]
         private string currentIconName;
+
+        /// <summary>
+        /// The currently selected icon's name, as defined by the FontIconSet ScriptableObject.
+        /// </summary>
         public string CurrentIconName
         {
-            get
-            {
-                return currentIconName;
-            }
+            get => currentIconName;
 
             set
             {
@@ -38,12 +44,16 @@ namespace Microsoft.MixedReality.Toolkit.UX
             }
         }
 
-        [Tooltip("The TextMeshPro Component to be used to show the icon.")]
+        [Tooltip("The TextMeshPro used to show the icon.")]
         [SerializeField]
         private TMP_Text textMeshProComponent;
+
+        /// <summary>
+        /// The TextMeshPro used to show the icon.
+        /// </summary>
         public TMP_Text TextMeshProComponent => textMeshProComponent;
 
-        protected void Awake()
+        private void Awake()
         {
             if (textMeshProComponent == null)
             {
@@ -57,15 +67,14 @@ namespace Microsoft.MixedReality.Toolkit.UX
             SetIcon(currentIconName);
         }
 
-        /// <summary>
-        /// A TextMeshPro Font Asset that contains the desired icons as glyphs that map to Unicode character values.
-        /// </summary>
-        public TMP_FontAsset IconFontAsset => iconFontAsset;
-
         [Tooltip("Any TextMeshPro Font Asset that contains the desired icons as glyphs that map to Unicode character values.")]
         [SerializeField]
         private TMP_FontAsset iconFontAsset = null;
 
+        /// <summary>
+        /// A TextMeshPro Font Asset that contains the desired icons as glyphs that map to Unicode character values.
+        /// </summary>
+        public TMP_FontAsset IconFontAsset => iconFontAsset;
 
         private void SetIcon(string newIconName)
         {


### PR DESCRIPTION
## Overview
The FontIconSelector wasn't correctly recording changes to objects when it was updating icons, resulting in broken prefab modifications and all kinds of chaos. Fixes problems associated with #10706.

## Changes
- Fixes: that.
- Cleans up `FontIconSelector`, adding missing doccomments, etc
