### PR TITLE
Fixing FuzzyGaze being too "shy"

### DIFF
--- a/com.microsoft.mrtk.input/Interactors/Gaze/FuzzyGazeInteractor.cs
+++ b/com.microsoft.mrtk.input/Interactors/Gaze/FuzzyGazeInteractor.cs
@@ -69,10 +69,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (IsHitValidPerfMarker.Auto())
             {
-                // Immediately reject our hit if we can't select or target it.
-                // This lets the ray "pass through" any non-selectable objects.
-                if ((target is IXRSelectInteractable selectInteractable && !selectInteractable.IsSelectableBy(this)) ||
-                    (target is IXRHoverInteractable hoverInteractable && !hoverInteractable.IsHoverableBy(this)))
+                // Immediately reject our hit if we can't hover it.
+                // This lets the ray "pass through" any objects that reject gaze hovers.
+                if (target is IXRHoverInteractable hoverInteractable && !hoverInteractable.IsHoverableBy(this))
                 {
                     return false;
                 }

--- a/com.microsoft.mrtk.input/Interactors/Gaze/GazeInteractor.cs
+++ b/com.microsoft.mrtk.input/Interactors/Gaze/GazeInteractor.cs
@@ -8,7 +8,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// An XRRayInteractor that enables eye gaze for focus and interaction.
-    /// Functionally empty while we learn more about the tooling necessary for successful gaze interaction development
     /// </summary>
     [AddComponentMenu("MRTK/Input/Gaze Interactor")]
     public class GazeInteractor : XRRayInteractor, IGazeInteractor


### PR DESCRIPTION
## Overview
This was quite the rabbit hole. The original symptom was "Can't gazepinch Sliders in simulation!" The cause was:

- FuzzyGaze hits Slider, adds to ValidTargets
- GazePinch gets ValidTargets from FuzzyGaze
- GazePinch initiates selection on Slider
- < next frame >
- FuzzyGaze hits Slider, but IsSelectableBy() _**fails**_, because Slider rejects all incoming selections after the first selection
- FuzzyGaze no longer has Slider in ValidTargets
- GazePinch gets ValidTargets from FuzzyGaze
- Slider is no longer in ValidTargets, GazePinch drops selection

Solution: For some reason FuzzyGaze was checking to see if each interactable was actually _selectable_ when evaluating whether it was a valid hit or not. The fix is to make FuzzyGaze only check to see if the interactable is _hoverable_.