### PR TITLE
Allow for custom min and max ranges for sliders

### DIFF
--- a/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/DrawIfPropertyDrawer.cs
+++ b/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/DrawIfPropertyDrawer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit
             DrawIfAttribute drawIf = attribute as DrawIfAttribute;
             if (drawIf == null) { return true; }
 
-            string path = property.propertyPath.Contains(".") ? System.IO.Path.ChangeExtension(property.propertyPath, drawIf.ComparedPropertyName) : drawIf.ComparedPropertyName;
+            string path = drawIf.ComparedPropertyName;
 
             SerializedProperty propertyToCheck = property.serializedObject.FindProperty(path);
             if (propertyToCheck == null)

--- a/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/VariableRangeAttributeDrawer.cs
+++ b/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/VariableRangeAttributeDrawer.cs
@@ -10,13 +10,13 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
     [CustomPropertyDrawer(typeof(VariableRangeAttribute))]
-    public class VariableRangePropertyDrawerer : PropertyDrawer
+    public class VariableRangePropertyDrawer : PropertyDrawer
     {
-        private GUIContent dropLabel;
         private GUIStyle labelStyle;
 
-        public VariableRangePropertyDrawerer()
+        public VariableRangePropertyDrawer()
         {
+            labelStyle = EditorGUIUtility.GetBuiltinSkin(EditorSkin.Inspector).label;
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
@@ -49,7 +49,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             float minValue = minVariableProperty.floatValue;
             float maxValue = maxVariableProperty.floatValue;
 
-            labelStyle = EditorGUIUtility.GetBuiltinSkin(EditorSkin.Inspector).label;
             float labelWidth = labelStyle.CalcSize(label).x + EditorGUIUtility.singleLineHeight;
             Rect labelRect = new Rect(position.x, position.y, labelWidth, EditorGUIUtility.singleLineHeight);
             EditorGUI.PrefixLabel(labelRect, label);

--- a/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/VariableRangeAttributeDrawer.cs
+++ b/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/VariableRangeAttributeDrawer.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
@@ -30,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 return;
             }
 
-            string minVariablePath = property.propertyPath.Contains(".") ? System.IO.Path.ChangeExtension(property.propertyPath, range.MinVariableName) : range.MinVariableName;
+            string minVariablePath = range.MinVariableName;
             SerializedProperty minVariableProperty = property.serializedObject.FindProperty(minVariablePath);
             if (minVariableProperty == null || !(minVariableProperty.propertyType == SerializedPropertyType.Float || minVariableProperty.propertyType == SerializedPropertyType.Integer))
             {
@@ -38,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 return;
             }
 
-            string maxVariablePath = property.propertyPath.Contains(".") ? System.IO.Path.ChangeExtension(property.propertyPath, range.MaxVariableName) : range.MaxVariableName;
+            string maxVariablePath = range.MaxVariableName;
             SerializedProperty maxVariableProperty = property.serializedObject.FindProperty(maxVariablePath);
             if (maxVariableProperty == null || !(maxVariableProperty.propertyType == SerializedPropertyType.Float || maxVariableProperty.propertyType == SerializedPropertyType.Integer))
             {
@@ -53,10 +50,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             Rect labelRect = new Rect(position.x, position.y, labelWidth, EditorGUIUtility.singleLineHeight);
             EditorGUI.PrefixLabel(labelRect, label);
 
-            Rect sliderRect = new Rect(position.x + labelWidth, position.y, position.width - labelWidth, EditorGUIUtility.singleLineHeight);
-            property.floatValue = EditorGUI.Slider(sliderRect, property.floatValue, minValue, maxValue);
-
             EditorGUI.BeginChangeCheck();
+            Rect sliderRect = new Rect(position.x + labelWidth, position.y, position.width - labelWidth, EditorGUIUtility.singleLineHeight);
             property.floatValue = EditorGUI.Slider(sliderRect, property.floatValue, minValue, maxValue);
             if (EditorGUI.EndChangeCheck())
             {

--- a/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/VariableRangeAttributeDrawer.cs
+++ b/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/VariableRangeAttributeDrawer.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    [CustomPropertyDrawer(typeof(VariableRangeAttribute))]
+    public class VariableRangePropertyDrawerer : PropertyDrawer
+    {
+        private GUIContent dropLabel;
+        private GUIStyle labelStyle;
+
+        public VariableRangePropertyDrawerer()
+        {
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            VariableRangeAttribute range = attribute as VariableRangeAttribute;
+            if (range == null)
+            {
+                Debug.LogError($"Property was did not have a VariableRangeAttribute");
+                return;
+            }
+
+            string minVariablePath = property.propertyPath.Contains(".") ? System.IO.Path.ChangeExtension(property.propertyPath, range.MinVariableName) : range.MinVariableName;
+            SerializedProperty minVariableProperty = property.serializedObject.FindProperty(minVariablePath);
+            if (minVariableProperty == null || !(minVariableProperty.propertyType == SerializedPropertyType.Float || minVariableProperty.propertyType == SerializedPropertyType.Integer))
+            {
+                Debug.LogError($"VariableRangeAttribute couldn't find the variable used to define the minRange (property name: {range.MinVariableName})");
+                return;
+            }
+
+            string maxVariablePath = property.propertyPath.Contains(".") ? System.IO.Path.ChangeExtension(property.propertyPath, range.MaxVariableName) : range.MaxVariableName;
+            SerializedProperty maxVariableProperty = property.serializedObject.FindProperty(maxVariablePath);
+            if (maxVariableProperty == null || !(maxVariableProperty.propertyType == SerializedPropertyType.Float || maxVariableProperty.propertyType == SerializedPropertyType.Integer))
+            {
+                Debug.LogError($"VariableRangeAttribute couldn't find a valid variable used to define the maxRange (property name: {range.MaxVariableName})");
+                return;
+            }
+
+            float minValue = minVariableProperty.floatValue;
+            float maxValue = maxVariableProperty.floatValue;
+
+            labelStyle = EditorGUIUtility.GetBuiltinSkin(EditorSkin.Inspector).label;
+            float labelWidth = labelStyle.CalcSize(label).x + EditorGUIUtility.singleLineHeight;
+            Rect labelRect = new Rect(position.x, position.y, labelWidth, EditorGUIUtility.singleLineHeight);
+            EditorGUI.PrefixLabel(labelRect, label);
+
+            Rect sliderRect = new Rect(position.x + labelWidth, position.y, position.width - labelWidth, EditorGUIUtility.singleLineHeight);
+            property.floatValue = EditorGUI.Slider(sliderRect, property.floatValue, minValue, maxValue);
+
+            EditorGUI.BeginChangeCheck();
+            property.floatValue = EditorGUI.Slider(sliderRect, property.floatValue, minValue, maxValue);
+            if (EditorGUI.EndChangeCheck())
+            {
+                property.serializedObject.ApplyModifiedProperties();
+                property.serializedObject.Update();
+            }
+
+            EditorGUI.EndProperty();
+        }
+    }
+}

--- a/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/VariableRangeAttributeDrawer.cs.meta
+++ b/com.microsoft.mrtk.core/Editor/Inspectors/PropertyDrawers/VariableRangeAttributeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4356068122d163047b093a205f1280ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.core/Utilities/Attributes/VariableRangeAttribute.cs
+++ b/com.microsoft.mrtk.core/Utilities/Attributes/VariableRangeAttribute.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit
+{
+    /// <summary>
+    /// An attribute that allows a particular field to be rendered as multi-selectable
+    /// set of flags.
+    /// </summary>
+    /// <remarks>
+    /// From https://answers.unity.com/questions/486694/default-editor-enum-as-flags-.html
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Field)]
+    public sealed class VariableRangeAttribute : PropertyAttribute
+    {
+        public string MinVariableName { get; private set; }
+
+        public string MaxVariableName { get; private set; }
+
+
+        public VariableRangeAttribute(string minVariableName, string maxVariableName)
+        {
+            MinVariableName = minVariableName;
+            MaxVariableName = maxVariableName;
+        }
+    }
+}

