### PR TITLE
Physics fixes

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/HandInteractionExamples.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/HandInteractionExamples.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -253,7 +253,6 @@ GameObject:
   - component: {fileID: 37486931}
   - component: {fileID: 37486934}
   - component: {fileID: 37486933}
-  - component: {fileID: 37486932}
   m_Layer: 0
   m_Name: Coffee
   m_TagString: Untagged
@@ -275,20 +274,6 @@ Transform:
   m_Father: {fileID: 1146931003}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &37486932
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 37486930}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!23 &37486933
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -343,6 +328,24 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1214529608091387485, guid: 0d3b2fd2079cd514d8dbce654f929320, type: 3}
   m_PrefabInstance: {fileID: 663760220}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &76807523 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 100016, guid: f9a8072f5d9b92347a999f10f01b8012, type: 3}
+  m_PrefabInstance: {fileID: 1294530691}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &76807524
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 76807523}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.10026801, y: 0.082757965, z: 0.093791895}
+  m_Center: {x: -0.00011960028, y: -0.000000057742, z: -0.008266095}
 --- !u!1 &76865735
 GameObject:
   m_ObjectHideFlags: 0
@@ -628,12 +631,12 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 79416685}
   serializedVersion: 2
-  m_Mass: 1
+  m_Mass: 0.1
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!114 &79416688
@@ -1920,6 +1923,7 @@ MonoBehaviour:
   handlesActive: 1
   enabledHandles: 2
   rotateAnchor: 0
+  scaleAnchor: 0
   scaleBehavior: 0
   smoothingActive: 1
   rotateLerpTime: 0.00001
@@ -2239,185 +2243,6 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 243610128}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b082f80c6b45164418a354f7e116f0a3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &247333379
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 247333380}
-  - component: {fileID: 247333382}
-  - component: {fileID: 247333381}
-  m_Layer: 0
-  m_Name: SectionTitle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &247333380
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 247333379}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.578}
-  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
-  m_Children: []
-  m_Father: {fileID: 1708103290}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.842, y: -0.276}
-  m_SizeDelta: {x: 20, y: 5}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &247333381
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 247333379}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: '<size=24>Manipulation Interaction</size>
-
-
-    <color=#FF9E00>ObjectManipulator.cs</color>
-    allows for the intuitive manipulation of objects using near grab, far ray, and
-    gaze + pinch manipulation.
-
-
-    The ManipulationLogic<T>s associated with each
-    type of manipulation can be customized and specified in the inspector.'
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
-  m_sharedMaterial: {fileID: 2100000, guid: b082f80c6b45164418a354f7e116f0a3, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 8
-  m_fontSizeBase: 8
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 0
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: -8.21011, w: 0.732635}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 247333382}
-  m_maskType: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
---- !u!23 &247333382
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 247333379}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -2883,6 +2708,25 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 87b5dae2c37568d4b93b1add68554deb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &422166483 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 100022, guid: f9a8072f5d9b92347a999f10f01b8012, type: 3}
+  m_PrefabInstance: {fileID: 1294530691}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &422166484
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 422166483}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.032281224
+  m_Height: 0.15444483
+  m_Direction: 1
+  m_Center: {x: 0.0000022638612, y: -0.055035494, z: 0.006171904}
 --- !u!1 &429539737
 GameObject:
   m_ObjectHideFlags: 0
@@ -3773,12 +3617,12 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 563549573}
   serializedVersion: 2
-  m_Mass: 0.001
+  m_Mass: 0.1
   m_Drag: 1
   m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!65 &563549579
@@ -5269,6 +5113,7 @@ MonoBehaviour:
   handlesActive: 0
   enabledHandles: 2
   rotateAnchor: 0
+  scaleAnchor: 0
   scaleBehavior: 0
   smoothingActive: 1
   rotateLerpTime: 0.00001
@@ -6333,12 +6178,12 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 888851581}
   serializedVersion: 2
-  m_Mass: 0.001
+  m_Mass: 0.1
   m_Drag: 1
   m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!65 &888851587
