### PR TITLE
Fix - Icon examples scene has misconfigured+wonky title backplate

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/FontIconExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/FontIconExample.unity
@@ -2458,7 +2458,7 @@ MonoBehaviour:
   onDisabled:
     m_PersistentCalls:
       m_Calls: []
-  hostTransform: {fileID: 1170466719}
+  hostTransform: {fileID: 1236496965}
   allowedManipulations: 7
   allowedInteractionTypes: -2147483641
   useForcesForNearManipulation: 0
@@ -2724,7 +2724,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1236496965}
     m_Modifications:
     - target: {fileID: 566361764857432160, guid: e8c3ea3c1046f8b4bbd682c2b7a0e4fe, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -2759,7 +2759,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3220012215463627515, guid: e8c3ea3c1046f8b4bbd682c2b7a0e4fe, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3220012215463627515, guid: e8c3ea3c1046f8b4bbd682c2b7a0e4fe, type: 3}
       propertyPath: m_AnchorMax.x
@@ -2865,11 +2865,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e8c3ea3c1046f8b4bbd682c2b7a0e4fe, type: 3}
---- !u!4 &1170466719 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5493534032387613222, guid: e8c3ea3c1046f8b4bbd682c2b7a0e4fe, type: 3}
-  m_PrefabInstance: {fileID: 1170466718}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1236496964
 GameObject:
   m_ObjectHideFlags: 0
@@ -2880,7 +2875,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1236496965}
   m_Layer: 0
-  m_Name: MixedRealityPlayspace
+  m_Name: MixedRealitySceneContent
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2898,8 +2893,9 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1268994939}
+  - {fileID: 1749873431}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1268994938
 GameObject:
@@ -4148,6 +4144,11 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!224 &1749873431 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3220012215463627515, guid: e8c3ea3c1046f8b4bbd682c2b7a0e4fe, type: 3}
+  m_PrefabInstance: {fileID: 1170466718}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1765249066
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Overview
Assigned SceneContent object to ObjectManipulator's host transform

## Changes
- Fixes: #10756 

![2022-07-19 15_43_57](https://user-images.githubusercontent.com/13754172/179684101-b14c786e-cf6c-4056-b8f8-592d8e240171.png)

![MRTk3_BugFix_FontIconExamples_DescPanel](https://user-images.githubusercontent.com/13754172/179684149-4a565bcd-a519-4280-b420-af8ed48625d8.gif)

