### PR TITLE
Add 3D app icon setting for UWP

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/MRTK.Generated/MRTKSettings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/MRTK.Generated/MRTKSettings.asset
@@ -1,5 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8396960163737442306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 897a89a485d29204b849545f0864a2f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  appLauncherModelLocation: Packages/com.microsoft.mrtk.extendedassets/Models/MRTK_Logo.glb
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20,3 +33,4 @@ MonoBehaviour:
       value: {fileID: 11400000, guid: c677e5c4eb85b7849a8da406775c299d, type: 2}
     - key: 1
       value: {fileID: 11400000, guid: c677e5c4eb85b7849a8da406775c299d, type: 2}
+  buildPreferences: {fileID: -8396960163737442306}

--- a/UnityProjects/MRTKDevTemplate/Assets/MRTK.Generated/MRTKSettings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/MRTK.Generated/MRTKSettings.asset
@@ -1,18 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-8396960163737442306
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 897a89a485d29204b849545f0864a2f8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  appLauncherModelLocation: Packages/com.microsoft.mrtk.extendedassets/Models/MRTK_Logo.glb
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -33,4 +20,5 @@ MonoBehaviour:
       value: {fileID: 11400000, guid: c677e5c4eb85b7849a8da406775c299d, type: 2}
     - key: 1
       value: {fileID: 11400000, guid: c677e5c4eb85b7849a8da406775c299d, type: 2}
-  buildPreferences: {fileID: -8396960163737442306}
+  buildPreferences:
+    appLauncherModel: {fileID: 8771091787928289351, guid: aa94f0fa662d8bd4e84361cc9f0d065a, type: 3}

