### PR TITLE
Dependency updates in package manifests

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Packages/manifest.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/manifest.json
@@ -19,7 +19,7 @@
     "com.microsoft.mrtk.uxcore": "file:../../../com.microsoft.mrtk.uxcore",
     "com.microsoft.mrtk.windowsspeech": "file:../../../com.microsoft.mrtk.windowsspeech",
     "com.microsoft.spatialaudio.spatializer.unity": "file:../../../ExternalDependencies/com.microsoft.spatialaudio.spatializer.unity-1.0.246.tgz",
-    "com.unity.collab-proxy": "1.15.18",
+    "com.unity.collab-proxy": "1.17.2",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",

--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -36,7 +36,7 @@
       "source": "local",
       "dependencies": {
         "com.microsoft.mrtk.core": "3.0.0-development",
-        "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
+        "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
         "com.unity.textmeshpro": "3.0.6"
       }
     },
@@ -107,7 +107,7 @@
       "source": "local",
       "dependencies": {
         "com.microsoft.mrtk.core": "3.0.0-development",
-        "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
+        "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
         "com.unity.inputsystem": "1.3.0",
         "com.unity.xr.interaction.toolkit": "2.0.3",
         "com.unity.xr.core-utils": "2.1.0-pre.1"
@@ -129,7 +129,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.microsoft.mrtk.graphicstools.unity": "0.3.15"
+        "com.microsoft.mrtk.graphicstools.unity": "0.4.0"
       }
     },
     "com.microsoft.mrtk.tools": {
@@ -156,7 +156,7 @@
       "source": "local",
       "dependencies": {
         "com.microsoft.mrtk.core": "3.0.0-development",
-        "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
+        "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
         "com.unity.inputsystem": "1.3.0",
         "com.unity.textmeshpro": "3.0.6",
         "com.unity.xr.interaction.toolkit": "2.0.3"

--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -53,7 +53,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.xr.interaction.toolkit": "2.0.2",
+        "com.unity.xr.interaction.toolkit": "2.0.3",
         "com.unity.xr.management": "4.2.1",
         "com.unity.xr.core-utils": "2.1.0-pre.1"
       }
@@ -109,8 +109,8 @@
         "com.microsoft.mrtk.core": "3.0.0-development",
         "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
         "com.unity.inputsystem": "1.3.0",
-        "com.unity.xr.interaction.toolkit": "2.0.2",
-        "com.unity.xr.core-utils": "2.0.0"
+        "com.unity.xr.interaction.toolkit": "2.0.3",
+        "com.unity.xr.core-utils": "2.1.0-pre.1"
       }
     },
     "com.microsoft.mrtk.spatialmanipulation": {
@@ -121,7 +121,7 @@
         "com.microsoft.mrtk.core": "3.0.0-development",
         "com.microsoft.mrtk.uxcore": "3.0.0-development",
         "com.unity.inputsystem": "1.3.0",
-        "com.unity.xr.interaction.toolkit": "2.0.2"
+        "com.unity.xr.interaction.toolkit": "2.0.3"
       }
     },
     "com.microsoft.mrtk.standardassets": {
@@ -159,7 +159,7 @@
         "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
         "com.unity.inputsystem": "1.3.0",
         "com.unity.textmeshpro": "3.0.6",
-        "com.unity.xr.interaction.toolkit": "2.0.2"
+        "com.unity.xr.interaction.toolkit": "2.0.3"
       }
     },
     "com.microsoft.mrtk.windowsspeech": {
@@ -186,7 +186,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "1.15.18",
+      "version": "1.17.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -360,7 +360,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.interaction.toolkit": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/UnityProjects/MRTKDevTemplate/ProjectSettings/ProjectVersion.txt
+++ b/UnityProjects/MRTKDevTemplate/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.37f1
-m_EditorVersionWithRevision: 2020.3.37f1 (8c66806a0c04)
+m_EditorVersion: 2020.3.38f1
+m_EditorVersionWithRevision: 2020.3.38f1 (8f5fde82e2dc)

--- a/com.microsoft.mrtk.accessibility/package.json
+++ b/com.microsoft.mrtk.accessibility/package.json
@@ -1,22 +1,22 @@
 {
   "name": "com.microsoft.mrtk.accessibility",
   "version": "1.0.0-development",
-  "description": "*** Please note ***\nThe MRTK3 accessibility features are in early preview and may not contain all planned features. Early preview releases also may undergo significant, breaking architectural changes before release.\n\nFeatures and subsystem to enable accessibility in mixed reality experiences.\n",
+  "description": "*** Please note ***\nThe MRTK3 accessibility features are in early preview and may not contain all planned features. Early preview releases also may undergo significant, breaking architectural changes before release.\n\nFeatures and subsystem to enable accessibility in mixed reality experiences.",
   "displayName": "MRTK Accessibility Early Preview",
   "msftFeatureCategory": "MRTK3",
   "author": "Microsoft",
   "license": "MIT",
   "repository": {
-      "type": "git",
-      "url": "https://github.com/microsoft/MixedRealityToolkit-Unity.git"
+    "type": "git",
+    "url": "https://github.com/microsoft/MixedRealityToolkit-Unity.git"
   },
   "bugs": {
-      "url": "https://github.com/microsoft/MixedRealityToolkit-Unity/issues"
+    "url": "https://github.com/microsoft/MixedRealityToolkit-Unity/issues"
   },
   "unity": "2020.3",
-  "dependencies": { 
+  "dependencies": {
     "com.microsoft.mrtk.core": "3.0.0-development",
-    "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
+    "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
     "com.unity.textmeshpro": "3.0.6"
   }
 }

--- a/com.microsoft.mrtk.core/package.json
+++ b/com.microsoft.mrtk.core/package.json
@@ -15,7 +15,7 @@
   },
   "unity": "2020.3",
   "dependencies": {
-    "com.unity.xr.interaction.toolkit": "2.0.2",
+    "com.unity.xr.interaction.toolkit": "2.0.3",
     "com.unity.xr.management": "4.2.1",
     "com.unity.xr.core-utils": "2.1.0-pre.1"
   }

--- a/com.microsoft.mrtk.input/package.json
+++ b/com.microsoft.mrtk.input/package.json
@@ -18,7 +18,7 @@
     "com.microsoft.mrtk.core": "3.0.0-development",
     "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
     "com.unity.inputsystem": "1.3.0",
-    "com.unity.xr.interaction.toolkit": "2.0.2",
-    "com.unity.xr.core-utils": "2.0.0"
+    "com.unity.xr.interaction.toolkit": "2.0.3",
+    "com.unity.xr.core-utils": "2.1.0-pre.1"
   }
 }

