### PR TITLE
[MRTK3] Updated HandMenu & NearMenu prefabs to use CanvasBackplate.mat in the  StandardAssets package

### DIFF
--- a/com.microsoft.mrtk.uxcomponents.noncanvas/HandMenu/HandMenu2x4.prefab
+++ b/com.microsoft.mrtk.uxcomponents.noncanvas/HandMenu/HandMenu2x4.prefab
@@ -560,7 +560,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e4220fa33d0e48745b2cb5c52731e75e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 2100000, guid: a522d7149601c2642b1b5daf4fd94c40, type: 2}
+  m_Material: {fileID: 2100000, guid: 65972ebbfd5c529479f9c30fd3ec3f6a, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}

--- a/com.microsoft.mrtk.uxcomponents.noncanvas/NearMenu/NearMenu4x2.prefab
+++ b/com.microsoft.mrtk.uxcomponents.noncanvas/NearMenu/NearMenu4x2.prefab
@@ -887,7 +887,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e4220fa33d0e48745b2cb5c52731e75e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 2100000, guid: a522d7149601c2642b1b5daf4fd94c40, type: 2}
+  m_Material: {fileID: 2100000, guid: 65972ebbfd5c529479f9c30fd3ec3f6a, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}


### PR DESCRIPTION
## Overview
HandMenu & NearMenu prefabs were using CanvasBackplate.mat from the MRGT package which was not updated to Linear color space. Assigned CanvasBackplate.mat from the StandardAssets package.
(Pin button was already using the correct material)

We are going to need to document this difference + update MRGT one to avoid confusion.

## Changes
- Fixes: #11008

## Before & After

<img width="788" alt="2022-09-13 19_29_22-MRTKDevTemplate - NearMenuExamples - Universal Windows Platform - Unity 2020 3 3" src="https://user-images.githubusercontent.com/13754172/190045597-d38373fa-de33-4bb0-afee-1648f8e4c8b3.png">

<img width="788" alt="2022-09-13 19_28_45-MRTKDevTemplate - NearMenuExamples - Universal Windows Platform - Unity 2020 3 3" src="https://user-images.githubusercontent.com/13754172/190045610-7adaabb4-9592-4423-ba0f-8255e905624a.png">

<img width="569" alt="2022-09-13 19_30_25-MRTKDevTemplate - HandMenuExamples - Universal Windows Platform - Unity 2020 3 3" src="https://user-images.githubusercontent.com/13754172/190045633-8280ec41-6b17-41f0-831b-26a037d464a1.png">