--- a/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs
@@ -72,7 +72,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         string newAppLauncherModelLocation = AssetDatabase.GetAssetPath(newGlbModel);
                         if (check.changed
                             && (newAppLauncherModelLocation.EndsWith(".glb")
-                                || newAppLauncherModelLocation.EndsWith(".gltf")
                                 || string.IsNullOrWhiteSpace(newAppLauncherModelLocation)))
                         {
                             Settings.BuildPreferences.appLauncherModel = newGlbModel;

--- a/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    /// <summary>
+    /// Settings provider for build-specific settings, like the 3D app launcher model for Windows builds.
+    /// </summary>
+    public class MRTKBuildPreferences : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+    {
+        private const string AppLauncherPath = @"Assets\AppLauncherModel.glb";
+        private static readonly GUIContent AppLauncherModelLabel = new GUIContent("3D App Launcher Model", "Location of .glb model to use as a 3D App Launcher");
+        private static UnityEditor.Editor gameObjectEditor = null;
+        private static GUIStyle appLauncherPreviewBackgroundColor = null;
+        private static bool isBuilding = false;
+
+        // Arbitrary callback order, chosen to be larger so that it runs after other things that
+        // a developer may have already.
+        int IOrderedCallback.callbackOrder => 100;
+
+        [SettingsProvider]
+        private static SettingsProvider BuildPreferences()
+        {
+            var provider = new SettingsProvider("Project/MRTK3/Build Settings", SettingsScope.Project)
+            {
+                guiHandler = GUIHandler,
+
+                keywords = new HashSet<string>(new[] { "Mixed", "Reality", "Toolkit", "Build" })
+            };
+
+            void GUIHandler(string searchContext)
+            {
+                EditorGUILayout.HelpBox("These settings are serialized into ProjectPreferences.asset in the MixedRealityToolkit-Generated folder.\nThis file can be checked into source control to maintain consistent settings across collaborators.", MessageType.Info);
+                DrawAppLauncherModelField();
+            }
+
+            return provider;
+        }
+
+        private static MRTKSettings Settings => settings != null ? settings : settings = MRTKSettings.GetOrCreateSettings();
+        private static MRTKSettings settings = null;
+
+        /// <summary>
+        /// Helper script for rendering an object field to set the 3D app launcher model in an editor window.
+        /// </summary>
+        /// <remarks>See <see href="https://docs.microsoft.com/en-us/windows/mixed-reality/distribute/3d-app-launcher-design-guidance">3D app launcher design guidance</see> for more information.</remarks>
+        public static void DrawAppLauncherModelField(bool showInteractivePreview = true)
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                GameObject newGlbModel;
+                bool appLauncherChanged = false;
+
+                // 3D launcher model
+                //string curAppLauncherModelLocation = BuildDeployPreferences.AppLauncherModelLocation;
+                string curAppLauncherModelLocation = Settings.AppLauncherModelLocation;
+                var curGlbModel = AssetDatabase.LoadAssetAtPath(curAppLauncherModelLocation, typeof(GameObject));
+
+                using (new EditorGUILayout.VerticalScope())
+                {
+                    EditorGUILayout.HelpBox("This field will only accept .glb and .gltf files. Any other file type will be silently rejected.", MessageType.Info);
+
+                    EditorGUILayout.LabelField(AppLauncherModelLabel);
+                    newGlbModel = EditorGUILayout.ObjectField(curGlbModel, typeof(GameObject), false, GUILayout.MaxWidth(256)) as GameObject;
+                    string newAppLauncherModelLocation = AssetDatabase.GetAssetPath(newGlbModel);
+                    if (newAppLauncherModelLocation != curAppLauncherModelLocation
+                        && (newAppLauncherModelLocation.EndsWith(".glb")
+                            || newAppLauncherModelLocation.EndsWith(".gltf")
+                            || string.IsNullOrWhiteSpace(newAppLauncherModelLocation)))
+                    {
+                        //BuildDeployPreferences.AppLauncherModelLocation = newAppLauncherModelLocation;
+                        Settings.AppLauncherModelLocation = newAppLauncherModelLocation;
+                        appLauncherChanged = true;
+                    }
+                }
+
+                // The preview GUI has a problem during the build, so we don't render it
+                if (newGlbModel != null && showInteractivePreview && !isBuilding)
+                {
+                    if (gameObjectEditor == null || appLauncherChanged)
+                    {
+                        gameObjectEditor = UnityEditor.Editor.CreateEditor(newGlbModel);
+                    }
+
+                    if (appLauncherPreviewBackgroundColor == null)
+                    {
+                        appLauncherPreviewBackgroundColor = new GUIStyle();
+                        appLauncherPreviewBackgroundColor.normal.background = EditorGUIUtility.whiteTexture;
+                    }
+
+                    gameObjectEditor.OnInteractivePreviewGUI(GUILayoutUtility.GetRect(128, 128), appLauncherPreviewBackgroundColor);
+                }
+            }
+        }
+
+        void IPreprocessBuildWithReport.OnPreprocessBuild(BuildReport report)
+        {
+            if (report.summary.platformGroup == BuildTargetGroup.WSA && !string.IsNullOrEmpty(Settings.AppLauncherModelLocation))
+            {
+                isBuilding = true;
+                // Sets the editor to null. On a build, Unity reloads the object preview
+                // in a seemingly unexpected way, so it starts rendering a null texture.
+                // This refreshes the preview window instead.
+                gameObjectEditor = null;
+            }
+        }
+
+        void IPostprocessBuildWithReport.OnPostprocessBuild(BuildReport report)
+        {
+            if (report.summary.platformGroup == BuildTargetGroup.WSA && !string.IsNullOrEmpty(Settings.AppLauncherModelLocation))
+            {
+                string appxPath = $"{report.summary.outputPath}/{PlayerSettings.productName}";
+
+                Debug.Log($"3D App Launcher: {Settings.AppLauncherModelLocation}, Destination: {appxPath}/{AppLauncherPath}");
+
+                FileUtil.ReplaceFile(Settings.AppLauncherModelLocation, $"{appxPath}/{AppLauncherPath}");
+                AddAppLauncherModelToProject($"{appxPath}/{PlayerSettings.productName}.vcxproj");
+                AddAppLauncherModelToFilter($"{appxPath}/{PlayerSettings.productName}.vcxproj.filters");
+                UpdateManifest($"{appxPath}/Package.appxmanifest");
+
+                isBuilding = false;
+            }
+        }
+
+        private static void AddAppLauncherModelToProject(string filePath)
+        {
+            var text = File.ReadAllText(filePath);
+            var doc = new XmlDocument();
+            doc.LoadXml(text);
+            var root = doc.DocumentElement;
+
+            // Check to see if model has already been added
+            XmlNodeList nodes = root.SelectNodes($"//None[@Include = \"{AppLauncherPath}\"]");
+            if (nodes.Count > 0)
+            {
+                return;
+            }
+
+            var newNodeDoc = new XmlDocument();
+            newNodeDoc.LoadXml($"<None Include=\"{AppLauncherPath}\">" +
+                            "<DeploymentContent>true</DeploymentContent>" +
+                            "</None>");
+            var newNode = doc.ImportNode(newNodeDoc.DocumentElement, true);
+            var list = doc.GetElementsByTagName("ItemGroup");
+            var items = list.Item(1);
+            items.AppendChild(newNode);
+            doc.Save(filePath);
+        }
+
+        private static void AddAppLauncherModelToFilter(string filePath)
+        {
+            var text = File.ReadAllText(filePath);
+            var doc = new XmlDocument();
+            doc.LoadXml(text);
+            var root = doc.DocumentElement;
+
+            // Check to see if model has already been added
+            XmlNodeList nodes = root.SelectNodes($"//None[@Include = \"{AppLauncherPath}\"]");
+            if (nodes.Count > 0)
+            {
+                return;
+            }
+
+            var newNodeDoc = new XmlDocument();
+            newNodeDoc.LoadXml($"<None Include=\"{AppLauncherPath}\">" +
+                            "<Filter>Assets</Filter>" +
+                            "</None>");
+            var newNode = doc.ImportNode(newNodeDoc.DocumentElement, true);
+            var list = doc.GetElementsByTagName("ItemGroup");
+            var items = list.Item(0);
+            items.AppendChild(newNode);
+            doc.Save(filePath);
+        }
+
+        private static void UpdateManifest(string filePath)
+        {
+            var text = File.ReadAllText(filePath);
+            var doc = new XmlDocument();
+            doc.LoadXml(text);
+            var root = doc.DocumentElement;
+
+            // Check to see if the element exists already
+            XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.NameTable);
+            nsmgr.AddNamespace("uap5", "http://schemas.microsoft.com/appx/manifest/uap/windows10/5");
+            XmlNodeList nodes = root.SelectNodes("//uap5:MixedRealityModel", nsmgr);
+            foreach (XmlNode node in nodes)
+            {
+                if (node.Attributes != null && node.Attributes["Path"].Value == AppLauncherPath)
+                {
+                    return;
+                }
+            }
+            root.SetAttribute("xmlns:uap5", "http://schemas.microsoft.com/appx/manifest/uap/windows10/5");
+
+            var ignoredValue = root.GetAttribute("IgnorableNamespaces");
+            root.SetAttribute("IgnorableNamespaces", ignoredValue + " uap5");
+
+            var newElement = doc.CreateElement("uap5", "MixedRealityModel", "http://schemas.microsoft.com/appx/manifest/uap/windows10/5");
+            newElement.SetAttribute("Path", AppLauncherPath);
+            var list = doc.GetElementsByTagName("uap:DefaultTile");
+            var items = list.Item(0);
+            items.AppendChild(newElement);
+
+            doc.Save(filePath);
+        }
+    }
+}

