### PR TITLE
Create PoseSourceDriver

### DIFF
--- a/com.microsoft.mrtk.input/Utilities/PoseSource/PoseSourceDriver.cs
+++ b/com.microsoft.mrtk.input/Utilities/PoseSource/PoseSourceDriver.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    /// <summary>
+    /// Uses a specified <see cref="IPoseSource"/> to drive the pose of the object this is placed on.
+    /// </summary>
+    /// <remarks>Similar in purpose to <see cref="UnityEngine.InputSystem.XR.TrackedPoseDriver"/>.</remarks>
+    [AddComponentMenu("MRTK/Input/Pose Source Driver")]
+    internal class PoseSourceDriver : MonoBehaviour
+    {
+        [SerializeReference, InterfaceSelector]
+        private IPoseSource poseSource;
+
+        protected void Update()
+        {
+            if (poseSource.TryGetPose(out Pose pose))
+            {
+                transform.SetPositionAndRotation(pose.position, pose.rotation);
+            }
+        }
+    }
+}

--- a/com.microsoft.mrtk.input/Utilities/PoseSource/PoseSourceDriver.cs.meta
+++ b/com.microsoft.mrtk.input/Utilities/PoseSource/PoseSourceDriver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 911420bfc4317664084379b7bee2c10c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

Adds a helper script for using the new `IPoseSource` implementations to drive a specific object's pose.

Starting this class as `internal` to reserve some implementation iteration room.