### PR TITLE
Burninate obsolete API surface >= 5mo old

### DIFF
--- a/com.microsoft.mrtk.core/Subsystems/Hands/HandsAggregatorSubsystem.cs
+++ b/com.microsoft.mrtk.core/Subsystems/Hands/HandsAggregatorSubsystem.cs
@@ -41,10 +41,6 @@ namespace Microsoft.MixedReality.Toolkit.Subsystems
             public abstract bool TryGetNearInteractionPoint(XRNode hand, out HandJointPose jointPose);
 
             /// <inheritdoc/>
-            [Obsolete("Use TryGetJoint(TrackedHandJoint.Palm...) instead.")]
-            public abstract bool TryGetHandCenter(XRNode hand, out HandJointPose jointPose);
-
-            /// <inheritdoc/>
             public abstract bool TryGetPinchingPoint(XRNode hand, out HandJointPose jointPose);
 
             /// <inheritdoc/>
@@ -67,11 +63,6 @@ namespace Microsoft.MixedReality.Toolkit.Subsystems
         /// <inheritdoc/>
         public bool TryGetNearInteractionPoint(XRNode hand, out HandJointPose jointPose)
             => provider.TryGetNearInteractionPoint(hand, out jointPose);
-
-        /// <inheritdoc/>
-        [Obsolete("Use TryGetJoint(TrackedHandJoint.Palm...) instead.")]
-        public bool TryGetHandCenter(XRNode hand, out HandJointPose jointPose)
-            => provider.TryGetHandCenter(hand, out jointPose);
 
         /// <inheritdoc/>
         public bool TryGetPinchingPoint(XRNode hand, out HandJointPose jointPose)

--- a/com.microsoft.mrtk.core/Subsystems/Hands/IHandsAggregatorSubsystem.cs
+++ b/com.microsoft.mrtk.core/Subsystems/Hands/IHandsAggregatorSubsystem.cs
@@ -31,15 +31,6 @@ namespace Microsoft.MixedReality.Toolkit.Subsystems
         bool TryGetNearInteractionPoint(XRNode hand, out HandJointPose jointPose);
 
         /// <summary>
-        /// The playspace-local pose of the "root" of the hand. This is used for
-        /// hand rays, or any other case where a reasonable palm root position is
-        /// needed. This will return the controller position if no hand data is
-        /// available on the platform.
-        /// </summary>
-        [Obsolete("Use TryGetJoint(TrackedHandJoint.Palm...) instead.")]
-        bool TryGetHandCenter(XRNode hand, out HandJointPose jointPose);
-
-        /// <summary>
         /// The playspace-local pose of the grab/pinch location. This is typically
         /// halfway between the thumb tip and the index tip.
         /// </summary>

--- a/com.microsoft.mrtk.core/Utilities/TrackedHandJoint.cs
+++ b/com.microsoft.mrtk.core/Utilities/TrackedHandJoint.cs
@@ -26,24 +26,15 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         ThumbMetacarpal,
 
-        [Obsolete("Use ThumbMetacarpal instead.")]
-        ThumbMetacarpalJoint = ThumbMetacarpal,
-
         /// <summary>
         /// The thumb's second (middle-ish) joint.
         /// </summary>
         ThumbProximal,
 
-        [Obsolete("Use ThumbProximal instead.")]
-        ThumbProximalJoint = ThumbProximal,
-
         /// <summary>
         /// The thumb's first (furthest) joint.
         /// </summary>
         ThumbDistal,
-
-        [Obsolete("Use ThumbDistal instead.")]
-        ThumbDistalJoint = ThumbDistal,
 
         /// <summary>
         /// The tip of the thumb.
@@ -60,24 +51,15 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         IndexProximal,
 
-        [Obsolete("Use IndexProximal instead.")]
-        IndexKnuckle = IndexProximal,
-
         /// <summary>
         /// The middle joint of the index finger.
         /// </summary>
         IndexIntermediate,
 
-        [Obsolete("Use IndexIntermediate instead.")]
-        IndexMiddleJoint = IndexIntermediate,
-
         /// <summary>
         /// The joint nearest the tip of the index finger.
         /// </summary>
         IndexDistal,
-
-        [Obsolete("Use IndexDistal instead.")]
-        IndexDistalJoint = IndexDistal,
 
         /// <summary>
         /// The tip of the index finger.
@@ -94,24 +76,15 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         MiddleProximal,
 
-        [Obsolete("Use MiddleProximal instead.")]
-        MiddleKnuckle = MiddleProximal,
-
         /// <summary>
         /// The middle joint of the middle finger.
         /// </summary>
         MiddleIntermediate,
 
