### PR TITLE
Fixing incorrect transition time + missing font icon reference

### DIFF
--- a/com.microsoft.mrtk.uxcomponents/Buttons/Canvas/Action Button.prefab
+++ b/com.microsoft.mrtk.uxcomponents/Buttons/Canvas/Action Button.prefab
@@ -913,7 +913,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8714766618717182506, guid: b85e005d231192249b7077b40a4d4e45, type: 3}
       propertyPath: stateContainers.entries.Array.data[0].value.effects.Array.data[1].transitionDuration
-      value: 0.3
+      value: 0.15
       objectReference: {fileID: 0}
     - target: {fileID: 8714766618717182506, guid: b85e005d231192249b7077b40a4d4e45, type: 3}
       propertyPath: stateContainers.entries.Array.data[4].value.effects.Array.data[1].transitionDuration
@@ -946,7 +946,7 @@ PrefabInstance:
     - target: {fileID: 8714766618717182506, guid: b85e005d231192249b7077b40a4d4e45, type: 3}
       propertyPath: stateContainers.entries.Array.data[0].value.effects.Array.data[1].tintables.Array.data[4]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 5095746839500215027}
     - target: {fileID: 8714766618717182506, guid: b85e005d231192249b7077b40a4d4e45, type: 3}
       propertyPath: stateContainers.entries.Array.data[4].value.effects.Array.data[1].tintables.Array.data[0]
       value: 


### PR DESCRIPTION
## Overview
The font icon wasn't referenced in the Disabled effect on our buttons, plus the transition time was incorrect.

## Changes
- Adds font icon reference to StateViz in `Action Button`
- Fixes transition time