### PR TITLE
Update to ControllerVisualizer.cs to only control the lifecycle of direct actions

### DIFF
--- a/com.microsoft.mrtk.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
+++ b/com.microsoft.mrtk.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
@@ -19,21 +19,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
         Name = "com.microsoft.mixedreality.synthhands",
         DisplayName = "Subsystem for Hand Synthesis",
         Author = "Microsoft",
-        ProviderType = typeof(SynthesisProvider),
+        ProviderType = typeof(SyntheticHandsProvider),
         SubsystemTypeOverride = typeof(SyntheticHandsSubsystem),
         ConfigType = typeof(SyntheticHandsConfig))]
     public class SyntheticHandsSubsystem : HandsSubsystem
     {
-        private SynthesisProvider m_synthesisProvider;
-        private SynthesisProvider synthesisProvider
+        private SyntheticHandsProvider syntheticProvider;
+        private SyntheticHandsProvider SyntheticProvider
         {
             get
             {
-                if (m_synthesisProvider == null || m_synthesisProvider != provider)
+                if (syntheticProvider == null || syntheticProvider != provider)
                 {
-                    m_synthesisProvider = provider as SynthesisProvider;
+                    syntheticProvider = provider as SyntheticHandsProvider;
                 }
-                return m_synthesisProvider;
+                return syntheticProvider;
             }
         }
 
@@ -68,6 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </returns>
         [Obsolete("Please use the GetNeutralHandshape(handNode) instead.")]
         public HandshapeId GetNeutralPose(XRNode handNode) => GetNeutralHandshape(handNode);
+
         /// <summary>
         /// Sets the neutral pose for the specified hand.
         /// </summary>
@@ -103,7 +104,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </returns>
         public HandshapeId GetNeutralHandshape(XRNode handNode)
         {
-            return synthesisProvider.GetNeutralHandshape(handNode);
+            return SyntheticProvider.GetNeutralHandshape(handNode);
         }
 
         /// <summary>
@@ -113,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="handshapeId">The desired hand handshape.</param>
         public void SetNeutralHandshape(XRNode handNode, HandshapeId handshapeId)
         {
-            synthesisProvider.SetNeutralHandshape(handNode, handshapeId);
+            SyntheticProvider.SetNeutralHandshape(handNode, handshapeId);
         }
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </returns>
         public HandshapeId GetSelectionHandshape(XRNode handNode)
         {
-            return synthesisProvider.GetSelectionHandshape(handNode);
+            return SyntheticProvider.GetSelectionHandshape(handNode);
         }
 
         /// <summary>
@@ -135,20 +136,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="handshapeId">The desired hand handshape.</param>
         public void SetSelectionHandshape(XRNode handNode, HandshapeId handshapeId)
         {
-            synthesisProvider.SetSelectionHandshape(handNode, handshapeId);
+            SyntheticProvider.SetSelectionHandshape(handNode, handshapeId);
         }
 
         private class SyntheticHandContainer : HandDataContainer
         {
             // The current handshape in hand-space, untransformed.
             private HandJointPose[] currentHandshape = new HandJointPose[(int)TrackedHandJoint.TotalJoints];
-
-            // The 'neutral' handshape (ex: flat or open) to be displayed.
-            private HandshapeId neutralHandshape = HandshapeId.Open;
-
-            // The 'selection' handshape (ex: pinch) to be displayed.
-            // Does not have to correspond to a selecting action, but the pose lerps based on the value of the selectAction
-            private HandshapeId selectionHandshape = HandshapeId.Pinch;
 
             // The Input Action associated with the root position of this hand.
             private InputActionProperty positionAction;
@@ -185,7 +179,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                         InputActionProperty selectAction,
                                         Vector3 poseOffset) : base(handNode)
             {
-                this.neutralHandshape = baseHandshape;
+                NeturalHandshape = baseHandshape;
+
                 this.positionAction = positionAction;
                 this.rotationAction = rotationAction;
                 this.selectAction = selectAction;
@@ -198,20 +193,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             /// <summary>
             /// Gets or sets the synthetic hand's neutral hand shape.
             /// </summary>
-            public HandshapeId NeturalHandshape
-            {
-                get => neutralHandshape;
-                set => neutralHandshape = value;
-            }
+            public HandshapeId NeturalHandshape { get; set; } = HandshapeId.Open;
 
             /// <summary>
             /// Gets or sets the synthetic hand's selection hand shape.
             /// </summary>
-            public HandshapeId SelectionHandshape
-            {
-                get => selectionHandshape;
-                set => selectionHandshape = value;
-            }
+            public HandshapeId SelectionHandshape { get; set; } = HandshapeId.Pinch;
 
             /// <inheritdoc/>
             public override bool TryGetEntireHand(out IReadOnlyList<HandJointPose> result)
@@ -287,7 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // binding and grab the control list ourselves, and assume the first control is
                     // the one we want.
                     InputControl positionControl = positionAction.action?.activeControl ??
-                                                    (positionAction.action?.controls.Count > 0 ? positionAction.action?.controls[0] : null);
+                        (positionAction.action?.controls.Count > 0 ? positionAction.action?.controls[0] : null);
 
                     if (positionControl?.device is TrackedDevice positionTrackedDevice)
                     {
@@ -311,7 +298,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // binding and grab the control list ourselves, and assume the first control is
                     // the one we want.
                     InputControl rotationControl = rotationAction.action?.activeControl ??
-                                                    (rotationAction.action?.controls.Count > 0 ? rotationAction.action?.controls[0] : null);
+                        (rotationAction.action?.controls.Count > 0 ? rotationAction.action?.controls[0] : null);
 
                     if (rotationControl?.device is TrackedDevice rotationTrackedDevice)
                     {
@@ -368,8 +355,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 using (UpdatehandshapePerfMarker.Auto())
                 {
-                    SimulatedArticulatedHandshapes.GetHandshapeJointPoseData(neutralHandshape, out HandJointPose[] baseData);
-                    SimulatedArticulatedHandshapes.GetHandshapeJointPoseData(selectionHandshape, out HandJointPose[] pinchData);
+                    SimulatedArticulatedHandshapes.GetHandshapeJointPoseData(NeturalHandshape, out HandJointPose[] baseData);
+                    SimulatedArticulatedHandshapes.GetHandshapeJointPoseData(SelectionHandshape, out HandJointPose[] pinchData);
 
                     selectAmount = selectAction.action.ReadValue<float>();
 
@@ -392,7 +379,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         [Preserve]
-        class SynthesisProvider : Provider
+        class SyntheticHandsProvider : Provider
         {
             protected SyntheticHandsConfig Config { get; private set; }
 

--- a/com.microsoft.mrtk.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
+++ b/com.microsoft.mrtk.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.Scripting;
 using UnityEngine.XR;
-
+using UnityEngine.XR.Interaction.Toolkit.Inputs;
 using HandshapeId = Microsoft.MixedReality.Toolkit.Input.HandshapeTypes.HandshapeId;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -185,6 +185,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 this.rotationAction = rotationAction;
                 this.selectAction = selectAction;
                 this.poseOffset = poseOffset;
+            }
+
+            public void Start()
+            {
+                positionAction.EnableDirectAction();
+                rotationAction.EnableDirectAction();
+                selectAction.EnableDirectAction();
+            }
+
+            public void Stop()
+            {
+                positionAction.DisableDirectAction();
+                rotationAction.DisableDirectAction();
+                selectAction.DisableDirectAction();
             }
 
             private static readonly ProfilerMarker TryGetEntireHandPerfMarker =
@@ -409,6 +423,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                                                 Config.PoseOffset) }
                 };
 
+                hands[XRNode.LeftHand].Start();
+                hands[XRNode.RightHand].Start();
+
                 InputSystem.onBeforeUpdate += ResetHands;
             }
 
@@ -416,6 +433,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 ResetHands();
                 InputSystem.onBeforeUpdate -= ResetHands;
+
+                hands[XRNode.LeftHand].Stop();
+                hands[XRNode.RightHand].Stop();
+
                 base.Stop();
             }
 

