### PR TITLE
Fix Android build and multiple artifact publication

### DIFF
--- a/Pipelines/Templates/Tasks/build-appx.yaml
+++ b/Pipelines/Templates/Tasks/build-appx.yaml
@@ -4,40 +4,44 @@
 # [Template] Build appx from a Unity-built sln.
 
 parameters:
-- name: ProjectName
-  type: string
+  - name: ProjectName
+    type: string
 
-- name: Architectures
-  type: object
-  default: []
+  - name: Architectures
+    type: object
+    default: []
 
-- name: BuildFolderPath
-  type: string
+  - name: BuildFolderPath
+    type: string
 
-- name: Version
-  type: string
+  - name: Version
+    type: string
 
-- name: AdditionalSteps
-  type: stepList
-  default: []
+  - name: AdditionalSteps
+    type: stepList
+    default: []
+
+  - name: TargetFolder
+    type: string
+    default: $(Build.ArtifactStagingDirectory)/Apps
 
 steps:
-- ${{ each arch in parameters.Architectures }}:
-  - task: MSBuild@1
-    displayName: Build ${{ arch }} AppX
-    inputs:
-      solution: ${{ parameters.BuildFolderPath }}/${{ parameters.ProjectName }}.sln
-      platform: ${{ arch }}
-      configuration: Master
+  - ${{ each arch in parameters.Architectures }}:
+      - task: MSBuild@1
+        displayName: Build ${{ arch }} AppX
+        inputs:
+          solution: ${{ parameters.BuildFolderPath }}/${{ parameters.ProjectName }}.sln
+          platform: ${{ arch }}
+          configuration: Master
 
-  - ${{ each additionalStep in parameters.AdditionalSteps }}:
-    - ${{ additionalStep }}
+      - ${{ each additionalStep in parameters.AdditionalSteps }}:
+          - ${{ additionalStep }}
 
-  - task: CopyFiles@2
-    displayName: Copy ${{ arch }} AppX to artifacts staging directory
-    inputs:
-      ${{ if eq(arch, 'x86') }}:
-        sourceFolder: ${{ parameters.BuildFolderPath }}/AppPackages/${{ parameters.ProjectName }}/${{ parameters.ProjectName }}_${{ parameters.Version }}.0_Win32_Master_Test
-      ${{ if not(eq(arch, 'x86')) }}:
-        sourceFolder: ${{ parameters.BuildFolderPath }}/AppPackages/${{ parameters.ProjectName }}/${{ parameters.ProjectName }}_${{ parameters.Version }}.0_${{ arch }}_Master_Test
-      targetFolder: $(Build.ArtifactStagingDirectory)/Apps/uwp-${{ arch }}
+      - task: CopyFiles@2
+        displayName: Copy ${{ arch }} AppX to artifacts staging directory
+        inputs:
+          ${{ if eq(arch, 'x86') }}:
+            sourceFolder: ${{ parameters.BuildFolderPath }}/AppPackages/${{ parameters.ProjectName }}/${{ parameters.ProjectName }}_${{ parameters.Version }}.0_Win32_Master_Test
+          ${{ if not(eq(arch, 'x86')) }}:
+            sourceFolder: ${{ parameters.BuildFolderPath }}/AppPackages/${{ parameters.ProjectName }}/${{ parameters.ProjectName }}_${{ parameters.Version }}.0_${{ arch }}_Master_Test
+          targetFolder: ${{ parameters.TargetFolder }}/uwp-${{ arch }}

--- a/Pipelines/Templates/unity.yaml
+++ b/Pipelines/Templates/unity.yaml
@@ -2,105 +2,106 @@
 # Licensed under the MIT License.
 
 parameters:
-- name: UnityVersion
-  type: string
-  default: Latest
+  - name: UnityVersion
+    type: string
+    default: Latest
 
-- name: ProjectName
-  type: string
-  default: MRTK3 Sample
+  - name: ProjectName
+    type: string
+    default: MRTK3 Sample
 
-- name: CommandLineBuildMethod
-  type: string
-  default: Microsoft.MixedReality.Toolkit.Examples.Build.BuildApp.StartCommandLineBuild
+  - name: CommandLineBuildMethod
+    type: string
+    default: Microsoft.MixedReality.Toolkit.Examples.Build.BuildApp.StartCommandLineBuild
 
-- name: PathToProject
-  type: string
-  default: $(Build.SourcesDirectory)/MixedRealityToolkit-Unity/UnityProjects/MRTKDevTemplate
+  - name: PathToProject
+    type: string
+    default: $(Build.SourcesDirectory)/MixedRealityToolkit-Unity/UnityProjects/MRTKDevTemplate
 
-- name: RunTests
-  type: boolean
-  default: false
+  - name: RunTests
+    type: boolean
+    default: false
 
-- name: Platform
-  type: string
-  default: None
-  values:
-  - None
-  - Standalone
-  - UWP
-  - Android
+  - name: Platform
+    type: string
+    default: None
+    values:
+      - None
+      - Standalone
+      - UWP
+      - Android
 
 steps:
