### PR TITLE
Improve reset logic for hand data

### DIFF
--- a/com.microsoft.mrtk.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
+++ b/com.microsoft.mrtk.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Subsystems;
+using UnityEngine.InputSystem;
 
 #if MROPENXR_PRESENT && (UNITY_EDITOR_WIN || UNITY_WSA || UNITY_STANDALONE_WIN || UNITY_ANDROID)
 using Microsoft.MixedReality.OpenXR;
@@ -251,13 +252,29 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Preserve]
         private class OpenXRProvider : Provider, IHandsSubsystem
         {
-            private Dictionary<XRNode, OpenXRHandContainer> hands = new Dictionary<XRNode, OpenXRHandContainer>
-            {
-                { XRNode.LeftHand, new OpenXRHandContainer(XRNode.LeftHand) },
-                { XRNode.RightHand, new OpenXRHandContainer(XRNode.RightHand) }
-            };
+            private Dictionary<XRNode, OpenXRHandContainer> hands = null;
 
-            public override void Update()
+            public override void Start()
+            {
+                base.Start();
+
+                hands ??= new Dictionary<XRNode, OpenXRHandContainer>
+                {
+                    { XRNode.LeftHand, new OpenXRHandContainer(XRNode.LeftHand) },
+                    { XRNode.RightHand, new OpenXRHandContainer(XRNode.RightHand) }
+                };
+
+                InputSystem.onBeforeUpdate += ResetHands;
+            }
+
+            public override void Stop()
+            {
+                ResetHands();
+                InputSystem.onBeforeUpdate -= ResetHands;
+                base.Stop();
+            }
+
+            private void ResetHands()
             {
                 hands[XRNode.LeftHand].Reset();
                 hands[XRNode.RightHand].Reset();

--- a/com.microsoft.mrtk.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
+++ b/com.microsoft.mrtk.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
@@ -5,8 +5,11 @@ using Microsoft.MixedReality.Toolkit.Subsystems;
 using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using UnityEngine.Scripting;
 using UnityEngine.XR;
+using CommonUsages = UnityEngine.XR.CommonUsages;
+using InputDevice = UnityEngine.XR.InputDevice;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -260,13 +263,29 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Preserve]
         private class XRSDKProvider : Provider
         {
-            private Dictionary<XRNode, XRSDKHandContainer> hands = new Dictionary<XRNode, XRSDKHandContainer>
-            {
-                { XRNode.LeftHand, new XRSDKHandContainer(XRNode.LeftHand) },
-                { XRNode.RightHand, new XRSDKHandContainer(XRNode.RightHand) }
-            };
+            private Dictionary<XRNode, XRSDKHandContainer> hands = null;
 
-            public override void Update()
+            public override void Start()
+            {
+                base.Start();
+
+                hands ??= new Dictionary<XRNode, XRSDKHandContainer>
+                {
+                    { XRNode.LeftHand, new XRSDKHandContainer(XRNode.LeftHand) },
+                    { XRNode.RightHand, new XRSDKHandContainer(XRNode.RightHand) }
+                };
+
+                InputSystem.onBeforeUpdate += ResetHands;
+            }
+
+            public override void Stop()
+            {
+                ResetHands();
+                InputSystem.onBeforeUpdate -= ResetHands;
+                base.Stop();
+            }
+
+            private void ResetHands()
             {
                 hands[XRNode.LeftHand].Reset();
                 hands[XRNode.RightHand].Reset();

--- a/com.microsoft.mrtk.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
+++ b/com.microsoft.mrtk.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using UnityEngine.Scripting;
 using UnityEngine.XR;
 
@@ -199,28 +200,36 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Preserve]
         protected class MRTKAggregator : Provider
         {
-            protected MRTKHandsAggregatorConfig Config { get; }
+            protected MRTKHandsAggregatorConfig Config { get; private set; }
 
-            public MRTKAggregator() : base()
-            {
-                Config = XRSubsystemHelpers.GetConfiguration<MRTKHandsAggregatorConfig, MRTKHandsAggregatorSubsystem>();
-            }
-
-            private Dictionary<XRNode, AggregateHandContainer> hands;
+            private Dictionary<XRNode, AggregateHandContainer> hands = null;
 
             // Reusable pinch pose structs to reduce allocs.
             private HandJointPose leftPinchPose, rightPinchPose;
 
             public override void Start()
             {
-                hands = new Dictionary<XRNode, AggregateHandContainer>
+                base.Start();
+
+                Config = XRSubsystemHelpers.GetConfiguration<MRTKHandsAggregatorConfig, MRTKHandsAggregatorSubsystem>();
+
+                hands ??= new Dictionary<XRNode, AggregateHandContainer>
                 {
                     { XRNode.LeftHand, new AggregateHandContainer(XRNode.LeftHand) },
                     { XRNode.RightHand, new AggregateHandContainer(XRNode.RightHand) }
                 };
+
+                InputSystem.onBeforeUpdate += ResetHands;
             }
 
-            public override void Update()
+            public override void Stop()
+            {
+                ResetHands();
+                InputSystem.onBeforeUpdate -= ResetHands;
+                base.Stop();
+            }
+
+            private void ResetHands()
             {
                 hands[XRNode.LeftHand].Reset();
                 hands[XRNode.RightHand].Reset();
@@ -245,8 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             public override bool TryGetPinchingPoint(XRNode handNode, out HandJointPose jointPose)
             {
                 // GetJoint will reuse existing joint data if the hand was already queried this frame.
-                bool gotData = true;
-                gotData &= TryGetJoint(TrackedHandJoint.ThumbTip, handNode, out HandJointPose thumbPose);
+                bool gotData = TryGetJoint(TrackedHandJoint.ThumbTip, handNode, out HandJointPose thumbPose);
                 gotData &= TryGetJoint(TrackedHandJoint.IndexTip, handNode, out HandJointPose indexPose);
                 gotData &= TryGetJoint(TrackedHandJoint.Palm, handNode, out HandJointPose palmPose);
 
@@ -267,8 +275,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             /// <inheritdoc/>
             public override bool TryGetPinchProgress(XRNode handNode, out bool isReadyToPinch, out bool isPinching, out float pinchAmount)
             {
-                bool gotData = true;
-                gotData &= TryGetJoint(TrackedHandJoint.Palm, handNode, out HandJointPose palm);
+                bool gotData = TryGetJoint(TrackedHandJoint.Palm, handNode, out HandJointPose palm);
 
                 // Is the hand far enough up/in view to be eligible for pinching?
                 bool handIsUp = Vector3.Angle(Camera.main.transform.forward, (palm.Position - Camera.main.transform.position)) < Config.HandRaiseCameraFov;
@@ -312,8 +319,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             /// <inheritdoc/>
             public override bool TryGetPalmFacingAway(XRNode hand, out bool palmFacingAway)
             {
-                bool gotData = true;
-                gotData &= TryGetJoint(TrackedHandJoint.Palm, hand, out HandJointPose palm);
+                bool gotData = TryGetJoint(TrackedHandJoint.Palm, hand, out HandJointPose palm);
 
                 if (!gotData)
                 {
@@ -336,7 +342,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             ///<inheritdoc/>
             public override bool TryGetEntireHand(XRNode handNode, out IReadOnlyList<HandJointPose> jointPoses)
             {
-
                 Debug.Assert(handNode == XRNode.LeftHand || handNode == XRNode.RightHand, "Non-hand XRNode used in GetHand query");
 
                 return hands[handNode].TryGetEntireHand(out jointPoses);

--- a/com.microsoft.mrtk.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
+++ b/com.microsoft.mrtk.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
@@ -393,34 +393,45 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Preserve]
         class SynthesisProvider : Provider
         {
-            protected SyntheticHandsConfig config;
+            protected SyntheticHandsConfig Config { get; private set; }
 
-            private Dictionary<XRNode, SyntheticHandContainer> hands;
+            private Dictionary<XRNode, SyntheticHandContainer> hands = null;
 
-            public SynthesisProvider() : base()
+            public override void Start()
             {
-                config = XRSubsystemHelpers.GetConfiguration<SyntheticHandsConfig, SyntheticHandsSubsystem>();
+                base.Start();
 
-                hands = new Dictionary<XRNode, SyntheticHandContainer>
+                Config = XRSubsystemHelpers.GetConfiguration<SyntheticHandsConfig, SyntheticHandsSubsystem>();
+
+                hands ??= new Dictionary<XRNode, SyntheticHandContainer>
                 {
                     { XRNode.LeftHand, new SyntheticHandContainer(
                                                                 XRNode.LeftHand,
                                                                 HandshapeId.Flat,
-                                                                config.LeftHandPosition,
-                                                                config.LeftHandRotation,
-                                                                config.LeftHandSelect,
-                                                                config.PoseOffset) },
+                                                                Config.LeftHandPosition,
+                                                                Config.LeftHandRotation,
+                                                                Config.LeftHandSelect,
+                                                                Config.PoseOffset) },
                     { XRNode.RightHand, new SyntheticHandContainer(
                                                                 XRNode.RightHand,
                                                                 HandshapeId.Flat,
-                                                                config.RightHandPosition,
-                                                                config.RightHandRotation,
-                                                                config.RightHandSelect,
-                                                                config.PoseOffset) }
+                                                                Config.RightHandPosition,
+                                                                Config.RightHandRotation,
+                                                                Config.RightHandSelect,
+                                                                Config.PoseOffset) }
                 };
+
+                InputSystem.onBeforeUpdate += ResetHands;
             }
 
-            public override void Update()
+            public override void Stop()
+            {
+                ResetHands();
+                InputSystem.onBeforeUpdate -= ResetHands;
+                base.Stop();
+            }
+
+            private void ResetHands()
             {
                 hands[XRNode.LeftHand].Reset();
                 hands[XRNode.RightHand].Reset();
@@ -513,7 +524,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Debug.Assert(handNode == XRNode.LeftHand || handNode == XRNode.RightHand, "Non-hand XRNode used in GetHand query");
 
-                if (!config.ShouldSynthesize())
+                if (!Config.ShouldSynthesize())
                 {
                     jointPoses = System.Array.Empty<HandJointPose>();
                     return false;
@@ -527,7 +538,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Debug.Assert(handNode == XRNode.LeftHand || handNode == XRNode.RightHand, "Non-hand XRNode used in GetHand query");
 
-                if (!config.ShouldSynthesize())
+                if (!Config.ShouldSynthesize())
                 {
                     jointPose = default;
                     return false;


### PR DESCRIPTION
## Overview

Updates the lifecycle of the hands subsystems to be more consistent and predictable with the input system's update cycle.

(Potentially) fixes an issue where hand joints couldn't be queried the same frame a hand was detected.