### PR TITLE
Fixing tests, again

### DIFF
--- a/com.microsoft.mrtk.accessibility/Tests/Runtime/DescribableObjectTests.cs
+++ b/com.microsoft.mrtk.accessibility/Tests/Runtime/DescribableObjectTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Core.Tests;
 using Microsoft.MixedReality.Toolkit.Input.Tests;
 using NUnit.Framework;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;

--- a/com.microsoft.mrtk.accessibility/Tests/Runtime/DescribableObjectTests.cs
+++ b/com.microsoft.mrtk.accessibility/Tests/Runtime/DescribableObjectTests.cs
@@ -4,62 +4,18 @@
 using Microsoft.MixedReality.Toolkit.Core.Tests;
 using Microsoft.MixedReality.Toolkit.Input.Tests;
 using NUnit.Framework;
-using System.Collections;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
-
-using SCG = System.Collections.Generic;
 
 namespace Microsoft.MixedReality.Toolkit.Accessibility.Tests
 {
     /// <summary>
     /// Tests for verifying the behavior of the describable objects.
     /// </summary>
-    public class DescribableObjectTests : BaseRuntimeTests
+    public class DescribableObjectTests : BaseRuntimeInputTests
     {
-        #region Setup / TearDown
-
-        private readonly SCG.List<GameObject> sceneContents = new SCG.List<GameObject>();
-
-        /// <summary>
-        /// Ensures that the scene is properly prepared.
-        /// </summary>
-        [UnitySetUp]
-        public override IEnumerator Setup()
-        {
-            base.Setup();
-
-            yield return RuntimeTestUtilities.WaitForUpdates();
-
-            // The accessibility subsystem requires the MRTK lifecycle manager. This
-            // is currently attached to the rig, which resides in the input package.
-            InputTestUtilities.InstantiateRig();
-        }
-
-        /// <summary>
-        /// Cleans up the scene contents after testing describable object registration
-        /// and filtering.
-        /// </summary>
-        [UnityTearDown]
-        public override IEnumerator TearDown()
-        {
-            foreach (GameObject gameObj in sceneContents)
-            {
-                GameObject.Destroy(gameObj);
-            }
-
-            yield return null;
-
-            sceneContents.Clear();
-
-            base.TearDown();
-
-            yield return null;
-        }
-
-        #endregion Setup / TearDown
-
         #region Test cases
 
         private static string testCubeGuid = "d10f05ae3a6402045b70860918544ed9";
@@ -119,7 +75,6 @@ namespace Microsoft.MixedReality.Toolkit.Accessibility.Tests
                 gameObj.transform.localScale = Vector3.one * 0.1f;
             }
             gameObj.transform.position = location;
-            sceneContents.Add(gameObj);
         }
 
         /// <summary>
