### PR TITLE
Fixes SolverHandler issues when handedness flag is set to "everything" (i.e. 0xFFFFFFFF or -1)

### DIFF
--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/SolverHandler.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/SolverHandler.cs
@@ -483,8 +483,10 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
                             }
                         }
 
-                        UpdateCachedHandJointTransform();
-                        target = cachedHandJointTransform;
+                        if (UpdateCachedHandJointTransform())
+                        {
+                            target = cachedHandJointTransform;
+                        }
                     }
                 }
                 else if (TrackedTargetType == TrackedObjectType.CustomOverride)
@@ -499,8 +501,15 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         private static readonly ProfilerMarker UpdateCachedHandJointTransformPerfMarker =
             new ProfilerMarker("[MRTK] SolverHandler.UpdateCachedHandJointTransform");
 
-        private void UpdateCachedHandJointTransform()
+        /// <summary>
+        /// Update the cached transform's position to match that of the current track joint. 
+        /// </summary>
+        /// <returns>
+        /// True, if the tracked joint is found and cached transform is updated. False, otherwise.
+        /// </returns>
+        private bool UpdateCachedHandJointTransform()
         {
+            bool updated = false;
             using (UpdateCachedHandJointTransformPerfMarker.Auto())
             {
                 XRNode? handNode = currentTrackedHandedness.ToXRNode();
@@ -515,8 +524,10 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
                     }
 
                     cachedHandJointTransform.SetPositionAndRotation(jointPos.Position, jointPos.Rotation);
+                    updated = true;
                 }
             }
+            return updated;
         }
 
         private void TrackTransform(Transform target)

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/SolverHandler.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/SolverHandler.cs
@@ -552,7 +552,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </returns>
         private XRBaseInteractor GetControllerInteractor(Handedness handedness)
         {
-            if (!IsValidHandedness(handedness)) { return null; }
+            if (handedness == Handedness.None || !IsValidHandedness(handedness)) { return null; }
 
             return (handedness == Handedness.Left) ? LeftInteractor : RightInteractor;
         }
@@ -614,7 +614,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </returns>
         public static bool IsValidHandedness(Handedness hand)
         {
-            return hand.IsMatch(Handedness.Both);
+            return hand.IsMatch(Handedness.Both) || hand == Handedness.None;
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/SolverHandler.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/SolverHandler.cs
@@ -270,7 +270,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// is set to both left and right.
         /// </summary>
         /// <remarks>
-        /// Allowed <see cref="Handedness"/> values are Left or Right. Borh hands can't be preferred simultaneously.
+        /// Allowed <see cref="Handedness"/> values are Left or Right. Both hands can't be preferred simultaneously.
         /// </remarks>
         public Handedness PreferredTrackedHandedness
         {
@@ -577,12 +577,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             // If we were tracking a particular hand, check that our transform is still valid
             if (TrackedTargetType == TrackedObjectType.HandJoint && currentTrackedHandedness != Handedness.None)
             {
-                bool trackingLeft = IsHandTracked(Handedness.Left);
-                bool trackingRight = IsHandTracked(Handedness.Right);
-
-                return
-                    (trackingLeft && currentTrackedHandedness.IsMatch(Handedness.Left)) ||
-                    (trackingRight && currentTrackedHandedness.IsMatch(Handedness.Right));
+                bool trackingLeft = currentTrackedHandedness.IsMatch(Handedness.Left) && IsHandTracked(Handedness.Left);
+                bool trackingRight = currentTrackedHandedness.IsMatch(Handedness.Right) && IsHandTracked(Handedness.Right);
+                return !trackingLeft && !trackingRight;
             }
 
             return false;
@@ -605,7 +602,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             XRNode? node = hand.ToXRNode();
             if (!node.HasValue) { return false; }
             return XRSubsystemHelpers.HandsAggregator != null &&
-                XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, node.Value, out HandJointPose pose);
+                   XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, node.Value, out HandJointPose pose);
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverHandlerTests.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverHandlerTests.cs
@@ -12,6 +12,7 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
 using HandshapeId = Microsoft.MixedReality.Toolkit.Input.HandshapeTypes.HandshapeId;