--- a/com.microsoft.mrtk.core/Utilities/Attributes/VariableRangeAttribute.cs
+++ b/com.microsoft.mrtk.core/Utilities/Attributes/VariableRangeAttribute.cs
@@ -7,12 +7,8 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit
 {
     /// <summary>
-    /// An attribute that allows a particular field to be rendered as multi-selectable
-    /// set of flags.
+    /// An attribute that allows a particular field to be constrained to a range dependent on other variables
     /// </summary>
-    /// <remarks>
-    /// From https://answers.unity.com/questions/486694/default-editor-enum-as-flags-.html
-    /// </remarks>
     [AttributeUsage(AttributeTargets.Field)]
     public sealed class VariableRangeAttribute : PropertyAttribute
     {

--- a/com.microsoft.mrtk.core/Utilities/Attributes/VariableRangeAttribute.cs.meta
+++ b/com.microsoft.mrtk.core/Utilities/Attributes/VariableRangeAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae26120e0c505c742b4c578d172df5a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.uxcore/Slider/Slider.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Slider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
@@ -134,7 +135,13 @@ namespace Microsoft.MixedReality.Toolkit.UX
         [SerializeField]
         private float sliderValue = 0.5f;
 
-        public float SliderValue
+        [Obsolete("Use Value instead")]
+        public float SliderValue => Value;
+
+        /// <summary>
+        /// The current value of the slider
+        /// </summary>
+        public float Value
         {
             get => sliderValue;
             set
@@ -145,7 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             }
         }
 
-        public float NormalizedSliderValue => (MaxValue - MinValue) != 0 ? (sliderValue - MinValue) / (MaxValue - MinValue) : 0;
+        public float NormalizedValue => (MaxValue - MinValue) != 0 ? (sliderValue - MinValue) / (MaxValue - MinValue) : 0;
 
         [SerializeField]
         [Tooltip("Controls whether this slider is increments in steps or continuously.")]
@@ -286,7 +293,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             // Ensure that the proper constraints are applied to the possible values of the slider
             MinValue = minValue;
             MaxValue = maxValue;
-            SliderValue = sliderValue;
+            Value = sliderValue;
         }
 
         #endregion
