### PR TITLE
Add missing mappings for Quest Touch controller "touch" bindings

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -244,8 +244,14 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                         case DeviceInputType.PrimaryButtonPress:
                             buttonUsage = CommonUsages.primaryButton;
                             break;
+                        case DeviceInputType.PrimaryButtonTouch:
+                            buttonUsage = CommonUsages.primaryTouch;
+                            break;
                         case DeviceInputType.SecondaryButtonPress:
                             buttonUsage = CommonUsages.secondaryButton;
+                            break;
+                        case DeviceInputType.SecondaryButtonTouch:
+                            buttonUsage = CommonUsages.secondaryTouch;
                             break;
                         case DeviceInputType.TouchpadTouch:
                             buttonUsage = CommonUsages.secondary2DAxisTouch;


### PR DESCRIPTION
## Overview

The touch bindings from Unity's `CommonUsages` were missing from `GenericXRSDKController`.

## Changes
- Fixes: [#10486 
](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11019)
