### PR TITLE
Changing SqueezableBoxVisuals to allow no box renderer

### DIFF
--- a/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Visuals/SqueezableBoxVisuals.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Visuals/SqueezableBoxVisuals.cs
@@ -181,9 +181,13 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
             // Read the box properties out of the material. This will inform our (un)pinchScaleOffsets to keep
             // the handles aligned.
-            GetBoxProperties(boundsRenderer, out float padding, out float shrinkFraction);
-            unpinchScaleOffset = (Vector3.one * (2.0f * (padding)));
-            pinchScaleOffset = (Vector3.one * (2.0f * (padding * shrinkFraction)));
+            if (boundsRenderer != null)
+            {
+                GetBoxProperties(boundsRenderer, out float padding, out float shrinkFraction);
+                unpinchScaleOffset = (Vector3.one * (2.0f * (padding)));
+                pinchScaleOffset = (Vector3.one * (2.0f * (padding * shrinkFraction)));
+            }
+            
 
             // Compute flatten vector at startup.
             flattenVector = BoundsCalculator.CalculateFlattenVector(transform.lossyScale);


### PR DESCRIPTION
## Overview
An old bug #10686 requested that `SqueezableBoxVisuals` allow for no box renderer at all. Turns out we were 99% of the way there already, just needed a nullcheck. Note, `unpinchScaleOffset` and `pinchScaleOffset` default to `Vector3.zero` which is the correct value.

## Changes
- Fixes #10686 