### PR TITLE
Fix assembly version to match file/package

### DIFF
--- a/com.microsoft.mrtk.accessibility/AssemblyInfo.cs
+++ b/com.microsoft.mrtk.accessibility/AssemblyInfo.cs
@@ -12,4 +12,4 @@ using System.Runtime.CompilerServices;
 // The AssemblyVersion attribute is checked-in and is recommended not to be changed often.
 // https://docs.microsoft.com/troubleshoot/visualstudio/general/assembly-version-assembly-file-version
 // AssemblyFileVersion and AssemblyInformationalVersion are added by pack-upm.ps1 to match the current MRTK build version.
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
While working on breaking change detection, I discovered that the accessibility package had the wrong assembly version number (3.0.0 vs 1.0.0).

This change fixes that :smile: