### PR TITLE
Update InterfaceSelector to use Unity TypeCache and filter out uninstantiatable types

### DIFF
--- a/com.microsoft.mrtk.core/Utilities/Attributes/InterfaceSelectorAttribute.cs
+++ b/com.microsoft.mrtk.core/Utilities/Attributes/InterfaceSelectorAttribute.cs
@@ -6,25 +6,32 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit
 {
-    /// <summary>This attaches a Unity Inspector drawer that will enable
+    /// <summary>
+    /// This attaches a Unity Inspector drawer that will enable
     /// selection and instantiation of concrete classes that are assignable to
     /// this field. This pairs best with an interface and the
-    /// [SerializedReference] attribute, though technically any parent class
-    /// type will work!</summary>
+    /// [SerializeReference] attribute, though technically any parent class
+    /// type will work!
+    /// </summary>
     [AttributeUsage(AttributeTargets.Field)]
     public class InterfaceSelectorAttribute : PropertyAttribute
     {
-        /// <summary>Should the inspector add an option to set this field to
+        /// <summary>
+        /// Should the inspector add an option to set this field to
         /// null, or is null a bad idea for this field? This does _not_ mean
-        /// it's impossible for this field to be null if 'false'.</summary>
+        /// it's impossible for this field to be null if 'false'.
+        /// </summary>
         public bool AllowNull { get; private set; }
 
-        /// <summary>This attaches a Unity Inspector drawer that will enable
+        /// <summary>
+        /// This attaches a Unity Inspector drawer that will enable
         /// selection and instantiation of concrete classes that are assignable
         /// to this field. This pairs best with an interface and the
-        /// [SerializedReference] attribute, though technically any parent
-        /// class type will work!</summary>
-        /// <param name="allowNull">Should the inspector add an option to set
+        /// [SerializeReference] attribute, though technically any parent
+        /// class type will work!
+        /// </summary>
+        /// <param name="allowNull">
+        /// Should the inspector add an option to set
         /// this field to null, or is null a bad idea for this field? This does
         /// _not_ mean it's impossible for this field to be null if 'false'.
         /// </param>


### PR DESCRIPTION
## Overview

I hit an issue where `InterfaceSelector` was displaying an abstract class to me but throwing an exception when I tried to select it.
This converts the type lookup to use Unity's performant `TypeCache` as well as filtering out uninstantiatable types, like abstract classes and interfaces.