@@ -134,11 +89,11 @@ namespace Microsoft.MixedReality.Toolkit.Accessibility.Tests
 
             if (AccessibilityHelpers.Subsystem != null)
             {
-                SCG.List<DescribableObjectClassification> classifications = new SCG.List<DescribableObjectClassification>();
+                List<DescribableObjectClassification> classifications = new List<DescribableObjectClassification>();
                 bool success = AccessibilityHelpers.Subsystem.TryGetDescribableObjectClassifications(classifications);
                 Assert.IsTrue(success, "Failed to get the collection of describable object classifications.");
 
-                SCG.List<GameObject> describableObjects = new SCG.List<GameObject>();
+                List<GameObject> describableObjects = new List<GameObject>();
                 success = AccessibilityHelpers.Subsystem.TryGetDescribableObjects(
                     classifications,
                     DescribableObjectVisibility.Surround,
@@ -169,11 +124,11 @@ namespace Microsoft.MixedReality.Toolkit.Accessibility.Tests
 
                 yield return RuntimeTestUtilities.WaitForUpdates();
 
-                SCG.List<DescribableObjectClassification> classifications = new SCG.List<DescribableObjectClassification>();
+                List<DescribableObjectClassification> classifications = new List<DescribableObjectClassification>();
                 bool success = AccessibilityHelpers.Subsystem.TryGetDescribableObjectClassifications(classifications);
                 Assert.IsTrue(success, "Failed to get the collection of describable object classifications.");
 
-                SCG.List<GameObject> describableObjects = new SCG.List<GameObject>();
+                List<GameObject> describableObjects = new List<GameObject>();
                 success = AccessibilityHelpers.Subsystem.TryGetDescribableObjects(
                     classifications,
                     DescribableObjectVisibility.FieldOfView,
@@ -210,11 +165,11 @@ namespace Microsoft.MixedReality.Toolkit.Accessibility.Tests
 
                 yield return RuntimeTestUtilities.WaitForUpdates();
 
-                SCG.List<DescribableObjectClassification> classifications = new SCG.List<DescribableObjectClassification>();
+                List<DescribableObjectClassification> classifications = new List<DescribableObjectClassification>();
                 bool success = AccessibilityHelpers.Subsystem.TryGetDescribableObjectClassifications(classifications);
                 Assert.IsTrue(success, "Failed to get the collection of describable object classifications.");
 
-                SCG.List<GameObject> describableObjects = new SCG.List<GameObject>();
+                List<GameObject> describableObjects = new List<GameObject>();
                 success = AccessibilityHelpers.Subsystem.TryGetDescribableObjects(
                     classifications,
                     DescribableObjectVisibility.FieldOfView,
@@ -256,11 +211,11 @@ namespace Microsoft.MixedReality.Toolkit.Accessibility.Tests
 
                 yield return RuntimeTestUtilities.WaitForUpdates();
 
-                SCG.List<DescribableObjectClassification> classifications = new SCG.List<DescribableObjectClassification>();
+                List<DescribableObjectClassification> classifications = new List<DescribableObjectClassification>();
                 bool success = AccessibilityHelpers.Subsystem.TryGetDescribableObjectClassifications(classifications);
                 Assert.IsTrue(success, "Failed to get the collection of describable object classifications.");
 
-                SCG.List<GameObject> describableObjects = new SCG.List<GameObject>();
+                List<GameObject> describableObjects = new List<GameObject>();
                 success = AccessibilityHelpers.Subsystem.TryGetDescribableObjects(
                     classifications,
                     DescribableObjectVisibility.Surround,

--- a/com.microsoft.mrtk.input/Simulation/Devices/SimulatedController.cs
+++ b/com.microsoft.mrtk.input/Simulation/Devices/SimulatedController.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Simulation
     internal class SimulatedController : IDisposable
     {
         private readonly MRTKSimulatedController simulatedController = null;
-        private readonly IHandRay handRay = new HandRay();
+        private readonly IHandRay handRay;
         private readonly ControllerSimulationSettings controllerSimulationSettings;
 
         private MRTKSimulatedControllerState simulatedControllerState;
@@ -156,8 +156,10 @@ namespace Microsoft.MixedReality.Toolkit.Input.Simulation
         public SimulatedController(
             Handedness handedness,
             ControllerSimulationSettings ctrlSettings,
-            Vector3 initialRelativePosition)
+            Vector3 initialRelativePosition,
+            float rayHalfLife = 0.01f)
         {
+            handRay = new HandRay(rayHalfLife);
             Handedness = handedness;
             controllerSimulationSettings = ctrlSettings;
 
@@ -556,7 +558,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Simulation
                     HandSubsystem.TryGetJoint(TrackedHandJoint.IndexProximal, Handedness.ToXRNode().Value, out HandJointPose knucklePose))
                 {
                     // If prompted to use the ray vector, this pose is calculated by simulating a hand ray.
-                    // This occurs only when the simulation mode is set to ArticulatedHand.
                     handRay.Update(
                         knucklePose.Position,
                         -palmPose.Up,

--- a/com.microsoft.mrtk.input/Tests/Runtime/BasicInputTests.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/BasicInputTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             var interactable = cube.AddComponent<MRTKBaseInteractable>();
 
-            Vector3 cubePos = new Vector3(0.1f, 0.1f, 1);
+            Vector3 cubePos = InputTestUtilities.InFrontOfUser();
             cube.transform.position = cubePos;
             cube.transform.localScale = Vector3.one * 1.0f;
             
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         {
             GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.AddComponent<StatefulInteractable>();
-            cube.transform.position = new Vector3(0.1f, 0.1f, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.2f, 0.2f, 0.5f));
             cube.transform.localScale = Vector3.one * 0.1f;
 
             // For this test, we won't use poke selection.
@@ -142,7 +142,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
 
             GameObject cube2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube2.AddComponent<StatefulInteractable>();
-            cube2.transform.position = new Vector3(-0.1f, -0.1f, 1);
+            cube2.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(-0.2f, -0.2f, 0.5f));
             cube2.transform.localScale = Vector3.one * 0.1f;
 
             // For this test, we won't use poke selection.
@@ -150,7 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
 
             var rightHand = new TestHand(Handedness.Right);
 
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             bool shouldTestToggle = false;
 
@@ -213,13 +213,13 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
                 secondCubeInteractable.ToggleMode = shouldTestToggle ? StatefulInteractable.ToggleType.Toggle : StatefulInteractable.ToggleType.Button;
                 secondCubeInteractable.TriggerOnRelease = (i % 2) == 0;
 
-                yield return rightHand.MoveTo(new Vector3(0, 0, 0.5f));
+                yield return rightHand.MoveTo(InputTestUtilities.InFrontOfUser(0.5f));
                 yield return rightHand.RotateTo(Quaternion.Euler(0, -45, 0));
 
                 Assert.IsFalse(secondCubeInteractable.IsGrabHovered,
                                "StatefulInteractable was already hovered.");
 
-                yield return rightHand.MoveTo(new Vector3(-0.1f, -0.1f, 1));
+                yield return rightHand.MoveTo(secondCubeInteractable.transform.position);
                 yield return RuntimeTestUtilities.WaitForUpdates();
                 Assert.IsTrue(secondCubeInteractable.IsGrabHovered,
                               "StatefulInteractable did not get hovered.");
@@ -255,7 +255,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
                     Assert.IsFalse(secondCubeInteractable.IsToggled, "StatefulInteractable shouldn't have been toggled, but it was.");
                 }
 
-                yield return rightHand.MoveTo(new Vector3(0, 0, 0.5f));
+                yield return rightHand.MoveTo(InputTestUtilities.InFrontOfUser(0.5f));
             }
 
             yield return null;
@@ -269,7 +269,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         {
             GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             StatefulInteractable interactable = cube.AddComponent<StatefulInteractable>();
-            cube.transform.position = new Vector3(0,0,1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser();
             cube.transform.localScale = Vector3.one * 0.1f;
 
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -279,7 +279,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             Assert.IsFalse(interactable.IsGazePinchHovered);
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0.1f, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser() + new Vector3(0.2f, 0, 0f));
 
             yield return RuntimeTestUtilities.WaitForUpdates();
 
@@ -399,7 +399,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         public IEnumerator InteractableDisabledDuringInteraction()
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = new Vector3(1.0f, 0.1f, 1.0f);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(1.0f, 0.1f, 1.0f));
             cube.transform.localScale = Vector3.one * 0.1f;
             cube.AddComponent<StatefulInteractable>();
 
@@ -407,7 +407,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             cube.GetComponent<StatefulInteractable>().selectMode = InteractableSelectMode.Multiple;
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser());
 
             yield return rightHand.MoveTo(cube.transform.position);
             yield return rightHand.SetHandshape(HandshapeId.Pinch);
@@ -452,7 +452,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         {
             // Spawn our hand.
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 1));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser());
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Prox detector should start out un-triggered.
@@ -468,7 +468,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             Assert.IsFalse(rightHandController.GetComponentInChildren<GrabInteractor>().enabled, "Grab started active, when it shouldn't");
 
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = new Vector3(0, 0, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser();
             cube.transform.localScale = Vector3.one * 0.1f;
             cube.AddComponent<StatefulInteractable>();
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -503,7 +503,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         public IEnumerator UntrackedControllerNearInteractions()
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = new Vector3(1.0f, 0.1f, 1.0f);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(1.0f, 0.1f, 1.0f));
             cube.transform.localScale = Vector3.one * 0.1f;
             cube.AddComponent<StatefulInteractable>();
 
@@ -511,7 +511,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             cube.GetComponent<StatefulInteractable>().selectMode = InteractableSelectMode.Multiple;
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             // First ensure that the interactor can interact with a cube normally
             yield return rightHand.MoveTo(cube.transform.position);
@@ -540,7 +540,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
 
             // Check that the hand cannot interact with any new interactables
             var newCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            newCube.transform.position = new Vector3(-3.0f, 0.1f, 1.0f);
+            newCube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(-3.0f, 0.1f, 1.0f));
             newCube.transform.localScale = Vector3.one * 0.1f;
             newCube.AddComponent<StatefulInteractable>();
 

--- a/com.microsoft.mrtk.input/Tests/Runtime/FuzzyGazeInteractorTests.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/FuzzyGazeInteractorTests.cs
@@ -28,17 +28,17 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             // Instantiate two foregound cubes and one background cube for testing
             GameObject cube1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube1.AddComponent<StatefulInteractable>();
-            cube1.transform.position = new Vector3(0.07f, 0.2f, 1);
+            cube1.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.07f, 0.2f, 1));
             cube1.transform.localScale = Vector3.one * 0.1f;
 
             GameObject cube2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube2.AddComponent<StatefulInteractable>();
-            cube2.transform.position = new Vector3(-0.05f, 0.2f, 1);
+            cube2.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, 0.2f, 1));
             cube2.transform.localScale = Vector3.one * 0.1f;
 
             GameObject backgroundCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             backgroundCube.AddComponent<StatefulInteractable>();
-            backgroundCube.transform.position = new Vector3(0, 0, 1.6f);
+            backgroundCube.transform.position = InputTestUtilities.InFrontOfUser(1.6f);
             backgroundCube.transform.localScale = Vector3.one;
 
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -52,8 +52,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
                            "StatefulInteractable was not hovered by FuzzyGazeInteractor.");
 
             // Move the cubes to bring them to the center on the y-axis
-            cube1.transform.position = new Vector3(0.07f, 0, 1);
-            cube2.transform.position = new Vector3(-0.05f, 0, 1);
+            cube1.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.07f, 0, 1));
+            cube2.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, 0, 1));
 
             yield return RuntimeTestUtilities.WaitForUpdates();
 
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
                            "StatefulInteractable was already hovered.");
 
             // Move cube 2 back to its birth position
-            cube2.transform.position = new Vector3(-0.05f, 0.2f, 1);
+            cube2.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, 0.2f, 1));
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Background cube should now be hovered
@@ -78,7 +78,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
                            "StatefulInteractable was not hovered by FuzzyGazeInteractor.");
 
             // Move background cube further back
-            backgroundCube.transform.position = new Vector3(0, 0, 4);
+            backgroundCube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0, 0, 4));
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Cube 1 should now be hovered
@@ -106,12 +106,12 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             // Instantiate one foregound cubes and one background cube for testing
             GameObject foregroundCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             foregroundCube.AddComponent<StatefulInteractable>();
-            foregroundCube.transform.position = new Vector3(0.241f, 0, 2);
+            foregroundCube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.241f, 0, 2));
             foregroundCube.transform.localScale = new Vector3(0.4f, 0.1f, 0.2f);
 
             GameObject backgroundCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             backgroundCube.AddComponent<StatefulInteractable>();
-            backgroundCube.transform.position = new Vector3(-0.4f, 0, 2.4f);
+            backgroundCube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(-0.4f, 0, 2.4f));
             backgroundCube.transform.localScale = new Vector3(1.4f, 1.4f, 0.2f);
             backgroundCube.transform.localEulerAngles = new Vector3(0, -58, 0);
 

--- a/com.microsoft.mrtk.input/Tests/Runtime/InteractionModeManagerTests.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/InteractionModeManagerTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
-using Microsoft.MixedReality.Toolkit.Core.Tests;
-using NUnit.Framework;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.MixedReality.Toolkit.Core.Tests;
+using Microsoft.MixedReality.Toolkit.Input.Simulation;
+using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.XR.Interaction.Toolkit;
@@ -60,18 +60,18 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         public IEnumerator InteractionDetectorTest()
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = new Vector3(0.0f, 0.0f, 1.5f);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(1.5f);
             cube.transform.localScale = Vector3.one * 0.2f;
             cube.AddComponent<StatefulInteractable>();
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser());
 
             XRBaseController rightHandController = CachedLookup.RightHandController;
             Assert.IsTrue(rightHandController != null, "No controllers found for right hand.");
 
             // Moving the hand to a position where it's far ray is hovering over the cube
-            yield return rightHand.MoveTo(cube.transform.position + new Vector3(0.02f, -0.02f, -0.8f));
+            yield return rightHand.AimAt(cube.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             InteractionMode currentMode = rightHandController.GetComponentInChildren<MRTKRayInteractor>().GetComponent<InteractionDetector>().ModeOnHover;
@@ -101,18 +101,21 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         public IEnumerator ModeMediationTest()
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = new Vector3(0f, 0.1f, 1.5f);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(1.5f);
             cube.transform.localScale = Vector3.one * 0.2f;
             cube.AddComponent<StatefulInteractable>();
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser());
 
             XRBaseController rightHandController = CachedLookup.RightHandController;
             Assert.IsTrue(rightHandController != null, "No controllers found for right hand.");
 
