### PR TITLE
Update tracking state mapping for base hand controller prefab

### DIFF
--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK Hand Controller.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK Hand Controller.prefab
@@ -1197,7 +1197,7 @@ MonoBehaviour:
             m_Interactions: 
             m_SingletonActionBindings: []
             m_Flags: 0
-          m_Reference: {fileID: 7779212132400271959, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+          m_Reference: {fileID: -7613329581162844239, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
         positionActionProperty:
           m_UseReference: 1
           m_Action:


### PR DESCRIPTION
## Overview

It was set to `Translate Anchor` instead of `Tracking State`

<img width="591" alt="image" src="https://user-images.githubusercontent.com/3580640/189233254-a7d9a2dd-14dd-471b-ad2e-d6ee183d095a.png">

to 

<img width="581" alt="image" src="https://user-images.githubusercontent.com/3580640/189233440-8a8f9b58-67c9-4d6c-8dbf-095209b9c08d.png">
