### PR TITLE
ScrollRectCurve example script

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Prefabs/VirtualizedScrollRectList/VirtualizedListButton.prefab
+++ b/UnityProjects/MRTKDevTemplate/Assets/Prefabs/VirtualizedScrollRectList/VirtualizedListButton.prefab
@@ -1,5 +1,198 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5943888361501247746
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 155509664508198398}
+  - component: {fileID: 9050151835879164877}
+  - component: {fileID: 8485010927719397446}
+  - component: {fileID: 1837769044141572843}
+  - component: {fileID: 3370993524777301657}
+  m_Layer: 0
+  m_Name: UIButtonFontIconClipped
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &155509664508198398
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5943888361501247746}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 922104272095131977}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 32, y: 32}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!23 &9050151835879164877
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5943888361501247746}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 5762245003366665926, guid: 9b0d0ee11ff70b04d901a29b519cbaa0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &8485010927719397446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5943888361501247746}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uF710"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 9b0d0ee11ff70b04d901a29b519cbaa0, type: 2}
+  m_sharedMaterial: {fileID: 5762245003366665926, guid: 9b0d0ee11ff70b04d901a29b519cbaa0, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 10
+  m_fontSizeBase: 10
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 32
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1837769044141572843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5943888361501247746}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 258623d14a250c648b5b9f7b96354ba7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fontIcons: {fileID: 11400000, guid: b490f983baa13694cb7e5ecc6bd0dae3, type: 2}
+  currentIconName: Icon 133
+  textMeshProComponent: {fileID: 8485010927719397446}
+  iconFontAsset: {fileID: 0}
+--- !u!222 &3370993524777301657
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5943888361501247746}
+  m_CullTransparentMesh: 1
 --- !u!1001 &7560521100407856622
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7,6 +200,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 201938300658660728, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 952967652988581951, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
+      propertyPath: m_text
+      value: "\uF710"
+      objectReference: {fileID: 0}
     - target: {fileID: 2142167140070017856, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -63,9 +264,13 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7245587814888172855, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
+      propertyPath: currentIconName
+      value: Icon 133
+      objectReference: {fileID: 0}
     - target: {fileID: 8376646494505211202, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_Name
-      value: Action Button
+      value: VirtualizedListButton
       objectReference: {fileID: 0}
     - target: {fileID: 8376646494505211224, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_Size.x
@@ -169,3 +374,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
+--- !u!224 &922104272095131977 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7216918420766221479, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
+  m_PrefabInstance: {fileID: 7560521100407856622}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/VirtualizedScrollRectList.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/VirtualizedScrollRectList.unity
@@ -858,6 +858,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 7501429005754644618}
     m_Modifications:
+    - target: {fileID: 952967652988581951, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
+      propertyPath: m_text
+      value: "\uF2B7"
+      objectReference: {fileID: 0}
     - target: {fileID: 2228947736508096533, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -885,6 +889,10 @@ PrefabInstance:
     - target: {fileID: 7216918420766221479, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245587814888172855, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
+      propertyPath: currentIconName
+      value: Icon 61
       objectReference: {fileID: 0}
     - target: {fileID: 8376646494505211202, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_Name
@@ -1082,6 +1090,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1092809238}
+  - component: {fileID: 1092809239}
   m_Layer: 5
   m_Name: Content
   m_TagString: Untagged
@@ -1108,6 +1117,20 @@ RectTransform:
   m_AnchoredPosition: {x: 0.000011200085, y: 0}
   m_SizeDelta: {x: 199, y: 300}
   m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &1092809239
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1092809237}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 66865df98758d1541b975b64c29fa0cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scrollRect: {fileID: 0}
+  curveDepth: 20
 --- !u!224 &1190237320 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8376646494505211229, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
@@ -1622,6 +1645,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 7501429005754644618}
     m_Modifications:
+    - target: {fileID: 952967652988581951, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
+      propertyPath: m_text
+      value: "\uF2A4"
+      objectReference: {fileID: 0}
     - target: {fileID: 2228947736508096533, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -1649,6 +1676,10 @@ PrefabInstance:
     - target: {fileID: 7216918420766221479, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245587814888172855, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
+      propertyPath: currentIconName
+      value: Icon 58
       objectReference: {fileID: 0}
     - target: {fileID: 8376646494505211202, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_Name

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/ScrollRectCurve.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/ScrollRectCurve.cs
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
                 // reduced version of the first, and should be faster than 2
                 // trig calls.
 
-                //float offset = Mathf.Sin(Mathf.PI - (Mathf.Atan(1.0f / tangent) + Mathf.PI / 2.0f)) * (tr.rect.height / 2.0f) * Mathf.Sign(tangent);
+                // float offset = Mathf.Sin(Mathf.PI - (Mathf.Atan(1.0f / tangent) + Mathf.PI / 2.0f)) * (tr.rect.height / 2.0f) * Mathf.Sign(tangent);
                 float offset = (tr.rect.height / 2.0f) / Mathf.Sqrt(1.0f / (tangent*tangent) + 1) * Mathf.Sign(tangent);
 
                 Vector3 pos = tr.localPosition;

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/ScrollRectCurve.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/ScrollRectCurve.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Microsoft.MixedReality.Toolkit.Examples.Demos
+{
+    /// <summary>
+    /// This component works on the content of a ScrollRect window! It will
+    /// 'curve' the position and orientation of contents based on their
+    /// position within the ScrollRect's viewport.
+    /// 
+    /// This component should be placed on the "Content" GameObject of a Scroll
+    /// View, as it uses OnTransformChildrenChanged, and works directly on the
+    /// children of the GameObject it's assigned to. This component will not
+    /// look great on items that are vertically large, as items are curved at a
+    /// GameObject level. Their contents will remain flat.
+    /// </summary>
+    [AddComponentMenu("MRTX/Examples/Scroll Rect Curve")]
+    public class ScrollRectCurve : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("A link to the ScrollRect this component is curving. If unassigned, this component will find the first ScrollRect in its parent chain.")]
+        private ScrollRect scrollRect;
+
+        [SerializeField]
+        [Tooltip("How much should the UI elements be curved, in local units? This is the distance from the content base position, to the curvature's maximum Z distance from the base position.")]
+        private float curveDepth = 20;
+
+        void Awake()
+        {
+            scrollRect = scrollRect ?? gameObject.GetComponentInParent<ScrollRect>(true);
+            scrollRect.onValueChanged.AddListener(a => UpdatePositions());
+        }
+
+        void OnTransformChildrenChanged() => UpdatePositions();
+        void OnValidate()                 => UpdatePositions();
+
+        void UpdatePositions()
+        {
+            if (scrollRect == null) { return; }
+
+            float height  = scrollRect.viewport.rect.top - scrollRect.viewport.rect.bottom;
+            float height2 = height * height;
+            float top     = ((RectTransform)transform).rect.yMax + transform.localPosition.y;
+
+            for (int i = 0; i < transform.childCount; i++)
+            {
+                RectTransform tr = (RectTransform)transform.GetChild(i);
+                float         y  = (tr.localPosition.y + tr.rect.center.y) + top;
+
+                // This uses a parabola for the curve (tested alongside a
+                // cosine curve, the parabola looked better), and the
+                // derivative of that curve to determine the tangent/normal for
+                // building the orientation.
+                //
+                // Graph for this here:
+                // https://www.desmos.com/calculator/sfwaxipupr
+                float curve   = -(4 * curveDepth * y * (-height + y)) / height2;
+                float tangent = -(4 * curveDepth * (height - 2 * y)) / height2;
+
+                // Correct for the pivot point being in the top left corner,
+                // rotation should happen around the center of the item. This
+                // math finds the z axis translation of the center of the UI
+                // element caused by the rotation around the pivot point.
+                //
+                // Both these lines are equivalent, the Sqrt version is a
+                // reduced version of the first, and should be faster than 2
+                // trig calls.
+
+                //float offset = Mathf.Sin(Mathf.PI - (Mathf.Atan(1.0f / tangent) + Mathf.PI / 2.0f)) * (tr.rect.height / 2.0f) * Mathf.Sign(tangent);
+                float offset = (tr.rect.height / 2.0f) / Mathf.Sqrt(1.0f / (tangent*tangent) + 1) * Mathf.Sign(tangent);
+
+                Vector3 pos = tr.localPosition;
+                tr.localPosition = new Vector3(pos.x, pos.y, (curve - offset) - curveDepth );
+                tr.localRotation = Quaternion.LookRotation(new Vector3(0, tangent, 1), Vector3.up);
+            }
+        }
+    }
+}

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/ScrollRectCurve.cs.meta
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/ScrollRectCurve.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66865df98758d1541b975b64c29fa0cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/VirtualizedScrollRectListTester.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/VirtualizedScrollRectListTester.cs
@@ -25,7 +25,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
             list = GetComponent<VirtualizedScrollRectList>();
             list.OnVisible = (go, i) =>
             {
-                go.GetComponentInChildren<TextMeshProUGUI>().text = i.ToString() + " " + words[i%words.Length];
+                foreach (var text in go.GetComponentsInChildren<TextMeshProUGUI>())
+                {
+                    if (text.gameObject.name == "Text")
+	                    text.text = $"{i} {words[i%words.Length]}";
+                }
             };
         }
 


### PR DESCRIPTION
A short script demonstrating curving the content of a ScrollRect. It stands by itself just fine and looks pretty neat, but is perhaps a bit off the beaten path as far as MRTK features go. This is added as a sample script used in the VirtualizedScrollRectList scene.

This PR also includes some small adjustment to the scene's UI to fix clipping and icon issues that drifted in.

![CurvedScrollRect](https://user-images.githubusercontent.com/8484884/180884917-d94f8105-9b1c-4efb-8f9a-54992a969459.gif)