### PR TITLE
Fix rigged hands in remoting

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -292,8 +292,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // The base class takes care of updating all of the joint data
                 _ = base.UpdateHandJoints();
 
-                // Exit early and disable the rigged hand model if we've gotten a hand mesh from the underlying platform
-                if (ReceivingPlatformHandMesh || MixedRealityHand.IsNull())
+                // Exit early and disable the rigged hand model if we've gotten a hand mesh from the underlying platform or the display is transparent
+                if (ReceivingPlatformHandMesh
+                    || MixedRealityHand.IsNull()
+                    || (!XRSubsystemHelpers.DisplaySubsystem?.displayOpaque ?? false))
                 {
                     HandRenderer.enabled = false;
                     return false;
@@ -302,8 +304,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 IMixedRealityInputSystem inputSystem = CoreServices.InputSystem;
                 MixedRealityHandTrackingProfile handTrackingProfile = inputSystem?.InputSystemProfile != null ? inputSystem.InputSystemProfile.HandTrackingProfile : null;
 
-                // Only runs if render hand mesh is true
-                bool renderHandmesh = handTrackingProfile != null && handTrackingProfile.EnableHandMeshVisualization && MixedRealityHand.TryGetJoint(TrackedHandJoint.Palm, out _);
+                // Only render the hand mesh if visualization is enabled and the hand joints are tracked
+                bool renderHandmesh = handTrackingProfile != null
+                    && handTrackingProfile.EnableHandMeshVisualization
+                    && MixedRealityHand.TryGetJoint(TrackedHandJoint.Palm, out _);
                 HandRenderer.enabled = renderHandmesh;
                 if (renderHandmesh)
                 {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/RiggedHandVisualizer/RiggedHandVisualizer.cs
@@ -120,11 +120,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Precalculated values for LeapMotion testhand fingertip lengths
         /// </summary>
-        private const float thumbFingerTipLength = 0.02167f;
-        private const float indexingerTipLength = 0.01582f;
-        private const float middleFingerTipLength = 0.0174f;
-        private const float ringFingerTipLength = 0.0173f;
-        private const float pinkyFingerTipLength = 0.01596f;
+        private const float ThumbFingerTipLength = 0.02167f;
+        private const float IndexFingerTipLength = 0.01582f;
+        private const float MiddleFingerTipLength = 0.0174f;
+        private const float RingFingerTipLength = 0.0173f;
+        private const float PinkyFingerTipLength = 0.01596f;
 
         /// <summary>
         /// Precalculated fingertip lengths used for scaling the fingertips of the skinnedmesh
@@ -132,11 +132,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         private Dictionary<TrackedHandJoint, float> fingerTipLengths = new Dictionary<TrackedHandJoint, float>()
         {
-            {TrackedHandJoint.ThumbTip, thumbFingerTipLength },
-            {TrackedHandJoint.IndexTip, indexingerTipLength },
-            {TrackedHandJoint.MiddleTip, middleFingerTipLength },
-            {TrackedHandJoint.RingTip, ringFingerTipLength },
-            {TrackedHandJoint.PinkyTip, pinkyFingerTipLength }
+            { TrackedHandJoint.ThumbTip, ThumbFingerTipLength },
+            { TrackedHandJoint.IndexTip, IndexFingerTipLength },
+            { TrackedHandJoint.MiddleTip, MiddleFingerTipLength },
+            { TrackedHandJoint.RingTip, RingFingerTipLength },
+            { TrackedHandJoint.PinkyTip, PinkyFingerTipLength }
         };
 
         /// <summary>

--- a/Assets/MRTK/SDK/Profiles/ObsoleteMixedRealityXRSDKControllerVisualizationProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/ObsoleteMixedRealityXRSDKControllerVisualizationProfile.asset
@@ -33,18 +33,7 @@ MonoBehaviour:
     controllerType:
       reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.WindowsMixedRealityXRSDKMotionController,
         Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
-    handedness: 1
-    usePlatformModels: 1
-    platformModelMaterial: {fileID: 0}
-    overrideModel: {fileID: 0}
-    controllerVisualizationType:
-      reference: Microsoft.MixedReality.Toolkit.Input.WindowsMixedRealityControllerVisualizer,
-        Microsoft.MixedReality.Toolkit.SDK
-  - description: Windows Mixed Reality XRSDK Motion Controller
-    controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.WindowsMixedRealityXRSDKMotionController,
-        Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
-    handedness: 2
+    handedness: 3
     usePlatformModels: 1
     platformModelMaterial: {fileID: 0}
     overrideModel: {fileID: 0}
@@ -55,40 +44,18 @@ MonoBehaviour:
     controllerType:
       reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.WindowsMixedRealityXRSDKArticulatedHand,
         Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
-    handedness: 1
+    handedness: 3
     usePlatformModels: 0
     platformModelMaterial: {fileID: 0}
     overrideModel: {fileID: 1227372834072826, guid: 378f91dbbff9e2343b27a467467750bf,
       type: 3}
     controllerVisualizationType:
       reference: Microsoft.MixedReality.Toolkit.Input.BaseHandVisualizer, Microsoft.MixedReality.Toolkit
-  - description: Windows Mixed Reality XRSDK Articulated Hand
-    controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.WindowsMixedRealityXRSDKArticulatedHand,
-        Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
-    handedness: 2
-    usePlatformModels: 0
-    platformModelMaterial: {fileID: 0}
-    overrideModel: {fileID: 1788309537287834, guid: 132c9402d5843aa4f94380840186fd41,
-      type: 3}
-    controllerVisualizationType:
-      reference: Microsoft.MixedReality.Toolkit.Input.BaseHandVisualizer, Microsoft.MixedReality.Toolkit
   - description: HP Motion Controller
     controllerType:
       reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.HPMotionController,
         Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
-    handedness: 1
-    usePlatformModels: 1
-    platformModelMaterial: {fileID: 0}
-    overrideModel: {fileID: 0}
-    controllerVisualizationType:
-      reference: Microsoft.MixedReality.Toolkit.Input.WindowsMixedRealityControllerVisualizer,
-        Microsoft.MixedReality.Toolkit.SDK
-  - description: HP Motion Controller
-    controllerType:
-      reference: Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality.HPMotionController,
-        Microsoft.MixedReality.Toolkit.Providers.XRSDK.WindowsMixedReality
-    handedness: 2
+    handedness: 3
     usePlatformModels: 1
     platformModelMaterial: {fileID: 0}
     overrideModel: {fileID: 0}


### PR DESCRIPTION
## Overview

This PR updates the rigged hands logic to not display when a transparent display is used, like over remoting. We'd been getting reports of rigged hands not aligning well with the physical hands and causing confusion.

This also fixes some potential null refs when the rigged hand material isn't set.
This also simplifies one of the controller visualization profiles that wasn't using "both" handedness for certain entries.
This also includes some like formatting and style updates for simplification.