### PR TITLE
Adding single-arg overload to ForceSetToggled for UnityEvents

### DIFF
--- a/com.microsoft.mrtk.core/Interactable/StatefulInteractable.cs
+++ b/com.microsoft.mrtk.core/Interactable/StatefulInteractable.cs
@@ -305,6 +305,19 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        /// <summary>
+        /// Forcibly toggle the interactable and fire the relevant events.
+        /// This is a single-arg overload for ForceSetToggled for use
+        /// with UnityEvents. Consider using ForceSetToggled(bool, bool) instead,
+        /// especially if you'd like to suppress the resulting toggle events.
+        /// </summary>
+        public void ForceSetToggled(bool active)
+        {
+            // This will fire toggle events.
+            IsToggled.Active = active;
+        }
+
+
         private static readonly ProfilerMarker OnFirstSelectEnteredPerfMarker =
             new ProfilerMarker("[MRTK] StatefulInteractable.OnFirstSelectEntered");
 


### PR DESCRIPTION
## Overview
Adds a single-arg overload to ForceSetToggled, so that it can be invoked from a UnityEvent. Based on discussion with Matt R and Matt F, the single-arg overload _will_ invoke toggle events.

## Changes
- Fixes #11006 