@@ -305,7 +312,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// </summary>
         private void InitializeStepDivisions()
         {
-            SliderValue = SnapSliderToStepPositions(SliderValue);
+            Value = SnapSliderToStepPositions(Value);
         }
 
         private float SnapSliderToStepPositions(float value)
@@ -325,7 +332,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
             float unsnappedValue = Mathf.Clamp(StartSliderValue + handDelta / SliderTrackDirection.magnitude, MinValue, MaxValue);
 
-            SliderValue = useSliderStepDivisions ? SnapSliderToStepPositions(unsnappedValue) : unsnappedValue;
+            Value = useSliderStepDivisions ? SnapSliderToStepPositions(unsnappedValue) : unsnappedValue;
         }
 
         #endregion

--- a/com.microsoft.mrtk.uxcore/Slider/Slider.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Slider.cs
@@ -107,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             }
             set
             {
-                minValue = value;
+                minValue = Mathf.Min(value, maxValue);
             }
         }
 
@@ -126,7 +126,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             }
             set
             {
-                maxValue = value;
+                maxValue = Mathf.Max(minValue, value);
             }
         }
 
@@ -144,6 +144,8 @@ namespace Microsoft.MixedReality.Toolkit.UX
                 OnValueUpdated.Invoke(new SliderEventData(oldSliderValue, value));
             }
         }
+
+        public float NormalizedSliderValue => (MaxValue - MinValue) != 0 ? (sliderValue - MinValue) / (MaxValue - MinValue) : 0;
 
         [SerializeField]
         [Tooltip("Controls whether this slider is increments in steps or continuously.")]
@@ -280,6 +282,11 @@ namespace Microsoft.MixedReality.Toolkit.UX
         private void OnValidate()
         {
             ApplyRequiredSettings();
+
+            // Ensure that the proper constraints are applied to the possible values of the slider
+            MinValue = minValue;
+            MaxValue = maxValue;
+            SliderValue = sliderValue;
         }
 
         #endregion

--- a/com.microsoft.mrtk.uxcore/Slider/Slider.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Slider.cs
@@ -92,7 +92,45 @@ namespace Microsoft.MixedReality.Toolkit.UX
             set => trackCollider = value;
         }
 
-        [Range(minVal, maxVal)]
+        [SerializeField]
+        [Tooltip("The minimum value that the slider can take on")]
+        private float minValue = 0.0f;
+
+        /// <summary>
+        /// The minimum value that the slider can take on
+        /// </summary>
+        public float MinValue
+        {
+            get
+            {
+                return minValue;
+            }
+            set
+            {
+                minValue = value;
+            }
+        }
+
+        [SerializeField]
+        [Tooltip("The maximum value that the slider can take on")]
+        private float maxValue = 1.0f;
+
+        /// <summary>
+        /// The maximum value that the slider can take on
+        /// </summary>
+        public float MaxValue
+        {
+            get
+            {
+                return maxValue;
+            }
+            set
+            {
+                maxValue = value;
+            }
+        }
+
+        [VariableRange("minValue", "maxValue")]
         [SerializeField]
         private float sliderValue = 0.5f;
 
