### PR TITLE
Update rigged hand mesh flicker bug fix to not be a breaking interface change

### DIFF
--- a/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHand.cs
+++ b/Assets/MRTK/Core/Interfaces/Devices/IMixedRealityHand.cs
@@ -11,11 +11,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public interface IMixedRealityHand : IMixedRealityController
     {
         /// <summary>
-        /// Has the hand any joint data available.
-        /// </summary>
-        bool IsJointDataAvailable { get; }
-
-        /// <summary>
         /// Get the current pose of a hand joint.
         /// </summary>
         /// <remarks>

--- a/Assets/MRTK/Core/Providers/Hands/BaseHand.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHand.cs
@@ -79,9 +79,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #endregion Gesture Definitions
 
         /// <inheritdoc />
-        public abstract bool IsJointDataAvailable { get; }
-
-        /// <inheritdoc />
         public abstract bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose);
 
         private Vector3 GetJointPosition(TrackedHandJoint jointToGet)

--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedHand.cs
@@ -100,9 +100,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             : base(trackingState, controllerHandedness, inputSource, interactions, definition)
         { }
 
-        /// <inheritdoc/>
-        public override bool IsJointDataAvailable => jointPoses.Count > 0;
-
         /// <inheritdoc />
         public override bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose) => jointPoses.TryGetValue(joint, out pose);
 

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
@@ -44,9 +44,6 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
 
         #region IMixedRealityHand Implementation
 
-        /// <inheritdoc />
-        public override bool IsJointDataAvailable => jointPoses.Count > 0;
-
         /// <inheritdoc/>
         public override bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose) => jointPoses.TryGetValue(joint, out pose);
 

--- a/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/MRTK-Quest/Scripts/Input/Controllers/OculusHand.cs
@@ -84,9 +84,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Oculus.Input
         protected readonly Dictionary<TrackedHandJoint, MixedRealityPose> jointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
 
         /// <inheritdoc/>
-        public override bool IsJointDataAvailable => jointPoses.Count > 0;
-
-        /// <inheritdoc/>
         public override bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose)
         {
             return jointPoses.TryGetValue(joint, out pose);

--- a/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/MicrosoftArticulatedHand.cs
@@ -51,9 +51,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         #region IMixedRealityHand Implementation
 
         /// <inheritdoc/>
-        public bool IsJointDataAvailable => unityJointPoses != null;
-
-        /// <inheritdoc/>
         public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose)
         {
             if (unityJointPoses != null)

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
@@ -48,16 +48,21 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             handMeshProvider = (controllerHandedness == Handedness.Left) ? WindowsMixedRealityHandMeshProvider.Left : WindowsMixedRealityHandMeshProvider.Right;
             handMeshProvider.SetInputSource(inputSource);
 
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
             articulatedHandApiAvailable = WindowsApiChecker.IsMethodAvailable(
                 "Windows.UI.Input.Spatial",
                 "SpatialInteractionSourceState",
                 "TryGetHandPose");
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
         }
 
         private readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
         private readonly ArticulatedHandDefinition handDefinition;
         private readonly WindowsMixedRealityHandMeshProvider handMeshProvider;
+
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
         private readonly bool articulatedHandApiAvailable = false;
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
 
         #region IMixedRealityHand Implementation
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -64,9 +64,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         #region IMixedRealityHand Implementation
 
         /// <inheritdoc/>
-        public bool IsJointDataAvailable => jointPoses != null;
-
-        /// <inheritdoc/>
         public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose)
         {
             if (jointPoses != null)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -305,7 +305,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile != null ? inputSystem.InputSystemProfile.HandTrackingProfile : null;
 
                 // Only runs if render hand mesh is true
-                bool renderHandmesh = handTrackingProfile != null && handTrackingProfile.EnableHandMeshVisualization && MixedRealityHand.IsJointDataAvailable;
+                bool renderHandmesh = handTrackingProfile != null && handTrackingProfile.EnableHandMeshVisualization && MixedRealityHand.TryGetJoint(TrackedHandJoint.Palm, out _);
                 HandRenderer.enabled = renderHandmesh;
                 if (renderHandmesh)
                 {


### PR DESCRIPTION
## Overview

Follow-up to #10754. At this point in MRTK2's lifecycle, we're trying to avoid breaking changes, especially to interfaces that might be implemented in any number of other projects.

This PR reverts the breaking change and updates the rigged hand logic to render if the palm joint is accessible.

I also added some `#if`s that I should have added a while back, since I was in this code anyway.