### PR TITLE
Change to use IndentLevelScope

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
@@ -522,28 +522,26 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
                 if (foldouts[i])
                 {
-                    EditorGUI.indentLevel++;
-
-                    MixedRealityInputAction newBaseAction;
-                    baseActionId.intValue = RenderBaseInputAction(baseActionId.intValue, out newBaseAction, true);
-                    baseActionDescription.stringValue = newBaseAction.Description;
-                    baseActionConstraint.intValue = (int)newBaseAction.AxisConstraint;
-
-                    if (baseActionId.intValue == ruleActionId.intValue || newBaseAction == MixedRealityInputAction.None || baseActionConstraint.intValue != ruleActionConstraint.intValue)
+                    using (new EditorGUI.IndentLevelScope())
                     {
-                        criteria.Reset();
-                        ruleActionId.intValue = (int)MixedRealityInputAction.None.Id;
-                        ruleActionDescription.stringValue = MixedRealityInputAction.None.Description;
-                        ruleActionConstraint.intValue = (int)MixedRealityInputAction.None.AxisConstraint;
+                        baseActionId.intValue = RenderBaseInputAction(baseActionId.intValue, out MixedRealityInputAction newBaseAction, true);
+                        baseActionDescription.stringValue = newBaseAction.Description;
+                        baseActionConstraint.intValue = (int)newBaseAction.AxisConstraint;
+
+                        if (baseActionId.intValue == ruleActionId.intValue || newBaseAction == MixedRealityInputAction.None || baseActionConstraint.intValue != ruleActionConstraint.intValue)
+                        {
+                            criteria.Reset();
+                            ruleActionId.intValue = (int)MixedRealityInputAction.None.Id;
+                            ruleActionDescription.stringValue = MixedRealityInputAction.None.Description;
+                            ruleActionConstraint.intValue = (int)MixedRealityInputAction.None.AxisConstraint;
+                        }
+
+                        RenderCriteriaField(newBaseAction, criteria);
+
+                        ruleActionId.intValue = RenderRuleInputAction(ruleActionId.intValue, out MixedRealityInputAction newRuleAction);
+                        ruleActionDescription.stringValue = newRuleAction.Description;
+                        ruleActionConstraint.intValue = (int)newRuleAction.AxisConstraint;
                     }
-
-                    RenderCriteriaField(newBaseAction, criteria);
-
-                    MixedRealityInputAction newRuleAction;
-                    ruleActionId.intValue = RenderRuleInputAction(ruleActionId.intValue, out newRuleAction);
-                    ruleActionDescription.stringValue = newRuleAction.Description;
-                    ruleActionConstraint.intValue = (int)newRuleAction.AxisConstraint;
-                    EditorGUI.indentLevel--;
                 }
 
                 EditorGUILayout.Space();

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/MixedRealityPosePropertyDrawer.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/MixedRealityPosePropertyDrawer.cs
@@ -25,24 +25,25 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUIUtility.wideMode = true;
             EditorGUI.BeginProperty(position, label, property);
             EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
-            EditorGUI.indentLevel++;
 
-            var fieldHeight = position.height / NumberOfLines;
-            var positionRect = new Rect(position.x, position.y + fieldHeight, position.width, fieldHeight);
-            var rotationRect = new Rect(position.x, position.y + fieldHeight * 2, position.width, fieldHeight);
-
-            EditorGUI.PropertyField(positionRect, property.FindPropertyRelative("position"), positionContent);
-
-            EditorGUI.BeginChangeCheck();
-            var rotationProperty = property.FindPropertyRelative("rotation");
-            var newEulerRotation = EditorGUI.Vector3Field(rotationRect, rotationContent, rotationProperty.quaternionValue.eulerAngles);
-
-            if (EditorGUI.EndChangeCheck())
+            using (new EditorGUI.IndentLevelScope())
             {
-                rotationProperty.quaternionValue = Quaternion.Euler(newEulerRotation);
+                var fieldHeight = position.height / NumberOfLines;
+                var positionRect = new Rect(position.x, position.y + fieldHeight, position.width, fieldHeight);
+                var rotationRect = new Rect(position.x, position.y + fieldHeight * 2, position.width, fieldHeight);
+
+                EditorGUI.PropertyField(positionRect, property.FindPropertyRelative("position"), positionContent);
+
+                EditorGUI.BeginChangeCheck();
+                var rotationProperty = property.FindPropertyRelative("rotation");
+                var newEulerRotation = EditorGUI.Vector3Field(rotationRect, rotationContent, rotationProperty.quaternionValue.eulerAngles);
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    rotationProperty.quaternionValue = Quaternion.Euler(newEulerRotation);
+                }
             }
 
-            EditorGUI.indentLevel--;
             EditorGUIUtility.wideMode = lastMode;
             EditorGUI.EndProperty();
         }

--- a/Assets/MRTK/Core/Inspectors/Utilities/Lines/DataProviders/EllipseLineDataProviderInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/Lines/DataProviders/EllipseLineDataProviderInspector.cs
@@ -35,39 +35,38 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             EditorGUILayout.LabelField("Ellipse Settings");
 
-            EditorGUI.indentLevel++;
-
-            EditorGUILayout.PropertyField(resolution);
-
-            var prevRadius = radius.vector2Value;
-
-            EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(radius);
-
-            if (EditorGUI.EndChangeCheck())
+            using (new EditorGUI.IndentLevelScope())
             {
-                bool update = false;
-                tempRadius = radius.vector2Value;
+                EditorGUILayout.PropertyField(resolution);
 
-                if (radius.vector2Value.x <= 0)
-                {
-                    tempRadius.x = prevRadius.x;
-                    update = true;
-                }
+                var prevRadius = radius.vector2Value;
 
-                if (radius.vector2Value.y <= 0)
-                {
-                    tempRadius.y = prevRadius.x;
-                    update = true;
-                }
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.PropertyField(radius);
 
-                if (update)
+                if (EditorGUI.EndChangeCheck())
                 {
-                    radius.vector2Value = tempRadius;
+                    bool update = false;
+                    tempRadius = radius.vector2Value;
+
+                    if (radius.vector2Value.x <= 0)
+                    {
+                        tempRadius.x = prevRadius.x;
+                        update = true;
+                    }
+
+                    if (radius.vector2Value.y <= 0)
+                    {
+                        tempRadius.y = prevRadius.x;
+                        update = true;
+                    }
+
+                    if (update)
+                    {
+                        radius.vector2Value = tempRadius;
+                    }
                 }
             }
-
-            EditorGUI.indentLevel--;
 
             serializedObject.ApplyModifiedProperties();
         }


### PR DESCRIPTION
## Overview

Another found branch. Updates some editor code paths to use the built-in `EditorGUI.IndentLevelScope()` instead of managing indentation manually.