### PR TITLE
fix assembly version (accessibility editor was 3.0 instead of 1.0)

### DIFF
--- a/com.microsoft.mrtk.accessibility/Editor/AssemblyInfo.cs
+++ b/com.microsoft.mrtk.accessibility/Editor/AssemblyInfo.cs
@@ -9,4 +9,4 @@ using System.Reflection;
 // The AssemblyVersion attribute is checked-in and is recommended not to be changed often.
 // https://docs.microsoft.com/troubleshoot/visualstudio/general/assembly-version-assembly-file-version
 // AssemblyFileVersion and AssemblyInformationalVersion are added by pack-upm.ps1 to match the current MRTK build version.
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
Fixed an incorrect assembly version in the accessibility editor assembly, It was 3.0 when it should have been 1.0.

This should be the last remaining incorrect version in the current mrtk3 branch,