### PR TITLE
Upgrading XRI to 2.2

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/XRI/Settings/Resources/InteractionLayerSettings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/XRI/Settings/Resources/InteractionLayerSettings.asset
@@ -44,4 +44,4 @@ MonoBehaviour:
   - 
   - 
   - 
-  - 
+  - Teleport

--- a/UnityProjects/MRTKDevTemplate/Packages/manifest.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/manifest.json
@@ -31,6 +31,7 @@
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.4.8",
     "com.unity.ugui": "1.0.0",
+    "com.unity.xr.interaction.toolkit": "2.2.0",
     "com.unity.xr.management": "4.2.1",
     "com.unity.xr.openxr": "1.5.1",
     "com.unity.modules.ai": "1.0.0",

--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -373,11 +373,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.interaction.toolkit": {
-      "version": "2.0.3",
-      "depth": 1,
+      "version": "2.2.0",
+      "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.inputsystem": "1.2.0",
+        "com.unity.inputsystem": "1.3.0",
         "com.unity.ugui": "1.0.0",
         "com.unity.xr.core-utils": "2.0.0",
         "com.unity.xr.legacyinputhelpers": "2.1.8",

--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -62,7 +62,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.xr.interaction.toolkit": "2.0.3",
+        "com.unity.xr.interaction.toolkit": "2.2.0",
         "com.unity.xr.management": "4.2.1",
         "com.unity.xr.core-utils": "2.1.0"
       }
@@ -110,7 +110,7 @@
         "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
         "com.unity.inputsystem": "1.3.0",
         "com.unity.xr.arfoundation": "4.2.6",
-        "com.unity.xr.interaction.toolkit": "2.0.3",
+        "com.unity.xr.interaction.toolkit": "2.2.0",
         "com.unity.xr.core-utils": "2.1.0"
       }
     },
@@ -122,7 +122,7 @@
         "com.microsoft.mrtk.core": "3.0.0-development",
         "com.microsoft.mrtk.uxcore": "3.0.0-development",
         "com.unity.inputsystem": "1.3.0",
-        "com.unity.xr.interaction.toolkit": "2.0.3"
+        "com.unity.xr.interaction.toolkit": "2.2.0"
       }
     },
     "com.microsoft.mrtk.standardassets": {
@@ -170,7 +170,7 @@
         "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
         "com.unity.inputsystem": "1.3.0",
         "com.unity.textmeshpro": "3.0.6",
-        "com.unity.xr.interaction.toolkit": "2.0.3"
+        "com.unity.xr.interaction.toolkit": "2.2.0"
       }
     },
     "com.microsoft.mrtk.windowsspeech": {

--- a/com.microsoft.mrtk.core/package.json
+++ b/com.microsoft.mrtk.core/package.json
@@ -15,7 +15,7 @@
   },
   "unity": "2020.3",
   "dependencies": {
-    "com.unity.xr.interaction.toolkit": "2.0.3",
+    "com.unity.xr.interaction.toolkit": "2.2.0",
     "com.unity.xr.management": "4.2.1",
     "com.unity.xr.core-utils": "2.1.0"
   }

--- a/com.microsoft.mrtk.input/package.json
+++ b/com.microsoft.mrtk.input/package.json
@@ -19,7 +19,7 @@
     "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.xr.arfoundation": "4.2.6",
-    "com.unity.xr.interaction.toolkit": "2.0.3",
+    "com.unity.xr.interaction.toolkit": "2.2.0",
     "com.unity.xr.core-utils": "2.1.0"
   }
 }

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/ObjectManipulatorTests.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/ObjectManipulatorTests.cs
@@ -148,14 +148,14 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             Vector3 attachTransform = objManip.firstInteractorSelecting.GetAttachTransform(objManip).position;
             Vector3 originalAttachOffset = attachTransform - originalPosition;
 
-            Vector3 newPosition = originalPosition + Vector3.right * 0.5f;
+            Vector3 newPosition = originalPosition + Vector3.right * 1.5f;
             yield return rightHand.MoveTo(newPosition);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Smoothing should mean that the cube has lagged behind the hand.
             attachTransform = objManip.firstInteractorSelecting.GetAttachTransform(objManip).position;
             Vector3 attachOffset = attachTransform - cube.transform.position;
-            Assert.IsTrue((attachOffset - originalAttachOffset).magnitude > 0.2f,
+            Assert.IsTrue((attachOffset - originalAttachOffset).magnitude > 0.1f,
                 "Smoothing didn't seem to work. Current attachTransform offset should be different than the original, indicating lag.");
 
             // Wait long enough for the object to catch up.
@@ -168,7 +168,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // Disable smoothing, to check that it properly sticks to the hand once disabled.
             objManip.SmoothingNear = false;
 
-            newPosition = originalPosition - Vector3.right * 0.5f;
+            newPosition = originalPosition - Vector3.right * 1.5f;
             yield return rightHand.MoveTo(newPosition);
             yield return RuntimeTestUtilities.WaitForUpdates();
 

--- a/com.microsoft.mrtk.spatialmanipulation/package.json
+++ b/com.microsoft.mrtk.spatialmanipulation/package.json
@@ -18,7 +18,7 @@
     "com.microsoft.mrtk.core": "3.0.0-development",
     "com.microsoft.mrtk.uxcore": "3.0.0-development",
     "com.unity.inputsystem": "1.3.0",
-    "com.unity.xr.interaction.toolkit": "2.0.3"
+    "com.unity.xr.interaction.toolkit": "2.2.0"
   },
   "msftOptionalPackages": {
     "com.microsoft.mrtk.input": "3.0.0-development"

--- a/com.microsoft.mrtk.uxcore/package.json
+++ b/com.microsoft.mrtk.uxcore/package.json
@@ -19,7 +19,7 @@
     "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.textmeshpro": "3.0.6",
-    "com.unity.xr.interaction.toolkit": "2.0.3"
+    "com.unity.xr.interaction.toolkit": "2.2.0"
   },
   "msftOptionalPackages": {
     "com.microsoft.mrtk.data": "1.0.0-development"


### PR DESCRIPTION
## Overview
This PR bumps our XRI version to 2.2. We are doing this to keep up with the new API additions such as GrabTransformers

https://docs.unity3d.com/Packages/com.unity.xr.interaction.toolkit@2.2/manual/whats-new-2.2.0.html

Some tests and settings updated to be less flakey and clean up some of our warnings.