### PR TITLE
Update InterfaceSelector to work with arrays/lists

### DIFF
--- a/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/InterfaceSelectorDrawer.cs
+++ b/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/InterfaceSelectorDrawer.cs
@@ -47,12 +47,24 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             // Add a dropdown menu to select an interface, and generate an instance of it
             float labelWidth = labelStyle.CalcSize(label).x + EditorGUIUtility.singleLineHeight;
             Rect dropdownRect = new Rect(position.x + labelWidth, position.y, position.width - labelWidth, EditorGUIUtility.singleLineHeight);
-            dropLabel.text = $"{fieldInfo.FieldType.Name} - {typeName}";
+
+            Type fieldType = fieldInfo.FieldType;
+
+            if (fieldType.IsArray)
+            {
+                fieldType = fieldType.GetElementType();
+            }
+            else if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(List<>))
+            {
+                fieldType = fieldType.GetGenericArguments()[0];
+            }
+
+            dropLabel.text = $"{fieldType.Name} - {typeName}";
             if (EditorGUI.DropdownButton(dropdownRect, dropLabel, FocusType.Passive))
             {
                 // Grab a list of all Types currently loaded that implement our
                 // field's type.
-                List<Type> allDerivedTypes = TypeCache.GetTypesDerivedFrom(fieldInfo.FieldType)
+                List<Type> allDerivedTypes = TypeCache.GetTypesDerivedFrom(fieldType)
                     .Where(type => !type.IsAbstract && !type.IsInterface)
                     .ToList();
 

--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK Gaze Controller.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK Gaze Controller.prefab
@@ -53,6 +53,7 @@ MonoBehaviour:
   m_AttachTransform: {fileID: 0}
   m_KeepSelectedTargetValid: 1
   m_StartingSelectedInteractable: {fileID: 0}
+  m_StartingTargetFilter: {fileID: 0}
   m_HoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -65,6 +66,8 @@ MonoBehaviour:
   m_SelectExited:
     m_PersistentCalls:
       m_Calls: []
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
   m_OnHoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -80,6 +83,7 @@ MonoBehaviour:
   m_SelectActionTrigger: 1
   m_HideControllerOnSelect: 0
   m_AllowHoveredActivate: 0
+  m_TargetPriorityMode: 0
   m_PlayAudioClipOnSelectEntered: 0
   m_AudioClipForOnSelectEntered: {fileID: 0}
   m_PlayAudioClipOnSelectExited: 0
@@ -92,6 +96,7 @@ MonoBehaviour:
   m_AudioClipForOnHoverExited: {fileID: 0}
   m_PlayAudioClipOnHoverCanceled: 0
   m_AudioClipForOnHoverCanceled: {fileID: 0}
+  m_AllowHoverAudioWhileSelecting: 1
   m_PlayHapticsOnSelectEntered: 0
   m_HapticSelectEnterIntensity: 0
   m_HapticSelectEnterDuration: 0
@@ -110,6 +115,7 @@ MonoBehaviour:
   m_PlayHapticsOnHoverCanceled: 0
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
+  m_AllowHoverHapticsWhileSelecting: 1
   m_LineType: 0
   m_BlendVisualLinePoints: 1
   m_MaxRaycastDistance: 30
@@ -139,6 +145,7 @@ MonoBehaviour:
   m_RotateSpeed: 180
   m_TranslateSpeed: 1
   m_AnchorRotateReferenceFrame: {fileID: 0}
+  m_AnchorRotationMode: 0
   coneAngle: 10
   minGazeDistance: 0.1
   maxGazeDistance: 5
@@ -374,6 +381,18 @@ MonoBehaviour:
       m_Type: 0
       m_ExpectedControlType: 
       m_Id: 2b8598b6-3b69-47f7-8541-2c7d29b9a4ae
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_DirectionalAnchorRotationAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Directional Anchor Rotation
+      m_Type: 0
+      m_ExpectedControlType: 
+      m_Id: 1339e3a3-e6a3-4baf-8905-1ad03cc965b3
       m_Processors: 
       m_Interactions: 
       m_SingletonActionBindings: []

--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK Hand Controller.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK Hand Controller.prefab
@@ -58,6 +58,7 @@ MonoBehaviour:
   m_AttachTransform: {fileID: 0}
   m_KeepSelectedTargetValid: 1
   m_StartingSelectedInteractable: {fileID: 0}
+  m_StartingTargetFilter: {fileID: 0}
   m_HoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -70,6 +71,8 @@ MonoBehaviour:
   m_SelectExited:
     m_PersistentCalls:
       m_Calls: []
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
   m_OnHoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -85,6 +88,7 @@ MonoBehaviour:
   m_SelectActionTrigger: 1
   m_HideControllerOnSelect: 0
   m_AllowHoveredActivate: 0
+  m_TargetPriorityMode: 0
   m_PlayAudioClipOnSelectEntered: 0
   m_AudioClipForOnSelectEntered: {fileID: 0}
   m_PlayAudioClipOnSelectExited: 0
@@ -97,6 +101,7 @@ MonoBehaviour:
   m_AudioClipForOnHoverExited: {fileID: 0}
   m_PlayAudioClipOnHoverCanceled: 0
   m_AudioClipForOnHoverCanceled: {fileID: 0}
+  m_AllowHoverAudioWhileSelecting: 1
   m_PlayHapticsOnSelectEntered: 0
   m_HapticSelectEnterIntensity: 0
   m_HapticSelectEnterDuration: 0
@@ -115,6 +120,7 @@ MonoBehaviour:
   m_PlayHapticsOnHoverCanceled: 0
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
+  m_AllowHoverHapticsWhileSelecting: 1
   m_LineType: 0
   m_BlendVisualLinePoints: 1
   m_MaxRaycastDistance: 10
@@ -144,6 +150,7 @@ MonoBehaviour:
   m_RotateSpeed: 180
   m_TranslateSpeed: 1
   m_AnchorRotateReferenceFrame: {fileID: 0}
+  m_AnchorRotationMode: 0
   aimPoseSource:
     id: 0
   devicePoseSource:
@@ -153,19 +160,17 @@ MonoBehaviour:
     00000000:
       type: {class: FallbackCompositePoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
-        poseSources:
-        - source:
-            id: 2
-        - source:
-            id: 3
+        poseSourceList:
+        - id: 2
+        - id: 3
+        poseSources: []
     00000001:
       type: {class: FallbackCompositePoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
-        poseSources:
-        - source:
-            id: 4
-        - source:
-            id: 5
+        poseSourceList:
+        - id: 4
+        - id: 5
+        poseSources: []
     00000002:
       type: {class: InputActionPoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
@@ -524,6 +529,7 @@ MonoBehaviour:
   m_AttachTransform: {fileID: 1051247791254679178}
   m_KeepSelectedTargetValid: 1
   m_StartingSelectedInteractable: {fileID: 0}
+  m_StartingTargetFilter: {fileID: 0}
   m_HoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -536,6 +542,8 @@ MonoBehaviour:
   m_SelectExited:
     m_PersistentCalls:
       m_Calls: []
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
   m_OnHoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -551,6 +559,7 @@ MonoBehaviour:
   m_SelectActionTrigger: 1
   m_HideControllerOnSelect: 0
   m_AllowHoveredActivate: 0
+  m_TargetPriorityMode: 0
   m_PlayAudioClipOnSelectEntered: 0
   m_AudioClipForOnSelectEntered: {fileID: 0}
   m_PlayAudioClipOnSelectExited: 0
@@ -563,6 +572,7 @@ MonoBehaviour:
   m_AudioClipForOnHoverExited: {fileID: 0}
   m_PlayAudioClipOnHoverCanceled: 0
   m_AudioClipForOnHoverCanceled: {fileID: 0}
+  m_AllowHoverAudioWhileSelecting: 1
   m_PlayHapticsOnSelectEntered: 0
   m_HapticSelectEnterIntensity: 0
   m_HapticSelectEnterDuration: 0
@@ -581,6 +591,7 @@ MonoBehaviour:
   m_PlayHapticsOnHoverCanceled: 0
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
+  m_AllowHoverHapticsWhileSelecting: 1
   pinchPoseSource:
     id: 0
   references:
@@ -588,11 +599,10 @@ MonoBehaviour:
     00000000:
       type: {class: FallbackCompositePoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
-        poseSources:
-        - source:
-            id: 1
-        - source:
-            id: 2
+        poseSourceList:
+        - id: 1
+        - id: 2
+        poseSources: []
     00000001:
       type: {class: PinchPoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
@@ -864,6 +874,18 @@ MonoBehaviour:
       m_SingletonActionBindings: []
       m_Flags: 0
     m_Reference: {fileID: -7363382999065477798, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+  m_DirectionalAnchorRotationAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Directional Anchor Rotation
+      m_Type: 0
+      m_ExpectedControlType: 
+      m_Id: debc0bf7-c57b-4317-a05d-982f95726b56
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 0}
   m_TranslateAnchorAction:
     m_UseReference: 1
     m_Action:
@@ -933,6 +955,7 @@ MonoBehaviour:
   m_AttachTransform: {fileID: 8443923956584964973}
   m_KeepSelectedTargetValid: 0
   m_StartingSelectedInteractable: {fileID: 0}
+  m_StartingTargetFilter: {fileID: 0}
   m_HoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -945,6 +968,8 @@ MonoBehaviour:
   m_SelectExited:
     m_PersistentCalls:
       m_Calls: []
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
   m_OnHoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -960,6 +985,7 @@ MonoBehaviour:
   m_SelectActionTrigger: 1
   m_HideControllerOnSelect: 0
   m_AllowHoveredActivate: 0
+  m_TargetPriorityMode: 0
   m_PlayAudioClipOnSelectEntered: 0
   m_AudioClipForOnSelectEntered: {fileID: 0}
   m_PlayAudioClipOnSelectExited: 0
@@ -972,6 +998,7 @@ MonoBehaviour:
   m_AudioClipForOnHoverExited: {fileID: 0}
   m_PlayAudioClipOnHoverCanceled: 0
   m_AudioClipForOnHoverCanceled: {fileID: 0}
+  m_AllowHoverAudioWhileSelecting: 1
   m_PlayHapticsOnSelectEntered: 0
   m_HapticSelectEnterIntensity: 0
   m_HapticSelectEnterDuration: 0
@@ -990,6 +1017,7 @@ MonoBehaviour:
   m_PlayHapticsOnHoverCanceled: 0
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
+  m_AllowHoverHapticsWhileSelecting: 1
   pokePoseSource:
     id: 0
   references:
@@ -997,11 +1025,10 @@ MonoBehaviour:
     00000000:
       type: {class: FallbackCompositePoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
-        poseSources:
-        - source:
-            id: 1
-        - source:
-            id: 2
+        poseSourceList:
+        - id: 1
+        - id: 2
+        poseSources: []
     00000001:
       type: {class: HandJointPoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
@@ -1216,6 +1243,7 @@ MonoBehaviour:
   m_AttachTransform: {fileID: 0}
   m_KeepSelectedTargetValid: 1
   m_StartingSelectedInteractable: {fileID: 0}
+  m_StartingTargetFilter: {fileID: 0}
   m_HoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -1228,6 +1256,8 @@ MonoBehaviour:
   m_SelectExited:
     m_PersistentCalls:
       m_Calls: []
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
   m_OnHoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -1243,6 +1273,7 @@ MonoBehaviour:
   m_SelectActionTrigger: 1
   m_HideControllerOnSelect: 0
   m_AllowHoveredActivate: 0
+  m_TargetPriorityMode: 0
   m_PlayAudioClipOnSelectEntered: 0
   m_AudioClipForOnSelectEntered: {fileID: 0}
   m_PlayAudioClipOnSelectExited: 0
@@ -1255,6 +1286,7 @@ MonoBehaviour:
   m_AudioClipForOnHoverExited: {fileID: 0}
   m_PlayAudioClipOnHoverCanceled: 0
   m_AudioClipForOnHoverCanceled: {fileID: 0}
+  m_AllowHoverAudioWhileSelecting: 1
   m_PlayHapticsOnSelectEntered: 0
   m_HapticSelectEnterIntensity: 0
   m_HapticSelectEnterDuration: 0
@@ -1273,6 +1305,7 @@ MonoBehaviour:
   m_PlayHapticsOnHoverCanceled: 0
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
+  m_AllowHoverHapticsWhileSelecting: 1
   handController: {fileID: 6164080946324827545}
   devicePoseSource:
     id: 0
@@ -1288,11 +1321,10 @@ MonoBehaviour:
     00000000:
       type: {class: FallbackCompositePoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
-        poseSources:
-        - source:
-            id: 3
-        - source:
-            id: 4
+        poseSourceList:
+        - id: 3
+        - id: 4
+        poseSources: []
     00000001:
       type: {class: PinchPoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
@@ -1300,11 +1332,10 @@ MonoBehaviour:
     00000002:
       type: {class: FallbackCompositePoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:
-        poseSources:
-        - source:
-            id: 5
-        - source:
-            id: 6
+        poseSourceList:
+        - id: 5
+        - id: 6
+        poseSources: []
     00000003:
       type: {class: InputActionPoseSource, ns: Microsoft.MixedReality.Toolkit.Input, asm: Microsoft.MixedReality.Toolkit.Input}
       data:

--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
@@ -16,34 +16,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1948193615953854875, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1948193615953854875, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1948193615953854875, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1948193615953854875, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1948193615953854875, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1948193615953854875, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1948193615953854875, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1948193615953854875, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
@@ -64,7 +36,7 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1948193616346090107, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: pokePoseSource.poseSources.Array.data[0].source.hand
+      propertyPath: pokePoseSource.poseSourceList.Array.data[0].hand
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2082243679387671466, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
@@ -76,27 +48,15 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2572330550550829917, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: pinchPoseSource.poseSources.Array.data[0].source.hand
+      propertyPath: pinchPoseSource.poseSourceList.Array.data[0].hand
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: aimPoseSource.poseSources.Array.data[0].source.hand
+      propertyPath: aimPoseSource.poseSourceList.Array.data[1].hand
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: aimPoseSource.poseSources.Array.data[1].source.hand
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: devicePoseSource.poseSources.Array.data[1].source.hand
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: pointerPoseSource.poseSources.Array.data[0].source.hand
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: pointerPoseSource.poseSources.Array.data[1].source.hand
+      propertyPath: devicePoseSource.poseSourceList.Array.data[1].hand
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
@@ -104,15 +64,11 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: aimPoseSource.poseSources.Array.data[0].source.hand
+      propertyPath: aimPoseSource.poseSourceList.Array.data[1].hand
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: aimPoseSource.poseSources.Array.data[1].source.hand
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: devicePoseSource.poseSources.Array.data[1].source.hand
+      propertyPath: devicePoseSource.poseSourceList.Array.data[1].hand
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4299642553989019654, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}

--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK RightHand Controller.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK RightHand Controller.prefab
@@ -108,9 +108,21 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1948193616346090107, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: pokePoseSource.poseSourceList.Array.data[0].hand
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1948193616346090107, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: pokePoseSource.poseSources.Array.data[0].source.hand
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 1948193616346090107, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: pokePoseSource.poseSourceList.Array.data[1].positionActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: -3326005586356538449, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 1948193616346090107, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: pokePoseSource.poseSourceList.Array.data[1].rotationActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 5101698808175986029, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 1948193616346090107, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: pokePoseSource.poseSources.Array.data[1].source.positionActionProperty.m_Reference
       value: 
@@ -119,6 +131,10 @@ PrefabInstance:
       propertyPath: pokePoseSource.poseSources.Array.data[1].source.rotationActionProperty.m_Reference
       value: 
       objectReference: {fileID: 5101698808175986029, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 1948193616346090107, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: pokePoseSource.poseSourceList.Array.data[1].trackingStateActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 3239510804178183174, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 1948193616346090107, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: pokePoseSource.poseSources.Array.data[1].source.trackingStateActionProperty.m_Reference
       value: 
@@ -132,9 +148,21 @@ PrefabInstance:
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2572330550550829917, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: pinchPoseSource.poseSourceList.Array.data[0].hand
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2572330550550829917, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: pinchPoseSource.poseSources.Array.data[0].source.hand
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 2572330550550829917, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: pinchPoseSource.poseSourceList.Array.data[1].positionActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: -3326005586356538449, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 2572330550550829917, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: pinchPoseSource.poseSourceList.Array.data[1].rotationActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 5101698808175986029, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 2572330550550829917, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: pinchPoseSource.poseSources.Array.data[1].source.positionActionProperty.m_Reference
       value: 
@@ -144,9 +172,21 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5101698808175986029, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 2572330550550829917, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: pinchPoseSource.poseSourceList.Array.data[1].trackingStateActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 3239510804178183174, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 2572330550550829917, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: pinchPoseSource.poseSources.Array.data[1].source.trackingStateActionProperty.m_Reference
       value: 
       objectReference: {fileID: 3239510804178183174, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: aimPoseSource.poseSourceList.Array.data[1].hand
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: devicePoseSource.poseSourceList.Array.data[1].hand
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: aimPoseSource.poseSources.Array.data[0].source.hand
       value: 2
@@ -168,6 +208,22 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: aimPoseSource.poseSourceList.Array.data[0].positionActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: -3326005586356538449, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: aimPoseSource.poseSourceList.Array.data[0].rotationActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 5101698808175986029, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: devicePoseSource.poseSourceList.Array.data[0].positionActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: -1813146318149588949, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: devicePoseSource.poseSourceList.Array.data[0].rotationActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 5820880757197039143, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: aimPoseSource.poseSources.Array.data[0].source.positionActionProperty.m_Reference
       value: 
       objectReference: {fileID: -3326005586356538449, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
@@ -176,6 +232,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5101698808175986029, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: aimPoseSource.poseSourceList.Array.data[0].trackingStateActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 3239510804178183174, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: devicePoseSource.poseSources.Array.data[0].source.positionActionProperty.m_Reference
       value: 
       objectReference: {fileID: -1813146318149588949, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
@@ -183,6 +243,10 @@ PrefabInstance:
       propertyPath: devicePoseSource.poseSources.Array.data[0].source.rotationActionProperty.m_Reference
       value: 
       objectReference: {fileID: 5820880757197039143, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: devicePoseSource.poseSourceList.Array.data[0].trackingStateActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 3239510804178183174, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 2940030942784507886, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: pointerPoseSource.poseSources.Array.data[0].source.positionActionProperty.m_Reference
       value: 
@@ -208,6 +272,14 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: aimPoseSource.poseSourceList.Array.data[1].hand
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: devicePoseSource.poseSourceList.Array.data[1].hand
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: aimPoseSource.poseSources.Array.data[0].source.hand
       value: 2
       objectReference: {fileID: 0}
@@ -220,6 +292,22 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: aimPoseSource.poseSourceList.Array.data[0].positionActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: -3326005586356538449, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: aimPoseSource.poseSourceList.Array.data[0].rotationActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 5101698808175986029, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: devicePoseSource.poseSourceList.Array.data[0].positionActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: -1813146318149588949, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: devicePoseSource.poseSourceList.Array.data[0].rotationActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 5820880757197039143, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: aimPoseSource.poseSources.Array.data[0].source.positionActionProperty.m_Reference
       value: 
       objectReference: {fileID: -3326005586356538449, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
@@ -228,6 +316,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5101698808175986029, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: aimPoseSource.poseSourceList.Array.data[0].trackingStateActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 3239510804178183174, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: devicePoseSource.poseSources.Array.data[0].source.positionActionProperty.m_Reference
       value: 
       objectReference: {fileID: -1813146318149588949, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
@@ -235,6 +327,10 @@ PrefabInstance:
       propertyPath: devicePoseSource.poseSources.Array.data[0].source.rotationActionProperty.m_Reference
       value: 
       objectReference: {fileID: 5820880757197039143, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
+      propertyPath: devicePoseSource.poseSourceList.Array.data[0].trackingStateActionProperty.m_Reference
+      value: 
+      objectReference: {fileID: 3239510804178183174, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 3419360757097544916, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: aimPoseSource.poseSources.Array.data[0].source.trackingStateActionProperty.m_Reference
       value: 
@@ -295,10 +391,6 @@ PrefabInstance:
       propertyPath: m_SelectActionValue.m_Reference
       value: 
       objectReference: {fileID: 2995356199736570127, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
-    - target: {fileID: 6164080946324827545, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
-      propertyPath: m_HapticDeviceAction.m_Reference
-      value: 
-      objectReference: {fileID: -8222252007134549311, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 6164080946324827545, guid: a9ae130324a36134e99beedf50e7be6f, type: 3}
       propertyPath: m_RotateAnchorAction.m_Reference
       value: 

--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK XR Rig.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK XR Rig.prefab
@@ -387,6 +387,7 @@ MonoBehaviour:
   m_AttachTransform: {fileID: 0}
   m_KeepSelectedTargetValid: 1
   m_StartingSelectedInteractable: {fileID: 0}
+  m_StartingTargetFilter: {fileID: 0}
   m_HoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -399,6 +400,8 @@ MonoBehaviour:
   m_SelectExited:
     m_PersistentCalls:
       m_Calls: []
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
   m_OnHoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -480,6 +483,7 @@ MonoBehaviour:
   m_AttachTransform: {fileID: 0}
   m_KeepSelectedTargetValid: 1
   m_StartingSelectedInteractable: {fileID: 0}
+  m_StartingTargetFilter: {fileID: 0}
   m_HoverEntered:
     m_PersistentCalls:
       m_Calls: []
@@ -492,6 +496,8 @@ MonoBehaviour:
   m_SelectExited:
     m_PersistentCalls:
       m_Calls: []
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
   m_OnHoverEntered:
     m_PersistentCalls:
       m_Calls: []

--- a/com.microsoft.mrtk.input/Utilities/PoseSource/FallbackCompositePoseSource.cs
+++ b/com.microsoft.mrtk.input/Utilities/PoseSource/FallbackCompositePoseSource.cs
@@ -13,14 +13,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [Serializable]
     public class FallbackCompositePoseSource : IPoseSource
     {
-        [SerializeField]
+        [SerializeReference]
+        [InterfaceSelector]
         [Tooltip("An ordered list of pose sources to query.")]
-        private PoseSourceWrapper[] poseSources;
+        private IPoseSource[] poseSources;
 
         /// <summary>
         /// An ordered list of pose sources to query.
         /// </summary>
-        protected PoseSourceWrapper[] PoseSources { get => poseSources; set => poseSources = value; }
+        protected IPoseSource[] PoseSources { get => poseSources; set => poseSources = value; }
 
         /// <summary>
         /// Tries to get a pose from each pose source in order, returning the result of the first pose source
@@ -28,35 +29,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool TryGetPose(out Pose pose)
         {
-            pose = Pose.identity;
-            bool poseRetrieved = false;
-
             for (int i = 0; i < poseSources.Length; i++)
             {
-                IPoseSource currentPoseSource = poseSources[i].source;
-                poseRetrieved = currentPoseSource != null && currentPoseSource.TryGetPose(out pose);
-                if (poseRetrieved)
+                IPoseSource currentPoseSource = poseSources[i];
+                if (currentPoseSource != null && currentPoseSource.TryGetPose(out pose))
                 {
-                    break;
+                    return true;
                 }
             }
 
-            return poseRetrieved;
-        }
-
-        /// <summary>
-        /// An internal wrapper class which is required to allow the pose source to be properly selectable in editor
-        /// This is needed because GenericMenu's cannot be set as the active context when embedded inside other GUI contexts,
-        /// which in this particular instance, is the list element's container context.
-        /// Reference: https://forum.unity.com/threads/genericmenu-used-as-context-inside-a-menuitem.330235/
-        /// </summary>
-        [Serializable]
-        protected struct PoseSourceWrapper
-        {
-            [SerializeReference]
-            [InterfaceSelector]
-            [Tooltip("The pose source we are trying to get the pose of")]
-            public IPoseSource source;
+            pose = Pose.identity;
+            return false;
         }
     }
 }

--- a/com.microsoft.mrtk.input/Utilities/PoseSource/FallbackCompositePoseSource.cs
+++ b/com.microsoft.mrtk.input/Utilities/PoseSource/FallbackCompositePoseSource.cs
@@ -11,17 +11,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// which successfully returns a pose.
     /// </summary>
     [Serializable]
-    public class FallbackCompositePoseSource : IPoseSource
+    public class FallbackCompositePoseSource : IPoseSource, ISerializationCallbackReceiver
     {
         [SerializeReference]
         [InterfaceSelector]
         [Tooltip("An ordered list of pose sources to query.")]
-        private IPoseSource[] poseSources;
+        private IPoseSource[] poseSourceList;
+
+        [SerializeField]
+        [Tooltip("An ordered list of pose sources to query.")]
+        [Obsolete, HideInInspector]
+        private PoseSourceWrapper[] poseSources;
 
         /// <summary>
         /// An ordered list of pose sources to query.
         /// </summary>
-        protected IPoseSource[] PoseSources { get => poseSources; set => poseSources = value; }
+        protected IPoseSource[] PoseSources { get => poseSourceList; set => poseSourceList = value; }
 
         /// <summary>
         /// Tries to get a pose from each pose source in order, returning the result of the first pose source
@@ -29,9 +34,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool TryGetPose(out Pose pose)
         {
-            for (int i = 0; i < poseSources.Length; i++)
+            for (int i = 0; i < poseSourceList.Length; i++)
             {
-                IPoseSource currentPoseSource = poseSources[i];
+                IPoseSource currentPoseSource = poseSourceList[i];
                 if (currentPoseSource != null && currentPoseSource.TryGetPose(out pose))
                 {
                     return true;
@@ -40,6 +45,34 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             pose = Pose.identity;
             return false;
+        }
+
+        [Obsolete]
+        void ISerializationCallbackReceiver.OnAfterDeserialize()
+        {
+            if (poseSources != null && poseSources.Length > 0)
+            {
+                poseSourceList = new IPoseSource[poseSources.Length];
+
+                for (int i = 0; i < poseSources.Length; i++)
+                {
+                    PoseSourceWrapper poseSource = poseSources[i];
+                    poseSourceList[i] = poseSource.source;
+                }
+
+                poseSources = null;
+            }
+        }
+
+        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
+
+        [Serializable, Obsolete]
+        private struct PoseSourceWrapper
+        {
+            [SerializeReference]
+            [InterfaceSelector]
+            [Tooltip("The pose source we are trying to get the pose of")]
+            public IPoseSource source;
         }
     }
 }


### PR DESCRIPTION
## Overview

A less breaking version of #11182

Updates `InterfaceSelectorDrawer` to account for the type being an array or a list and properly extracting out the type for the dropdown