### PR TITLE
Prevent non-gaze pointers from overwriting the GazeTarget and use custom raycast provider in GGV pointer

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -196,8 +196,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
             else
             {
-                bool didHit = MixedRealityRaycaster.RaycastSimplePhysicsStep(Rays[0], Rays[0].Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out RaycastHit physicsHit);
-                hitInfo = new MixedRealityRaycastHit(didHit, physicsHit);
+				var raycastProvider = CoreServices.InputSystem.RaycastProvider;
+				bool didHit = raycastProvider.Raycast(Rays[0], prioritizedLayerMasks, focusIndividualCompoundCollider, out hitInfo);
                 Ray = Rays[0];
                 rayStepIndex = 0;
                 return didHit;
@@ -212,7 +212,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
             else
             {
-                bool didHit = MixedRealityRaycaster.RaycastSimplePhysicsStep(Rays[0], Rays[0].Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out RaycastHit physicsHit);
+				var raycastProvider = CoreServices.InputSystem.RaycastProvider;
+				bool didHit = raycastProvider.Raycast(Rays[0], prioritizedLayerMasks, focusIndividualCompoundCollider, out MixedRealityRaycastHit physicsHit);
                 if (didHit)
                 {
                     hitObject = physicsHit.collider.gameObject;


### PR DESCRIPTION
## Overview
Creates a new instance of a 'PointerHitResult' for the 'gazeHitResult' member of FocusProvider.

This way when other pointers re-use the 'hitResult3d' or 'hitResultUi', they do not modify the object that is pointed to by 'gazeHitResult'

## Changes
- Fixes: #11145
