### PR TITLE
Poke reticle bugfix, burninate the blue sphere

### DIFF
--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK Hand Controller.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK Hand Controller.prefab
@@ -239,7 +239,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1051247791254679178}
-  - {fileID: 3150077777945743705}
   m_Father: {fileID: 1948193615953854875}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -322,7 +321,7 @@ MonoBehaviour:
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
   handNode: 4
-  touchVisuals: {fileID: 2574534496695087052}
+  touchVisuals: {fileID: 0}
 --- !u!54 &5296314582960356879
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -679,87 +678,6 @@ MonoBehaviour:
   touchVisuals: {fileID: 4299642553587339577}
   handNode: 4
   joint: 10
---- !u!1 &2574534496695087052
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3150077777945743705}
-  - component: {fileID: 7937768370620796352}
-  - component: {fileID: 8759797020622511752}
-  m_Layer: 0
-  m_Name: Grab Cursor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3150077777945743705
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2574534496695087052}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
-  m_Children: []
-  m_Father: {fileID: 4443155524692848376}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &7937768370620796352
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2574534496695087052}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &8759797020622511752
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2574534496695087052}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: fd7308cd632034c4aa20b81ded4de6e8, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &4299642553989019656
 GameObject:
   m_ObjectHideFlags: 0

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/ReticleMagnetism.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/ReticleMagnetism.cs
@@ -128,6 +128,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private void OnEnable()
         {
             Application.onBeforeRender += OnBeforeRender;
+
+            // On enabling, snap the reticle immediately to the anchor point, to 
+            // avoid any chance of suddenly lerping the moment the reticle is visible.
+            smoothedMagnetRotation = transform.parent.rotation;
+            smoothedMagnetPosition = transform.parent.position;
         }
 
         private void OnDisable()


### PR DESCRIPTION
## Overview
This fixes an awkward poke reticle lerping bug on devices without an input action for position/rotation, and finally removes the "dev art" blue sphere for grabs ("MRTK2 parity" haha)

## Changes
- Fixes the poke reticle "zooming" back into place after the IMM switches the `PokeInteractor` back on, on devices like Quest
- Burninates the blue sphere