@@ -178,7 +216,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// <summary>
         /// Private member used to adjust slider values
         /// </summary>
-        private float SliderStepVal => (maxVal - minVal) / sliderStepDivisions;
+        private float SliderStepVal => (MaxValue - MinValue) / sliderStepDivisions;
 
         #endregion
 
@@ -194,20 +232,6 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// Computed by <see cref="GetInteractionPoint"> in <see cref="SetupForInteraction">
         /// </summary>
         protected Vector3 StartInteractionPoint { get; private set; }
-
-        #endregion
-
-        #region Constants
-
-        /// <summary>
-        /// The minimum value that the slider can take on
-        /// </summary>
-        private const float minVal = 0.0f;
-
-        /// <summary>
-        /// The maximum value that the slider can take on
-        /// </summary>
-        private const float maxVal = 1.0f;
 
         #endregion
 
@@ -281,7 +305,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         {
             var stepCount = value / SliderStepVal;
             var snappedValue = SliderStepVal * Mathf.RoundToInt(stepCount);
-            Mathf.Clamp(snappedValue, minVal, maxVal);
+            Mathf.Clamp(snappedValue, MinValue, MaxValue);
             return snappedValue;
         }
 
@@ -292,7 +316,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
             var handDelta = Vector3.Dot(SliderTrackDirection.normalized, interactorDelta);
 
-            float unsnappedValue = Mathf.Clamp(StartSliderValue + handDelta / SliderTrackDirection.magnitude, minVal, maxVal);
+            float unsnappedValue = Mathf.Clamp(StartSliderValue + handDelta / SliderTrackDirection.magnitude, MinValue, MaxValue);
 
             SliderValue = useSliderStepDivisions ? SnapSliderToStepPositions(unsnappedValue) : unsnappedValue;
         }

--- a/com.microsoft.mrtk.uxcore/Slider/Slider.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Slider.cs
@@ -4,6 +4,7 @@
 using System;
 using Unity.Profiling;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityEngine.XR.Interaction.Toolkit;
 
 using SliderEvent = UnityEngine.Events.UnityEvent<Microsoft.MixedReality.Toolkit.UX.SliderEventData>;
@@ -132,8 +133,9 @@ namespace Microsoft.MixedReality.Toolkit.UX
         }
 
         [VariableRange("minValue", "maxValue")]
+        [FormerlySerializedAs("sliderValue")]
         [SerializeField]
-        private float sliderValue = 0.5f;
+        private float value = 0.5f;
 
         [Obsolete("Use Value instead")]
         public float SliderValue => Value;
@@ -143,16 +145,16 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// </summary>
         public float Value
         {
-            get => sliderValue;
+            get => value;
             set
             {
-                var oldSliderValue = sliderValue;
-                sliderValue = value;
+                var oldSliderValue = this.value;
+                this.value = value;
                 OnValueUpdated.Invoke(new SliderEventData(oldSliderValue, value));
             }
         }
 
-        public float NormalizedValue => (MaxValue - MinValue) != 0 ? (sliderValue - MinValue) / (MaxValue - MinValue) : 0;
+        public float NormalizedValue => (MaxValue - MinValue) != 0 ? (value - MinValue) / (MaxValue - MinValue) : 0;
 
         [SerializeField]
         [Tooltip("Controls whether this slider is increments in steps or continuously.")]
@@ -283,7 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
                 InitializeStepDivisions();
             }
 
-            OnValueUpdated.Invoke(new SliderEventData(sliderValue, sliderValue));
+            OnValueUpdated.Invoke(new SliderEventData(value, value));
         }
 
         private void OnValidate()
@@ -293,7 +295,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             // Ensure that the proper constraints are applied to the possible values of the slider
             MinValue = minValue;
             MaxValue = maxValue;
-            Value = sliderValue;
+            Value = value;
         }
 
         #endregion
@@ -355,7 +357,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             else
             {
                 StartInteractionPoint = args.interactorObject.GetAttachTransform(this).position;
-                StartSliderValue = sliderValue;
+                StartSliderValue = value;
             }
         }
 

--- a/com.microsoft.mrtk.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             SliderState.OnValueUpdated.AddListener(UpdateHandle);
 
             // Initial update. We may miss the first OnValueUpdated, depending on execution order.
-            UpdateHandle(SliderState.NormalizedSliderValue);
+            UpdateHandle(SliderState.NormalizedValue);
             SetLayout(sliderDirection);
         }
 
@@ -178,7 +178,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             }
 
             // Update handle in editor view.