-        [Obsolete("Use MiddleIntermediate instead.")]
-        MiddleMiddleJoint = MiddleIntermediate,
-
         /// <summary>
         /// The joint nearest the tip of the finger.
         /// </summary>
         MiddleDistal,
-
-        [Obsolete("Use MiddleDistal instead.")]
-        MiddleDistalJoint = MiddleDistal,
 
         /// <summary>
         /// The tip of the middle finger.
@@ -128,24 +101,15 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         RingProximal,
 
-        [Obsolete("Use RingProximal instead.")]
-        RingKnuckle = RingProximal,
-
         /// <summary>
         /// The middle joint of the ring finger.
         /// </summary>
         RingIntermediate,
 
-        [Obsolete("Use RingIntermediate instead.")]
-        RingMiddleJoint = RingIntermediate,
-
         /// <summary>
         /// The joint nearest the tip of the ring finger.
         /// </summary>
         RingDistal,
-
-        [Obsolete("Use RingDistal instead.")]
-        RingDistalJoint = RingDistal,
 
         /// <summary>
         /// The tip of the ring finger.
@@ -157,40 +121,25 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         LittleMetacarpal,
 
-        [Obsolete("Use LittleMetacarpal instead.")]
-        PinkyMetacarpal = LittleMetacarpal,
-
         /// <summary>
         /// The knuckle joint of the little finger.
         /// </summary>
         LittleProximal,
-
-        [Obsolete("Use LittleProximal instead.")]
-        PinkyKnuckle = LittleProximal,
 
         /// <summary>
         /// The middle joint of the little finger.
         /// </summary>
         LittleIntermediate,
 
-        [Obsolete("Use LittleIntermediate instead.")]
-        PinkyMiddleJoint = LittleIntermediate,
-
         /// <summary>
         /// The joint nearest the tip of the little finger.
         /// </summary>
         LittleDistal,
 
-        [Obsolete("Use LittleDistal instead.")]
-        PinkyDistalJoint = LittleDistal,
-
         /// <summary>
         /// The tip of the little finger.
         /// </summary>
         LittleTip,
-
-        [Obsolete("Use LittleTip instead.")]
-        PinkyTip = LittleTip,
 
         /// <summary>
         /// Number of joints total (not counting None).

--- a/com.microsoft.mrtk.input/Controllers/ArticulatedHandController.cs
+++ b/com.microsoft.mrtk.input/Controllers/ArticulatedHandController.cs
@@ -35,16 +35,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool PinchSelectReady => (currentControllerState is ArticulatedHandControllerState handControllerState) && handControllerState.PinchSelectReady;
 
-        [Obsolete("Please use the selectInteractionState.value instead.")]
-        public float PinchSelectProgress => currentControllerState.selectInteractionState.value;
-
-        /// <summary>
-        /// The worldspace pose of the pinch selection.
-        /// </summary>
-        [Obsolete("We are moving away from querying the pinch select pose via the specific XR controller reference. It should be accessed via an IPoseSource interface or directly from the subsystem")]
-        public Pose PinchSelectPose => (currentControllerState is ArticulatedHandControllerState handControllerState) ?
-                                                handControllerState.PinchPose : Pose.identity;
-
         #endregion Associated hand select values
 
         #region Properties
@@ -111,19 +101,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 handControllerState.PinchSelectReady = isPinchReady;
-
-#pragma warning disable CS0618 // Type or member is obsolete
-                if (isPinching && HandsAggregator.TryGetPinchingPoint(handNode, out HandJointPose pinchPose))
-                {
-                    handControllerState.PinchPose.position = pinchPose.Position;
-                    handControllerState.PinchPose.rotation = pinchPose.Rotation;
-                }
-                else
-                {
-                    handControllerState.PinchPose.position = controllerState.position;
-                    handControllerState.PinchPose.rotation = controllerState.rotation;
-                }
-#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 

--- a/com.microsoft.mrtk.input/Controllers/ArticulatedHandControllerState.cs
+++ b/com.microsoft.mrtk.input/Controllers/ArticulatedHandControllerState.cs
@@ -21,20 +21,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public bool PinchSelectReady;
 
         /// <summary>