--- a/com.microsoft.mrtk.input/package.json
+++ b/com.microsoft.mrtk.input/package.json
@@ -16,7 +16,7 @@
   "unity": "2020.3",
   "dependencies": {
     "com.microsoft.mrtk.core": "3.0.0-development",
-    "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
+    "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.xr.interaction.toolkit": "2.0.3",
     "com.unity.xr.core-utils": "2.1.0-pre.1"

--- a/com.microsoft.mrtk.spatialmanipulation/package.json
+++ b/com.microsoft.mrtk.spatialmanipulation/package.json
@@ -18,7 +18,7 @@
     "com.microsoft.mrtk.core": "3.0.0-development",
     "com.microsoft.mrtk.uxcore": "3.0.0-development",
     "com.unity.inputsystem": "1.3.0",
-    "com.unity.xr.interaction.toolkit": "2.0.2"
+    "com.unity.xr.interaction.toolkit": "2.0.3"
   },
   "msftOptionalPackages": {
     "com.microsoft.mrtk.input": "3.0.0-development"

--- a/com.microsoft.mrtk.standardassets/package.json
+++ b/com.microsoft.mrtk.standardassets/package.json
@@ -15,6 +15,6 @@
     "url": "https://github.com/microsoft/MixedRealityToolkit-Unity/issues"
   },
   "dependencies": {
-    "com.microsoft.mrtk.graphicstools.unity": "0.3.15"
+    "com.microsoft.mrtk.graphicstools.unity": "0.4.0"
   }
 }

--- a/com.microsoft.mrtk.uxcore/package.json
+++ b/com.microsoft.mrtk.uxcore/package.json
@@ -16,7 +16,7 @@
   "unity": "2020.3",
   "dependencies": {
     "com.microsoft.mrtk.core": "3.0.0-development",
-    "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
+    "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.xr.interaction.toolkit": "2.0.3"

--- a/com.microsoft.mrtk.uxcore/package.json
+++ b/com.microsoft.mrtk.uxcore/package.json
@@ -19,7 +19,7 @@
     "com.microsoft.mrtk.graphicstools.unity": "0.3.15",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.textmeshpro": "3.0.6",
-    "com.unity.xr.interaction.toolkit": "2.0.2"
+    "com.unity.xr.interaction.toolkit": "2.0.3"
   },
   "msftOptionalPackages": {
     "com.microsoft.mrtk.data": "1.0.0-development"


### PR DESCRIPTION
This change updates to the v2.0.3 of the Unity XRI package plus the following changes:
* Sync all references to xr.core-utilities to v 2.1.0-pre.1 (previously adopted by the core defs packages)
* MRGT 0.3.15 -> 0.4.0 (latest published package)
* Ensure all XRI package references are 2.0.3
* Update to the latest Unity 2020.3 LTS (38f1)