### PR TITLE
Fixes for NREs in CanvasProxyInteractor

### DIFF
--- a/com.microsoft.mrtk.uxcore/Interop/UGUIInputAdapter.cs
+++ b/com.microsoft.mrtk.uxcore/Interop/UGUIInputAdapter.cs
@@ -132,9 +132,9 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
                 foreach (var interactor in interactorQueryList)
                 {
-                    if (interactor is IProxyInteractor)
+                    if (interactor is IProxyInteractor proxy)
                     {
-                        proxyInteractor = interactor as IProxyInteractor;
+                        proxyInteractor = proxy;
                         break;
                     }
                 }

--- a/com.microsoft.mrtk.uxcore/Interop/UGUIInputAdapter.cs
+++ b/com.microsoft.mrtk.uxcore/Interop/UGUIInputAdapter.cs
@@ -128,7 +128,6 @@ namespace Microsoft.MixedReality.Toolkit.UX
             if (proxyInteractor == null && ThisInteractable != null && InteractionManager != null)
             {
                 // Go find the proxy interactor that this shim is associated with.
-                interactorQueryList.Clear();
                 InteractionManager.GetRegisteredInteractors(interactorQueryList);
 
                 foreach (var interactor in interactorQueryList)

--- a/com.microsoft.mrtk.uxcore/Interop/UGUIInputAdapter.cs
+++ b/com.microsoft.mrtk.uxcore/Interop/UGUIInputAdapter.cs
@@ -156,7 +156,6 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
         protected virtual void OnInteractorRegistered(InteractorRegisteredEventArgs args)
         {
-            Debug.Log("Interactor registered");
             if (args.interactorObject is IProxyInteractor)
             {
                 proxyInteractor = args.interactorObject as IProxyInteractor;


### PR DESCRIPTION
## Overview
#10838 exposed an assumption in CanvasProxyInteractor that wasn't well-tested. `UGUIInputAdapter` assumed that a proxy interactor would stay registered throughout its lifetime, which #10838 made untrue.

Now, we nullcheck proxy interactors in the `UGUIInputAdapter`, as well as reducing the work done when referencing the `ProxyInteractor` getter while no proxy interactor is actually available. Before, it would re-query the list of all interactors from the manager every single time the getter was called while no interactor was available. Now, it grabs the interactor reference once at `Awake`, and then re-grabs it subsequently on each registration event.

## Changes
- Fixes #10872
- Fixes #10740 , as we now gracefully avoid NREs when no proxy interactor is available.
