### PR TITLE
Fixes poorly-configured znear/far

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
@@ -139,7 +139,7 @@ MonoBehaviour:
   - {fileID: -6001689167010836115}
   - {fileID: -3189435746241105910}
   m_renderMode: 1
-  m_depthSubmissionMode: 2
+  m_depthSubmissionMode: 1
 --- !u!114 &-6549014908254381072
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
@@ -139,7 +139,7 @@ MonoBehaviour:
   - {fileID: -6001689167010836115}
   - {fileID: -3189435746241105910}
   m_renderMode: 1
-  m_depthSubmissionMode: 1
+  m_depthSubmissionMode: 2
 --- !u!114 &-6549014908254381072
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK XR Rig.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK XR Rig.prefab
@@ -57,8 +57,8 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.01
-  far clip plane: 1000
+  near clip plane: 0.02
+  far clip plane: 100
   field of view: 60
   orthographic: 0
   orthographic size: 5


### PR DESCRIPTION
## Overview
The znear/far on the MRTK Rig prefab was set to **1cm** and **1km**, which is excessive for most MR applications and can lead to Z inaccuracy on our UI sometimes (most visible with our toggle-switches in the sample scenes). This makes nearZ/farZ 2cm to100m.

## Changes
- Fixes: #10755 