### PR TITLE
Added parameter to tune the gradient's max length

### DIFF
--- a/com.microsoft.mrtk.core/Utilities/ColorUtilities.cs
+++ b/com.microsoft.mrtk.core/Utilities/ColorUtilities.cs
@@ -29,12 +29,12 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Compresses the gradient to the range (p1, p2). The colors at the start and end of the result are the same as the gradient a.
+        /// Compresses the gradient to the interval (p1, p2). The colors at the start and end of the result are the same as the gradient a.
         /// </summary>
         /// <param name="a">The gradient we are trying to compress</param>
         /// <param name="p1">The starting position of the compressed gradient. 0 <= p1 < p2 <= 1</param>
         /// <param name="p2">The ending position of the compressed gradient. 0 <= p1 < p2 <= 1</param>
-        /// <returns></returns>
+        /// <returns>A new gradient with the gradient a compressed into the interval (p1, p2)</returns>
         public static Gradient GradientCompress(Gradient a, float p1, float p2)
         {
             if (p2 <= p1)

--- a/com.microsoft.mrtk.core/Utilities/ColorUtilities.cs
+++ b/com.microsoft.mrtk.core/Utilities/ColorUtilities.cs
@@ -28,6 +28,61 @@ namespace Microsoft.MixedReality.Toolkit
             return GradientLerp(a, b, t, false, true);
         }
 
+        /// <summary>
+        /// Compresses the gradient to the range (p1, p2). The colors at the start and end of the result are the same as the gradient a.
+        /// </summary>
+        /// <param name="a">The gradient we are trying to compress</param>
+        /// <param name="p1">The starting position of the compressed gradient. 0 <= p1 < p2 <= 1</param>
+        /// <param name="p2">The ending position of the compressed gradient. 0 <= p1 < p2 <= 1</param>
+        /// <returns></returns>
+        public static Gradient GradientCompress(Gradient a, float p1, float p2)
+        {
+            if (p2 <= p1)
+            {
+                Debug.LogError("Trying to compress the gradient with an invalid range");
+                return a;
+            }
+
+            // List of all the unique key times
+            cachedKeyTimes.Clear();
+
+            for (int i = 0; i < a.colorKeys.Length; i++)
+            {
+                float k = a.colorKeys[i].time;
+                if (!cachedKeyTimes.Contains(k))
+                    cachedKeyTimes.Add(k);
+            }
+
+            for (int i = 0; i < a.alphaKeys.Length; i++)
+            {
+                float k = a.alphaKeys[i].time;
+                if (!cachedKeyTimes.Contains(k))
+                    cachedKeyTimes.Add(k);
+            }
+
+            GradientColorKey[] clrs = new GradientColorKey[cachedKeyTimes.Count];
+            GradientAlphaKey[] alphas = new GradientAlphaKey[cachedKeyTimes.Count];
+            int gradientIdx = 0;
+
+            float compressionRatio = p2 - p1;
+
+            // Pick colors of both gradients at key times and lerp them
+            foreach (float time in cachedKeyTimes)
+            {
+                var newTime = p1 + compressionRatio * time;
+
+                var clr = a.Evaluate(time);
+                clrs[gradientIdx] = new GradientColorKey(clr, newTime);
+                alphas[gradientIdx] = new GradientAlphaKey(clr.a, newTime);
+                gradientIdx++;
+            }
+
+            var g = new Gradient();
+            g.SetKeys(clrs, alphas);
+
+            return g;
+        }
+
         // Caching the key times to not create a new HashSet every time this is called.
         static HashSet<float> cachedKeyTimes = new HashSet<float>();
         static Gradient GradientLerp(Gradient a, Gradient b, float t, bool noAlpha, bool noColor)

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
@@ -70,6 +70,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         [SerializeField]
+        [Tooltip("Controls the length of the visual that the gradient is applied relative to the ray interactor's max raycast distance")]
+        [Range(0.01f, 1)]
+        float maxGradientLength = 0.1f;
+
+        /// <summary>
+        /// Controls the length of the visual that the gradient is applied relative to the ray interactor's max raycast distance
+        /// </summary>
+        public float MaxGradientLength
+        {
+            get => maxGradientLength;
+            set => maxGradientLength = value;
+        }
+
+        [SerializeField]
         [Tooltip("The width of the line.")]
         private AnimationCurve lineWidth = AnimationCurve.Linear(0f, 1f, 1f, 1f);
 
@@ -358,6 +372,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     {
                         lineRenderer.colorGradient = NoTargetColorGradient;
                     }
+
+                    var compressionAmount = Mathf.Clamp(rayInteractor.maxRaycastDistance * MaxGradientLength / hitDistance, 0.0f, 1.0f);
+                    lineRenderer.colorGradient = ColorUtilities.GradientCompress(lineRenderer.colorGradient, 0.0f, compressionAmount);
                 }
 
                 // Project forward based on pointer direction to get an 'expected' position of the first control point if we've hit an object


### PR DESCRIPTION
## Overview
Over long distances, the gradient applied to the ray interactor can become near invisible or jarring because it is applied uniformly across the entire length of the ray. In cases where the ray stretches out for very long distances, this is undesirable.

This PR introduces a tunable parameter which allows users to specify a maximum length that the gradient can be applied over. The actual distance that the gradient is applied over is relative to the maxRaycast distance of the ray interactor.

![RayGradient](https://user-images.githubusercontent.com/39840334/208756059-c22609c8-cb8e-4b44-9dbe-8cc6c674459d.gif)

