### PR TITLE
BUG 11436 remove DrawIf usage from AnimationEffect

### DIFF
--- a/com.microsoft.mrtk.uxcore/StateVisualizer/Effects/AnimationEffect.cs
+++ b/com.microsoft.mrtk.uxcore/StateVisualizer/Effects/AnimationEffect.cs
@@ -49,7 +49,6 @@ namespace Microsoft.MixedReality.Toolkit.UX
         public WeightType WeightMode => weightMode;
 
         [SerializeField]
-        [DrawIf("weightMode", WeightType.Transition)]
         [Tooltip("How long should it take to transition to a weight of 1.0 when the state becomes active?")]
         private float transitionDuration;
 


### PR DESCRIPTION
## Overview

Bug: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11436

DrawIf operates on the object being serialized. In this case, we have a StateVisualizer that is being serialized, which contains a simple serializable class: AnimationEffect. AnimationEffect makes use of 'drawif' referencing one of its members, but AnimationEffect is not a monobehavior and will only ever be serialized in the context of another object. In this case, StateVisualizer. When the DrawIf attribute code is invoked, it looks for the specified property name (weightMode) on the object being serialized (a StateVisualizer) and throws an error because that doesn't exist.

## Changes

-BUG 11436 remove DrawIf usage from AnimationEffect