+using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 {
@@ -33,9 +34,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // Set up GameObject with a SolverHandler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             var solverHandler = testObject.AddComponent<SolverHandler>();
-            solverHandler.TrackedHandedness = Handedness.Both;
 
             // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Both;
             solverHandler.TrackedTargetType = TrackedObjectType.Interactor;
             var lookup = GameObject.FindObjectOfType<ControllerLookup>();
             var leftInteractor = lookup.LeftHandController.GetComponentInChildren<MRTKRayInteractor>();
@@ -91,9 +92,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // Set up GameObject with a SolverHandler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             var solverHandler = testObject.AddComponent<SolverHandler>();
-            solverHandler.TrackedHandedness = (Handedness)(-1);
 
             // Set it to track interactors
+            solverHandler.TrackedHandedness = (Handedness)(-1);
             solverHandler.TrackedTargetType = TrackedObjectType.Interactor;
             var lookup = GameObject.FindObjectOfType<ControllerLookup>();
             var leftInteractor = lookup.LeftHandController.GetComponentInChildren<MRTKRayInteractor>();
@@ -146,9 +147,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // Set up GameObject with a SolverHandler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             var solverHandler = testObject.AddComponent<SolverHandler>();
-            solverHandler.TrackedHandedness = Handedness.Left;
 
             // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Left;
             solverHandler.TrackedTargetType = TrackedObjectType.Interactor;
             var lookup = GameObject.FindObjectOfType<ControllerLookup>();
             var leftInteractor = lookup.LeftHandController.GetComponentInChildren<MRTKRayInteractor>();
@@ -201,9 +202,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             // Set up GameObject with a SolverHandler
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             var solverHandler = testObject.AddComponent<SolverHandler>();
-            solverHandler.TrackedHandedness = Handedness.Right;
 
             // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Right;
             solverHandler.TrackedTargetType = TrackedObjectType.Interactor;
             var lookup = GameObject.FindObjectOfType<ControllerLookup>();
             var leftInteractor = lookup.LeftHandController.GetComponentInChildren<MRTKRayInteractor>();
@@ -433,6 +434,250 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             Quaternion expectedDir = Camera.main.transform.rotation*Quaternion.Euler(30f, 30f, 30f);
             Assert.IsTrue(solverHandler.TransformTarget.position == expectedPos, $"Solver Handler not applying additional offset");
             Assert.IsTrue(solverHandler.TransformTarget.rotation == expectedDir, $"Solver Handler not applying additional rotation");
+        }
+
+        /// <summary>
+        /// This checks if the SolverHandler correctly switches to the active hand joint when tracking
+        /// two hands
+        /// </summary>
+        [UnityTest]
+        public IEnumerator SolverHandlerHandJointSwitchesToActiveHand()
+        {
+            // Disable gaze interactions for this unit test;
+            InputTestUtilities.DisableGaze();
+
+            // For tracking joint pose in test
+            HandJointPose jointPose = new HandJointPose();
+
+            // Set up GameObject with a SolverHandler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var solverHandler = testObject.AddComponent<SolverHandler>();
+            var joint = TrackedHandJoint.Palm;
+
+            // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Both;
+            solverHandler.TrackedTargetType = TrackedObjectType.HandJoint;
+            solverHandler.TrackedHandJoint = joint;
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+            XRNode rightHandNode = Handedness.Right.ToXRNode().Value;
+            XRNode leftHandNode = Handedness.Left.ToXRNode().Value;
+            var initialHandPosition = InputTestUtilities.InFrontOfUser(0.5f);
+
+            yield return rightHand.Show(initialHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if SolverHandler starts with target on right hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, rightHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler started tracking incorrect hand joint");
+
+            // Hide the right hand and make the left hand active at a new position
+            yield return rightHand.Hide();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            var secondHandPosition = new Vector3(-0.05f, -0.05f, 1f);
+            yield return leftHand.Show(secondHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if the SolverHandler moves the target to the left hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, leftHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not switch to active hand joint");
+
+            // Repeat the test, but hide the left hand this time
+            yield return leftHand.Hide();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Vector3 finalPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, 0.05f, 0.5f));
+            yield return rightHand.Show(finalPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if the SolverHandler moves the target back to the right hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, rightHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not switch to final hand joint");
+        }
+
+        /// <summary>
+        /// This checks if the SolverHandler correctly switches to the active hand joint when tracking
+        /// two hands, when the serialized `TrackedHandedness` value to set to Unity's
+        /// Everything value, with is -1 or 0xFFFFFFFF. Everything can be set via Unity's
+        /// inspector window.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator SolverHandlerHandJointSwitchesToActiveHandWithEverythingValue()
+        {
+            // Disable gaze interactions for this unit test;
+            InputTestUtilities.DisableGaze();
+
+            // For tracking joint pose in test
+            HandJointPose jointPose = new HandJointPose();
+
+            // Set up GameObject with a SolverHandler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var solverHandler = testObject.AddComponent<SolverHandler>();
+            var joint = TrackedHandJoint.Palm;
+
+            // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Both;
+            solverHandler.TrackedTargetType = TrackedObjectType.HandJoint;
+            solverHandler.TrackedHandJoint = joint;
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+            XRNode rightHandNode = Handedness.Right.ToXRNode().Value;
+            XRNode leftHandNode = Handedness.Left.ToXRNode().Value;
+            var initialHandPosition = InputTestUtilities.InFrontOfUser(0.5f);
+
+            yield return rightHand.Show(initialHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if SolverHandler starts with target on right hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, rightHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler started tracking incorrect hand joint");
+
+            // Hide the right hand and make the left hand active at a new position
+            yield return rightHand.Hide();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            var secondHandPosition = new Vector3(-0.05f, -0.05f, 1f);
+            yield return leftHand.Show(secondHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if the SolverHandler moves the target to the left hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, leftHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not switch to active hand joint");
+
+            // Repeat the test, but hide the left hand this time
+            yield return leftHand.Hide();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Vector3 finalPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, 0.05f, 0.5f));
+            yield return rightHand.Show(finalPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if the SolverHandler moves the target back to the right hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, rightHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not switch to final hand joint");
+        }
+
+        /// <summary>
+        /// This checks if the SolverHandler can be configured to only track left hand joint only
+        /// </summary>
+        [UnityTest]
+        public IEnumerator SolverHandlerHandJointLeftHandOnly()
+        {
+            // Disable gaze interactions for this unit test;
+            InputTestUtilities.DisableGaze();
+
+            // For tracking joint pose in test
+            HandJointPose jointPose = new HandJointPose();
+
+            // Set up GameObject with a SolverHandler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var solverHandler = testObject.AddComponent<SolverHandler>();
+            var joint = TrackedHandJoint.Palm;
+
+            // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Left;
+            solverHandler.TrackedTargetType = TrackedObjectType.HandJoint;
+            solverHandler.TrackedHandJoint = joint;
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+            XRNode rightHandNode = Handedness.Right.ToXRNode().Value;
+            XRNode leftHandNode = Handedness.Left.ToXRNode().Value;
+            var initialHandPosition = InputTestUtilities.InFrontOfUser(0.5f);
+
+            yield return rightHand.Show(initialHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if SolverHandler did not start with target on right hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, rightHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position != jointPose.Position, $"Solver Handler started tracking incorrect hand joint");
+
+            // Hide the right hand and make the left hand active at a new position
+            yield return rightHand.Hide();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            var secondHandPosition = new Vector3(-0.05f, -0.05f, 1f);
+            yield return leftHand.Show(secondHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if the SolverHandler moves the target to the left hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, leftHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not start to track correct hand joint");
+
+            // Repeat the test, but hide the left hand this time
+            yield return leftHand.Hide();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Vector3 finalPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, 0.05f, 0.5f));
+            yield return rightHand.Show(finalPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if the SolverHandler did not moves the target to the right hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, rightHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position != jointPose.Position, $"Solver Handler switched to incorrect hand joint");
+        }
+
+        /// <summary>
+        /// This checks if the SolverHandler can be configured to only track right hand only
+        /// </summary>
+        [UnityTest]
+        public IEnumerator SolverHandlerHandJointRightHandOnly()
+        {
+            // Disable gaze interactions for this unit test;
+            InputTestUtilities.DisableGaze();
+
+            // For tracking joint pose in test
+            HandJointPose jointPose = new HandJointPose();
+
+            // Set up GameObject with a SolverHandler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var solverHandler = testObject.AddComponent<SolverHandler>();
+            var joint = TrackedHandJoint.Palm;
+
+            // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Right;
+            solverHandler.TrackedTargetType = TrackedObjectType.HandJoint;
+            solverHandler.TrackedHandJoint = joint;
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+            XRNode rightHandNode = Handedness.Right.ToXRNode().Value;
+            XRNode leftHandNode = Handedness.Left.ToXRNode().Value;
+            var initialHandPosition = InputTestUtilities.InFrontOfUser(0.5f);
+
+            yield return leftHand.Show(initialHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if SolverHandler did not start with target on left hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, leftHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position != jointPose.Position, $"Solver Handler started tracking incorrect hand joint");
+
+            // Hide the left hand and make the right hand active at a new position
+            yield return leftHand.Hide();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            var secondHandPosition = new Vector3(-0.05f, -0.05f, 1f);
+            yield return rightHand.Show(secondHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if the SolverHandler moves the target to the right hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, rightHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not start to track correct hand joint");
+
+            // Repeat the test, but hide the right hand this time
+            yield return rightHand.Hide();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Vector3 finalPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, 0.05f, 0.5f));
+            yield return leftHand.Show(finalPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if the SolverHandler did not moves the target to the left hand joint
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, leftHandNode, out jointPose);
+            Assert.IsTrue(solverHandler.TransformTarget.position != jointPose.Position, $"Solver Handler switched to incorrect hand joint");
         }
     }
 }

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverHandlerTests.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverHandlerTests.cs
@@ -471,7 +471,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Check if SolverHandler starts with target on right hand joint
-            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, rightHandNode, out jointPose);
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, rightHandNode, out jointPose);
             Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler started tracking incorrect hand joint");
 
             // Hide the right hand and make the left hand active at a new position
