### PR TITLE
Update the asset selector to allow arbitrary glb files regardless of loader

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
@@ -223,7 +223,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             void GUIHandler(string searchContext)
             {
-                EditorGUILayout.HelpBox("These settings are serialized into ProjectPreferences.asset in the MixedRealityToolkit-Generated folder.\nThis file can be checked into source control to maintain consistent settings across collaborators.", MessageType.Info);
+                EditorGUILayout.HelpBox("These settings are serialized into ProjectPreferences.asset in the MixedRealityToolkit.Generated folder.\nThis file can be checked into source control to maintain consistent settings across collaborators.", MessageType.Info);
 
                 var prevLabelWidth = EditorGUIUtility.labelWidth;
                 EditorGUIUtility.labelWidth = 300f;


### PR DESCRIPTION
## Overview

When other loaders (like trilib or glTFast) are imported and the MRTK glTF loader is disabled, the 3D app launcher field becomes confusing and rejects all models. This was an artificial limitation, as there's no real dependency on the MRTK glTF loader.

This PR updates the field to be more in line with the MRTK3 version, allowing for arbitrary .glb files regardless of the Unity importer.

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/9592
