### PR TITLE
Update CameraCache failure case + perf

### DIFF
--- a/Assets/MRTK/Core/Utilities/CameraCache.cs
+++ b/Assets/MRTK/Core/Utilities/CameraCache.cs
@@ -31,14 +31,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 }
 
                 // If the cached camera is null, search for main
-                var mainCamera = Camera.main;
+                Camera mainCamera = Camera.main;
 
                 if (mainCamera == null)
                 {
                     Debug.Log("No main camera found. Searching for cameras in the scene.");
 
                     // If no main camera was found, try to determine one.
-                    Camera[] cameras = GameObject.FindObjectsOfType<Camera>();
+                    Camera[] cameras = Object.FindObjectsOfType<Camera>();
                     if (cameras.Length == 0)
                     {
                         Debug.LogWarning("No cameras found. Creating a \"MainCamera\".");
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     }
                     else
                     {
-                        Debug.LogWarning("The Mixed Reality Toolkit was unable to determine a main camera. Please tag the scene's primary camera as \"MainCamera\", in the hierarchy.");
+                        Debug.LogError("The Mixed Reality Toolkit was unable to determine a main camera. Please tag the scene's primary camera as \"MainCamera\", in the hierarchy.");
                     }
                 }
 

--- a/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
         {
             get
             {
-                currentDisplayType = DisplayType.Opaque;
+                DisplayType currentDisplayType = DisplayType.Opaque;
 
                 IReadOnlyList<IMixedRealityCameraSettingsProvider> dataProviders = GetDataProviders<IMixedRealityCameraSettingsProvider>();
                 if (dataProviders.Count > 0)
@@ -87,7 +87,6 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
         /// <inheritdoc/>
         public MixedRealityCameraProfile CameraProfile => ConfigurationProfile as MixedRealityCameraProfile;
 
-        private DisplayType currentDisplayType;
         private bool cameraOpaqueLastFrame = false;
 
         /// <summary>
@@ -140,7 +139,7 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
             {
                 cameraOpaqueLastFrame = IsOpaque;
 
-                if (IsOpaque)
+                if (cameraOpaqueLastFrame)
                 {
                     ApplySettingsForOpaqueDisplay();
                 }
@@ -212,11 +211,13 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
             {
                 base.Update();
 
-                if (IsOpaque != cameraOpaqueLastFrame)
-                {
-                    cameraOpaqueLastFrame = IsOpaque;
+                bool cameraOpaqueThisFrame = IsOpaque;
 
-                    if (IsOpaque)
+                if (cameraOpaqueThisFrame != cameraOpaqueLastFrame)
+                {
+                    cameraOpaqueLastFrame = cameraOpaqueThisFrame;
+
+                    if (cameraOpaqueThisFrame)
                     {
                         ApplySettingsForOpaqueDisplay();
                     }


### PR DESCRIPTION
## Overview

Upgrades the "no main camera found, but at least one camera found in the scene" case to an error. There are too many assumptions MRTK would have to make to handle any other case, like auto-tagging existing camera.

Also adds a cache for `IsOpaque` in some hot loops, which can be expensive.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9395 (essentially, at least, by upgrading the log to an error.)

