### PR TITLE
Polyfilling tracking state

### DIFF
--- a/com.microsoft.mrtk.input/Controllers/ArticulatedHandController.cs
+++ b/com.microsoft.mrtk.input/Controllers/ArticulatedHandController.cs
@@ -170,6 +170,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 Ray ray = handRay.Ray;
                 controllerState.position = ray.origin;
                 controllerState.rotation = Quaternion.LookRotation(ray.direction, PlayspaceUtilities.ReferenceTransform.TransformVector(palm.Up));
+
+                // Polyfill the tracking state, too.
+                controllerState.inputTrackingState = InputTrackingState.Position | InputTrackingState.Rotation;
             }
         }
     }

--- a/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // When the gaze pinch interactor is already selecting an object, use the default interactor behavior
                 if (hasSelection)
                 {
-                    return base.isHoverActive;
+                    return base.isHoverActive && IsTracked;
                 }
                 // Otherwise, this selector is only allowed to hover if we can tell that the palm for the corresponding hand/controller is facing away from the user.
                 else


### PR DESCRIPTION
## Overview
This extends the polyfill from #10749 to also cover the tracking state. This resolves several... oddities that happened as a result of that PR.

## Changes
- Fixes: #10821 
- Polyfills tracking state when joints are available but no position action is bound
- Ensures MRTKRayInteractor can't select when the controller isn't tracked