-- pwsh: Install-Module PowerShellGet -Force
-  displayName: Update PowerShellGet
+  - pwsh: Install-Module PowerShellGet -Force
+    displayName: Update PowerShellGet
 
-- pwsh: Install-Module UnitySetup -Scope CurrentUser -Force -AllowPrerelease
-  displayName: Install unitysetup.powershell
+  - pwsh: Install-Module UnitySetup -Scope CurrentUser -Force -AllowPrerelease
+    displayName: Install unitysetup.powershell
 
-- template: Templates/license-unity.yaml@PipelineTools
+  - template: Templates/license-unity.yaml@PipelineTools
 
-  # Standalone x64 tasks
+    # Standalone x64 tasks
 
-- ${{ if eq(parameters.Platform, 'Standalone') }}:
-  - template: Tasks/build-unity.yaml
-    parameters:
-      UnityVersion: ${{ parameters.UnityVersion }}
-      BuildTarget: StandaloneWindows64
-      CommandLineBuildMethod: ${{ parameters.CommandLineBuildMethod }}
-      PathToProject: ${{ parameters.PathToProject }}
-      OutputPath: $(Build.ArtifactStagingDirectory)/Apps/exe-x64/${{ parameters.ProjectName }}.exe
-      AdditionalArguments: -EnableCacheServer -cacheServerEndpoint 10.0.0.6 -cacheServerNamespacePrefix MRTK3 -cacheServerEnableDownload true -cacheServerEnableUpload true
+  - ${{ if eq(parameters.Platform, 'Standalone') }}:
+      - template: Tasks/build-unity.yaml
+        parameters:
+          UnityVersion: ${{ parameters.UnityVersion }}
+          BuildTarget: StandaloneWindows64
+          CommandLineBuildMethod: ${{ parameters.CommandLineBuildMethod }}
+          PathToProject: ${{ parameters.PathToProject }}
+          OutputPath: $(Build.ArtifactStagingDirectory)/Apps-${{ parameters.Platform }}/exe-x64/${{ parameters.ProjectName }}.exe
+          AdditionalArguments: -EnableCacheServer -cacheServerEndpoint 10.0.0.6 -cacheServerNamespacePrefix MRTK3 -cacheServerEnableDownload true -cacheServerEnableUpload true
 
-  # Run tests early, but don't bother if the standalone build failed.
-- ${{ if eq(parameters.RunTests, true) }}:
-  - template: tests.yaml
-    parameters:
-      UnityVersion: ${{ parameters.UnityVersion }}
-      BuildTarget: StandaloneWindows64
-      PathToProject: ${{ parameters.PathToProject }}
-      AdditionalArguments: -noGraphics -EnableCacheServer -cacheServerEndpoint 10.0.0.6 -cacheServerNamespacePrefix MRTK3 -cacheServerEnableDownload true
+    # Run tests early, but don't bother if the standalone build failed.
+  - ${{ if eq(parameters.RunTests, true) }}:
+      - template: tests.yaml
+        parameters:
+          UnityVersion: ${{ parameters.UnityVersion }}
+          BuildTarget: StandaloneWindows64
+          PathToProject: ${{ parameters.PathToProject }}
+          AdditionalArguments: -noGraphics -EnableCacheServer -cacheServerEndpoint 10.0.0.6 -cacheServerNamespacePrefix MRTK3 -cacheServerEnableDownload true
 
-  # UWP tasks
+    # UWP tasks
 
-- ${{ if eq(parameters.Platform, 'UWP') }}:
-  - template: Tasks/build-unity.yaml
-    parameters:
-      UnityVersion: ${{ parameters.UnityVersion }}
-      BuildTarget: WSAPlayer
-      CommandLineBuildMethod: ${{ parameters.CommandLineBuildMethod }}
-      PathToProject: ${{ parameters.PathToProject }}
-      OutputPath: $(Agent.TempDirectory)/build/uwp
-      AdditionalArguments: -EnableCacheServer -cacheServerEndpoint 10.0.0.6 -cacheServerNamespacePrefix MRTK3 -cacheServerEnableDownload true -cacheServerEnableUpload true
+  - ${{ if eq(parameters.Platform, 'UWP') }}:
+      - template: Tasks/build-unity.yaml
+        parameters:
+          UnityVersion: ${{ parameters.UnityVersion }}
+          BuildTarget: WSAPlayer
+          CommandLineBuildMethod: ${{ parameters.CommandLineBuildMethod }}
+          PathToProject: ${{ parameters.PathToProject }}
+          OutputPath: $(Agent.TempDirectory)/build/uwp
+          AdditionalArguments: -EnableCacheServer -cacheServerEndpoint 10.0.0.6 -cacheServerNamespacePrefix MRTK3 -cacheServerEnableDownload true -cacheServerEnableUpload true
 
