### PR TITLE
Fix flashing RiggedHandMesh

### DIFF
--- a/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHand.cs
+++ b/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHand.cs
@@ -11,6 +11,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public interface IMixedRealityHand : IMixedRealityController
     {
         /// <summary>
+        /// Has the hand any joint data available.
+        /// </summary>
+        bool IsJointDataAvailable { get; }
+
+        /// <summary>
         /// Get the current pose of a hand joint.
         /// </summary>
         /// <remarks>

--- a/Assets/MRTK/Core/Providers/Hands/BaseHand.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHand.cs
@@ -79,6 +79,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #endregion Gesture Definitions
 
         /// <inheritdoc />
+        public abstract bool IsJointDataAvailable { get; }
+
+        /// <inheritdoc />
         public abstract bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose);
 
         private Vector3 GetJointPosition(TrackedHandJoint jointToGet)

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
@@ -100,6 +100,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             : base(trackingState, controllerHandedness, inputSource, interactions, definition)
         { }
 
+        /// <inheritdoc/>
+        public override bool IsJointDataAvailable => jointPoses.Count > 0;
+
         /// <inheritdoc />
         public override bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose) => jointPoses.TryGetValue(joint, out pose);
 

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
@@ -44,6 +44,9 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
 
         #region IMixedRealityHand Implementation
 
+        /// <inheritdoc />
+        public override bool IsJointDataAvailable => jointPoses.Count > 0;
+
         /// <inheritdoc/>
         public override bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose) => jointPoses.TryGetValue(joint, out pose);
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -82,6 +82,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         #region IMixedRealityHand Implementation
 
         protected readonly Dictionary<TrackedHandJoint, MixedRealityPose> jointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
+
+        /// <inheritdoc/>
+        public override bool IsJointDataAvailable => jointPoses.Count > 0;
+
         /// <inheritdoc/>
         public override bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose)
         {

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -51,6 +51,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         #region IMixedRealityHand Implementation
 
         /// <inheritdoc/>
+        public bool IsJointDataAvailable => unityJointPoses != null;
+
+        /// <inheritdoc/>
         public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose)
         {
             if (unityJointPoses != null)

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -64,6 +64,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         #region IMixedRealityHand Implementation
 
         /// <inheritdoc/>
+        public bool IsJointDataAvailable => jointPoses != null;
+
+        /// <inheritdoc/>
         public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose)
         {
             if (jointPoses != null)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -305,7 +305,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile != null ? inputSystem.InputSystemProfile.HandTrackingProfile : null;
 
                 // Only runs if render hand mesh is true
-                bool renderHandmesh = handTrackingProfile != null && handTrackingProfile.EnableHandMeshVisualization;
+                bool renderHandmesh = handTrackingProfile != null && handTrackingProfile.EnableHandMeshVisualization && MixedRealityHand.IsJointDataAvailable;
                 HandRenderer.enabled = renderHandmesh;
                 if (renderHandmesh)
                 {


### PR DESCRIPTION
## Overview

There is a timing when the hand controller is already tracked and provides a position, though no joint data is available yet. I.e. when you move hands quickly into the HL2 tracking view. This results in the hand mesh being rendered already, while the joint data hasn't been set and the mesh is stuck at origin.
 
This change will now make sure the hand mesh is only rendered when there is actual joint data available.

## Changes
- Fixes: #10646
