### PR TITLE
Move some codepaths away from MixedRealityToolkitFiles

### DIFF
--- a/Assets/MRTK/Core/Attributes/MixedRealityExtensionServiceAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/MixedRealityExtensionServiceAttribute.cs
@@ -66,13 +66,9 @@ namespace Microsoft.MixedReality.Toolkit
                         return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(folder, DefaultProfilePath));
                     }
                 }
-                else
+                else if (EditorProjectUtilities.FindRelativeDirectory(PackageFolder, out string folder))
                 {
-                    string folder;
-                    if (EditorProjectUtilities.FindRelativeDirectory(PackageFolder, out folder))
-                    {
-                        return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(folder, DefaultProfilePath));
-                    }
+                    return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(folder, DefaultProfilePath));
                 }
 
                 // If we get here, there was an issue finding the profile.

--- a/Assets/MRTK/Core/Definitions/Devices/ControllerMappingLibrary.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/ControllerMappingLibrary.cs
@@ -6,6 +6,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 #endif
@@ -255,10 +256,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private static Texture2D GetControllerTextureCached(Type controllerType, Handedness handedness, string suffix)
         {
-            Texture2D texture;
-
             var key = new Tuple<Type, Handedness, string>(controllerType, handedness, suffix);
-            if (cachedTextures.TryGetValue(key, out texture))
+            if (cachedTextures.TryGetValue(key, out Texture2D texture))
             {
                 return texture;
             }
@@ -303,8 +302,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             string themeSuffix = EditorGUIUtility.isProSkin ? "_white" : "_black";
 
-            string fullTexturePath = MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.StandardAssets, $"{relativeTexturePath}{handednessSuffix}{themeSuffix}{suffix}.png");
-            return (Texture2D)AssetDatabase.LoadAssetAtPath(fullTexturePath, typeof(Texture2D));
+            string textureName = $"{Path.GetFileName(relativeTexturePath)}{handednessSuffix}{themeSuffix}{suffix}";
+            string[] textureGuids = AssetDatabase.FindAssets(textureName);
+            string texturePath = string.Empty;
+            foreach (string guid in textureGuids)
+            {
+                string tempPath = AssetDatabase.GUIDToAssetPath(guid);
+                // Ensure the path we're looking at contains the exact file name we're looking for
+                if (tempPath.Contains(textureName + ".png"))
+                {
+                    texturePath = tempPath;
+                    break;
+                }
+            }
+
+            return (Texture2D)AssetDatabase.LoadAssetAtPath(texturePath, typeof(Texture2D));
         }
 
 #endif // UNITY_EDITOR

--- a/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
@@ -16,7 +16,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 {
     public class ControllerPopupWindow : EditorWindow
     {
-        private const string EditorWindowOptionsPath = "Inspectors/Data/EditorWindowOptions.json";
+        // Inspectors/Data/EditorWindowOptions.json
+        private const string EditorWindowOptionsGuid = "28091d5ea9b5739419a221a06fa1ec89";
         private const float InputActionLabelWidth = 128f;
 
         /// <summary>
@@ -786,7 +787,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private static string ResolveEditorWindowOptionsPath()
         {
-            return MixedRealityToolkitFiles.MapRelativeFilePathToAbsolutePath(EditorWindowOptionsPath);
+            return Path.GetFullPath(AssetDatabase.GUIDToAssetPath(EditorWindowOptionsGuid));
         }
     }
 }

--- a/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/ControllerPopupWindow.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private const float InputActionLabelWidth = 128f;
 
         /// <summary>
-        /// Used to enable editing the input axis label positions on controllers
+        /// Used to enable editing the input axis label positions on controllers.
         /// </summary>
         private static readonly bool EnableWysiwyg = false;
 
@@ -188,12 +188,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         }
 
         /// <summary>
-        /// Displays the controller mapping window for the specified controller mapping
+        /// Displays the controller mapping window for the specified controller mapping.
         /// </summary>
-        /// <param name="controllerMapping"> The controller mapping being modified</param>
-        /// <param name="interactionsList"> The underlying serialized property being modified</param>
-        /// <param name="handedness"> The handedness of the controller </param>
-        /// <param name="mappedControllers"> The list of controller types affected by this mapping</param>
+        /// <param name="controllerMapping">The controller mapping being modified.</param>
+        /// <param name="interactionsList">The underlying serialized property being modified.</param>
+        /// <param name="handedness">The handedness of the controller.</param>
+        /// <param name="mappedControllers">The list of controller types affected by this mapping.</param>
         public static void Show(MixedRealityControllerMapping controllerMapping, SerializedProperty interactionsList, Handedness handedness = Handedness.None, List<string> mappedControllers = null)
         {
             if (window != null)
@@ -262,7 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         }
 
         /// <summary>