@@ -482,7 +482,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Check if the SolverHandler moves the target to the left hand joint
-            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, leftHandNode, out jointPose);
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, leftHandNode, out jointPose);
             Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not switch to active hand joint");
 
             // Repeat the test, but hide the left hand this time
@@ -493,7 +493,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Check if the SolverHandler moves the target back to the right hand joint
-            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, rightHandNode, out jointPose);
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, rightHandNode, out jointPose);
             Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not switch to final hand joint");
         }
 
@@ -534,7 +534,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Check if SolverHandler starts with target on right hand joint
-            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, rightHandNode, out jointPose);
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, rightHandNode, out jointPose);
             Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler started tracking incorrect hand joint");
 
             // Hide the right hand and make the left hand active at a new position
@@ -545,7 +545,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Check if the SolverHandler moves the target to the left hand joint
-            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, leftHandNode, out jointPose);
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, leftHandNode, out jointPose);
             Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not switch to active hand joint");
 
             // Repeat the test, but hide the left hand this time
@@ -556,7 +556,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             // Check if the SolverHandler moves the target back to the right hand joint
-            XRSubsystemHelpers.HandsAggregator.TryGetJoint(TrackedHandJoint.Palm, rightHandNode, out jointPose);
+            XRSubsystemHelpers.HandsAggregator.TryGetJoint(joint, rightHandNode, out jointPose);
             Assert.IsTrue(solverHandler.TransformTarget.position == jointPose.Position, $"Solver Handler did not switch to final hand joint");
         }
 


