### PR TITLE
Expose eye calibration state when using XR SDK

### DIFF
--- a/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
@@ -34,11 +34,6 @@
             "name": "com.unity.xr.openxr",
             "expression": "",
             "define": "UNITY_OPENXR"
-        },
-        {
-            "name": "com.microsoft.windows.mixedreality.dotnetwinrt",
-            "expression": "",
-            "define": "DOTNETWINRT_PRESENT"
         }
     ],
     "noEngineReferences": false

--- a/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
+++ b/Assets/MRTK/Providers/OpenXR/MRTK.OpenXR.asmdef
@@ -34,6 +34,11 @@
             "name": "com.unity.xr.openxr",
             "expression": "",
             "define": "UNITY_OPENXR"
+        },
+        {
+            "name": "com.microsoft.windows.mixedreality.dotnetwinrt",
+            "expression": "",
+            "define": "DOTNETWINRT_PRESENT"
         }
     ],
     "noEngineReferences": false

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
@@ -209,15 +209,17 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
         private void UpdateEyeTrackingCalibrationStatus(bool defaultValue)
         {
 #if MSFT_OPENXR && (WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT))
-            SpatialCoordinateSystem worldOrigin = MixedReality.OpenXR.PerceptionInterop.GetSceneCoordinateSystem(Pose.identity) as SpatialCoordinateSystem;
-            SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(worldOrigin, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
-            if (pointerPose != null)
+            if (MixedReality.OpenXR.PerceptionInterop.GetSceneCoordinateSystem(Pose.identity) is SpatialCoordinateSystem worldOrigin)
             {
-                EyesPose eyes = pointerPose.Eyes;
-                if (eyes != null)
+                SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(worldOrigin, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
+                if (pointerPose != null)
                 {
-                    Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, eyes.IsCalibrationValid);
-                    return;
+                    EyesPose eyes = pointerPose.Eyes;
+                    if (eyes != null)
+                    {
+                        Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, eyes.IsCalibrationValid);
+                        return;
+                    }
                 }
             }
 #endif // MSFT_OPENXR && (WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT))

--- a/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/OpenXR/Scripts/OpenXREyeGazeDataProvider.cs
@@ -14,19 +14,12 @@ using UnityEngine.XR.OpenXR;
 using UnityEngine.XR.OpenXR.Features.Interactions;
 #endif // UNITY_OPENXR
 
-#if MSFT_OPENXR
-#if WINDOWS_UWP
+#if MSFT_OPENXR && WINDOWS_UWP
 using Windows.Perception;
 using Windows.Perception.People;
 using Windows.Perception.Spatial;
 using Windows.UI.Input.Spatial;
-#elif UNITY_WSA && DOTNETWINRT_PRESENT
-using Microsoft.Windows.Perception;
-using Microsoft.Windows.Perception.People;
-using Microsoft.Windows.Perception.Spatial;
-using Microsoft.Windows.UI.Input.Spatial;
-#endif
-#endif // MSFT_OPENXR
+#endif // MSFT_OPENXR && WINDOWS_UWP
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 {
@@ -208,7 +201,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
 
         private void UpdateEyeTrackingCalibrationStatus(bool defaultValue)
         {
-#if MSFT_OPENXR && (WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT))
+#if MSFT_OPENXR && WINDOWS_UWP
             if (MixedReality.OpenXR.PerceptionInterop.GetSceneCoordinateSystem(Pose.identity) is SpatialCoordinateSystem worldOrigin)
             {
                 SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(worldOrigin, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
@@ -222,7 +215,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.OpenXR
                     }
                 }
             }
-#endif // MSFT_OPENXR && (WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT))
+#endif // MSFT_OPENXR && WINDOWS_UWP
 
             Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, defaultValue);
         }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -221,14 +221,17 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         {
 #if WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT)
             SpatialCoordinateSystem worldOrigin = Toolkit.WindowsMixedReality.WindowsMixedRealityUtilities.SpatialCoordinateSystem;
-            SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(worldOrigin, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
-            if (pointerPose != null)
+            if (worldOrigin != null)
             {
-                EyesPose eyes = pointerPose.Eyes;
-                if (eyes != null)
+                SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(worldOrigin, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
+                if (pointerPose != null)
                 {
-                    Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, eyes.IsCalibrationValid);
-                    return;
+                    EyesPose eyes = pointerPose.Eyes;
+                    if (eyes != null)
+                    {
+                        Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, eyes.IsCalibrationValid);
+                        return;
+                    }
                 }
             }
 #endif // WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT)


### PR DESCRIPTION
## Overview

This change properly queries the runtime for the calibration status instead of keying off the eye data availability.

## Changes

- Fixes: #10887 
