### PR TITLE
Don't share controller and source collections between instances

### DIFF
--- a/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
         private const float DeviceRefreshInterval = 3.0f;
 
-        protected static readonly Dictionary<string, GenericJoystickController> ActiveControllers = new Dictionary<string, GenericJoystickController>();
+        protected readonly Dictionary<string, GenericJoystickController> ActiveControllers = new Dictionary<string, GenericJoystickController>();
 
         private float deviceRefreshTimer;
         private string[] lastDeviceList;

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(inputSystem, name, priority, profile) { }
 
-        private static readonly Dictionary<int, UnityTouchController> ActiveTouches = new Dictionary<int, UnityTouchController>();
+        private readonly Dictionary<int, UnityTouchController> ActiveTouches = new Dictionary<int, UnityTouchController>();
 
         private List<UnityTouchController> touchesToRemove = new List<UnityTouchController>();
 

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         public event Action OnSaccadeY;
         private void GazeSmoother_OnSaccadeY() => OnSaccadeY?.Invoke();
 
-        private static readonly List<InputDevice> InputDeviceList = new List<InputDevice>();
+        private readonly List<InputDevice> InputDeviceList = new List<InputDevice>();
         private InputDevice eyeTrackingDevice = default(InputDevice);
 
         #region IMixedRealityCapabilityCheck Implementation

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
             return (capability == MixedRealityCapability.MotionController);
         }
 
-        protected static readonly Dictionary<InputDevice, GenericXRSDKController> ActiveControllers = new Dictionary<InputDevice, GenericXRSDKController>();
+        protected readonly Dictionary<InputDevice, GenericXRSDKController> ActiveControllers = new Dictionary<InputDevice, GenericXRSDKController>();
 
         private readonly List<InputDevice> inputDevices = new List<InputDevice>();
         private readonly List<InputDevice> inputDevicesSubset = new List<InputDevice>();
@@ -149,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
             InputDevices.deviceDisconnected -= InputDevices_deviceDisconnected;
 
             var controllersCopy = ActiveControllers.ToReadOnlyCollection();
-            foreach (var controller in controllersCopy)
+            foreach (KeyValuePair<InputDevice, GenericXRSDKController> controller in controllersCopy)
             {
                 RemoveController(controller.Key);
             }


### PR DESCRIPTION
## Overview

I found that the logs were actually coming from the "not" running Windows XR Plugin device manager, since these collections are shared between instances of XRSDKDeviceManager. Updates all local collections in device managers to no longer be `static` to fix this issue.

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11265