@@ -6516,9 +6361,17 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "Far Interaction with \nHand Ray or Gaze + Pinch\n\n<size=14>Dynamic visual
-    feedback based on the amount of pinch gesture (Selectedness) using StateVisualizer's
-    'Playback Time Matches Value'. Hover highlight is activated by MeshOutline script.</size>"
+  m_text: 'Manipulation with <color=#FF9E00>ObjectManipulator</color>
+
+
+    <size=8>Dynamic
+    visual feedback based on the amount of pinch gesture (Selectedness) using StateVisualizer''s
+    ''Playback Time Matches Value''. Hover highlight is activated by MeshOutline
+    script.
+
+
+    <color=#FF9E00>ObjectManipulator.cs</color> allows for the intuitive
+    manipulation of objects using near grab, far ray, and gaze + pinch manipulation.</size>'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: b082f80c6b45164418a354f7e116f0a3, type: 2}
@@ -8507,176 +8360,6 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!1 &1254210890
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1254210891}
-  - component: {fileID: 1254210893}
-  - component: {fileID: 1254210892}
-  m_Layer: 0
-  m_Name: ObjectLabel (6)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1254210891
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1254210890}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.344}
-  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
-  m_Children: []
-  m_Father: {fileID: 1727403011}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.814, y: -0.5433}
-  m_SizeDelta: {x: 20, y: 5}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1254210892
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1254210890}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: <size=18>Direct Near Interaction with Hand</size>
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
-  m_sharedMaterial: {fileID: 2100000, guid: b082f80c6b45164418a354f7e116f0a3, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 8
-  m_fontSizeBase: 8
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 0
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: -12.531235, w: 0.732635}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 1254210893}
-  m_maskType: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
---- !u!23 &1254210893
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1254210890}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b082f80c6b45164418a354f7e116f0a3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &1256458037 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3482465368609989420, guid: 8beb1e0a00bf1eb42921a53ffb52bdeb, type: 3}
@@ -9467,27 +9150,14 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1294530693}
   serializedVersion: 2
-  m_Mass: 1
+  m_Mass: 0.1
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!65 &1294530695
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1294530693}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.7807772, y: 0.6856407, z: 0.7518231}
-  m_Center: {x: 0.006204512, y: 0.3515834, z: 0.07445323}
 --- !u!114 &1294530696
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10415,12 +10085,12 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1357057977}
   serializedVersion: 2
-  m_Mass: 0.001
+  m_Mass: 0.1
   m_Drag: 1
   m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!65 &1357057983
@@ -11226,12 +10896,12 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1357838088}
   serializedVersion: 2
-  m_Mass: 0.001
+  m_Mass: 0.1
   m_Drag: 1
   m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!65 &1357838094
@@ -11459,7 +11129,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4205010513405509735, guid: c2f49d0d909d3fc4bbc20d1cb743ab1d, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4205010513405509735, guid: c2f49d0d909d3fc4bbc20d1cb743ab1d, type: 3}
       propertyPath: m_LocalScale.x
@@ -11540,6 +11210,24 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4205010513405509735, guid: c2f49d0d909d3fc4bbc20d1cb743ab1d, type: 3}
   m_PrefabInstance: {fileID: 1376890153}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1393598443 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 100012, guid: f9a8072f5d9b92347a999f10f01b8012, type: 3}
+  m_PrefabInstance: {fileID: 1294530691}
+  m_PrefabAsset: {fileID: 0}
+--- !u!135 &1393598444
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1393598443}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.08828581
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1404428860
 GameObject:
   m_ObjectHideFlags: 0
@@ -12059,7 +11747,6 @@ Transform:
   m_LocalPosition: {x: 0.077, y: 0, z: -0.072}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 247333380}
   - {fileID: 1376890154}
   - {fileID: 2131597836}
   - {fileID: 1727403011}
@@ -12112,6 +11799,7 @@ MonoBehaviour:
   handlesActive: 0
   enabledHandles: 2
   rotateAnchor: 1
+  scaleAnchor: 0
   scaleBehavior: 0
   smoothingActive: 1
   rotateLerpTime: 0.00001
@@ -13074,11 +12762,10 @@ Transform:
   - {fileID: 1357838089}
   - {fileID: 888851582}
   - {fileID: 563549574}
-  - {fileID: 1254210891}
   - {fileID: 79416684}
   - {fileID: 1294530692}
   m_Father: {fileID: 1708103290}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &1729004921 stripped
 AudioSource:
@@ -14114,6 +13801,25 @@ AudioSource:
   m_CorrespondingSourceObject: {fileID: 7513506229924595575, guid: 8f6fb5f907837b645a884d67d7b70393, type: 3}
   m_PrefabInstance: {fileID: 364946991195464072}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1959878136 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 100020, guid: f9a8072f5d9b92347a999f10f01b8012, type: 3}
+  m_PrefabInstance: {fileID: 1294530691}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &1959878137
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959878136}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.03228122
+  m_Height: 0.15444481
+  m_Direction: 1
+  m_Center: {x: 0.0000022076192, y: -0.055035967, z: 0.00617202}
 --- !u!1001 &1996988709
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15665,6 +15371,25 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   angularVelocity: 300
   rotationAxis: {x: 0, y: 1, z: 0}
