### PR TITLE
Add button to populate the profile field with the MRTK default

### DIFF
--- a/com.microsoft.mrtk.core/Editor/MRTKProfileInspector.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKProfileInspector.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// A container class, intended to wrap all information about a subsystem
         /// relevant to this custom editor.
         /// </summary>
-        internal class SubsystemItem
+        private class SubsystemItem
         {
             /// <summary>
             /// Constructs a <see cref="SubsystemItem"> from a <see cref="Type">.

--- a/com.microsoft.mrtk.core/Editor/MRTKSettingsEditor.cs
+++ b/com.microsoft.mrtk.core/Editor/MRTKSettingsEditor.cs
@@ -25,6 +25,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private GUIContent profileLabel = new GUIContent("Profile");
 
+        private const string MRTKDefaultProfileGUID = "c677e5c4eb85b7849a8da406775c299d";
+
         private void OnEnable()
         {
             profileDict = serializedObject.FindProperty("settings");
@@ -50,6 +52,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (profile.objectReferenceValue == null)
             {
                 EditorGUILayout.HelpBox("MixedRealityToolkit cannot initialize unless an Active Profile is assigned!", MessageType.Error);
+                if (GUILayout.Button(new GUIContent("Assign MRTK Default")))
+                {
+                    profile.objectReferenceValue = AssetDatabase.LoadAssetAtPath<MRTKProfile>(AssetDatabase.GUIDToAssetPath(MRTKDefaultProfileGUID));
+                }
             }
 
             EditorGUILayout.PropertyField(profile, profileLabel);

--- a/com.microsoft.mrtk.core/Utilities/XRSubsystemHelpers.cs
+++ b/com.microsoft.mrtk.core/Utilities/XRSubsystemHelpers.cs
@@ -220,11 +220,19 @@ namespace Microsoft.MixedReality.Toolkit
             // In editor, this is set in an Editor-only OnEnable() function to the
             // profile associated with the Standalone build target group.
             MRTKProfile profile = MRTKProfile.Instance;
-            Debug.Assert(profile != null, "MRTK Profile could not be retrieved");
+
+            if (profile == null)
+            {
+                Debug.LogError("MRTK Profile could not be retrieved.");
+                return null;
+            }
 
             // Attempt to retrieve the config associated with the indicated subsystem.
-            profile.TryGetConfigForSubsystem(typeof(SubsystemT), out BaseSubsystemConfig config);
-            Debug.Assert(config != null, "Configuration could not be retrieved for " + typeof(SubsystemT));
+            if (!profile.TryGetConfigForSubsystem(typeof(SubsystemT), out BaseSubsystemConfig config) || config == null)
+            {
+                Debug.LogError($"Configuration could not be retrieved for {typeof(SubsystemT)}.", profile);
+                return null;
+            }
 
             // Cast the config down to the requested config type for client's convenience.
             return config as ConfigT;


### PR DESCRIPTION
## Overview

Unfortunately, when consuming MRTK via tarballs, Unity's asset picker doesn't include assets from immutable folders...

<img width="484" alt="image" src="https://user-images.githubusercontent.com/3580640/204940637-2f749a08-84d0-4ad2-a3ad-97658a52b5a1.png">

This change adds a button to the MRTK Profile inspector to auto-populate the field with the default profile that we ship

<img width="488" alt="image" src="https://user-images.githubusercontent.com/3580640/204940693-d66ec074-7b6c-4c73-9a25-cd78ac6e325b.png">

I also changed some asserts to full `if`/`log`s to prevent null refs and changed a class from `internal` to `private` to better fit its usage.