### PR TITLE
Fix simulated motion controller grab

### DIFF
--- a/Assets/MRTK/Core/Providers/InputSimulation/SimulatedMotionController.cs
+++ b/Assets/MRTK/Core/Providers/InputSimulation/SimulatedMotionController.cs
@@ -132,10 +132,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         break;
                     case DeviceInputType.GripPress:
                     case DeviceInputType.TriggerPress:
-                        Interactions[i].FloatData = motionControllerData.ButtonState.IsGrabbing ? 1 : 0;
+                        Interactions[i].BoolData = motionControllerData.ButtonState.IsGrabbing;
                         if (Interactions[i].Changed)
                         {
-                            CoreServices.InputSystem?.RaiseFloatInputChanged(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction, motionControllerData.ButtonState.IsGrabbing ? 1 : 0);
+                            if (Interactions[i].BoolData)
+                            {
+                                CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction);
+                            }
+                            else
+                            {
+                                CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction);
+                            }
                         }
                         break;
                     case DeviceInputType.Menu:


### PR DESCRIPTION
## Overview

Simulated motion controller grab wasn't working in Editor, because it raised a float input event instead of a boolean.
This PR fixes this, by changing the input event to boolean, like the simulated grab for articulated hands.

## Verification

Create a new scene with the MRTK rig. Make sure to use profiles that use the Motion Controller Simulation Mode (Input -> Input Data Providers -> Input Simulation Service -> Default Controller Simulation Mode: `Motion Controller`)
Add a simple cube to the scene with an `Object Manipulator` with disabled far manipulation and a `NearInteractionGrabbable`. In Play Mode, use either the left or right controller and the mapped grab key (Default `G`) to grab and move the cube.