-  - pwsh: |
-      $manifestPath = "$(Agent.TempDirectory)/build/uwp/${{ parameters.ProjectName }}/Package.appxmanifest"
-      ((Get-Content -Path $manifestPath -Raw) -Replace '(<Identity[^\>]*Version=)"[0-9.]+', '$1"$(MRTKVersion).0') | Set-Content -Path $manifestPath -NoNewline
-    displayName: Patch UWP AppX version
+      - pwsh: |
+          $manifestPath = "$(Agent.TempDirectory)/build/uwp/${{ parameters.ProjectName }}/Package.appxmanifest"
+          ((Get-Content -Path $manifestPath -Raw) -Replace '(<Identity[^\>]*Version=)"[0-9.]+', '$1"$(MRTKVersion).0') | Set-Content -Path $manifestPath -NoNewline
+        displayName: Patch UWP AppX version
 
-  - template: Tasks/build-appx.yaml
-    parameters:
-      ProjectName: ${{ parameters.ProjectName }}
-      BuildFolderPath: $(Agent.TempDirectory)/build/uwp
-      Architectures: [x64,ARM64]
-      Version: $(MRTKVersion)
+      - template: Tasks/build-appx.yaml
+        parameters:
+          ProjectName: ${{ parameters.ProjectName }}
+          BuildFolderPath: $(Agent.TempDirectory)/build/uwp
+          Architectures: [x64, ARM64]
+          Version: $(MRTKVersion)
+          TargetFolder: $(Build.ArtifactStagingDirectory)/Apps-${{ parameters.Platform }}
 
-  # Android tasks
+    # Android tasks
 
-- ${{ if eq(parameters.Platform, 'Android') }}:
-  - template: Tasks/build-unity.yaml
-    parameters:
-      UnityVersion: ${{ parameters.UnityVersion }}
-      BuildTarget: Android
-      CommandLineBuildMethod: ${{ parameters.CommandLineBuildMethod }}
-      PathToProject: ${{ parameters.PathToProject }}
-      OutputPath: $(Build.ArtifactStagingDirectory)/Apps/apk/${{ parameters.ProjectName }}.apk
+  - ${{ if eq(parameters.Platform, 'Android') }}:
+      - template: Tasks/build-unity.yaml
+        parameters:
+          UnityVersion: ${{ parameters.UnityVersion }}
+          BuildTarget: Android
+          CommandLineBuildMethod: ${{ parameters.CommandLineBuildMethod }}
+          PathToProject: ${{ parameters.PathToProject }}
+          OutputPath: $(Build.ArtifactStagingDirectory)/Apps-${{ parameters.Platform }}/apk/${{ parameters.ProjectName }}.apk
 
-  # Publishing tasks
+    # Publishing tasks
 
-- ${{ if not(eq(parameters.Platform, 'None')) }}:
-  - task: PublishPipelineArtifact@1
-    displayName: Publish apps
-    inputs:
-      targetPath: $(Build.ArtifactStagingDirectory)/Apps
-      artifactName: Apps-${{ parameters.ProjectName }}-${{ parameters.Platform }}
+  - ${{ if not(eq(parameters.Platform, 'None')) }}:
+      - task: PublishPipelineArtifact@1
+        displayName: Publish apps
+        inputs:
+          targetPath: $(Build.ArtifactStagingDirectory)/Apps-${{ parameters.Platform }}
+          artifactName: Apps-${{ parameters.ProjectName }}-${{ parameters.Platform }}

--- a/UnityProjects/MRTKDevTemplate/Assets/BuildAssets/IconBlackBackground.png.meta
+++ b/UnityProjects/MRTKDevTemplate/Assets/BuildAssets/IconBlackBackground.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -81,7 +81,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -93,7 +93,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -105,7 +105,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/com.microsoft.mrtk.windowsspeech/Subsystems/TextToSpeech/WindowsTextToSpeechSubsystem.cs
+++ b/com.microsoft.mrtk.windowsspeech/Subsystems/TextToSpeech/WindowsTextToSpeechSubsystem.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Scripting;
+
 #if WINDOWS_UWP
 using System.Threading.Tasks;
 using Windows.Foundation;
@@ -159,12 +160,11 @@ namespace Microsoft.MixedReality.Toolkit.Speech.Windows
                     Debug.LogError("The Windows Text-To-Speech subsystem is not supported on the current platform.");
                     haveLogged = true;
                 }
-                return await Task.FromResult(null);
+                return await Task.FromResult<byte[]>(null);
 #endif
             }
 
 #if WINDOWS_UWP
-
             private SpeechSynthesizer synthesizer = new SpeechSynthesizer();
 #endif
 


### PR DESCRIPTION
## Overview

Fixes `D:\a\_work\1\s\MixedRealityToolkit-Unity\com.microsoft.mrtk.windowsspeech\Subsystems\TextToSpeech\WindowsTextToSpeechSubsystem.cs(162,35): error CS0411: The type arguments for method 'Task.FromResult<TResult>(TResult)' cannot be inferred from the usage. Try specifying the type arguments explicitly.`.

Also fixes `Compressed texture IconBlackBackground is used as icon. This might compromise visual quality of the final image. Uncompressed format might be considered as better import option.`

Also fixes an issue where some artifacts were being inadvertantly published multiple times.