### PR TITLE
Updating MRTK3 package dependencies weren't updated to 2.3

### DIFF
--- a/Tooling/Test/run_playmode_tests.ps1
+++ b/Tooling/Test/run_playmode_tests.ps1
@@ -18,7 +18,7 @@ param(
     # Unity version override
     [Parameter(Mandatory = $false)]
     [string]
-    $unityVersion = "2020.3.35f1",
+    $unityVersion = "2021.3.21f1",
     # Path to your Unity Executable
     [ValidateScript({ [System.IO.File]::Exists($_) -and $_.EndsWith(".exe") })]
     [string]

--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -63,7 +63,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.xr.interaction.toolkit": "2.2.0",
+        "com.unity.xr.interaction.toolkit": "2.3.0",
         "com.unity.xr.management": "4.2.1",
         "com.unity.xr.core-utils": "2.1.0"
       }
@@ -111,7 +111,7 @@
         "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
         "com.unity.inputsystem": "1.3.0",
         "com.unity.xr.arfoundation": "5.0.5",
-        "com.unity.xr.interaction.toolkit": "2.2.0",
+        "com.unity.xr.interaction.toolkit": "2.3.0",
         "com.unity.xr.core-utils": "2.1.0"
       }
     },
@@ -123,7 +123,7 @@
         "com.microsoft.mrtk.core": "3.0.0-development",
         "com.microsoft.mrtk.uxcore": "3.0.0-development",
         "com.unity.inputsystem": "1.3.0",
-        "com.unity.xr.interaction.toolkit": "2.2.0"
+        "com.unity.xr.interaction.toolkit": "2.3.0"
       }
     },
     "com.microsoft.mrtk.standardassets": {
@@ -157,7 +157,7 @@
         "com.microsoft.mrtk.uxcore": "3.0.0-development",
         "com.microsoft.mrtk.spatialmanipulation": "3.0.0-development",
         "com.microsoft.mrtk.standardassets": "3.0.0-development",
-        "com.unity.xr.interaction.toolkit": "2.2.0"
+        "com.unity.xr.interaction.toolkit": "2.3.0"
       }
     },
     "com.microsoft.mrtk.uxcomponents.noncanvas": {
@@ -179,7 +179,7 @@
         "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
         "com.unity.inputsystem": "1.3.0",
         "com.unity.textmeshpro": "3.0.6",
-        "com.unity.xr.interaction.toolkit": "2.2.0"
+        "com.unity.xr.interaction.toolkit": "2.3.0"
       }
     },
     "com.microsoft.mrtk.windowsspeech": {

--- a/com.microsoft.mrtk.core/Tests/TestUtilities/BaseRuntimeTests.cs
+++ b/com.microsoft.mrtk.core/Tests/TestUtilities/BaseRuntimeTests.cs
@@ -11,9 +11,26 @@ namespace Microsoft.MixedReality.Toolkit.Core.Tests
     /// </summary>
     public abstract class BaseRuntimeTests
     {
+        int originalTargetFrameRate = 0;
+
+        /// <summary>
+        /// Get the target framerate at which tests should run at.
+        /// </summary>
+        /// <remarks>
+        /// This is used so frame timings to be consistent across various machine types. Thus ensure consistent test behavios.
+        /// </remarks>
+        protected virtual int TargetFrameRate { get; } = 60;
+
+        /// <summary>
+        /// Get the target frame time for these tests.
+        /// </summary>
+        protected float TargetFrameTime => 1.0f / TargetFrameRate;
+
         [UnitySetUp]
         public virtual IEnumerator Setup()
         {
+            originalTargetFrameRate = UnityEngine.Application.targetFrameRate;
+            UnityEngine.Application.targetFrameRate = TargetFrameRate;
             RuntimeTestUtilities.SetupScene();
             yield return null;
         }
@@ -22,6 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Tests
         public virtual IEnumerator TearDown()
         {
             RuntimeTestUtilities.TeardownScene();
+            UnityEngine.Application.targetFrameRate = originalTargetFrameRate;
             yield return null;
         }
     }

--- a/com.microsoft.mrtk.core/Tests/TestUtilities/RuntimeTestUtilities.cs
+++ b/com.microsoft.mrtk.core/Tests/TestUtilities/RuntimeTestUtilities.cs
@@ -125,7 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Tests
         /// We set it fairly conservatively to ensure that after waiting
         /// all input events have been sent.
         /// </summary>
-        public static IEnumerator WaitForUpdates(int frameCount = 120)
+        public static IEnumerator WaitForUpdates(int frameCount = 10)
         {
             for (int i = 0; i < frameCount; i++)
             {

--- a/com.microsoft.mrtk.core/package.json
+++ b/com.microsoft.mrtk.core/package.json
@@ -15,7 +15,7 @@
   },
   "unity": "2021.3",
   "dependencies": {
-    "com.unity.xr.interaction.toolkit": "2.2.0",
+    "com.unity.xr.interaction.toolkit": "2.3.0",
     "com.unity.xr.management": "4.2.1",
     "com.unity.xr.core-utils": "2.1.0"
   }

--- a/com.microsoft.mrtk.input/Tests/Runtime/InteractorDwellManagerTests.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/InteractorDwellManagerTests.cs
@@ -38,11 +38,14 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
             Assert.IsNotNull(dwellManager, "InteractorDwellManager does not exist on the MRTK RightHand Controller/Far Ray GameObject.");
 
             // Show the hand and confirm the interactable is being hovered but not selected yet
+            var halfDwellFrameCount = (int)((dwellTime * TargetFrameRate) / 2);
             var rightHand = new TestHand(Handedness.Right);
             yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
             yield return RuntimeTestUtilities.WaitForUpdates();
-            yield return rightHand.AimAt(cube.transform.position);
+            yield return rightHand.AimAt(-cube.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return rightHand.AimAt(cube.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates(frameCount: halfDwellFrameCount);
 
             Assert.IsTrue(interactable.IsRayHovered,
                           "StatefulInteractable did not get RayHovered.");
@@ -50,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
                           "StatefulInteractable gets Selected too early.");
 
             // Wait for the dwell time to pass and confirm the interactable is selected
-            yield return new WaitForSeconds(dwellTime);
+            yield return RuntimeTestUtilities.WaitForUpdates(frameCount: halfDwellFrameCount + 1);
             Assert.IsTrue(interactable.isSelected,
                           "StatefulInteractable did not get Selected.");
 

--- a/com.microsoft.mrtk.input/package.json
+++ b/com.microsoft.mrtk.input/package.json
@@ -19,7 +19,7 @@
     "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.xr.arfoundation": "5.0.5",
-    "com.unity.xr.interaction.toolkit": "2.2.0",
+    "com.unity.xr.interaction.toolkit": "2.3.0",
     "com.unity.xr.core-utils": "2.1.0"
   }
 }

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/ObjectManipulatorTests.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/ObjectManipulatorTests.cs
@@ -85,8 +85,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 
             // Put hand out in front, in-FOV, but not too close to cube as to
             // disable the far interactors.
-            yield return rightHand.MoveTo(InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0, 0.5f)));
-            yield return RuntimeTestUtilities.WaitForUpdates(frameCount: 90);
+            yield return rightHand.MoveTo(InputTestUtilities.InFrontOfUser(new Vector3(0.2f, 0, 0.5f)));
+            yield return RuntimeTestUtilities.WaitForUpdates();
 
             Assert.IsTrue(objManip.IsGazePinchHovered,
                 "ObjManip didn't report IsGazePinchHovered");
@@ -132,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
             yield return RuntimeTestUtilities.WaitForUpdates();
             yield return rightHand.MoveTo(cube.transform.position);
-            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return new WaitForSeconds(0.1f);
 
             Assert.IsFalse(objManip.IsPokeHovered, "ObjManip shouldn't get IsPokeHovered");
             Assert.IsTrue(objManip.IsGrabHovered, "ObjManip didn't report IsGrabHovered");
@@ -152,7 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 
             Vector3 newPosition = originalPosition + Vector3.right * 1.5f;
             yield return rightHand.MoveTo(newPosition);
-            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return new WaitForSeconds(0.1f);
 
             // Smoothing should mean that the cube has lagged behind the hand.
             attachTransform = objManip.firstInteractorSelecting.GetAttachTransform(objManip).position;
@@ -172,7 +172,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 
             newPosition = originalPosition - Vector3.right * 1.5f;
             yield return rightHand.MoveTo(newPosition);
-            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return new WaitForSeconds(0.1f);
 
             // Immediately check to make sure the cube matches our grab exactly.
             attachTransform = objManip.firstInteractorSelecting.GetAttachTransform(objManip).position;

--- a/com.microsoft.mrtk.spatialmanipulation/package.json
+++ b/com.microsoft.mrtk.spatialmanipulation/package.json
@@ -18,7 +18,7 @@
     "com.microsoft.mrtk.core": "3.0.0-development",
     "com.microsoft.mrtk.uxcore": "3.0.0-development",
     "com.unity.inputsystem": "1.3.0",
-    "com.unity.xr.interaction.toolkit": "2.2.0"
+    "com.unity.xr.interaction.toolkit": "2.3.0"
   },
   "msftOptionalPackages": {
     "com.microsoft.mrtk.input": "3.0.0-development"

--- a/com.microsoft.mrtk.uxcomponents/package.json
+++ b/com.microsoft.mrtk.uxcomponents/package.json
@@ -19,7 +19,7 @@
     "com.microsoft.mrtk.uxcore": "3.0.0-development",
     "com.microsoft.mrtk.spatialmanipulation": "3.0.0-development",
     "com.microsoft.mrtk.standardassets": "3.0.0-development",
-    "com.unity.xr.interaction.toolkit": "2.2.0"
+    "com.unity.xr.interaction.toolkit": "2.3.0"
   },
   "msftTestDependencies": {
     "com.microsoft.mrtk.input": "3.0.0-development",

--- a/com.microsoft.mrtk.uxcore/package.json
+++ b/com.microsoft.mrtk.uxcore/package.json
@@ -19,7 +19,7 @@
     "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.textmeshpro": "3.0.6",
-    "com.unity.xr.interaction.toolkit": "2.2.0"
+    "com.unity.xr.interaction.toolkit": "2.3.0"
   },
   "msftOptionalPackages": {
     "com.microsoft.mrtk.data": "1.0.0-development",


### PR DESCRIPTION
## Overview
In a previous change the MRTK3 samples were updated to XRI 2.3, but MRTK3 package dependencies weren't updated to 2.3.  This updates the package dependencies to use XRI 2.3

Also improving the unit test so that they should now pass consistently, regardless of the speed of the executing machine. The fix was to set a target framerate to 60Hz while running test cases.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11539
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11475


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
