### PR TITLE
A couple changes to help with logging

### DIFF
--- a/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -120,6 +120,12 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
 
                     object[] args = { this, configuration.ComponentName, configuration.Priority, configuration.SettingsProfile };
 
+                    DebugUtilities.LogVerboseFormat(
+                        "Attempting to register camera system settings {0}, {1}, {2}",
+                        configuration.ComponentType,
+                        configuration.ComponentName,
+                        configuration.RuntimePlatform);
+
                     if (RegisterDataProvider<IMixedRealityCameraSettingsProvider>(
                         configuration.ComponentType.Type,
                         configuration.ComponentName,

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -294,7 +294,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     DebugUtilities.LogVerboseFormat(
                         "Attempting to register input system data provider {0}, {1}, {2}",
-                        configuration.ComponentType.Type,
+                        configuration.ComponentType,
                         configuration.ComponentName,
                         configuration.RuntimePlatform);
 


### PR DESCRIPTION
## Overview

Another branch from a couple of years ago. Updates some MRTK logs to be more clear on the full component type being registered, as well as adding a new log for the camera system.

By default, these changes won't add any additional logging. It's only if you change the MRTK logging setting to "Verbose" that you'll start to see a difference.