### PR DESCRIPTION
## Overview

Fixes SolverHandler issues when handedness flag is set to `Everything` (i.e. 0xFFFFFFFF or -1)

<img width="202" alt="image" src="https://user-images.githubusercontent.com/36461279/236562924-1637a5ad-bfe8-4be1-9a84-fd3f10b03bae.png">

When selecting `Everything` in the inspector, the serialized value gets set to -1 (or 0xFFFFFFFF) and not 0x3.  Because of the way `SolverHandler` was checking the handedness flag, this caused bug #11398.  

This change updates `SolverHandler` to use the `&` operator to correctly check for `handiness` including both `Left` and `Right` flags. 

The change also resolves the _TODO_ in `SolverHandler.IsHandTracked`.  The `XRSubsystemHelpers.HandsAggregator.TryGetJoint(...)` now appears to be correctly returning `false` when the joint is not found, and `true` when it is.  Prior to resolving the _TODO_ in `IsHandTracked`, `IsHandTracked` would always return true if there was a hand tracking system.  As a result, `currentTrackedHandedness` now can go from `left|right` to `none`, when TrackedHandedness is contain both the `left` and `right` flags (this was previously not possible). When `currentTrackedHandedness` goes from `left|right` to `none`, the `trackingTarget` should be set to `null`.  Originally this was not happening, because of this old logic in `AttachToNewTrackedObject()`:

```
UpdateCachedHandJointTransform();
target = cachedHandJointTransform;
```

This old logic would always set the `trackingTarget` to a non-null, even if the `cachedHandJointTransform` was pointing to a joint that was no longer being tracked.  Changing this logic to the following resolves this problem:

```
if (UpdateCachedHandJointTransform())
{
    target = cachedHandJointTransform;
}
```

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11398


## Verification
- [x] Added Unit Tests to verify bug is fixed
- [x] Ran Unit Tests in Editor
- [x] Ran ALL Samples on HL2 Device. Verify hand menu in all samples, and can skip to next and previous scenes via hand menu
- [x] Verified bug #11398 is resolved