--- a/com.microsoft.mrtk.input/Visualizers/ControllerVisualizer/ControllerVisualizer.cs
+++ b/com.microsoft.mrtk.input/Visualizers/ControllerVisualizer/ControllerVisualizer.cs
@@ -4,11 +4,10 @@
 using Microsoft.MixedReality.Toolkit.Input.Simulation;
 using Microsoft.MixedReality.Toolkit.Subsystems;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.XR;
 using UnityEngine.XR.Interaction.Toolkit.Inputs;
-using InputAction = UnityEngine.InputSystem.InputAction;
-using InputActionProperty = UnityEngine.InputSystem.InputActionProperty;
 using UnityInputSystem = UnityEngine.InputSystem;
 
 namespace Microsoft.MixedReality.Toolkit.Input

--- a/com.microsoft.mrtk.input/Visualizers/ControllerVisualizer/ControllerVisualizer.cs
+++ b/com.microsoft.mrtk.input/Visualizers/ControllerVisualizer/ControllerVisualizer.cs
@@ -6,6 +6,7 @@ using Microsoft.MixedReality.Toolkit.Subsystems;
 using UnityEngine;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.XR;
+using UnityEngine.XR.Interaction.Toolkit.Inputs;
 using InputAction = UnityEngine.InputSystem.InputAction;
 using InputActionProperty = UnityEngine.InputSystem.InputActionProperty;
 using UnityInputSystem = UnityEngine.InputSystem;
@@ -72,13 +73,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (controllerDetectedAction == null || controllerDetectedAction.action == null) { return; }
             controllerDetectedAction.action.started += RenderControllerVisuals;
             controllerDetectedAction.action.canceled += RemoveControllerVisuals;
-            controllerDetectedAction.action.Enable();
+            controllerDetectedAction.EnableDirectAction();
         }
 
         protected void OnDisable()
         {
             if (controllerDetectedAction == null || controllerDetectedAction.action == null) { return; }
-            controllerDetectedAction.action.Disable();
+            controllerDetectedAction.DisableDirectAction();
             controllerDetectedAction.action.started -= RenderControllerVisuals;
             controllerDetectedAction.action.canceled -= RemoveControllerVisuals;
         }


### PR DESCRIPTION
## Overview

XRI has a helper for only controlling the lifecycle of directly serialized actions, leaving action references to be controlled by their source (in most cases, an Input Action Asset filled with mappings).

```c#
/// <remarks>
/// This can make it easier to allow the enabled state of the <see cref="InputAction"/> serialized with
/// a <see cref="MonoBehaviour"/> to be owned by the behavior itself, but let a reference type be managed
/// elsewhere.
/// </remarks>
```