### PR TITLE
Voice Commands When Interactable isHovered

### DIFF
--- a/com.microsoft.mrtk.input/Interactors/Speech/SpeechInteractor.cs
+++ b/com.microsoft.mrtk.input/Interactors/Speech/SpeechInteractor.cs
@@ -94,7 +94,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     foreach (var interactable in interactableList)
                     {
-                        if (!interactable.VoiceRequiresFocus || interactable.IsGazeHovered)
+                        if (!interactable.VoiceRequiresFocus || interactable.isHovered)
                         {
                             selectedInteractables.Insert(0, (interactable, VoiceCommandTriggerTime));
                             interactionManager.SelectEnter(this, interactable as IXRSelectInteractable);


### PR DESCRIPTION
## Overview

Update the SpeechInteractor component so that voice commands are enabled when an interactable isHovered instead of IsGazeHovered. Allows the use of voice commands with far rays, pinch interactors.