### PR TITLE
Updated hand materials for Linear colorspace

### DIFF
--- a/com.microsoft.mrtk.input/Visualizers/RiggedHandVisualizer/RiggedHand-InvertedShell.mat
+++ b/com.microsoft.mrtk.input/Visualizers/RiggedHandVisualizer/RiggedHand-InvertedShell.mat
@@ -37,7 +37,7 @@ Material:
     - _Metallic: 0
     - _OutlineExponent: 1
     - _OutlineSmoothing: 0.05
-    - _OutlineThickness: 0.0000119
+    - _OutlineThickness: 0.00001337
     - _OutlineThreshold: 0.474
     - _PinchAmount: 0
     - _Radius_: 0.09
@@ -46,6 +46,6 @@ Material:
     - _Center_: {r: 0.5, g: 0.5, b: 0, a: 0}
     - _Color_: {r: 1, g: 1, b: 1, a: 1}
     - _HandColor: {r: 0.14150941, g: 0.14150941, b: 0.14150941, a: 0.7137255}
-    - _OutlineColor: {r: 1, g: 1, b: 1, a: 0.2901961}
+    - _OutlineColor: {r: 1, g: 1, b: 1, a: 0.03529412}
     - _OutlineColorPinching: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []

--- a/com.microsoft.mrtk.input/Visualizers/RiggedHandVisualizer/RiggedHand-Main.mat
+++ b/com.microsoft.mrtk.input/Visualizers/RiggedHandVisualizer/RiggedHand-Main.mat
@@ -31,8 +31,8 @@ Material:
     - _Fade_In_End_: 0
     - _Fade_In_Start_: 0
     - _HandThickness: 0
-    - _IlluminationAmount: 0.04
-    - _IlluminationExponent: 1.78
+    - _IlluminationAmount: 0.01
+    - _IlluminationExponent: 0.56
     - _Intensity_: 0.81
     - _Metallic: 0
     - _OutlineExponent: 1
@@ -45,7 +45,7 @@ Material:
     m_Colors:
     - _Center_: {r: 0.5, g: 0.5, b: 0, a: 0}
     - _Color_: {r: 1, g: 1, b: 1, a: 1}
-    - _HandColor: {r: 0.14150941, g: 0.14150941, b: 0.14150941, a: 0.7137255}
+    - _HandColor: {r: 0.01886791, g: 0.01886791, b: 0.01886791, a: 0.8}
     - _OutlineColor: {r: 1, g: 1, b: 1, a: 0.2901961}
     - _OutlineColorPinching: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []


### PR DESCRIPTION
## Overview
We never updated the rigged hand materials for Linear colorspace. This resulted in materials that were too bright vs the original intent.

Before vs After
<img height="200" alt="image" src="https://user-images.githubusercontent.com/5544935/209726509-ac522c01-9f53-4331-af1c-f9cae2a8e121.png"><img height="200" alt="image" src="https://user-images.githubusercontent.com/5544935/209726524-55f296c1-6328-441d-845b-312ae554f8f1.png">

Quest Shell vs MRTK3
<img height="230" alt="image" src="https://user-images.githubusercontent.com/5544935/209726719-adc0ab0c-18bc-4bc8-9b00-4d6d253a0e61.jpg"><img height="230" alt="image" src="https://user-images.githubusercontent.com/5544935/209726737-1f0eb919-8a80-4203-aef2-d6b4cdb46fcb.jpg">

Some inconsistencies are due to differences in Unity editor screenshot vs Quest in-HMD screenshot. Don't really know why.

## Changes
- Tweaks illumination + base color
- Makes outline thickness ever so slightly thicker
