### PR TITLE
ui polish: company name -> organization name

### DIFF
--- a/com.microsoft.mrtk.tools/SubsystemWizard/SubsystemWizardWindow.cs
+++ b/com.microsoft.mrtk.tools/SubsystemWizard/SubsystemWizardWindow.cs
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.Tools
                 EditorGUILayout.Space(6);
                 EditorGUILayout.LabelField("Please enter your organization or project name.", EditorStyles.boldLabel);
                 subsystemGenerator.OrganizationName = EditorGUILayout.TextField(
-                    "Company name", subsystemGenerator.OrganizationName);
+                    "Organization name", subsystemGenerator.OrganizationName);
                 EditorGUILayout.Space(4);
                 EditorGUILayout.LabelField("Please enter the name for the subsystem base class.", EditorStyles.boldLabel);
                 subsystemGenerator.BaseClassName = EditorGUILayout.TextField(


### PR DESCRIPTION
This change fixes a reference to "Company name" that was missed in the previous checkin. Now uses "Organization name" in the UI.

![image](https://user-images.githubusercontent.com/13281406/184988012-d8546b04-8887-41bb-aeff-8b308a5be175.png)
