### PR TITLE
Update raycast layers on NearInteractionModeDetector and GrabInteractor

### DIFF
--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
@@ -410,6 +410,7 @@ MonoBehaviour:
     m_Mode: 0
     m_NumColorKeys: 2
     m_NumAlphaKeys: 2
+  maxGradientLength: 0.1
   lineWidth:
     serializedVersion: 2
     m_Curve:
@@ -1101,7 +1102,7 @@ GameObject:
   - component: {fileID: 4299642553989019653}
   - component: {fileID: 6450185055475174866}
   - component: {fileID: 7678414244376504105}
-  m_Layer: 0
+  m_Layer: 2
   m_Name: NearInteractionModeDetector
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1456,7 +1457,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1051247791254679178}
   - component: {fileID: 6800936895746535163}
-  m_Layer: 0
+  m_Layer: 2
   m_Name: AttachTransform
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK XR Rig.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK XR Rig.prefab
@@ -91,7 +91,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_EventMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 4294967291
   m_MaxRayIntersections: 0
 --- !u!81 &2351505566771328560
 AudioListener:

--- a/com.microsoft.mrtk.input/Utilities/PlatformAwarePhysicsRaycaster.cs
+++ b/com.microsoft.mrtk.input/Utilities/PlatformAwarePhysicsRaycaster.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License
 
-using System.Collections.Generic;
-using UnityEngine;
 using UnityEngine.EventSystems;
 
 namespace Microsoft.MixedReality.Toolkit.Input


### PR DESCRIPTION
## Overview

Quick fix for #11321: this PR Moves NearInteractionModeDetector and `GrabInteractor`'s attach transform onto the "Ignore Raycast" layer.
It also updates the `PlatformAwarePhysicsRaycaster` on the MRTK XR Rig to ignore that layer by default.

## Changes

- Fixes: #11321 

