### PR TITLE
[MRTK3] Fix audio sample scenes, some script simplification

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/Audio/AudioLoFiExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/Audio/AudioLoFiExample.unity
@@ -597,9 +597,9 @@ AudioSource:
   Loop: 1
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
-  DopplerLevel: 1
+  DopplerLevel: 0
   MinDistance: 1
   MaxDistance: 500
   Pan2D: 0
@@ -967,7 +967,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4906210948401705404, guid: c028545ea0a56b34993228b8997220cd, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.132
+      value: 0.136
       objectReference: {fileID: 0}
     - target: {fileID: 4906210948401705404, guid: c028545ea0a56b34993228b8997220cd, type: 3}
       propertyPath: m_LocalPosition.x
@@ -977,6 +977,26 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 0.005
       objectReference: {fileID: 0}
+    - target: {fileID: 6547287731041676193, guid: c028545ea0a56b34993228b8997220cd, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6547287731185703676, guid: c028545ea0a56b34993228b8997220cd, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6547287731569261317, guid: c028545ea0a56b34993228b8997220cd, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6547287732552794944, guid: c028545ea0a56b34993228b8997220cd, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8607088663772162018, guid: c028545ea0a56b34993228b8997220cd, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 5762245003366665926, guid: 9b0d0ee11ff70b04d901a29b519cbaa0, type: 2}
     m_RemovedComponents:
     - {fileID: 3433554895966514137, guid: c028545ea0a56b34993228b8997220cd, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: c028545ea0a56b34993228b8997220cd, type: 3}

--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/Audio/AudioOcclusionExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/Audio/AudioOcclusionExample.unity
@@ -292,7 +292,6 @@ MonoBehaviour:
   updateInterval: 0.25
   maxDistance: 20
   maxObjects: 10
-  audioSource: {fileID: 629829903}
 --- !u!82 &629829903
 AudioSource:
   m_ObjectHideFlags: 0
@@ -310,9 +309,9 @@ AudioSource:
   Loop: 1
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
-  DopplerLevel: 1
+  DopplerLevel: 0
   MinDistance: 1
   MaxDistance: 500
   Pan2D: 0
@@ -649,7 +648,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7585035320575375756, guid: ad5b753b73e311143a85055b15cea562, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ad5b753b73e311143a85055b15cea562, type: 3}

--- a/com.microsoft.mrtk.audio/Effects/AudioInfluencerController.cs
+++ b/com.microsoft.mrtk.audio/Effects/AudioInfluencerController.cs
@@ -43,6 +43,11 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         public static readonly float NeutralHighFrequency = 22000.0f;
 
         /// <summary>
+        /// The source of the audio.
+        /// </summary>
+        private AudioSource audioSource;
+
+        /// <summary>
         /// Time, in seconds, between audio influence updates.
         /// </summary>
         /// <remarks>
@@ -106,12 +111,6 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         private DateTime lastUpdate = DateTime.MinValue;
 
         /// <summary>
-        /// The source of the audio.
-        /// </summary>
-        [SerializeField]
-        private AudioSource audioSource;
-
-        /// <summary>
         /// The initial volume level of the audio source.
         /// </summary>
         private float initialAudioSourceVolume;
@@ -160,10 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             effectsToApply = new List<IAudioInfluencer>(maxObjects);
             effectsToRemove = new List<IAudioInfluencer>(maxObjects);
 
-            if (audioSource == null)
-            {
-                audioSource = GetComponent<AudioSource>();
-            }
+            audioSource = GetComponent<AudioSource>();
 
             initialAudioSourceVolume = audioSource.volume;
 


### PR DESCRIPTION
This change brings improvements to the audio effect sample scenes.

1. Enable 'Spatialize Post Effects' (in both example scenes) to ensure that the effects are properly applied when using an Audio Spatializer
2. Lo-Fi example: Adapt to changes in the button bar prefab (a text icon was added that was obscuring the button text)
3. Simplify AudioInfluencerController - the script is designed to be placed on each emitter so we will always get the audio source from the attached game object.