### PR TITLE
add RequiresHover field to StatefulInteractable

### DIFF
--- a/com.microsoft.mrtk.core/Editor/Editors/StatefulInteractableEditor.cs
+++ b/com.microsoft.mrtk.core/Editor/Editors/StatefulInteractableEditor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializedProperty ToggleMode;
         private SerializedProperty TriggerOnRelease;
         private SerializedProperty allowSelectByVoice;
-        private SerializedProperty requiresHover;
+        private SerializedProperty SelectRequiresHover;
         private SerializedProperty speechRecognitionKeyword;
         private SerializedProperty VoiceRequiresFocus;
         private SerializedProperty UseGazeDwell;
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             speechRecognitionKeyword = SetUpProperty(nameof(speechRecognitionKeyword));
             VoiceRequiresFocus = SetUpAutoProp(nameof(VoiceRequiresFocus));
 
-            requiresHover = SetUpProperty(nameof(requiresHover));
+            SelectRequiresHover = SetUpAutoProp(nameof(SelectRequiresHover));
 
             UseGazeDwell = SetUpAutoProp(nameof(UseGazeDwell));
             GazeDwellTime = SetUpAutoProp(nameof(GazeDwellTime));
@@ -163,7 +163,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                     EditorGUILayout.PropertyField(TriggerOnRelease);
 
-                    EditorGUILayout.PropertyField(requiresHover);
+                    EditorGUILayout.PropertyField(SelectRequiresHover);
                 }
             }
 

--- a/com.microsoft.mrtk.core/Editor/Editors/StatefulInteractableEditor.cs
+++ b/com.microsoft.mrtk.core/Editor/Editors/StatefulInteractableEditor.cs
@@ -17,6 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializedProperty ToggleMode;
         private SerializedProperty TriggerOnRelease;
         private SerializedProperty allowSelectByVoice;
+        private SerializedProperty requiresHover;
         private SerializedProperty speechRecognitionKeyword;
         private SerializedProperty VoiceRequiresFocus;
         private SerializedProperty UseGazeDwell;
@@ -47,6 +48,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             allowSelectByVoice = SetUpProperty(nameof(allowSelectByVoice));
             speechRecognitionKeyword = SetUpProperty(nameof(speechRecognitionKeyword));
             VoiceRequiresFocus = SetUpAutoProp(nameof(VoiceRequiresFocus));
+
+            requiresHover = SetUpProperty(nameof(requiresHover));
 
             UseGazeDwell = SetUpAutoProp(nameof(UseGazeDwell));
             GazeDwellTime = SetUpAutoProp(nameof(GazeDwellTime));
@@ -159,6 +162,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     }
 
                     EditorGUILayout.PropertyField(TriggerOnRelease);
+
+                    EditorGUILayout.PropertyField(requiresHover);
                 }
             }
 

--- a/com.microsoft.mrtk.core/Interactables/StatefulInteractable.cs
+++ b/com.microsoft.mrtk.core/Interactables/StatefulInteractable.cs
@@ -135,15 +135,12 @@ namespace Microsoft.MixedReality.Toolkit
             Tooltip("If true, then the voice command will only respond to voice commands while this Interactable has focus.")]
         public bool VoiceRequiresFocus { get; private set; } = true;
 
-        [SerializeField, Tooltip("If true, then the OnClick event will only get fired while this Interactable is being hovered.")]
-        private bool requiresHover = false;
-
-        /// <inheritdoc />
-        public bool RequiresHover
-        {
-            get => requiresHover;
-            set => requiresHover = value;
-        }
+        /// <summary>
+		/// Does the interactable require the interactor to hover over it?
+        /// If true, then the OnClick event will only get fired while this Interactable is being hovered.
+        /// </summary>
+        [field: SerializeField, Tooltip("If true, then the OnClick event will only get fired while this Interactable is being hovered.")]
+        public bool SelectRequiresHover { get; private set; } = false;
 
         #endregion Settings
 
@@ -354,7 +351,7 @@ namespace Microsoft.MixedReality.Toolkit
             // This check will prevent OnClick from firing when the interactable is not being hovered.
             bool IsTargetValid()
             {
-                return !requiresHover ||
+                return !SelectRequiresHover ||
                        !(args.interactableObject is IXRHoverInteractable hoverInteractable) ||
                        hoverInteractable.isHovered;
             }

--- a/com.microsoft.mrtk.core/Interactables/StatefulInteractable.cs
+++ b/com.microsoft.mrtk.core/Interactables/StatefulInteractable.cs
@@ -135,6 +135,16 @@ namespace Microsoft.MixedReality.Toolkit
             Tooltip("If true, then the voice command will only respond to voice commands while this Interactable has focus.")]
         public bool VoiceRequiresFocus { get; private set; } = true;
 
+        [SerializeField, Tooltip("If true, then the OnClick event will only get fired while this Interactable is being hovered.")]
+        private bool requiresHover = false;
+
+        /// <inheritdoc />
+        public bool RequiresHover
+        {
+            get => requiresHover;
+            set => requiresHover = value;
+        }
+
         #endregion Settings
 
         #region Public state
@@ -323,16 +333,31 @@ namespace Microsoft.MixedReality.Toolkit
         /// <returns>True if the interactable should fire click/toggle event from this current deselect event.</returns>
         internal protected virtual bool CanClickOnLastSelectExited(SelectExitEventArgs args)
         {
+            return TriggerOnRelease && IsRegistered() && IsInteractorTracked() && IsTargetValid();
+
+            // This check will prevent OnClick from firing when the interactable or interactor was unregistered.
+            bool IsRegistered()
+            {
+                return !args.isCanceled;
+            }
+
             // This check will prevent OnClick from firing when the interactor loses tracking.
             // XRI interactor interfaces don't have a good API for "is this interactor tracked?"
             // Hover-active is a good equivalent, though, as MRTK interactors set hoverActive false
             // when their controller loses tracking.
-            if (args.interactorObject is IXRHoverInteractor hoverInteractor)
+            bool IsInteractorTracked()
             {
-                return TriggerOnRelease && hoverInteractor.isHoverActive;
+                return !(args.interactorObject is IXRHoverInteractor hoverInteractor) ||
+                       hoverInteractor.isHoverActive;
             }
 
-            return TriggerOnRelease;
+            // This check will prevent OnClick from firing when the interactable is not being hovered.
+            bool IsTargetValid()
+            {
+                return !requiresHover ||
+                       !(args.interactableObject is IXRHoverInteractable hoverInteractable) ||
+                       hoverInteractable.isHovered;
+            }
         }
 
         // Attempt to toggle our own IsToggled state.


### PR DESCRIPTION
## Overview
Added a (default false) "RequiresHover" field to StatefulInteractable, of which the only inheritor in the package is PressableButton. Setting this field to true (through inspector or code) prevents basic (also non-MRTK) interactors to trigger a OnClick event when not hovering and ending the selection (on button release, etc.).

## Changes
- Added a (default false) "RequiresHover" field to StatefulInteractable, of which the only inheritor in the package is PressableButton.
- Make that field accessible through the editor panel / inspector in Unity.
- Made changes to CanClickOnLastSelectExited method in StatefulInteractable, so that a OnClick event is only invoked when the interactable is being hovered over when RequiresHover field is set.
- Minor bugfix: add isCancelled check as well - when interactors/interactables get unregistered and XRInteractionManager sends a "cancelled" selectexit, the OnClick event is now not triggered.


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
