### PR TITLE
Porting auto-labeler CI actions from mrtk3 branch

### DIFF
--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -1,0 +1,21 @@
+name: "Issue Labeling"
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  label-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            if (context.payload.issue.title.includes("MRTK3") || context.payload.issue.body.includes("MRTK3"))
+            {
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['MRTK3']
+              })
+            }

--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            if (context.payload.issue.title.includes("MRTK3") || context.payload.issue.body.includes("MRTK3"))
+            if (context.payload.issue.title.toLowerCase().includes("mrtk3") || context.payload.issue.body.toLowerCase().includes("mrtk3"))
             {
               github.rest.issues.addLabels({
                 issue_number: context.issue.number,

--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -10,12 +10,23 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            if (context.payload.issue.title.toLowerCase().includes("mrtk3") || context.payload.issue.body.toLowerCase().includes("mrtk3"))
+            if (context.payload.issue.title.toLowerCase().includes("mrtk3") ||
+                context.payload.issue.body.toLowerCase().includes("mrtk3"))
             {
               github.rest.issues.addLabels({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 labels: ['MRTK3']
+              })
+            }
+            if (context.payload.issue.title.toLowerCase().includes("mrtk2") ||
+                context.payload.issue.body.toLowerCase().includes("mrtk2"))
+            {
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['MRTK2']
               })
             }

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -1,5 +1,7 @@
 name: "PR Labeling"
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened, closed, synchronize, reopened, edited, ready_for_review]
   
 permissions:
   contents: read

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -1,0 +1,23 @@
+name: "PR Labeling"
+on: pull_request_target
+  
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            if (context.payload.pull_request.base_ref == "mrtk3")
+            {
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['MRTK3']
+              })
+            }

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -12,12 +12,23 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            if (context.payload.pull_request.base_ref == "mrtk3")
+            if (context.payload.pull_request.base.ref == 'mrtk3')
             {
               github.rest.issues.addLabels({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 labels: ['MRTK3']
+              })
+            }
+
+            // When we switch the repo to MRTK3, we'll have to edit this.
+            if (context.payload.pull_request.base.ref == 'main')
+            {
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['MRTK2']
               })
             }


### PR DESCRIPTION
## Overview
This cherrypicks a few commits from the mrtk3 branch to bring the CI autolabeler actions over to our "default" branch.