### PR TITLE
Update Non-canvas package display name for UPM alphabetical ordering

### DIFF
--- a/com.microsoft.mrtk.uxcomponents.noncanvas/package.json
+++ b/com.microsoft.mrtk.uxcomponents.noncanvas/package.json
@@ -2,7 +2,7 @@
   "name": "com.microsoft.mrtk.uxcomponents.noncanvas",
   "version": "3.0.0-development",
   "description": "MRTK non-Canvas UX component library, for building 3D UX without Canvas layout. For most production-grade UI, we recommend the dynamic hybrid Canvas-based UX systems, located in com.microsoft.mrtk.uxcomponents. However, in some circumstances, static/non-Canvas UI may offer improved performance and batching, and may be desirable in resource-constrained scenarios.",
-  "displayName": "MRTK (Non-Canvas) UX Components",
+  "displayName": "MRTK UX Components (Non-Canvas)",
   "msftFeatureCategory": "MRTK3",
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
## Overview

The location of this package in the UPM UI is slightly misaligned contextually

from this

<img width="206" alt="image" src="https://user-images.githubusercontent.com/3580640/188997744-4ac26265-e6c6-48ec-8b59-7cfd7275b37c.png">

to this

<img width="204" alt="image" src="https://user-images.githubusercontent.com/3580640/188997692-8e618aae-ce51-478c-bf3d-28ba5ad7fa87.png">
