### PR TITLE
Oculus controller detection Hand Constraint Bug Fix

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -289,11 +289,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
                 if (isValidController && SolverHandler.TransformTarget != null)
                 {
-                    if (updateWhenOppositeHandNear || !IsOppositeHandNear(trackedController))
-                    {
+                    // The following lines on being commented solves the issue where Oculus Controllers are not Detected on first 
+                    // when using HandConstraint
+
+                    //if (updateWhenOppositeHandNear || !IsOppositeHandNear(trackedController))
+                    //{
                         GoalPosition = CalculateGoalPosition();
                         GoalRotation = CalculateGoalRotation();
-                    }
+                    //}
                 }
             }
             else


### PR DESCRIPTION
## Overview
Bug in Hand Constraint Script wherein the Oculus Controllers are not detected when in TrackedTargetType of Control Mapping in Solver Handler

## Changes
- Fixes: # commented if statement for Opposite Hand Near check. Although this would lead to an additional computation, it is not much compared to the intensity of bug which at the moment does not seem to have another fix.


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