-        /// Use this to repaint the popup window
+        /// Use this to repaint the pop-up window.
         /// </summary>
         public static void RepaintWindow()
         {

--- a/Assets/MRTK/Core/Utilities/Editor/EditorProjectUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/EditorProjectUtilities.cs
@@ -85,8 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </param>
         internal static bool FindRelativeDirectory(string directoryPathToSearch, string directoryName, out string path)
         {
-            string absolutePath;
-            if (FindDirectory(directoryPathToSearch, directoryName, out absolutePath))
+            if (FindDirectory(directoryPathToSearch, directoryName, out string absolutePath))
             {
                 path = MixedRealityToolkitFiles.GetAssetDatabasePath(absolutePath);
                 return true;

--- a/Assets/MRTK/Tests/PlayModeTests/Core/Utilities/LRUCacheUnitTests.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/Core/Utilities/LRUCacheUnitTests.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -5,8 +5,8 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 
 #if UNITY_EDITOR
-using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using Microsoft.MixedReality.Toolkit.Editor;
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -416,16 +416,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [MenuItem("Mixed Reality/Toolkit/Utilities/Update/Icons/Tests")]
         private static void UpdateTestScriptIcons()
         {
-            Texture2D icon = null;
-
-            foreach (string iconPath in MixedRealityToolkitFiles.GetFiles(MixedRealityToolkitModuleType.StandardAssets, "Icons"))
-            {
-                if (iconPath.EndsWith("test_icon.png"))
-                {
-                    icon = AssetDatabase.LoadAssetAtPath<Texture2D>(iconPath);
-                    break;
-                }
-            }
+            // test_icon.png
+            Texture2D icon = AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath("731058d908be67544b92b0341f29d906"));
 
             if (icon == null)
             {

--- a/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.CSharp;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -278,11 +277,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         #region paths
 
         private string ExtensionsFolder => Path.Combine("Assets", DefaultGeneratedFolderName, DefaultExtensionsFolderName);
-        private string ServiceTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionScriptTemplate.txt");
-        private string ServiceConstructorTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionConstructorTemplate.txt");
-        private string InspectorTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionInspectorTemplate.txt");
-        private string InterfaceTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionInterfaceTemplate.txt");
-        private string ProfileTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionProfileTemplate.txt");
+        // ExtensionServiceCreator/Templates/ExtensionScriptTemplate.txt
+        private string ServiceTemplatePath => AssetDatabase.GUIDToAssetPath("bd6d5de0b9c435345a4e4e25dda3afd1");
+        // ExtensionServiceCreator/Templates/ExtensionConstructorTemplate.txt
+        private string ServiceConstructorTemplatePath => AssetDatabase.GUIDToAssetPath("41b9c612c56dddd4691c98456dc221f2");
+        // ExtensionServiceCreator/Templates/ExtensionInspectorTemplate.txt
+        private string InspectorTemplatePath => AssetDatabase.GUIDToAssetPath("2283bd5be15f3074fa8839ef90573636");
+        // ExtensionServiceCreator/Templates/ExtensionInterfaceTemplate.txt
+        private string InterfaceTemplatePath => AssetDatabase.GUIDToAssetPath("1179733a8171c7a49bb1cbdc1ff0c04c");
+        // ExtensionServiceCreator/Templates/ExtensionProfileTemplate.txt
+        private string ProfileTemplatePath => AssetDatabase.GUIDToAssetPath("d67b9bbb1a49ad743a30f55e814007b9");
 
         #endregion
 

--- a/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -286,33 +286,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #endregion
 
-        private string ServiceFieldName => Char.ToLowerInvariant(ServiceName[0]) + ServiceName.Substring(1);
-        private string ProfileFieldName => Char.ToLowerInvariant(ProfileName[0]) + ProfileName.Substring(1);
+        private string ServiceFieldName => char.ToLowerInvariant(ServiceName[0]) + ServiceName.Substring(1);
+        private string ProfileFieldName => char.ToLowerInvariant(ProfileName[0]) + ProfileName.Substring(1);
 
-        private string ServiceFolderPath
-        {
-            get { return ServiceFolderObject != null ? AssetDatabase.GetAssetPath(ServiceFolderObject) : string.Empty; }
-        }
+        private string ServiceFolderPath => ServiceFolderObject != null ? AssetDatabase.GetAssetPath(ServiceFolderObject) : string.Empty;
 
-        private string InspectorFolderPath
-        {
-            get { return InspectorFolderObject != null ? AssetDatabase.GetAssetPath(InspectorFolderObject) : string.Empty; }
-        }
+        private string InspectorFolderPath => InspectorFolderObject != null ? AssetDatabase.GetAssetPath(InspectorFolderObject) : string.Empty;
 
-        private string InterfaceFolderPath
-        {
-            get { return InterfaceFolderObject != null ? AssetDatabase.GetAssetPath(InterfaceFolderObject) : string.Empty; }
-        }
+        private string InterfaceFolderPath => InterfaceFolderObject != null ? AssetDatabase.GetAssetPath(InterfaceFolderObject) : string.Empty;
 
-        private string ProfileFolderPath
-        {
-            get { return ProfileFolderObject != null ? AssetDatabase.GetAssetPath(ProfileFolderObject) : string.Empty; }
-        }
-
-        private string ProfileAssetFolderPath
-        {
-            get { return ProfileAssetFolderObject != null ? AssetDatabase.GetAssetPath(ProfileAssetFolderObject) : string.Empty; }
-        }
+        private string ProfileFolderPath => ProfileFolderObject != null ? AssetDatabase.GetAssetPath(ProfileFolderObject) : string.Empty;
 
         private string ServiceTemplate;
         private string ServiceConstructorTemplate;


### PR DESCRIPTION
## Overview

MixedRealityToolkitFiles has always had some issues around Assets vs Packages, relative vs absolute, and some less-standard forms of referencing MRTK2.

This PR moves away from most of the more problematic cases for in-MRTK code to use Unity's `AssetDatabase` APIs instead.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4904