-        /// The world-space pose of hand/controller performing the pinch.
-        /// </summary>
-        [Obsolete("We are moving away from querying the pinch select pose via the specific XR controller reference. It should be accessed via an IPoseSource interface or directly from the subsystem")]
-        public Pose PinchPose;
-
-        /// <summary>
         /// Constructs a new ArticulatedHandControllerState with default values.
         /// </summary>
         public ArticulatedHandControllerState() : base()
         {
             PinchSelectReady = false;
-#pragma warning disable CS0618 // Type or member is obsolete
-            PinchPose = Pose.identity;
-#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/com.microsoft.mrtk.input/InteractionModes/InteractionModeDefinition.cs
+++ b/com.microsoft.mrtk.input/InteractionModes/InteractionModeDefinition.cs
@@ -27,23 +27,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private List<SystemType> associatedTypes = new List<SystemType>();
 
         private HashSet<Type> associatedTypesHashSet = new HashSet<Type>();
+        
         /// <summary>
         /// Stores the types associated with this Interaction Mode Definition
         /// </summary>
         internal HashSet<Type> AssociatedTypes => associatedTypesHashSet;
-
-        [SerializeField]
-        private bool isEnabled = true;
-
-        [Obsolete("This property is no longer used")]
-        public bool IsEnabled
-        {
-            get => isEnabled;
-            set => isEnabled = value;
-        }
-
-        [Obsolete("This property is no longer used")]
-        public int Id { get; internal set; }
 
         /// <summary>
         /// Constructor for a mode definition, requires a name and the interactor types which are to be enabled while in this mode.

--- a/com.microsoft.mrtk.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
+++ b/com.microsoft.mrtk.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
@@ -244,13 +244,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             /// <inheritdoc/>
-            [Obsolete("Use TryGetJoint(TrackedHandJoint.Palm...) instead.")]
-            public override bool TryGetHandCenter(XRNode handNode, out HandJointPose jointPose)
-            {
-                return TryGetJoint(TrackedHandJoint.Palm, handNode, out jointPose);
-            }
-
-            /// <inheritdoc/>
             public override bool TryGetPinchingPoint(XRNode handNode, out HandJointPose jointPose)
             {
                 // GetJoint will reuse existing joint data if the hand was already queried this frame.

--- a/com.microsoft.mrtk.spatialmanipulation/Constraints/MinMaxScaleConstraint.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Constraints/MinMaxScaleConstraint.cs
@@ -14,27 +14,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
     [AddComponentMenu("MRTK/Spatial Manipulation/Min Max Scale Constraint")]
     public class MinMaxScaleConstraint : TransformConstraint
     {
-        #region Obsolete Properties
-
-        /// <summary>
-        /// Minimum scaling allowed
-        /// </summary>
-        [Obsolete("Use MinimumScale instead")]
-        public float ScaleMinimum
-        {
-            get => minimumScale.x;
-            set => minimumScale = Vector3.one * value;
-        }
-
-        [Obsolete("Use MaximumScale instead")]
-        public float ScaleMaximum
-        {
-            get => maximumScale.x;
-            set => maximumScale = Vector3.one * value;
-        }
-
-        #endregion Obsolete Properties
-
         #region Properties
 
         [SerializeField]

--- a/com.microsoft.mrtk.spatialmanipulation/Constraints/TransformConstraint.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Constraints/TransformConstraint.cs
@@ -64,9 +64,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             }
         }
 
-        [Obsolete("Use WorldPoseOnManipulationStart instead.")]
-        protected MixedRealityTransform worldPoseOnManipulationStart;
-
         /// <summary>
         /// The world pose of the object when the manipulation began.
         /// </summary>
@@ -90,9 +87,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         {
             InitialWorldPose = worldPose;
         }
-
-        [Obsolete("Use OnManipulationStarted instead")]
-        public virtual void Initialize(MixedRealityTransform worldPose) => OnManipulationStarted(worldPose);
 
         /// <summary>
         /// Called when manipulation starts on the attached object.


### PR DESCRIPTION
## Overview
This PR burninates any API surface that was marked obsolete at least 5 months ago. Does _not_ include some of the more recent playspace/rig/transformation API changes, and also doesn't include some of the more recent PoseSource changes.

## Changes
- Deletes obsolete `TryGetHandCenter` from the hands API
- Deletes obsolete joint names from `TrackedHandJoint`
- Deletes obsolete `PinchSelectProgress` and `PinchSelectPose` from `ArticulatedHandController`
- Deletes obsolete `PinchPose` state from `ArticulatedHandControllerState`
- Deletes obsolete `IsEnabled` and `Id` properties from `InteractionModeDefinition`
- Deletes obsolete `ScaleMinimum` and `ScaleMaximum` properties from `MinMaxScaleConstraint` (legacy)
- Deletes obsolete field `worldPoseOnManipulationStart` and obsolete method `Initialize` from `TransformConstraint` (legacy)

## Verification
All tests should pass and no errors/warnings should be generated.
