### PR TITLE
Fix NullReferenceException when opening PointerProfile without main camera in scene

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -110,18 +110,22 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
                     EditorGUILayout.Space();
 
-                    var gazeProvider = CameraCache.Main.GetComponent<IMixedRealityGazeProvider>();
-                    CreateCachedEditor((Object)gazeProvider, null, ref gazeProviderEditor);
                     showGazeProviderProperties = EditorGUILayout.Foldout(showGazeProviderProperties, "Gaze Provider Settings", true, boldFoldout);
-                    if (showGazeProviderProperties && !gazeProviderEditor.IsNull())
+                    if (showGazeProviderProperties && CameraCache.Main != null)
                     {
+                        var gazeProvider = CameraCache.Main.GetComponent<IMixedRealityGazeProvider>();
+                        CreateCachedEditor((Object)gazeProvider, null, ref gazeProviderEditor);
+
                         // Provide a convenient way to toggle the gaze provider as enabled/disabled via editor
                         gazeProvider.Enabled = EditorGUILayout.Toggle("Enable Gaze Provider", gazeProvider.Enabled);
 
-                        using (new EditorGUI.IndentLevelScope())
+                        if (gazeProviderEditor != null)
                         {
-                            // Draw out the rest of the Gaze Provider's settings
-                            gazeProviderEditor.OnInspectorGUI();
+                            using (new EditorGUI.IndentLevelScope())
+                            {
+                                // Draw out the rest of the Gaze Provider's settings
+                                gazeProviderEditor.OnInspectorGUI();
+                            }
                         }
                     }
                 }

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -564,10 +564,10 @@ namespace Microsoft.MixedReality.Toolkit
 
         private void EnsureEditorSetup()
         {
-            if (ActiveProfile.RenderDepthBuffer)
+            if (ActiveProfile.RenderDepthBuffer && CameraCache.Main != null)
             {
-                CameraCache.Main.gameObject.EnsureComponent<DepthBufferRenderer>();
-                DebugUtilities.LogVerbose("Added a DepthBufferRenderer to the main camera");
+                CameraCache.Main.EnsureComponent<DepthBufferRenderer>();
+                DebugUtilities.LogVerbose("Added a DepthBufferRenderer to the main camera.");
             }
         }
 
@@ -575,20 +575,22 @@ namespace Microsoft.MixedReality.Toolkit
         {
             // There's lots of documented cases that if the camera doesn't start at 0,0,0, things break with the WMR SDK specifically.
             // We'll enforce that here, then tracking can update it to the appropriate position later.
-            CameraCache.Main.transform.position = Vector3.zero;
-            CameraCache.Main.transform.rotation = Quaternion.identity;
+            if (CameraCache.Main != null)
+            {
+                CameraCache.Main.transform.SetPositionAndRotation(Vector3.zero, Quaternion.identity);
+            }
 
             // This will create the playspace
             _ = MixedRealityPlayspace.Transform;
 
             bool addedComponents = false;
-            if (!Application.isPlaying)
+            if (!Application.isPlaying && CameraCache.Main != null)
             {
-                var eventSystems = FindObjectsOfType<EventSystem>();
+                EventSystem[] eventSystems = FindObjectsOfType<EventSystem>();
 
                 if (eventSystems.Length == 0)
                 {
-                    CameraCache.Main.gameObject.EnsureComponent<EventSystem>();
+                    CameraCache.Main.EnsureComponent<EventSystem>();
                     addedComponents = true;
                 }
                 else
@@ -611,10 +613,10 @@ namespace Microsoft.MixedReality.Toolkit
                 }
             }
 
-            if (!addedComponents)
+            if (!addedComponents && CameraCache.Main != null)
             {
-                CameraCache.Main.gameObject.EnsureComponent<EventSystem>();
-                DebugUtilities.LogVerbose("Added an EventSystem to the main camera");
+                CameraCache.Main.EnsureComponent<EventSystem>();
+                DebugUtilities.LogVerbose("Added an EventSystem to the main camera.");
             }
         }
 

--- a/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -102,13 +102,14 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
         {
             base.Initialize();
 
-            MixedRealityCameraProfile profile = ConfigurationProfile as MixedRealityCameraProfile;
+            MixedRealityCameraProfile profile = CameraProfile;
             var cameraSettingProviders = GetDataProviders<IMixedRealityCameraSettingsProvider>();
 
             if ((cameraSettingProviders.Count == 0) && (profile != null))
             {
+                int settingsConfigurationsLength = profile.SettingsConfigurations.Length;
                 // Register the settings providers.
-                for (int i = 0; i < profile.SettingsConfigurations.Length; i++)
+                for (int i = 0; i < settingsConfigurationsLength; i++)
                 {
                     MixedRealityCameraSettingsConfiguration configuration = profile.SettingsConfigurations[i];
 

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -309,7 +309,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void InstantiateGazeProvider(MixedRealityPointerProfile pointerProfile)
         {
-            if (pointerProfile != null && pointerProfile.GazeProviderType?.Type != null)
+            if (pointerProfile != null && pointerProfile.GazeProviderType?.Type != null && CameraCache.Main != null)
             {
                 IMixedRealityGazeProvider existingGazeProvider = CameraCache.Main.gameObject.GetComponent<IMixedRealityGazeProvider>();
                 if (existingGazeProvider != null && existingGazeProvider.GetType() != pointerProfile.GazeProviderType.Type)
@@ -336,7 +336,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             else
             {
                 Debug.LogError("The input system is missing the required GazeProviderType!");
-                return;
             }
         }
 


### PR DESCRIPTION
## Overview

Added a handful of null checks for `CameraCache.Main` and updated some paths to use existing helper functions. This will help reduce the likelihood of hitting null refs when a camera isn't properly tagged as "main".

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/10712