--- a/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs
@@ -88,6 +88,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                             && (newAppLauncherModelLocation.EndsWith(".glb")
                                 || string.IsNullOrWhiteSpace(newAppLauncherModelLocation)))
                         {
+                            Undo.RecordObject(Settings, "Change app launcher model");
                             Settings.BuildPreferences.appLauncherModel = newGlbModel;
                             appLauncherChanged = true;
                             EditorUtility.SetDirty(Settings);

--- a/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs
@@ -15,6 +15,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     /// <summary>
     /// Settings provider for build-specific settings, like the 3D app launcher model for Windows builds.
     /// </summary>
+    /// <remarks>
+    /// See <see href="https://docs.microsoft.com/windows/mixed-reality/distribute/3d-app-launcher-design-guidance">3D app launcher design guidance</see> for more information.
+    /// </remarks>
     [Serializable]
     internal class MRTKBuildPreferences : IPreprocessBuildWithReport, IPostprocessBuildWithReport
     {
@@ -31,7 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         // a developer may have already.
         int IOrderedCallback.callbackOrder => 100;
 
-        /// <remarks>See <see href="https://docs.microsoft.com/windows/mixed-reality/distribute/3d-app-launcher-design-guidance">3D app launcher design guidance</see> for more information.</remarks>
         [SerializeField]
         private GameObject appLauncherModel;
 

--- a/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs.meta
+++ b/com.microsoft.mrtk.core/Editor/MRTKBuildPreferences.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 897a89a485d29204b849545f0864a2f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.core/Editor/MRTKBuildProcessor.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKBuildProcessor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <summary>
         /// Clean old settings and bundle new settings.
         /// </summary>
-        public void OnPreprocessBuild(BuildReport report)
+        void IPreprocessBuildWithReport.OnPreprocessBuild(BuildReport report)
         {
             Clean();
 
@@ -82,7 +82,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <summary>
         /// Clean old settings post-build.
         /// </summary>
-        public void OnPostprocessBuild(BuildReport report)
+        void IPostprocessBuildWithReport.OnPostprocessBuild(BuildReport report)
         {
             Clean();
         }

--- a/com.microsoft.mrtk.core/Editor/MRTKSettings.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKSettings.cs
@@ -20,6 +20,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [SerializeField]
         private SerializableDictionary<BuildTargetGroup, MRTKProfile> settings = new SerializableDictionary<BuildTargetGroup, MRTKProfile>();
 
+        [SerializeField]
+        private string appLauncherModelLocation = string.Empty;
+
+        public string AppLauncherModelLocation
+        {
+            get => appLauncherModelLocation;
+            internal set => appLauncherModelLocation = value;
+        }
+
         private void OnEnable()
         {
             MRTKProfile.Instance = GetProfileForBuildTarget(BuildTargetGroup.Standalone);

--- a/com.microsoft.mrtk.core/Editor/MRTKSettings.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKSettings.cs
@@ -21,12 +21,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializableDictionary<BuildTargetGroup, MRTKProfile> settings = new SerializableDictionary<BuildTargetGroup, MRTKProfile>();
 
         [SerializeField]
-        private string appLauncherModelLocation = string.Empty;
+        private MRTKBuildPreferences buildPreferences = default;
 
-        public string AppLauncherModelLocation
+        internal MRTKBuildPreferences BuildPreferences
         {
-            get => appLauncherModelLocation;
-            internal set => appLauncherModelLocation = value;
+            get => buildPreferences;
+            set => buildPreferences = value;
         }
 
         private void OnEnable()

--- a/com.microsoft.mrtk.core/Editor/MRTKSettings.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKSettings.cs
@@ -23,11 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [SerializeField]
         private MRTKBuildPreferences buildPreferences = default;
 
-        internal MRTKBuildPreferences BuildPreferences
-        {
-            get => buildPreferences;
-            set => buildPreferences = value;
-        }
+        internal MRTKBuildPreferences BuildPreferences => buildPreferences;
 
         private void OnEnable()
         {


### PR DESCRIPTION
## Overview

Adds the ability to set a 3D app launcher model for WMR UWP.
https://docs.microsoft.com/en-us/windows/mixed-reality/distribute/creating-3d-models-for-use-in-the-windows-mixed-reality-home

The settings can be found under Project Settings -> MRTK3 -> Build Settings

![image](https://user-images.githubusercontent.com/3580640/187280920-f2d553a5-609e-425b-9bda-3a12e8671dfa.png)

Works great with #10923 🥳

![image](https://user-images.githubusercontent.com/3580640/187280761-4996ec53-ecda-4372-afb3-2528a245b863.png)

## Changes

- Fixes: #10929 
