### PR TITLE
Update docs pipeline status badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you're an experienced Mixed Reality or MRTK developer, check the links in the
 
 | Branch | CI Status | Docs Status |
 |---|---|---|
-| `main` |[![CI Status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_CI?branchName=main)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=15)|[![Docs Status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_docs?branchName=main)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=7)
+| `main` |[![CI Status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_CI?branchName=main)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=15)|[![Docs Validation (MRTK2)](https://github.com/microsoft/MixedRealityToolkit-Unity/actions/workflows/docs_mrtk2.yaml/badge.svg?branch=main)](https://github.com/microsoft/MixedRealityToolkit-Unity/actions/workflows/docs_mrtk2.yaml)
 
 # Required software
 


### PR DESCRIPTION
## Overview

It currently points to the old, no longer in use pipeline: 
<img width="408" alt="image" src="https://user-images.githubusercontent.com/3580640/185686037-57f00c4c-e334-4b15-9843-b90614962bd3.png">

This now points to the GitHub action for docs validation:
<img width="419" alt="image" src="https://user-images.githubusercontent.com/3580640/185686098-e396941b-68d5-4c8e-af0f-2a6bc014c3fd.png">
