### PR TITLE
[DRAFT] Fixes TapToPlace Solver To Respond to Left Hand and Voice Commands

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
@@ -227,9 +227,6 @@ MonoBehaviour:
   maintainScaleOnInitialization: 1
   smoothing: 1
   lifetime: 0
-  placementActionReferences:
-  - {fileID: 187161793506945269, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
-  - {fileID: -6131295136447488360, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
   autoStart: 0
   defaultPlacementDistance: 1.5
   maxRaycastDistance: 20
@@ -2418,9 +2415,6 @@ MonoBehaviour:
   maintainScaleOnInitialization: 1
   smoothing: 1
   lifetime: 0
-  placementActionReferences:
-  - {fileID: 187161793506945269, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
-  - {fileID: -6131295136447488360, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
   autoStart: 0
   defaultPlacementDistance: 1.5
   maxRaycastDistance: 20

--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
@@ -259,8 +259,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3986155c7a728454f8bbbabd2e274601, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  leftInteractor: {fileID: 1127029052}
-  rightInteractor: {fileID: 0}
+  leftInteractor: {fileID: 1745518020}
+  rightInteractor: {fileID: 1127029052}
   trackedTargetType: 1
   trackedHandedness: 3
   trackedHandJoint: 2
@@ -1212,6 +1212,10 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 8479077998186684813, guid: 4d7e2f87fefe0ba468719b15288b46e7, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4d7e2f87fefe0ba468719b15288b46e7, type: 3}
 --- !u!4 &1127029051 stripped
@@ -1871,6 +1875,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1745518020 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7115113329451106245, guid: 4d7e2f87fefe0ba468719b15288b46e7, type: 3}
+  m_PrefabInstance: {fileID: 1127029050}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e85416945309f8244a5715a2ec5c254f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1898082442
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
@@ -188,6 +188,7 @@ GameObject:
   - component: {fileID: 396224581}
   - component: {fileID: 396224580}
   - component: {fileID: 396224585}
+  - component: {fileID: 396224586}
   m_Layer: 0
   m_Name: ExampleObject-TrackingRay
   m_TagString: Untagged
@@ -227,7 +228,9 @@ MonoBehaviour:
   maintainScaleOnInitialization: 1
   smoothing: 1
   lifetime: 0
-  placementActionReference: {fileID: 187161793506945269, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+  placementActionReferences:
+  - {fileID: 187161793506945269, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+  - {fileID: -6131295136447488360, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
   autoStart: 0
   defaultPlacementDistance: 1.5
   maxRaycastDistance: 20
@@ -577,6 +580,43 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   <OnDisabled>k__BackingField:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &396224586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 396224579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ef52421bb8639ef4a80a74143e7afcfe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  updateLinkedTransform: 0
+  moveLerpTime: 0.1
+  rotateLerpTime: 0.1
+  scaleLerpTime: 0
+  maintainScaleOnInitialization: 1
+  smoothing: 1
+  lifetime: 0
+  placementActionReferences: []
+  autoStart: 0
+  defaultPlacementDistance: 1.5
+  maxRaycastDistance: 20
+  surfaceNormalOffset: 0
+  useDefaultSurfaceNormalOffset: 1
+  keepOrientationVertical: 0
+  rotateAccordingToSurface: 0
+  magneticSurfaces:
+  - serializedVersion: 2
+    m_Bits: 4294967291
+  debugEnabled: 1
+  onPlacingStarted:
+    m_PersistentCalls:
+      m_Calls: []
+  onPlacingStopped:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &409902409
@@ -2401,7 +2441,9 @@ MonoBehaviour:
   maintainScaleOnInitialization: 1
   smoothing: 1
   lifetime: 0
-  placementActionReference: {fileID: 187161793506945269, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+  placementActionReferences:
+  - {fileID: 187161793506945269, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+  - {fileID: -6131295136447488360, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
   autoStart: 0
   defaultPlacementDistance: 1.5
   maxRaycastDistance: 20

--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
@@ -188,7 +188,6 @@ GameObject:
   - component: {fileID: 396224581}
   - component: {fileID: 396224580}
   - component: {fileID: 396224585}
-  - component: {fileID: 396224586}
   m_Layer: 0
   m_Name: ExampleObject-TrackingRay
   m_TagString: Untagged
@@ -580,43 +579,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   <OnDisabled>k__BackingField:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &396224586
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 396224579}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ef52421bb8639ef4a80a74143e7afcfe, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  updateLinkedTransform: 0
-  moveLerpTime: 0.1
-  rotateLerpTime: 0.1
-  scaleLerpTime: 0
-  maintainScaleOnInitialization: 1
-  smoothing: 1
-  lifetime: 0
-  placementActionReferences: []
-  autoStart: 0
-  defaultPlacementDistance: 1.5
-  maxRaycastDistance: 20
-  surfaceNormalOffset: 0
-  useDefaultSurfaceNormalOffset: 1
-  keepOrientationVertical: 0
-  rotateAccordingToSurface: 0
-  magneticSurfaces:
-  - serializedVersion: 2
-    m_Bits: 4294967291
-  debugEnabled: 1
-  onPlacingStarted:
-    m_PersistentCalls:
-      m_Calls: []
-  onPlacingStopped:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &409902409

--- a/com.microsoft.mrtk.spatialmanipulation/Editor/Solvers/TapToPlaceEditor.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Editor/Solvers/TapToPlaceEditor.cs
@@ -16,10 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Editor
     {
         private TapToPlace instance;
 
-        private GUIContent placementActionContent = new GUIContent("Placement actions");
-
         // Tap to Place properties
-        private SerializedProperty placementAction;
         private SerializedProperty autoStart;
         private SerializedProperty defaultPlacementDistance;
         private SerializedProperty maxRaycastDistance;
@@ -48,7 +45,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Editor
             instance = (TapToPlace)target;
 
             // Main Tap to Place Properties
-            placementAction = serializedObject.FindProperty("placementActionReferences");
             autoStart = serializedObject.FindProperty("autoStart");
             defaultPlacementDistance = serializedObject.FindProperty("defaultPlacementDistance");
             maxRaycastDistance = serializedObject.FindProperty("maxRaycastDistance");
@@ -81,7 +77,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Editor
         {
             serializedObject.Update();
 
-            EditorGUILayout.PropertyField(placementAction, placementActionContent);
             EditorGUILayout.PropertyField(autoStart);
             EditorGUILayout.PropertyField(defaultPlacementDistance);
             EditorGUILayout.PropertyField(maxRaycastDistance);

--- a/com.microsoft.mrtk.spatialmanipulation/Editor/Solvers/TapToPlaceEditor.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Editor/Solvers/TapToPlaceEditor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Editor
     {
         private TapToPlace instance;
 
-        private GUIContent placementActionContent = new GUIContent("Placement action");
+        private GUIContent placementActionContent = new GUIContent("Placement actions");
 
         // Tap to Place properties
         private SerializedProperty placementAction;
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Editor
             instance = (TapToPlace)target;
 
             // Main Tap to Place Properties
-            placementAction = serializedObject.FindProperty("placementActionReference");
+            placementAction = serializedObject.FindProperty("placementActionReferences");
             autoStart = serializedObject.FindProperty("autoStart");
             defaultPlacementDistance = serializedObject.FindProperty("defaultPlacementDistance");
             maxRaycastDistance = serializedObject.FindProperty("maxRaycastDistance");

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
@@ -241,6 +241,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         // The interactable used to pick up the obect. 
         private StatefulInteractable interactable;
 
+        // Cache of the most recent input actions registered to place the object
+        private List<InputActionReference> lastActionReferences = new List<InputActionReference>();
         #region MonoBehaviour Implementation
 
         protected override void Start()
@@ -478,6 +480,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
                 }
                 placementAction.performed += StopPlacement;
             }
+            lastActionReferences = placementActionReferences;
         }
 
         /// <summary>
@@ -498,7 +501,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void UnregisterPlacementAction()
         {
-            foreach (InputActionReference placementActionReference in placementActionReferences)
+            foreach (InputActionReference placementActionReference in lastActionReferences)
             {
                 InputAction placementAction = GetInputActionFromReference(placementActionReference);
                 if (placementAction == null)
@@ -508,6 +511,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
                 }
                 placementAction.performed -= StopPlacement;
             }
+            lastActionReferences = new List<InputActionReference>();
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System; 
 using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
@@ -281,7 +282,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// <summary>
         /// Finds all of the select input actions in a scene
         /// </summary>
-        public void FindSelectActions()
+        private void FindSelectActions()
         {
             foreach (ActionBasedController xrController in FindObjectsOfType<ActionBasedController>())
             {
@@ -301,7 +302,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// game object from following the TrackedTargetType.  The game object layer is changed to IgnoreRaycast temporarily and then
         /// restored to its original layer in StopPlacement().
         /// </summary>
-        public void StartPlacement()
+        private void StartPlacement()
         {
             // Checking the amount of time passed between when StartPlacement or StopPlacement is called twice in
             // succession. If these methods are called twice very rapidly, the object will be
@@ -354,7 +355,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// <summary>
         /// Helper method to call StopPlacement 
         /// </summary>
-        public void StopPlacementAction(InputAction.CallbackContext context)
+        private void StopPlacementAction(InputAction.CallbackContext context)
         {
             StopPlacement();
         }
@@ -362,7 +363,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// <summary>
         /// Stop the placement of a game object without the need of the OnPointerClicked event. 
         /// </summary>
-        public void StopPlacement()
+        private void StopPlacement()
         {
             // Checking the amount of time passed between when StartPlacement or StopPlacement is called twice in
             // succession. If these methods are called twice very rapidly, the object will be
@@ -498,7 +499,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
                 if (placementAction == null)
                 {
                     Debug.Log("Failed to register the placement action, the action reference was null or contained no action.");
-                    return;
+                    continue;
                 }
                 placementAction.performed += StopPlacementAction;
             }
@@ -510,12 +511,14 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void RegisterPickupEvent()
         {
-            if (interactable == null)
+            try
             {
-                Debug.Log("Failed to register the pick up event. There is no StatefulInteractable set.");
-                return;
+                interactable.OnClicked.AddListener(StartPlacement);
             }
-            interactable.OnClicked.AddListener(StartPlacement);
+            catch (Exception e)
+            {
+                Debug.Log($"Failed to register the pick up event: {e}");
+            }
         }
 
         /// <summary>
@@ -523,12 +526,14 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void RegisterPlacementEvent()
         {
-            if (interactable == null)
+            try
             {
-                Debug.Log("Failed to register the placement event. There is no StatefulInteractable set.");
-                return;
+                interactable.OnClicked.AddListener(StopPlacement);
             }
-            interactable.OnClicked.AddListener(StopPlacement);
+            catch (Exception e)
+            {
+                Debug.Log($"Failed to register the placemenent event: {e}");
+            }
         }
 
         /// <summary>
@@ -536,12 +541,12 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void UnregisterPlacementAction()
         {
-            foreach (InputAction placementAction in placementActions)
+            foreach (InputAction placementAction in lastActions)
             {
                 if (placementAction == null)
                 {
                     Debug.Log("Failed to unregister the placement action, the action reference was null or contained no action.");
-                    return;
+                    continue;
                 }
                 placementAction.performed -= StopPlacementAction;
             }
@@ -553,12 +558,14 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void UnregisterPickupEvent()
         {
-            if (interactable == null)
+            try
             {
-                Debug.Log("Failed to unregister the pick up event. There is no StatefulInteractable set.");
-                return;
+                interactable.OnClicked.RemoveListener(StartPlacement);
             }
-            interactable.OnClicked.RemoveListener(StartPlacement);
+            catch (Exception e)
+            {
+                Debug.Log($"Failed to unregister the pick up event: {e}");
+            }
         }
 
         /// <summary>
@@ -566,12 +573,14 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void UnregisterPlacementEvent()
         {
-            if (interactable == null)
+            try
             {
-                Debug.Log("Failed to unregister the pick up event. There is no StatefulInteractable set.");
-                return;
+                interactable.OnClicked.RemoveListener(StopPlacement);
             }
-            interactable.OnClicked.RemoveListener(StopPlacement);
+            catch (Exception e)
+            {
+                Debug.Log($"Failed to unregister the placemenent event: {e}");
+            }
         }
     }
 }

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Events;
@@ -17,16 +18,16 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
     public class TapToPlace : Solver
     {
         [SerializeField]
-        [Tooltip("The input action which is to control placement.")]
-        private InputActionReference placementActionReference = null;
+        [Tooltip("The input actions which are to control placement.")]
+        private List<InputActionReference> placementActionReferences = new List<InputActionReference>();
 
         /// <summary>
-        /// The input action which is to control placement.
+        /// The input actions which are to control placement.
         /// </summary>
-        public InputActionReference PlacementActionReference
+        public List<InputActionReference> PlacementActionReferences
         {
-            get => placementActionReference;
-            set => placementActionReference = value;
+            get => placementActionReferences;
+            set => placementActionReferences = value;
         }
 
         // todo: needed? [Space(10)]
@@ -467,13 +468,16 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void RegisterPlacementAction()
         {
-            InputAction placementAction = GetInputActionFromReference(placementActionReference);
-            if (placementAction == null)
+            foreach(InputActionReference placementActionReference in placementActionReferences)
             {
-                Debug.Log("Failed to register the placement action, the action reference was null or contained no action.");
-                return;
+                InputAction placementAction = GetInputActionFromReference(placementActionReference);
+                if (placementAction == null)
+                {
+                    Debug.Log("Failed to register the placement action, the action reference was null or contained no action.");
+                    return;
+                }
+                placementAction.performed += StopPlacement;
             }
-            placementAction.performed += StopPlacement;
         }
 
         /// <summary>
@@ -494,13 +498,16 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void UnregisterPlacementAction()
         {
-            InputAction placementAction = GetInputActionFromReference(placementActionReference);
-            if (placementAction == null)
+            foreach (InputActionReference placementActionReference in placementActionReferences)
             {
-                Debug.Log("Failed to unregister the placement action, the action reference was null or contained no action.");
-                return;
+                InputAction placementAction = GetInputActionFromReference(placementActionReference);
+                if (placementAction == null)
+                {
+                    Debug.Log("Failed to unregister the placement action, the action reference was null or contained no action.");
+                    return;
+                }
+                placementAction.performed -= StopPlacement;
             }
-            placementAction.performed -= StopPlacement;
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
Makes some changes to the TapToPlace Solver and sample scene in order to allow the user to tap with either hand or use the 'select' keyword in order to pickup and place the target. 

On start, the TapToPlace Solver finds all of the select input actions in the scene, and the stateful interactable of the target. It 
registers the pickup event (stateful interactable OnClicked), to allow the target to be picked up when in focus. Once the user picks up the object, it unregisters the pickup event and registers OnClicked as the placement event. The select input actions in the scene are also registered to trigger placement. This way a user can place an object that is not in focus. Once the object is placed, it unregisters placement event and reregisters pickup event.

## Changes
- Fixes: #11527 .
