### PR TITLE
Fix docs pipeline

### DIFF
--- a/pipelines/docs-binaries.yml
+++ b/pipelines/docs-binaries.yml
@@ -28,7 +28,6 @@ jobs:
         -OutputDirectory $(Build.ArtifactStagingDirectory)
 
   - task: PublishPipelineArtifact@1
-    condition: always()
     displayName: Publish docs binaries
     inputs:
       targetPath: $(Build.ArtifactStagingDirectory)
@@ -56,7 +55,6 @@ jobs:
         -OutputDirectory $(Build.ArtifactStagingDirectory)
 
   - task: PublishPipelineArtifact@1
-    condition: always()
     displayName: Publish docs binaries
     inputs:
       targetPath: $(Build.ArtifactStagingDirectory)

--- a/pipelines/docs-binaries.yml
+++ b/pipelines/docs-binaries.yml
@@ -9,6 +9,8 @@ jobs:
 - job: BuildUnity2020
   pool:
     name: Analog-Unity
+    demands:
+      - ImageVersionOverride -equals 20220218.0.1
 
   steps:
   - checkout: self
@@ -36,6 +38,8 @@ jobs:
 - job: BuildUnity2019
   pool:
     name: Analog-Unity
+    demands:
+      - ImageVersionOverride -equals 20220218.0.1
 
   steps:
   - checkout: self


### PR DESCRIPTION
## Overview

Looks like a change went into the VM image we use for docs generation that's causing things to break.
This reverts to an LFG image that we already use for MRTK2 CI.

I'll have a follow up investigation to get us back on the latest VMs, but this is at least a quick unblocker (hopefully!).