### PR TITLE
Explicitly specify registry in npm install

### DIFF
--- a/Pipelines/Scripts/publish-upm.ps1
+++ b/Pipelines/Scripts/publish-upm.ps1
@@ -33,7 +33,7 @@ try {
     }
 
     if ($Authenticate.IsPresent) {
-        npm install -g vsts-npm-auth
+        npm install -g vsts-npm-auth --registry https://registry.npmjs.com --always-auth false
         vsts-npm-auth -config $npmrcPath
     }
 


### PR DESCRIPTION
## Overview
Update publish-upm.ps1 to use the command suggested by ADO. I ran into a 404 error stating "The package 'vsts-npm-auth' was not found in feed 'my-feed'".