+            // Grab stabilization == ray stabilization
+            InputTestUtilities.SetHandAnchorPoint(Handedness.Right, ControllerAnchorPoint.Grab);
+
             // Moving the hand to a position where it's far ray is hovering over the cube
-            yield return rightHand.MoveTo(cube.transform.position + new Vector3(0.02f, -0.1f, -0.8f));
+            yield return rightHand.AimAt(cube.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
             InteractionMode farRayMode = rightHandController.GetComponentInChildren<MRTKRayInteractor>().GetComponent<InteractionDetector>().ModeOnHover;
             Assert.AreEqual(farRayMode, rightHandController.GetComponentInChildren<MRTKRayInteractor>().GetComponent<InteractionDetector>().ModeOnDetection);

--- a/com.microsoft.mrtk.input/Tests/Runtime/InteractorDwellManagerTests.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/InteractorDwellManagerTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
 using System.Collections;
+using Microsoft.MixedReality.Toolkit.Core.Tests;
+using Microsoft.MixedReality.Toolkit.Input.Simulation;
+using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -22,7 +24,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             // Instantiate a cube and attach the StatefulInteractable component
             GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             StatefulInteractable interactable = cube.AddComponent<StatefulInteractable>();
-            cube.transform.position = new Vector3(0, 0, 2);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(1.5f);
+            cube.transform.localScale = Vector3.one * 0.2f;
 
             // Configure the StatefulInteractable component to use far ray dwell
             const float dwellTime = 1f;
@@ -36,7 +39,9 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
 
             // Show the hand and confirm the interactable is being hovered but not selected yet
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f), true);
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
+            yield return rightHand.AimAt(cube.transform.position);
+
             Assert.IsTrue(interactable.IsRayHovered,
                           "StatefulInteractable did not get RayHovered.");
             Assert.IsFalse(interactable.isSelected,
@@ -64,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             // Instantiate a cube and attach the StatefulInteractable component
             GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             StatefulInteractable interactable = cube.AddComponent<StatefulInteractable>();
-            cube.transform.position = new Vector3(0, 0, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser();
             cube.transform.localScale = Vector3.one * 0.1f;
 
             // Configure the StatefulInteractable component to use gaze dwell

--- a/com.microsoft.mrtk.input/Tests/Runtime/MRTK.Input.RuntimeTests.asmdef
+++ b/com.microsoft.mrtk.input/Tests/Runtime/MRTK.Input.RuntimeTests.asmdef
@@ -9,6 +9,7 @@
         "Unity.InputSystem.TestFramework",
         "UnityEditor.TestRunner",
         "UnityEngine.TestRunner",
+        "Unity.XR.CoreUtils",
         "Unity.XR.Interaction.Toolkit"
     ],
     "includePlatforms": [],

--- a/com.microsoft.mrtk.input/Tests/Runtime/Utilities/BaseRuntimeInputTests.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/Utilities/BaseRuntimeInputTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             InputSystem.RegisterBindingComposite<QuaternionFallbackComposite>();
 
             InputTestUtilities.InstantiateRig();
-            InputTestUtilities.SetupSimulation();
+            InputTestUtilities.SetupSimulation(0.0f);
             yield return null;
         }
 

--- a/com.microsoft.mrtk.input/Tests/Runtime/Utilities/InputTestUtilities.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/Utilities/InputTestUtilities.cs
@@ -125,11 +125,11 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
 
         /// <summary>
         /// Returns a position placed in front of the user's head, offset by the given vector, which
-        /// is transformed by the XROrigin's camera offset object's reference frame.
+        /// is transformed by the camera's reference frame.
         /// </summary>
         public static Vector3 InFrontOfUser(Vector3 offset)
         {
-            return Camera.main.transform.position + PlayspaceUtilities.XROrigin.CameraFloorOffsetObject.transform.TransformVector(offset);
+            return Camera.main.transform.position + Camera.main.transform.TransformVector(offset);
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.input/Tests/Runtime/Utilities/InputTestUtilities.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/Utilities/InputTestUtilities.cs
@@ -116,6 +116,23 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         }
 
         /// <summary>
+        /// Returns a position placed in front of the user's head, offset forward by the given distance.
+        /// </summary>
+        public static Vector3 InFrontOfUser(float distanceFromHead = 0.4f)
+        {
+            return Camera.main.transform.position + Camera.main.transform.forward * distanceFromHead;
+        }
+
+        /// <summary>
+        /// Returns a position placed in front of the user's head, offset by the given vector, which
+        /// is transformed by the XROrigin's camera offset object's reference frame.
+        /// </summary>
+        public static Vector3 InFrontOfUser(Vector3 offset)
+        {
+            return Camera.main.transform.position + PlayspaceUtilities.XROrigin.CameraFloorOffsetObject.transform.TransformVector(offset);
+        }
+
+        /// <summary>
         /// Destroys the MRTK rig object.
         /// </summary>
         public static void TeardownRig()
@@ -130,7 +147,10 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         /// Creates the simulated devices (two <see cref="SimulatedController"/>s and a <see cref="SimulatedHMD"/>)
         /// as well as the associated <see cref="ControllerControls"/> for each.
         /// </summary>