-            UpdateHandle(SliderState.NormalizedSliderValue);
+            UpdateHandle(SliderState.NormalizedValue);
         }
 #endif // UNITY_EDITOR
 
@@ -314,7 +314,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
                 }
             }
 
-            UpdateHandle(SliderState.NormalizedSliderValue);
+            UpdateHandle(SliderState.NormalizedValue);
         }
     }
 }

--- a/com.microsoft.mrtk.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             SliderState.OnValueUpdated.AddListener(UpdateHandle);
 
             // Initial update. We may miss the first OnValueUpdated, depending on execution order.
-            UpdateHandle(SliderState.SliderValue);
+            UpdateHandle(SliderState.NormalizedSliderValue);
             SetLayout(sliderDirection);
         }
 
@@ -178,7 +178,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             }
 
             // Update handle in editor view.
-            UpdateHandle(SliderState.SliderValue);
+            UpdateHandle(SliderState.NormalizedSliderValue);
         }
 #endif // UNITY_EDITOR
 
@@ -314,7 +314,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
                 }
             }
 
-            UpdateHandle(SliderState.SliderValue);
+            UpdateHandle(SliderState.NormalizedSliderValue);
         }
     }
 }

--- a/com.microsoft.mrtk.uxcore/Slider/Visuals/SliderVisuals.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Visuals/SliderVisuals.cs
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
         void Update()
         {
-            handle.position = SliderState.SliderStart.position + (SliderState.NormalizedSliderValue * SliderState.SliderTrackDirection);
+            handle.position = SliderState.SliderStart.position + (SliderState.NormalizedValue * SliderState.SliderTrackDirection);
             trackArea.transform.position = (SliderState.SliderStart.position + SliderState.SliderEnd.position) * 0.5f;
 
             Vector2 localSliderTrackDirection = SliderState.transform.InverseTransformDirection(SliderState.SliderTrackDirection);
@@ -88,8 +88,8 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
             if (fillVisual != null)
             {
-                fillVisual.localPosition = new Vector3(-0.5f + SliderState.NormalizedSliderValue * 0.5f, fillVisual.localPosition.y, fillVisual.localPosition.z);
-                fillVisual.localScale = new Vector3(SliderState.NormalizedSliderValue, fillVisual.localScale.y, fillVisual.localScale.z);
+                fillVisual.localPosition = new Vector3(-0.5f + SliderState.NormalizedValue * 0.5f, fillVisual.localPosition.y, fillVisual.localPosition.z);
+                fillVisual.localScale = new Vector3(SliderState.NormalizedValue, fillVisual.localScale.y, fillVisual.localScale.z);
             }
         }
     }

--- a/com.microsoft.mrtk.uxcore/Slider/Visuals/SliderVisuals.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Visuals/SliderVisuals.cs
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
         void Update()
         {
-            handle.position = SliderState.SliderStart.position + (SliderState.SliderValue * SliderState.SliderTrackDirection);
+            handle.position = SliderState.SliderStart.position + (SliderState.NormalizedSliderValue * SliderState.SliderTrackDirection);
             trackArea.transform.position = (SliderState.SliderStart.position + SliderState.SliderEnd.position) * 0.5f;
 
             Vector2 localSliderTrackDirection = SliderState.transform.InverseTransformDirection(SliderState.SliderTrackDirection);
@@ -88,8 +88,8 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
             if (fillVisual != null)
             {
-                fillVisual.localPosition = new Vector3(-0.5f + SliderState.SliderValue * 0.5f, fillVisual.localPosition.y, fillVisual.localPosition.z);
-                fillVisual.localScale = new Vector3(SliderState.SliderValue, fillVisual.localScale.y, fillVisual.localScale.z);
+                fillVisual.localPosition = new Vector3(-0.5f + SliderState.NormalizedSliderValue * 0.5f, fillVisual.localPosition.y, fillVisual.localPosition.z);
+                fillVisual.localScale = new Vector3(SliderState.NormalizedSliderValue, fillVisual.localScale.y, fillVisual.localScale.z);
             }
         }
     }


### PR DESCRIPTION
## Overview
![Slider1](https://user-images.githubusercontent.com/39840334/200971543-b5516c42-c0ec-4763-89f6-827e1b626d58.gif)

This PR allows for min and max values to be defined for the slider and adds corresponding helpful inspector UI.

This also adds `NormalizedSliderValue` to accomodate for `SliderValue` no longer always being a normalized value between 0 and 1

## Changes
- Fixes: #10803 

