### PR TITLE
Remove duplicate PlayspaceUtilities.ReferenceTransform.rotation application

### DIFF
--- a/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -197,7 +197,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // Use the Device Pose Sources to calculate the attach transform's pose
                     if (DevicePoseSource != null && DevicePoseSource.TryGetPose(out Pose devicePose))
                     {
-                        attachTransform.rotation = PlayspaceUtilities.ReferenceTransform.rotation * devicePose.rotation;
+                        attachTransform.rotation = devicePose.rotation;
                     }
                 }
             }

--- a/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractorVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/Ray/MRTKRayInteractorVisual.cs
@@ -439,7 +439,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 reticleNormal = hitTargetTransform.TransformDirection(targetLocalHitNormal);
                 rayHasHit = true;
             }
-            // Otherwise draw out the line exactly as the Ray Interactor perscribes
+            // Otherwise draw out the line exactly as the Ray Interactor prescribes
             else
             {
                 // If the ray hits an object, truncate the visual appropriately


### PR DESCRIPTION
## Overview

`DevicePoseSource` already return its pose with PlayspaceUtilities.ReferenceTransform.rotation applied

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/46fd40f0b88ae03810187447b2e1becac47a963a/com.microsoft.mrtk.input/Utilities/PoseSource/InputActionPoseSource.cs#L42-L43