### PR TITLE
Fix TouchPointer NullReferenceException

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1199,7 +1199,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 int focusingPokePointerCount = 0;
                 for (int i = 0; i < focusingPointers.Count; i++)
                 {
-                    if (focusingPointers[i].InputSourceParent.SourceId == data.SourceId)
+                    if (focusingPointers[i].InputSourceParent != null && focusingPointers[i].InputSourceParent.SourceId == data.SourceId)
                     {
                         focusingPointerCount++;
                         if (focusingPointers[i] is PokePointer)
@@ -1224,7 +1224,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
             bool isAnyNearpointerFocusing = false;
             for (int i = 0; i < focusingPointers.Count; i++)
             {
-                if (focusingPointers[i].InputSourceParent.SourceId == eventData.InputSource.SourceId && focusingPointers[i] is IMixedRealityNearPointer)
+                if (focusingPointers[i].InputSourceParent != null &&
+                    focusingPointers[i].InputSourceParent.SourceId == eventData.InputSource.SourceId && 
+                    focusingPointers[i] is IMixedRealityNearPointer)
                 {
                     isAnyNearpointerFocusing = true;
                     break;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -330,7 +330,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public virtual void OnPointerUp(MixedRealityPointerEventData eventData)
         {
-            if (IsPointerValid)
+            if (IsPointerValid && eventData.InputSource != null)
             {
                 foreach (var sourcePointer in eventData.InputSource.Pointers)
                 {


### PR DESCRIPTION
## Overview
Fixed the NullReferenceException that occurs when using the TouchPointer on mobile devices (MRTK 2.8.2).

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/10771.
