### PR TITLE
Adding missing nullcheck on InputAdapter OnDrag handler

### DIFF
--- a/com.microsoft.mrtk.uxcore/Interop/UGUIInputAdapterDraggable.cs
+++ b/com.microsoft.mrtk.uxcore/Interop/UGUIInputAdapterDraggable.cs
@@ -35,8 +35,11 @@ namespace Microsoft.MixedReality.Toolkit.UX
             // and we don't want to duplicate them.
             if (IsXRUIEvent(pointerEventData)) { return; }
 
-            // We only adapt drags for selectable interactables.
-            if (!(ThisInteractable is IXRSelectInteractable selectInteractable)) { return; }
+            // We only adapt drags for selectable interactables,
+            // and if we have a valid proxy interactor.
+            if (ThisInteractable is IXRSelectInteractable selectInteractable &&
+                ProxyInteractor != null)
+            { return; }
 
             // If we have no event camera at all, abort!
             if (eventCamera == null) { return; }


### PR DESCRIPTION
## Overview
Fixes missing nullcheck for validity of `IProxyInteractor` in the `UGUIInputAdapterDraggable`.

## Changes
- Fixes: #11354