-        public static void SetupSimulation()
+        /// <param name="rayHalfLife">
+        /// Optional value for ray smoothing halflife, handy for suppressing smoothing during automated tests.
+        /// </param>
+        public static void SetupSimulation(float rayHalfLife = 0.01f)
         {
             // See comments for UseSlowTestController for why this is reset to false on each test case.
             UseSlowTestController = false;
@@ -139,9 +159,9 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             rightControllerSettings = new ControllerSimulationSettings();
 
             leftController = new SimulatedController(
-                Handedness.Left, leftControllerSettings, Vector3.zero);
+                Handedness.Left, leftControllerSettings, Vector3.zero, rayHalfLife);
             rightController = new SimulatedController(
-                Handedness.Right, rightControllerSettings, Vector3.zero);
+                Handedness.Right, rightControllerSettings, Vector3.zero, rayHalfLife);
 
             leftControls = new ControllerControls();
             rightControls = new ControllerControls();
@@ -203,11 +223,9 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
 
             SimulatedController controller = handedness == Handedness.Right ? rightController : leftController;
             ControllerControls controls = handedness == Handedness.Right ? rightControls : leftControls;
-            ControllerSimulationMode controllerSimulationMode = handedness == Handedness.Right ? rightControllerSettings.SimulationMode : leftControllerSettings.SimulationMode;
             ControllerAnchorPoint anchorPoint = handedness == Handedness.Right ? rightControllerSettings.AnchorPoint : leftControllerSettings.AnchorPoint;
 
             float startPinch = controls.TriggerAxis;
-            bool shouldUseRayVector = controllerSimulationMode == ControllerSimulationMode.ArticulatedHand;
 
             for (int i = 1; i <= numSteps; i++)
             {
@@ -222,14 +240,17 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
                 controls.TriggerAxis = pinchAmount;
                 switch (anchorPoint)
                 {
+                    // We always pass in useRayVector = false during unit tests, because we always want the pointerPosition
+                    // to match the devicePosition so that we can aim the "hand" wherever we'd like. Otherwise, we'd
+                    // be using the generated hand-joint-based ray vector which is unreliable to aim from automated tests.
                     case ControllerAnchorPoint.Device:
-                        controller.UpdateAbsolute(handPose, controls, ControllerRotationMode.UserControl, shouldUseRayVector);
+                        controller.UpdateAbsolute(handPose, controls, ControllerRotationMode.UserControl, false);
                         break;
                     case ControllerAnchorPoint.IndexFinger:
-                        controller.UpdateAbsoluteWithPokeAnchor(handPose, controls, ControllerRotationMode.UserControl, shouldUseRayVector);
+                        controller.UpdateAbsoluteWithPokeAnchor(handPose, controls, ControllerRotationMode.UserControl, false);
                         break;
                     case ControllerAnchorPoint.Grab:
-                        controller.UpdateAbsoluteWithGrabAnchor(handPose, controls, ControllerRotationMode.UserControl, shouldUseRayVector);
+                        controller.UpdateAbsoluteWithGrabAnchor(handPose, controls, ControllerRotationMode.UserControl, false);
                         break;
                 }
 

--- a/com.microsoft.mrtk.input/Tests/Runtime/Utilities/TestController.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/Utilities/TestController.cs
@@ -74,6 +74,19 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         public abstract IEnumerator RotateTo(Quaternion newRotation, int numSteps = InputTestUtilities.ControllerMoveStepsSentinelValue, bool waitForFixedUpdate = true);
 
         /// <summary>
+        /// Rotates the controller to aim at the given world-relative position over some number of frames.
+        /// This forces the controller's anchor point to be ControllerAnchorPoint.Device.
+        /// </summary>
+        /// <param name="target">Point in worldspace to aim at (i.e., rotate the device's pose to aim at)</param>
+        /// <param name="numSteps">
+        /// How many frames to move over. This defaults to the "sentinel" value which tells the system
+        /// to use the default number of steps. For more information on this value, see
+        /// <see cref="PlayModeTestUtilities.ControllerMoveStepsSentinelValue"/>
+        /// </param>
+        /// <param name="waitForFixedUpdate">If true, waits a physics frame after moving the controller</param>
+        public abstract IEnumerator AimAt(Vector3 target, int numSteps = InputTestUtilities.ControllerMoveStepsSentinelValue, bool waitForFixedUpdate = true);
+
+        /// <summary>
         /// Perform a sequence of actions that represent a click for the controller
         /// </summary>
         public abstract IEnumerator Click();

--- a/com.microsoft.mrtk.input/Tests/Runtime/Utilities/TestHand.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/Utilities/TestHand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         public override IEnumerator Show(Vector3 position, bool waitForFixedUpdate = true)
         {
             yield return InputTestUtilities.SetHandTrackingState(handedness, true);
-            yield return MoveTo(position, 1);
+            yield return MoveTo(position, 2);
             if (waitForFixedUpdate)
             {
                 yield return new WaitForFixedUpdate();
@@ -74,6 +74,18 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         public override IEnumerator RotateTo(Quaternion newRotation, int numSteps = InputTestUtilities.ControllerMoveStepsSentinelValue, bool waitForFixedUpdate = true)
         {
             yield return InputTestUtilities.RotateHandTo(newRotation, handshapeId, handedness, numSteps);
+            if (waitForFixedUpdate)
+            {
+                yield return new WaitForFixedUpdate();
+            }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerator AimAt(Vector3 target, int numSteps = InputTestUtilities.ControllerMoveStepsSentinelValue, bool waitForFixedUpdate = true)
+        {
+            InputTestUtilities.SetHandAnchorPoint(handedness, Simulation.ControllerAnchorPoint.Device);
+            Vector3 currentPosition = InputTestUtilities.GetHandPose(handedness).position;
+            yield return InputTestUtilities.RotateHandTo(Quaternion.LookRotation(target - currentPosition, Vector3.up), handshapeId, handedness);
             if (waitForFixedUpdate)
             {
                 yield return new WaitForFixedUpdate();

--- a/com.microsoft.mrtk.input/Utilities/HandRay.cs
+++ b/com.microsoft.mrtk.input/Utilities/HandRay.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private const float CursorBeamUpTolerance = 0.8f;
 
         // Smoothing factor for ray stabilization.
-        private float stabilizedRayHalfLife = 0.01f;
+        private readonly float stabilizedRayHalfLife = 0.01f;
 
         private readonly StabilizedRay stabilizedRay;
         private Vector3 palmNormal;

--- a/com.microsoft.mrtk.input/Utilities/HandRay.cs
+++ b/com.microsoft.mrtk.input/Utilities/HandRay.cs
@@ -7,6 +7,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     public class HandRay : IHandRay
     {
+        /// <summary>
+        /// Constructs the hand ray generator with an optional
+        /// customized half-life value for the smoothing/filtering function.
+        /// A smaller half-life results in less smoothing.
+        /// </summary>
+        public HandRay(float halfLife = 0.01f)
+        {
+            stabilizedRayHalfLife = halfLife;
+            stabilizedRay = new StabilizedRay(stabilizedRayHalfLife);
+        }
+
         /// <inheritdoc />
         public Ray Ray
         {
@@ -58,9 +69,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private const float CursorBeamUpTolerance = 0.8f;
 
         // Smoothing factor for ray stabilization.
-        private const float StabilizedRayHalfLife = 0.01f;
+        private float stabilizedRayHalfLife = 0.01f;
 
-        private readonly StabilizedRay stabilizedRay = new StabilizedRay(StabilizedRayHalfLife);
+        private readonly StabilizedRay stabilizedRay;
         private Vector3 palmNormal;
         private Vector3 headForward;
 

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/BoundsControlTests.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/BoundsControlTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
                 boundsControlGameObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             }
 
-            boundsControlGameObject.transform.position = Vector3.forward * 0.75f;
+            boundsControlGameObject.transform.position = InputTestUtilities.InFrontOfUser(0.75f);
             boundsControlGameObject.transform.localScale = Vector3.one * 0.1f;
 
             BoundsControl boundsControl = boundsControlGameObject.AddComponent<BoundsControl>();
@@ -160,7 +160,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             }
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             Assert.IsFalse(bc.IsManipulated, "BC thought we were already manipulated");
 

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/ObjectManipulatorTests.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/ObjectManipulatorTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
         {
             GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.AddComponent<ObjectManipulator>();
-            cube.transform.position = new Vector3(0.1f, 0.1f, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.1f, 1));
             cube.transform.localScale = Vector3.one * 0.2f;
 
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
                 "ObjManip started out with incorrect AllowedManipulations");
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             yield return rightHand.MoveTo(cube.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -79,11 +79,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 
             // We don't have full gaze support in sim yet, so this is an approximation.
             // Set cube's position to straight ahead.
-            cube.transform.position = new Vector3(0, 0, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(1.0f);
 
             // Put hand out in front, in-FOV, but not too close to cube as to
             // disable the far interactors.
-            yield return rightHand.MoveTo(new Vector3(0.1f, 0, 0.5f));
+            yield return rightHand.MoveTo(InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0, 0.5f)));
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             Assert.IsTrue(objManip.IsGazePinchHovered,
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
         {
             GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.AddComponent<ObjectManipulator>();
-            cube.transform.position = new Vector3(0.1f, 0.1f, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.1f, 1));
             cube.transform.localScale = Vector3.one * 0.2f;
 
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -127,7 +127,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             objManip.SmoothingNear = false;
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             yield return rightHand.MoveTo(cube.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -216,7 +216,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             objectManipulator.hoverEntered.AddListener((eventData) => hoverEnterCount++);
             objectManipulator.hoverExited.AddListener((eventData) => hoverExitCount++);
 
-            testObject.transform.position = new Vector3(0, 0, 1.0f);
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(1.0f);
 
             yield return new WaitForFixedUpdate();
             yield return null;
@@ -266,7 +266,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
+            Vector3 initialObjectPosition = InputTestUtilities.InFrontOfUser(1f);
             testObject.transform.position = initialObjectPosition;
             var objectManipulator = testObject.AddComponent<ObjectManipulator>();
             objectManipulator.HostTransform = testObject.transform;
@@ -278,8 +278,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 
             const int numCircleSteps = 10;
 
-            Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
-            Vector3 initialGrabPosition = new Vector3(-0.05f, -0.05f, 1f); // grab around the left bottom corner of the cube
+            Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(0.5f);
+            Vector3 initialGrabPosition = InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, -0.05f, 1f)); // grab around the left bottom corner of the cube
             Quaternion initialGrabRotation = Quaternion.identity;
             TestHand hand = new TestHand(Handedness.Right);
 
@@ -395,7 +395,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             testObject.transform.localScale = Vector3.one * 0.3f;
-            Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
+            Vector3 initialObjectPosition = InputTestUtilities.InFrontOfUser(1f);
             testObject.transform.position = initialObjectPosition;
             var objectManipulator = testObject.AddComponent<ObjectManipulator>();
             objectManipulator.HostTransform = testObject.transform;
@@ -408,7 +408,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             const int numCircleSteps = 10;
 
             // Hand pointing at the cube
-            Vector3 initialHandPosition = new Vector3(0, 0.0f, 0.6f);
+            Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(0.6f);
             Quaternion initialHandRotation = Quaternion.identity;
             TestHand hand = new TestHand(Handedness.Right);
 
@@ -527,7 +527,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 
             // Set up cube with ObjectManipulator
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
+            Vector3 initialObjectPosition = InputTestUtilities.InFrontOfUser(1f);
             testObject.transform.position = initialObjectPosition;
             var objectManipulator = testObject.AddComponent<ObjectManipulator>();
             objectManipulator.HostTransform = testObject.transform;
@@ -539,7 +539,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 
             const int numCircleSteps = 10;
 
-            Vector3 initialHandPosition = new Vector3(0, 0, 0.5f); // Hand hovers in the center of the fov, but the hand ray misses the cube
+            Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(0.5f); // Hand hovers in the center of the fov, but the hand ray misses the cube
             Quaternion initialHandRotation = Quaternion.identity;
             TestHand hand = new TestHand(Handedness.Right);
 
@@ -649,7 +649,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             GameObject cube1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
             ObjectManipulator objmanip1 = cube1.AddComponent<ObjectManipulator>();
             objmanip1.SmoothingNear = false;
-            cube1.transform.position = new Vector3(0.1f, 0.1f, 1);
+            cube1.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.1f, 1));
             cube1.transform.localScale = Vector3.one * 0.2f;
 
             // First cube gets a FaceUserConstraint
@@ -658,7 +658,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             GameObject cube2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
             ObjectManipulator objmanip2 = cube2.AddComponent<ObjectManipulator>();
             objmanip2.SmoothingNear = false;
-            cube2.transform.position = new Vector3(0.5f, 0.1f, 1);
+            cube2.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.5f, 0.1f, 1));
             cube2.transform.localScale = Vector3.one * 0.2f;
 
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -667,13 +667,13 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             Assert.IsTrue(cube1.GetComponent<ConstraintManager>() != null, "Runtime-spawned ObjManip didn't also spawn ConstraintManager");
             Assert.IsTrue(cube2.GetComponent<ConstraintManager>() != null, "Runtime-spawned ObjManip didn't also spawn ConstraintManager");
 
-            // Assert that HostTransform defualts to the object's transform.
+            // Assert that HostTransform defaults to the object's transform.
             Assert.IsTrue(objmanip1.HostTransform == cube1.transform, "ObjManip's HostTransform didn't default to the object itself!");
             Assert.IsTrue(objmanip2.HostTransform == cube2.transform, "ObjManip's HostTransform didn't default to the object itself!");
 
             var rightHand = new TestHand(Handedness.Right);
             InputTestUtilities.SetHandAnchorPoint(Handedness.Left, ControllerAnchorPoint.Grab);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             yield return rightHand.MoveTo(cube1.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -707,7 +707,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             Assert.IsTrue(cube1.transform.position.CloseEnoughTo(cube1Pos), "Cube1 moved when it shouldn't have!");
-            Assert.IsTrue(cube2.transform.position.CloseEnoughTo(cube2Pos + Vector3.right * 0.5f), "Cube2 didn't move when it should have!");
+            Assert.IsTrue(!cube2.transform.position.CloseEnoughTo(cube2Pos), "Cube2 didn't move when it should have!");
             
             // Cube2 should be facing the user.
             Assert.IsTrue(cube2.transform.forward.CloseEnoughTo(-(cube2.transform.position - Camera.main.transform.position).normalized), "Cube2 didn't stay facing user!");
@@ -870,7 +870,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             testObject.transform.localScale = Vector3.one * 0.5f;
-            testObject.transform.position = new Vector3(0f, 0f, 1f);
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(1f);
 
             var rigidbody = testObject.AddComponent<Rigidbody>();
             rigidbody.useGravity = false;
@@ -885,11 +885,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // set up static cube to collide with
             var backgroundObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             backgroundObject.transform.localScale = Vector3.one;
-            backgroundObject.transform.position = new Vector3(0f, 0f, 2f);
+            backgroundObject.transform.position = InputTestUtilities.InFrontOfUser(2f);
             backgroundObject.GetComponent<MeshRenderer>().material.color = Color.green;
 
             TestHand hand = new TestHand(Handedness.Right);
-            yield return hand.Show(new Vector3(0.1f, -0.1f, 0.5f));
+            yield return hand.Show(InputTestUtilities.InFrontOfUser(new Vector3(0.1f, -0.1f, 0.5f)));
             yield return null;
 
             // Grab the cube and move towards the collider
@@ -914,7 +914,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // set up cube with manipulation handler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             testObject.transform.localScale = Vector3.one * 0.5f;
-            testObject.transform.position = new Vector3(0f, 0f, 1f);
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(1f);
 
             var rigidbody = testObject.AddComponent<Rigidbody>();
             rigidbody.useGravity = false;
@@ -929,13 +929,13 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // set up static cube to collide with
             var backgroundObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             backgroundObject.transform.localScale = Vector3.one;
-            backgroundObject.transform.position = new Vector3(0f, 0f, 2f);
+            backgroundObject.transform.position = InputTestUtilities.InFrontOfUser(2f);
             backgroundObject.GetComponent<MeshRenderer>().material.color = Color.green;
             var backgroundRigidbody = backgroundObject.AddComponent<Rigidbody>();
             backgroundRigidbody.useGravity = false;
 
             TestHand hand = new TestHand(Handedness.Right);
-            yield return hand.Show(new Vector3(0.1f, -0.1f, 0.5f));
+            yield return hand.Show(InputTestUtilities.InFrontOfUser(new Vector3(0.1f, -0.1f, 0.5f)));
             yield return null;
 
             // Grab the cube and move towards the collider

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/TransformViaInteractorTests.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/TransformViaInteractorTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // Create cube with ObjectManipulator
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             testObject.transform.localScale = Vector3.one;
-            testObject.transform.position = new Vector3(0, 0, 1.0f);
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0, 0, 1.0f));
             var objectManipulator = testObject.AddComponent<ObjectManipulator>();
             objectManipulator.SmoothingFar = false; // by default scale changes have smoothing but disabling makes testing quicker
 
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             Assert.AreEqual(1, hoverEnterCount, $"ObjectManipulator did not receive hover enter event, count is {hoverEnterCount}");
 
             // Select the cube with a pinch
