### PR TITLE
Fix 11208: Scale relative to the position of the interactors, not the attach points

### DIFF
--- a/com.microsoft.mrtk.spatialmanipulation/ObjectManipulator/MoveLogics/ScaleLogic.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/ObjectManipulator/MoveLogics/ScaleLogic.cs
@@ -77,8 +77,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
                 for (int j = i + 1; j < interactors.Count; j++)
                 {
                     // Defer square root until end for performance.
-                    var distance = Vector3.SqrMagnitude(interactors[i].GetAttachTransform(interactable).position -
-                                                       interactors[j].GetAttachTransform(interactable).position);
+                    var distance = Vector3.SqrMagnitude(interactors[i].transform.position -
+                                                       interactors[j].transform.position);
                     if (distance < result)
                     {
                         result = distance;


### PR DESCRIPTION
## Overview
Change ScaleLogic.cs to scale relative to the distance between two interactors instead of the distance between their attach points.

## Changes
- Fixes: #11208.


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
