### PR TITLE
Caching get component calls and removing hot path risks

### DIFF
--- a/com.microsoft.mrtk.spatialmanipulation/BoundsControl/BoundsCalculator.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/BoundsControl/BoundsCalculator.cs
@@ -69,9 +69,10 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             totalBoundsCorners.Clear();
             childTransforms.Clear();
             containsCanvas = false;
+            target.GetComponentsInChildren<Transform>(includeInactiveObjects, childTransforms);
 
             // Iterate transforms and collect bound volumes
-            foreach (Transform childTransform in target.GetComponentsInChildren<Transform>(includeInactiveObjects))
+            foreach (Transform childTransform in childTransforms)
             {
                 // Reject if child of exclude 
                 if (childTransform.IsChildOf(exclude)) { continue; }

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/DirectionalIndicator.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/DirectionalIndicator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
 
@@ -51,6 +52,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
         private bool indicatorShown = false;
 
+        // Private scratchpad to reduce allocs.
+        private static List<Renderer> childRenderers = new List<Renderer>();
+
         protected override void Start()
         {
             base.Start();
@@ -88,8 +92,10 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         private void SetIndicatorVisibility(bool showIndicator)
         {
             SolverHandler.UpdateSolvers = showIndicator;
+            childRenderers.Clear();
+            GetComponentsInChildren<Renderer>(childRenderers);
 
-            foreach (var renderer in GetComponentsInChildren<Renderer>())
+            foreach (var renderer in childRenderers)
             {
                 renderer.enabled = showIndicator;
             }

--- a/com.microsoft.mrtk.spatialmanipulation/Utilities/Solver.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Utilities/Solver.cs
@@ -223,6 +223,21 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             }
 
             currentLifetime = 0;
+
+            // Register the solver with it's solver hander
+            if (SolverHandler != null)
+            {
+                SolverHandler.RegisterSolver(this);
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            // Unregister the solver with it's solver hander
+            if (SolverHandler != null)
+            {
+                SolverHandler.UnregisterSolver(this);
+            }
         }
 
         protected virtual void Start()
@@ -248,18 +263,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
                 {
                     controllerLookup = lookups[0];
                 }
-            }
-
-            if (SolverHandler != null)
-            {
-                SolverHandler.RegisterSolver(this);
-            }
-        }
-        protected virtual void OnDestroy()
-        {
-            if (SolverHandler != null)
-            {
-                SolverHandler.UnregisterSolver(this);
             }
         }
 

--- a/com.microsoft.mrtk.spatialmanipulation/Utilities/SolverHandler.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Utilities/SolverHandler.cs
@@ -389,7 +389,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// <summary>
         /// Adds <paramref name="solver"/> to the list of <see cref="Solvers"/> guaranteeing inspector ordering.
         /// </summary>
-        public void RegisterSolver(Solver solver)
+        internal void RegisterSolver(Solver solver)
         {
             if (!solvers.Contains(solver))
             {
@@ -407,7 +407,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// <summary>
         /// Removes <paramref name="solver"/> from the list of <see cref="Solvers"/>.
         /// </summary>
-        public void UnregisterSolver(Solver solver)
+        internal void UnregisterSolver(Solver solver)
         {
             solvers.Remove(solver);
         }

--- a/com.microsoft.mrtk.spatialmanipulation/Utilities/SolverHandler.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Utilities/SolverHandler.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.Subsystems;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -192,7 +191,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             set => updateSolvers = value;
         }
 
-        protected readonly List<Solver> solvers = new List<Solver>();
+        protected List<Solver> solvers = new List<Solver>();
 
         /// <summary>
         /// List of solvers that this handler will manage and update.
@@ -388,11 +387,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         public void RegisterSolver(Solver solver)
         {
+            GetComponents<Solver>(solvers);
+
             if (!solvers.Contains(solver))
             {
                 solvers.Add(solver);
-                IEnumerable<Solver> inspectorOrderedSolvers = GetComponents<Solver>().Intersect(solvers);
-                Solvers = inspectorOrderedSolvers.Union(Solvers).ToReadOnlyCollection();
             }
         }
 

--- a/com.microsoft.mrtk.spatialmanipulation/Utilities/SolverHandler.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Utilities/SolverHandler.cs
@@ -193,7 +193,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         }
 
         protected readonly List<Solver> solvers = new List<Solver>();
-        private bool updateSolversList = false;
 
         /// <summary>
         /// List of solvers that this handler will manage and update.
@@ -346,14 +345,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
         private void LateUpdate()
         {
-            if (updateSolversList)
-            {
-                IEnumerable<Solver> inspectorOrderedSolvers = GetComponents<Solver>().Intersect(solvers);
-                Solvers = inspectorOrderedSolvers.Union(Solvers).ToReadOnlyCollection();
-
-                updateSolversList = false;
-            }
-
             if (UpdateSolvers)
             {
                 // Before calling solvers, update goal to be the transform so that working and transform will match
@@ -400,7 +391,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             if (!solvers.Contains(solver))
             {
                 solvers.Add(solver);
-                updateSolversList = true;
+                IEnumerable<Solver> inspectorOrderedSolvers = GetComponents<Solver>().Intersect(solvers);
+                Solvers = inspectorOrderedSolvers.Union(Solvers).ToReadOnlyCollection();
             }
         }
 


### PR DESCRIPTION
Performance review showed that we can reduce some allocs by caching the results using GetComponents(List<T>). This PR also removes a potentially costly Linq call from a fixed update function, reducing risks there. 