### PR TITLE
Amend Debug.Assert in MixedRealityInputSystem.DispatchEventToGlobalListeners

### DIFF
--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -600,7 +600,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Debug.Assert(baseInputEventData != null);
                 Debug.Assert(!baseInputEventData.used);
-                if (baseInputEventData.InputSource == null) { Debug.Assert(baseInputEventData.InputSource != null, $"Failed to find an input source for {baseInputEventData}"); }
+                if (!(baseInputEventData is MixedRealityPointerEventData)) { Debug.Assert(baseInputEventData.InputSource != null, $"Failed to find an input source for {baseInputEventData}"); }
 
                 // Send the event to global listeners
                 base.HandleEvent(baseInputEventData, eventHandler);


### PR DESCRIPTION

- Interface `IMixedRealityInputSystem` allows `RaisePointerXxx` API to be called with optional parameter `IMixedRealityInputSource inputSource = null`
- In `MixedRealityInputSystem.DispatchEventToGlobalListeners` the `baseInputEventData.InputSource` should not be asserted for `baseInputEventData is MixedRealityPointerEventData`, as this is a valid use case

## Overview
Since Version 2.8.2 we saw a regression, where `TouchPointers` created by the `UnityTouchDeviceManager` would not work anymore in development builds.
Every touch interaction would prompt an error message `Failed to find an input source for Microsoft.MixedReality.Toolkit.Input.MixedRealityPointerEventData`

## Changes
- Changes `DebugAssert` in `MixedRealityInputSystem.DispatchEventToGlobalListeners` to not check `baseInputEventData.InputSource != null` when `baseInputEventData` is of type `MixedRealityPointerEventData `