+--- !u!1 &2126969654 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 100024, guid: f9a8072f5d9b92347a999f10f01b8012, type: 3}
+  m_PrefabInstance: {fileID: 1294530691}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &2126969655
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2126969654}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.032281216
+  m_Height: 0.15444481
+  m_Direction: 1
+  m_Center: {x: 0.00000202417, y: -0.05503555, z: 0.006171601}
 --- !u!1001 &2128020769
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15818,7 +15543,7 @@ Transform:
   - {fileID: 1923515645}
   - {fileID: 956891493}
   m_Father: {fileID: 1708103290}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4326491061339189 stripped
 Transform:

--- a/com.microsoft.mrtk.spatialmanipulation/ObjectManipulator/ObjectManipulator.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/ObjectManipulator/ObjectManipulator.cs
@@ -12,9 +12,20 @@ using UnityEngine.XR.Interaction.Toolkit;
 namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 {
     /// <summary>
-    /// ObjectManipulator is an interactable that enables the grabbing/moving of objects, with one or two hands,
-    /// with near, far, and gaze interaction.
+    /// ObjectManipulator allows for the manipulation (move, rotate, scale)
+    /// of an object by any interactor with a valid attach transform.
+    /// Multi-handed interactions and physics-enabled objects are also supported.
     /// </summary>
+    /// <remarks>
+    /// ObjectManipulator works with both rigidbody and non-rigidbody objects,
+    /// and allows for throwing and catching interactions. Any interactor
+    /// with a well-formed attach transform can interact with and manipulate
+    /// an ObjectManipulator. This is a drop-in replacement for the built-in
+    /// XRI XRGrabInteractable, that allows for flexible multi-handed interactions.
+    /// ObjectManipulator doesn't track controller velocity, so for precise fast-paced
+    /// throwing interactions that only need one hand, XRGrabInteractable may
+    /// give better results.
+    /// </remarks>
     [RequireComponent(typeof(ConstraintManager))]
     [AddComponentMenu("MRTK/Spatial Manipulation/Object Manipulator")]
     public class ObjectManipulator : StatefulInteractable
@@ -55,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         private Transform hostTransform = null;
 
         /// <summary>
-        /// Transform that will be dragged. Defaults to the object of the component.
+        /// Transform to be manipulated. Defaults to the object of the component.
         /// </summary>
         public Transform HostTransform
         {
@@ -70,22 +81,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             }
             set => hostTransform = value;
         }
-
-        // TODO: Interactable needs support for this.
-
-        // [SerializeField]
-        // [EnumFlags]
-        // [Tooltip("Can manipulation be done only with one hand, only with two hands, or with both?")]
-        // private ManipulationHandFlags manipulationType = ManipulationHandFlags.OneHanded | ManipulationHandFlags.TwoHanded;
-
-        // /// <summary>
-        // /// Can manipulation be done only with one hand, only with two hands, or with both?
-        // /// </summary>
-        // public ManipulationHandFlags ManipulationType
-        // {
-        //     get => manipulationType;
-        //     set => manipulationType = value;
-        // }
 
         [SerializeField]
         [EnumFlags]
@@ -515,7 +510,10 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             {
                 base.OnSelectEntered(args);
 
-                if (rigidBody != null)
+                // Only record rigidbody settings if this is the *first*
+                // selection event! Otherwise, we'll record the during-interaction
+                // rigidbody information, which we've already dirtied.
+                if (rigidBody != null && interactorsSelecting.Count == 1)
                 {
                     wasGravity = rigidBody.useGravity;
                     wasKinematic = rigidBody.isKinematic;
@@ -547,7 +545,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             {
                 base.OnSelectExited(args);
 
-                if (rigidBody != null)
+                // Only release the rigidbody (restore rigidbody settings/configuration)
+                // if this is the last select event!
+                if (rigidBody != null && interactorsSelecting.Count == 0)
                 {
                     ReleaseRigidBody(rigidBody.velocity, rigidBody.angularVelocity);
                 }


### PR DESCRIPTION
## Overview
ObjManip had a bug wherein it would corrupt the physics settings on objects by recording the "previous settings" *during* a multihanded interaction. This fixes that bug.

![physics](https://user-images.githubusercontent.com/5544935/185819880-1c4c5e68-4010-462d-86a9-1d1e6f51efdc.gif)

In addition, our rigidbodies in the HIE sample scene had unrealistically configured weights, as well as no interpolation settings, which was causing unreliable interactions as well as jittery manipulations when the display refresh rate != physics tickrate.

Lastly, the sample rigidbodies had some very wonky collider setups, too. This resolves those.

## Changes
- Fixes #10894 
- Fixes #10883 
- Fixes jittery manipulations/framerate problems
- Some clarity edits to labels in the scene
- Fixes wonky colliders