### PR TITLE
Cursor now shows up on top of Unity base UI canvas elements when canvas selection is enabled

### DIFF
--- a/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractorVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractorVisual.cs
@@ -481,7 +481,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
-            UpdateReticle(rayInteractor.hasHover || rayInteractor.hasSelection || (rayInteractor.enableUIInteraction && rayInteractor.TryGetCurrentUIRaycastResult(out _)));
+            UpdateReticle(rayInteractor.hasHover ||
+                            rayInteractor.hasSelection ||
+                            (rayInteractor.enableUIInteraction && rayInteractor.TryGetCurrentUIRaycastResult(out _)));
 
             // Project forward based on pointer direction to get an 'expected' position of the first control point if we've hit an object
             if (rayHasHit)

--- a/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractorVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractorVisual.cs
@@ -481,7 +481,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
-            UpdateReticle(rayInteractor.hasHover || rayInteractor.hasSelection);
+            UpdateReticle(rayInteractor.hasHover || rayInteractor.hasSelection || (rayInteractor.enableUIInteraction && rayInteractor.TryGetCurrentUIRaycastResult(out _)));
 
             // Project forward based on pointer direction to get an 'expected' position of the first control point if we've hit an object
             if (rayHasHit)
@@ -531,7 +531,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 reticleToUse.transform.position = reticlePosition;
                 reticleToUse.transform.forward = reticleNormal;
 
-                if (reticleToUse.activeSelf == false)
+                if (!reticleToUse.activeSelf)
                 {
                     reticleToUse.SetActive(true);
                 }


### PR DESCRIPTION
## Overview
Enables the cursor to be rendered over selectable Unity UI elements. Selectable Unity UI elements can be created via these steps: https://docs.unity3d.com/Packages/com.unity.xr.interaction.toolkit@2.0/manual/ui-setup.html

## Changes
- Fixes: #10839