-            Vector3 initialHandPosition = new Vector3(0.1f, 0.0f, 0.3f);
+            Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.0f, 0.3f));
             TestHand hand = new TestHand(Handedness.Right);
 
             yield return hand.Show(initialHandPosition);
@@ -195,12 +195,12 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             var initialLocalScale = new Vector3(1.5f, 1f, 0.9f); // non-uniform scale
             testObject.transform.localScale = initialLocalScale;
-            testObject.transform.position = new Vector3(0, 0, 1.0f);
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0, 0, 1.0f));
             var objectManipulator = testObject.AddComponent<ObjectManipulator>();
             objectManipulator.SmoothingFar = false; // by default scale changes have smoothing but disabling makes testing quicker
 
             // Select the cube with a pinch
-            Vector3 initialHandPosition = new Vector3(0.3f, 0.0f, 0.3f);
+            Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.3f, 0.0f, 0.3f));
             TestHand hand = new TestHand(Handedness.Right);
 
             yield return hand.Show(initialHandPosition);
@@ -236,12 +236,12 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             var initialLocalScale = Vector3.one;
             testObject.transform.localScale = initialLocalScale;
-            testObject.transform.position = new Vector3(0, 0, 1.0f);
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(1.0f);
             var objectManipulator = testObject.AddComponent<ObjectManipulator>();
             objectManipulator.SmoothingFar = false; // by default scale changes have smoothing but disabling makes testing quicker
 
             // Select the cube with a pinch
