### PR TITLE
Fixes #11340 - Splash image is not set when tracking is lost in hololens

### DIFF
--- a/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
+++ b/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
@@ -114,7 +114,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
                 base.Update();
 
                 // This combination of states is from the Windows XR Plugin docs, describing the combination when positional tracking is inhibited.
-                if (sessionSubsystem.trackingState == UnityEngine.XR.ARSubsystems.TrackingState.None && sessionSubsystem.notTrackingReason == NotTrackingReason.Relocalizing)
+                // OpenXR implementation is less likely to drop all the way to TrackingState.None
+                if (sessionSubsystem.trackingState != UnityEngine.XR.ARSubsystems.TrackingState.Tracking && sessionSubsystem.notTrackingReason == NotTrackingReason.Relocalizing)
                 {
                     SetTrackingLost(true);
                 }


### PR DESCRIPTION
## Overview
OpenXR implementation is less likely to drop all the way to TrackingState.None when the XR device has lost its tracking.

## Changes
- Fixes: #11340 - Splash image is not set when tracking is lost in hololens.


## Verification
I only tested this code in HoloLens 2, but I think it is harmless for all other XR devices, as it is less restrictive.
