### PR TITLE
Making HeroShadow.mat use new alpha gradient feature

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Prefabs/CanvasExample/HeroShadow.mat
+++ b/UnityProjects/MRTKDevTemplate/Assets/Prefabs/CanvasExample/HeroShadow.mat
@@ -42,7 +42,7 @@ Material:
     - _AlbedoAssignedAtRuntime: 0
     - _Bevel_Radius_: 0.4
     - _Bias_: 0.5
-    - _BlendOp: 2
+    - _BlendOp: 0
     - _Blend_Exponent_: 1
     - _BlendedClippingWidth: 1
     - _BlurBorderIntensity: 0
@@ -63,7 +63,7 @@ Material:
     - _CustomMode: 2
     - _Cutoff: 0.5
     - _DirectionalLight: 0
-    - _DstBlend: 1
+    - _DstBlend: 10
     - _EdgeSmoothingMode: 1
     - _EdgeSmoothingValue: 0.5
     - _EnableChannelMap: 0
@@ -98,7 +98,7 @@ Material:
     - _Max_Intensity_: 0.5
     - _Metallic: 0
     - _MipmapBias: -2
-    - _Mode: 5
+    - _Mode: 2
     - _Motion_: 0
     - _NearLightFade: 0
     - _NearPlaneFade: 0
@@ -121,7 +121,7 @@ Material:
     - _Smoothness: 0.5
     - _SpecularHighlights: 1
     - _SphericalHarmonics: 0
-    - _SrcBlend: 1
+    - _SrcBlend: 5
     - _Stencil: 0
     - _StencilComp: 0
     - _StencilComparison: 0
@@ -153,10 +153,12 @@ Material:
     - _EnvironmentColorX: {r: 1, g: 0, b: 0, a: 1}
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
-    - _GradientColor0: {r: 0, g: 0, b: 0, a: 0.45633632}
-    - _GradientColor1: {r: 0.6415094, g: 0.6415094, b: 0.6415094, a: 1}
-    - _GradientColor2: {r: 0.6415094, g: 0.6415094, b: 0.6415094, a: 1}
-    - _GradientColor3: {r: 0.6415094, g: 0.6415094, b: 0.6415094, a: 1}
+    - _GradientAlpha: {r: 0, g: 0.7411765, b: 0.7411765, a: 0.7411765}
+    - _GradientAlphaTime: {r: 0.54706645, g: 1, b: 1, a: 1}
+    - _GradientColor0: {r: 0, g: 0, b: 0, a: 0}
+    - _GradientColor1: {r: 0, g: 0, b: 0, a: 1}
+    - _GradientColor2: {r: 0, g: 0, b: 0, a: 1}
+    - _GradientColor3: {r: 0, g: 0, b: 0, a: 1}
     - _GradientColor4: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 1, g: 1, b: 1, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.75}


### PR DESCRIPTION
## Overview
A previous breaking change regarding material blend modes in MRGT broke our `CanvasExample` hero button shadows. This takes advantage of the new alpha gradient feature in MRGT and fixes the shadows.

## Changes
- Adjusts gradient on `HeroShadow.mat` in sample scene.

![image](https://user-images.githubusercontent.com/5544935/178350561-d13bdea6-ebf5-4d13-9f59-1d9b5c661d23.png)