-            Vector3 initialHandPosition = new Vector3(0.1f, 0.0f, 0.3f);
+            Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.0f, 0.3f));
             TestHand hand = new TestHand(Handedness.Right);
 
 

--- a/com.microsoft.mrtk.uxcore/Tests/Runtime/StateVisualizerTests.cs
+++ b/com.microsoft.mrtk.uxcore/Tests/Runtime/StateVisualizerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             cube.AddComponent<Animator>();
             StateVisualizer sv = cube.AddComponent<StateVisualizer>() as StateVisualizer;
 
-            cube.transform.position = new Vector3(0.1f, 0.1f, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.1f, 1));
             cube.transform.localScale = Vector3.one * 0.1f;
 
             GameObject cubeToToggle = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             Assert.IsFalse(cubeToToggle.activeSelf, "The cube should be immediately toggled off when the effect is added.");
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             yield return rightHand.MoveTo(cube.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -136,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             cube.AddComponent<Animator>();
             StateVisualizer sv = cube.AddComponent<StateVisualizer>() as StateVisualizer;
 
-            cube.transform.position = new Vector3(0.1f, 0.1f, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.1f, 1));
             cube.transform.localScale = Vector3.one * 0.1f;
 
             // Attach a toggle effect to the Select state.
@@ -144,7 +144,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             sv.AddEffect("Select", customEffect);
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             yield return rightHand.MoveTo(cube.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -171,7 +171,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             cube.AddComponent<Animator>();
             StateVisualizer sv = cube.AddComponent<StateVisualizer>() as StateVisualizer;
 
-            cube.transform.position = new Vector3(0.5f, 0.5f, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.5f, 0.5f, 1));
             cube.transform.localScale = Vector3.one * 0.1f;
 
             // Attach a test effect to the Select state.
@@ -186,7 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             Assert.IsFalse(sv.Animator.enabled, "The animator should be disabled after the keepAliveTime has elapsed.");
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             yield return rightHand.MoveTo(cube.transform.position);
             yield return null;
@@ -238,7 +238,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             cube.AddComponent<Animator>();
             StateVisualizer sv = cube.AddComponent<StateVisualizer>() as StateVisualizer;
 
-            cube.transform.position = new Vector3(0.1f, 0.1f, 1);
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.1f, 1));
             cube.transform.localScale = Vector3.one * 0.1f;
 
             // Attach a test effect to the Select state.
@@ -253,7 +253,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             Assert.IsFalse(sv.Animator.enabled, "The animator should be disabled after the keepAliveTime has elapsed.");
 
             var rightHand = new TestHand(Handedness.Right);
-            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             yield return rightHand.MoveTo(cube.transform.position);
             yield return null;

--- a/com.microsoft.mrtk.uxcore/Tests/Runtime/StateVisualizerTests.cs
+++ b/com.microsoft.mrtk.uxcore/Tests/Runtime/StateVisualizerTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             yield return rightHand.MoveTo(cube.transform.position);
-            yield return null;
+            yield return RuntimeTestUtilities.WaitForUpdates();
 
             Assert.IsTrue(sv.Animator.enabled, "The animator should have woken up when hovered.");
 
@@ -256,7 +256,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
 
             yield return rightHand.MoveTo(cube.transform.position);
-            yield return null;
+            yield return RuntimeTestUtilities.WaitForUpdates();
 
             Assert.IsTrue(sv.Animator.enabled, "The animator should have woken up when hovered.");
 


### PR DESCRIPTION
## Overview
There's been some test rot over the past week or so. We're working on getting PRs blocking on failing unit tests so this doesn't keep happening in #11027.

## Changes
- `DescribableObjectTests` were duplicating the rig setup, causing subsequent tests in other packages to fail, introduced in #11021 , tracked here #11119
- Removed aliased `System.Collections.Generic` namespace in `DescribableObjectTests`
- Absolute world-space object placements in unit tests would fail when they required gaze, because the user (even in unit tests) is now 1.6m tall #11120
- Ray aiming broke due to changes in how the simulator/test harness computed hand rays from hand joints. Now, all unit tests direct the simulated controllers to `useRayVector = false`, which causes the `pointerRotation == deviceRotation` , tracked by #11121
- Introduced `AimAt` utility method in `TestHand`, for easily aiming hand rays at objects
- Allowed (and set) smoothing in the HandRay generator to be disabled during unit tests

## Verification
All unit tests pass.
