### PR TITLE
Further obsolete ArticulatedHandController's PinchPose

### DIFF
--- a/com.microsoft.mrtk.input/Controllers/ArticulatedHandController.cs
+++ b/com.microsoft.mrtk.input/Controllers/ArticulatedHandController.cs
@@ -114,6 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 handControllerState.PinchSelectReady = isPinchReady;
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (isPinching && HandsAggregator.TryGetPinchingPoint(handNode, out HandJointPose pinchPose))
                 {
                     handControllerState.PinchPose.position = pinchPose.Position;
@@ -124,6 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     handControllerState.PinchPose.position = controllerState.position;
                     handControllerState.PinchPose.rotation = controllerState.rotation;
                 }
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 

--- a/com.microsoft.mrtk.input/Controllers/ArticulatedHandController.cs
+++ b/com.microsoft.mrtk.input/Controllers/ArticulatedHandController.cs
@@ -85,7 +85,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 Debug.Assert(handControllerState != null);
 
-
                 // If we still don't have an aggregator, then don't update selects.
                 if (HandsAggregator == null) { return; }
 

--- a/com.microsoft.mrtk.input/Controllers/ArticulatedHandControllerState.cs
+++ b/com.microsoft.mrtk.input/Controllers/ArticulatedHandControllerState.cs
@@ -23,6 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// The world-space pose of hand/controller performing the pinch.
         /// </summary>
+        [Obsolete("We are moving away from querying the pinch select pose via the specific XR controller reference. It should be accessed via an IPoseSource interface or directly from the subsystem")]
         public Pose PinchPose;
 
         /// <summary>
@@ -31,7 +32,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public ArticulatedHandControllerState() : base()
         {
             PinchSelectReady = false;
+#pragma warning disable CS0618 // Type or member is obsolete
             PinchPose = Pose.identity;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }


### PR DESCRIPTION
## Overview

Follow up to #10897. Adds an additional obsolete attribute to an `internal` class to further dissuade usage of this PinchPose.