### PR TITLE
Fix the docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ project.json
 project.lock.json
 *.package
 **/.DS_Store
-Assets/Oculus/
-Assets/Oculus.meta
+**/Assets/Oculus/
+**/Assets/Oculus.meta
 
 # ============ #
 # Certificates #

--- a/Assets/MRTK/Providers/OpenXR/Editor/OpenXRCameraSettingsProfileInspector.cs
+++ b/Assets/MRTK/Providers/OpenXR/Editor/OpenXRCameraSettingsProfileInspector.cs
@@ -40,11 +40,14 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR.Editor
                     "Look for \"Disable First Person Observer\".", MessageType.Info);
 
 #if MSFT_OPENXR
-                mrcSettingsButtonContent ??= new GUIContent()
+                if (mrcSettingsButtonContent == null)
                 {
-                    image = EditorGUIUtility.IconContent("Settings").image,
-                    text = " OpenXR plug-in settings",
-                };
+                    mrcSettingsButtonContent = new GUIContent()
+                    {
+                        image = EditorGUIUtility.IconContent("Settings").image,
+                        text = " OpenXR plug-in settings",
+                    };
+                }
 
                 using (new EditorGUILayout.HorizontalScope())
                 {


### PR DESCRIPTION
## Overview

#11127 broke the Unity 2020 docs build, but it's unclear exactly why. This is an attempt to fix.