### PR TITLE
Add support for editTimeDisplayType

### DIFF
--- a/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
+++ b/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
@@ -20,6 +20,12 @@ namespace Microsoft.MixedReality.Toolkit
     public class MixedRealityCameraProfile : BaseMixedRealityProfile
     {
         [SerializeField]
+        [Tooltip("The camera settings to apply at edit time, for ease of building a specific type of experience.")]
+        private DisplayType editTimeDisplayType = DisplayType.Transparent;
+
+        internal DisplayType EditTimeDisplayType => editTimeDisplayType;
+
+        [SerializeField]
         [Tooltip("Configuration objects describing the registered settings providers.")]
         private MixedRealityCameraSettingsConfiguration[] settingsConfigurations = new MixedRealityCameraSettingsConfiguration[0];
 

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -19,6 +19,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private bool showDisplaySettings = false;
         private const string showDisplaySettingsPreferenceKey = "ShowCameraSystem_DisplaySettings_PreferenceKey";
 
+        private SerializedProperty editTimeDisplayType;
+
         private SerializedProperty opaqueNearClip;
         private SerializedProperty opaqueFarClip;
         private SerializedProperty opaqueClearFlags;
@@ -48,6 +50,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             base.OnEnable();
 
+            editTimeDisplayType = serializedObject.FindProperty("editTimeDisplayType");
+
             opaqueNearClip = serializedObject.FindProperty("nearClipPlaneOpaqueDisplay");
             opaqueFarClip = serializedObject.FindProperty("farClipPlaneOpaqueDisplay");
             opaqueClearFlags = serializedObject.FindProperty("cameraClearFlagsOpaqueDisplay");
@@ -72,6 +76,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             using (new EditorGUI.DisabledGroupScope(IsProfileLock((BaseMixedRealityProfile)target)))
             {
                 serializedObject.Update();
+
+                EditorGUILayout.PropertyField(editTimeDisplayType);
 
                 RenderFoldout(ref showProviders, "Camera Settings Providers", () =>
                 {

--- a/Assets/MRTK/Core/Providers/BaseCameraSettingsProvider.cs
+++ b/Assets/MRTK/Core/Providers/BaseCameraSettingsProvider.cs
@@ -20,34 +20,41 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
             string name = null,
             uint priority = DefaultPriority,
             BaseCameraSettingsProfile profile = null) : base(cameraSystem, name, priority, profile)
-        { }
+        {
+            CameraProfile = cameraSystem?.CameraProfile;
+        }
+
+        protected MixedRealityCameraProfile CameraProfile { get; }
 
         /// <inheritdoc/>
-        public virtual bool IsOpaque { get; } = false;
+        public virtual bool IsOpaque =>
+            Application.isEditor
+            && !Application.isPlaying
+            && CameraProfile != null
+            && CameraProfile.EditTimeDisplayType == DisplayType.Opaque;
 
         /// <inheritdoc/>
         public virtual void ApplyConfiguration()
         {
             // It is the responsibility of the camera settings provider to set the display settings (this allows overriding the
             // default values with per-camera provider values).
-            MixedRealityCameraProfile cameraProfile = Service?.CameraProfile;
-            if (cameraProfile == null) { return; }
+            if (CameraProfile == null || CameraCache.Main == null) { return; }
 
             if (IsOpaque)
             {
-                CameraCache.Main.clearFlags = cameraProfile.CameraClearFlagsOpaqueDisplay;
-                CameraCache.Main.nearClipPlane = cameraProfile.NearClipPlaneOpaqueDisplay;
-                CameraCache.Main.farClipPlane = cameraProfile.FarClipPlaneOpaqueDisplay;
-                CameraCache.Main.backgroundColor = cameraProfile.BackgroundColorOpaqueDisplay;
-                QualitySettings.SetQualityLevel(cameraProfile.OpaqueQualityLevel, false);
+                CameraCache.Main.clearFlags = CameraProfile.CameraClearFlagsOpaqueDisplay;
+                CameraCache.Main.nearClipPlane = CameraProfile.NearClipPlaneOpaqueDisplay;
+                CameraCache.Main.farClipPlane = CameraProfile.FarClipPlaneOpaqueDisplay;
+                CameraCache.Main.backgroundColor = CameraProfile.BackgroundColorOpaqueDisplay;
+                QualitySettings.SetQualityLevel(CameraProfile.OpaqueQualityLevel, false);
             }
             else
             {
-                CameraCache.Main.clearFlags = cameraProfile.CameraClearFlagsTransparentDisplay;
-                CameraCache.Main.backgroundColor = cameraProfile.BackgroundColorTransparentDisplay;
-                CameraCache.Main.nearClipPlane = cameraProfile.NearClipPlaneTransparentDisplay;
-                CameraCache.Main.farClipPlane = cameraProfile.FarClipPlaneTransparentDisplay;
-                QualitySettings.SetQualityLevel(cameraProfile.TransparentQualityLevel, false);
+                CameraCache.Main.clearFlags = CameraProfile.CameraClearFlagsTransparentDisplay;
+                CameraCache.Main.backgroundColor = CameraProfile.BackgroundColorTransparentDisplay;
+                CameraCache.Main.nearClipPlane = CameraProfile.NearClipPlaneTransparentDisplay;
+                CameraCache.Main.farClipPlane = CameraProfile.FarClipPlaneTransparentDisplay;
+                QualitySettings.SetQualityLevel(CameraProfile.TransparentQualityLevel, false);
             }
         }
     }

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -26,7 +26,7 @@ RenderSettings:
   m_AmbientIntensity: 1
   m_AmbientMode: 0
   m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
-  m_SkyboxMaterial: {fileID: 0}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
   m_FlareFadeSpeed: 3

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRCameraSettings.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXRCameraSettings.cs
@@ -88,6 +88,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
         /// <inheritdoc/>
         public override bool IsOpaque =>
+            (Application.isEditor && !Application.isPlaying) ?
+            base.IsOpaque :
             XRSubsystemHelpers.DisplaySubsystem == null
             || !XRSubsystemHelpers.DisplaySubsystem.running
             || XRSubsystemHelpers.DisplaySubsystem.displayOpaque;

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityCameraSettings.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
 
 #if UNITY_WSA
 using UnityEngine.XR.WSA;
@@ -40,6 +41,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 
         /// <inheritdoc/>
         public override bool IsOpaque =>
+            (Application.isEditor && !Application.isPlaying) ?
+            base.IsOpaque :
 #if UNITY_WSA
             HolographicSettings.IsDisplayOpaque;
 #else

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityCameraSettings.cs
@@ -72,6 +72,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
         /// <inheritdoc/>
         public override bool IsOpaque =>
+            (Application.isEditor && !Application.isPlaying) ?
+            base.IsOpaque :
             XRSubsystemHelpers.DisplaySubsystem == null
             || !XRSubsystemHelpers.DisplaySubsystem.running
             || XRSubsystemHelpers.DisplaySubsystem.displayOpaque;

--- a/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
+++ b/Assets/MRTK/Providers/XRSDK/GenericXRSDKCameraSettings.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
 
 #if SPATIALTRACKING_ENABLED
 using UnityEngine.SpatialTracking;
@@ -42,6 +43,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
 
         /// <inheritdoc/>
         public override bool IsOpaque =>
+            (Application.isEditor && !Application.isPlaying) ?
+            base.IsOpaque :
             XRSubsystemHelpers.DisplaySubsystem == null
             || !XRSubsystemHelpers.DisplaySubsystem.running
             || XRSubsystemHelpers.DisplaySubsystem.displayOpaque;

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealityCameraProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealityCameraProfile.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: DefaultMixedRealityCameraProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
+  editTimeDisplayType: 1
   settingsConfigurations:
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.WindowsMixedRealityCameraSettings,

--- a/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: DefaultHoloLens1CameraProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
+  editTimeDisplayType: 1
   settingsConfigurations:
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.WindowsMixedRealityCameraSettings,
@@ -44,9 +45,9 @@ MonoBehaviour:
     settingsProfile: {fileID: 11400000, guid: 32349edfa9bacb94a9fe58923e9a2400, type: 2}
   nearClipPlaneOpaqueDisplay: 0.3
   farClipPlaneOpaqueDisplay: 1000
-  cameraClearFlagsOpaqueDisplay: 2
+  cameraClearFlagsOpaqueDisplay: 1
   backgroundColorOpaqueDisplay: {r: 0, g: 0, b: 0, a: 1}
-  opaqueQualityLevel: 0
+  opaqueQualityLevel: 5
   nearClipPlaneTransparentDisplay: 0.3
   farClipPlaneTransparentDisplay: 50
   cameraClearFlagsTransparentDisplay: 2

--- a/Assets/MRTK/SDK/Profiles/HoloLens2/DefaultHoloLens2CameraProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/HoloLens2/DefaultHoloLens2CameraProfile.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: DefaultHoloLens2CameraProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
+  editTimeDisplayType: 1
   settingsConfigurations:
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.WindowsMixedRealityCameraSettings,
@@ -44,9 +45,9 @@ MonoBehaviour:
     settingsProfile: {fileID: 11400000, guid: 32349edfa9bacb94a9fe58923e9a2400, type: 2}
   nearClipPlaneOpaqueDisplay: 0.1
   farClipPlaneOpaqueDisplay: 1000
-  cameraClearFlagsOpaqueDisplay: 2
+  cameraClearFlagsOpaqueDisplay: 1
   backgroundColorOpaqueDisplay: {r: 0, g: 0, b: 0, a: 1}
-  opaqueQualityLevel: 0
+  opaqueQualityLevel: 5
   nearClipPlaneTransparentDisplay: 0.1
   farClipPlaneTransparentDisplay: 50
   cameraClearFlagsTransparentDisplay: 2


### PR DESCRIPTION
## Overview

This is something I've had rattling in my head for a bit. Allows for a dev to specify which display type they want the editor to show for edit-time design.

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9991

