### PR TITLE
Fix ArgumentNullException: Value cannot be null. Parameter name: _unity_self

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRCameraSettings.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRCameraSettings.cs
@@ -87,7 +87,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         #region IMixedRealityCameraSettings
 
         /// <inheritdoc/>
-        public override bool IsOpaque => XRSubsystemHelpers.DisplaySubsystem?.displayOpaque ?? true;
+        public override bool IsOpaque =>
+            XRSubsystemHelpers.DisplaySubsystem == null
+            || !XRSubsystemHelpers.DisplaySubsystem.running
+            || XRSubsystemHelpers.DisplaySubsystem.displayOpaque;
 
         #endregion IMixedRealityCameraSettings
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
@@ -71,7 +71,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         #region IMixedRealityCameraSettings
 
         /// <inheritdoc/>
-        public override bool IsOpaque => XRSubsystemHelpers.DisplaySubsystem?.displayOpaque ?? true;
+        public override bool IsOpaque =>
+            XRSubsystemHelpers.DisplaySubsystem == null
+            || !XRSubsystemHelpers.DisplaySubsystem.running
+            || XRSubsystemHelpers.DisplaySubsystem.displayOpaque;
 
         #endregion IMixedRealityCameraSettings
     }

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
@@ -41,7 +41,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         #region IMixedRealityCameraSettings
 
         /// <inheritdoc/>
-        public override bool IsOpaque => XRSubsystemHelpers.DisplaySubsystem?.displayOpaque ?? true;
+        public override bool IsOpaque =>
+            XRSubsystemHelpers.DisplaySubsystem == null
+            || !XRSubsystemHelpers.DisplaySubsystem.running
+            || XRSubsystemHelpers.DisplaySubsystem.displayOpaque;
 
 #if SPATIALTRACKING_ENABLED
         /// <inheritdoc/>


### PR DESCRIPTION
## Overview

This tends to happen when you reference a subsystem that isn't running

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9036 (at least, explicitly Issue 3. Issue 1 may be fixed with some changes I made to Windows XR Plugin a while back, and I haven't been able to repro Issue 2)
