### PR TITLE
Fixing edge case duplication bug in VirtualizedScrollRectList

### DIFF
--- a/com.microsoft.mrtk.uxcore/ScrollRect/VirtualizedScrollRectList.cs
+++ b/com.microsoft.mrtk.uxcore/ScrollRect/VirtualizedScrollRectList.cs
@@ -412,6 +412,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
             OnInvisible?.Invoke(go, i);
             poolDict.Remove(i);
+            go.SetActive(false);
             pool.Enqueue(go);
         }
 
@@ -419,6 +420,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         {
             GameObject go = pool.Dequeue();
             go.transform.localPosition = ItemLocation(i);
+            go.SetActive(true);
             poolDict.Add(i, go);
             OnVisible?.Invoke(go, i);
         }


### PR DESCRIPTION
## Overview
When VirtualizedScrollRectList is initialized, the pool size is always being set to the number of items that could possibly be visible on the screen. EX For a 3x3 grid, the Scroll Rect content will always have 15 GameObjects, even if the item count is lower. VirtualizedScrollRectList 'recycles' these GameObjects to display the information for the item that is in view, relying on the user to (re)set the information upon the OnVisible event. This information is not cleared when the item becomes invisible and the GameObject is not disabled.

The result is that scrolling down and then back up on lists of a certain size will result in duplicate items: when it scrolls up it pulls a new GameObject out of the pool and adds the item information, while the old GameObject is still there, active/visible and with its own copy of the information.

This PR patches the duplication issue by disabling the GameObjects on MakeInvisible and enabling them on MakeVisible.

## Changes
- Fixes: #11416 .
