### PR TITLE
Fixes MRTK3's `Tap to Place` solver to work with any hand and interactor

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/TapToPlaceExample.unity
@@ -257,8 +257,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3986155c7a728454f8bbbabd2e274601, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  leftInteractor: {fileID: 1127029052}
-  rightInteractor: {fileID: 0}
+  leftInteractor: {fileID: 1127029054}
+  rightInteractor: {fileID: 1127029052}
   trackedTargetType: 1
   trackedHandedness: 3
   trackedHandJoint: 2
@@ -572,7 +572,20 @@ MonoBehaviour:
         m_Calls: []
   <OnClicked>k__BackingField:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 396224581}
+        m_TargetAssemblyTypeName: Microsoft.MixedReality.Toolkit.SpatialManipulation.TapToPlace,
+          Microsoft.MixedReality.Toolkit.SpatialManipulation
+        m_MethodName: StartPlacement
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   <OnEnabled>k__BackingField:
     m_PersistentCalls:
       m_Calls: []
@@ -1210,6 +1223,10 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 8479077998186684813, guid: 4d7e2f87fefe0ba468719b15288b46e7, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4d7e2f87fefe0ba468719b15288b46e7, type: 3}
 --- !u!4 &1127029051 stripped
@@ -1237,6 +1254,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 83e4e6cca11330d4088d729ab4fc9d9f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1127029054 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7115113329451106245, guid: 4d7e2f87fefe0ba468719b15288b46e7, type: 3}
+  m_PrefabInstance: {fileID: 1127029050}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e85416945309f8244a5715a2ec5c254f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1167916486
@@ -2650,7 +2678,20 @@ MonoBehaviour:
         m_Calls: []
   <OnClicked>k__BackingField:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 4125495309857526231}
+        m_TargetAssemblyTypeName: Microsoft.MixedReality.Toolkit.SpatialManipulation.TapToPlace,
+          Microsoft.MixedReality.Toolkit.SpatialManipulation
+        m_MethodName: StartPlacement
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   <OnEnabled>k__BackingField:
     m_PersistentCalls:
       m_Calls: []

--- a/com.microsoft.mrtk.spatialmanipulation/Editor/Solvers/TapToPlaceEditor.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Editor/Solvers/TapToPlaceEditor.cs
@@ -16,8 +16,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Editor
     {
         private TapToPlace instance;
 
-        private GUIContent placementActionContent = new GUIContent("Placement action");
-
         // Tap to Place properties
         private SerializedProperty placementAction;
         private SerializedProperty autoStart;
@@ -81,7 +79,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Editor
         {
             serializedObject.Update();
 
-            EditorGUILayout.PropertyField(placementAction, placementActionContent);
             EditorGUILayout.PropertyField(autoStart);
             EditorGUILayout.PropertyField(defaultPlacementDistance);
             EditorGUILayout.PropertyField(maxRaycastDistance);

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.InputSystem;
+using UnityEngine.XR.Interaction.Toolkit;
 using UnityPhysics = UnityEngine.Physics;
 
 namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
@@ -12,7 +14,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
     /// <summary>
     /// Tap to place is a far interaction component used to place objects on a surface.
     /// </summary>
-    [RequireComponent(typeof(StatefulInteractable))]
     [AddComponentMenu("MRTK/Spatial Manipulation/Solvers/Tap To Place")]
     public class TapToPlace : Solver
     {
@@ -237,8 +238,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         // Used to mark whether StartPlacement() is called before Start() is called.
         private bool placementRequested;
 
-        // The interactable used to pick up the obect. 
-        private StatefulInteractable interactable;
+        // Used to obtain list of known interactors
+        private XRInteractionManager interactionManager;
+
+        // Used to cache a known set of interactor
+        private List<IXRInteractor> interactorsCache;
 
         #region MonoBehaviour Implementation
 
@@ -257,9 +261,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
             startCalled = true;
 
-            interactable = gameObject.GetComponent<StatefulInteractable>();
-            RegisterPickupAction();
-
             if (AutoStart || placementRequested)
             {
                 StartPlacement();
@@ -272,8 +273,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
         protected override void OnDisable()
         {
-            UnregisterPlacementAction();
-            UnregisterPickupAction();
+            StopPlacement();
             base.OnDisable();
         }
 
@@ -284,13 +284,13 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
         /// <summary>
         /// Start the placement of a game object without the need of the OnPointerClicked event. The game object will begin to follow the 
-        /// TrackedTargetType (Head by default) at a default distance. StopPlacement() must be called after StartPlacement() to stop the 
+        /// TrackedTargetType (Head by default) at a default distance. StopPlacementViaPerformedAction() must be called after StartPlacement() to stop the 
         /// game object from following the TrackedTargetType.  The game object layer is changed to IgnoreRaycast temporarily and then
-        /// restored to its original layer in StopPlacement().
+        /// restored to its original layer in StopPlacementViaPerformedAction().
         /// </summary>
         public void StartPlacement()
         {
-            // Checking the amount of time passed between when StartPlacement or StopPlacement is called twice in
+            // Checking the amount of time passed between when StartPlacement or StopPlacementViaPerformedAction is called twice in
             // succession. If these methods are called twice very rapidly, the object will be
             // selected and then immediately unselected. If two calls occur within the
             // double click timeout, then return to prevent an immediate object state switch.
@@ -299,6 +299,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             {
                 return;
             }
+
             // Get the time of this click action
             LastTimeClicked = Time.time;
 
@@ -333,14 +334,31 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         }
 
         private static readonly ProfilerMarker StopPlacementPerfMarker =
-            new ProfilerMarker("[MRTK] TapToPlace.StopPlacement");
+            new ProfilerMarker("[MRTK] TapToPlace.StopPlacementViaPerformedAction");
 
         /// <summary>
-        /// Stop the placement of a game object without the need of the OnPointerClicked event. 
+        /// Stop the placement of a game object via an action's performance.
         /// </summary>
-        public void StopPlacement(InputAction.CallbackContext context)
+        private void StopPlacementViaPerformedAction(InputAction.CallbackContext context)
         {
-            // Checking the amount of time passed between when StartPlacement or StopPlacement is called twice in
+            StopPlacement();
+        }
+
+        /// <summary>
+        /// Stop the placement of a game object via an interactor's select event.
+        /// </summary>
+        /// <param name="args"></param>
+        private void StopPlacementViaSelect(SelectEnterEventArgs args)
+        {
+            StopPlacement();
+        }
+
+        /// <summary>
+        /// Stop the placement of a game object. 
+        /// </summary>
+        public void StopPlacement()
+        {
+            // Checking the amount of time passed between when StartPlacement or StopPlacementViaPerformedAction is called twice in
             // succession. If these methods are called twice very rapidly, the object will be
             // selected and then immediately unselected. If two calls occur within the
             // double click timeout, then return to prevent an immediate object state switch.
@@ -353,7 +371,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
             using (StopPlacementPerfMarker.Auto())
             {
-                // Added for code configurability to avoid multiple calls to StopPlacement in a row
+                // Added for code configurability to avoid multiple calls to StopPlacementViaPerformedAction in a row
                 if (IsBeingPlaced)
                 {
                     // Change the game object layer back to the game object's layer on start
@@ -467,26 +485,38 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void RegisterPlacementAction()
         {
-            InputAction placementAction = GetInputActionFromReference(placementActionReference);
-            if (placementAction == null)
-            {
-                Debug.Log("Failed to register the placement action, the action reference was null or contained no action.");
-                return;
-            }
-            placementAction.performed += StopPlacement;
-        }
+            // Refresh the registeration if they already exist
+            UnregisterPlacementAction();
 
-        /// <summary>
-        /// Registers the event which performs pickup.
-        /// </summary>
-        private void RegisterPickupAction()
-        {
-            if (interactable == null)
+            if (interactionManager == null)
             {
-                Debug.Log("Failed to register the pick up event. There is no StatefulInteractable set.");
-                return;
+                interactionManager = FindObjectOfType<XRInteractionManager>();
+                if (interactionManager == null)
+                {
+                    Debug.LogError("No interaction manager found in scene. Please add an interaction manager to the scene.");
+                }
             }
-            interactable.OnClicked.AddListener(StartPlacement);
+
+            if (interactorsCache == null)
+            {
+                interactorsCache = new List<IXRInteractor>();
+            }
+
+            // Try registering for the controller's "action" so object selection isn't required for placement.
+            // If no controller, then fallback to using object selections for placement.
+            interactionManager.GetRegisteredInteractors(interactorsCache);
+            foreach (IXRInteractor interactor in interactorsCache)
+            {
+                if (interactor is XRBaseControllerInteractor controllerInteractor &&
+                    controllerInteractor.xrController is ActionBasedController actionController)
+                {
+                    actionController.selectAction.action.performed += StopPlacementViaPerformedAction;
+                }
+                else if (interactor is IXRSelectInteractor selectInteractor)
+                {
+                    selectInteractor.selectEntered.AddListener(StopPlacementViaSelect);
+                }
+            }
         }
 
         /// <summary>
@@ -494,26 +524,22 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// </summary>
         private void UnregisterPlacementAction()
         {
-            InputAction placementAction = GetInputActionFromReference(placementActionReference);
-            if (placementAction == null)
+            if (interactorsCache != null)
             {
-                Debug.Log("Failed to unregister the placement action, the action reference was null or contained no action.");
-                return;
+                foreach (IXRInteractor interactor in interactorsCache)
+                {
+                    if (interactor is XRBaseControllerInteractor controllerInteractor &&
+                        controllerInteractor.xrController is ActionBasedController actionController)
+                    {
+                        actionController.selectAction.action.performed -= StopPlacementViaPerformedAction;
+                    }
+                    else if (interactor is IXRSelectInteractor selectInteractor)
+                    {
+                        selectInteractor.selectEntered.RemoveListener(StopPlacementViaSelect);
+                    }
+                }
+                interactorsCache.Clear();
             }
-            placementAction.performed -= StopPlacement;
-        }
-
-        /// <summary>
-        /// Unregisters the event which performs pickup.
-        /// </summary>
-        private void UnregisterPickupAction()
-        {
-            if (interactable == null)
-            {
-                Debug.Log("Failed to unregister the pick up event. There is no StatefulInteractable set.");
-                return;
-            }
-            interactable.OnClicked.RemoveListener(StartPlacement);
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
@@ -17,18 +17,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
     [AddComponentMenu("MRTK/Spatial Manipulation/Solvers/Tap To Place")]
     public class TapToPlace : Solver
     {
-        [SerializeField]
-        [Tooltip("The input action which is to control placement.")]
-        private InputActionReference placementActionReference = null;
-
-        /// <summary>
-        /// The input action which is to control placement.
-        /// </summary>
-        public InputActionReference PlacementActionReference
-        {
-            get => placementActionReference;
-            set => placementActionReference = value;
-        }
 
         // todo: needed? [Space(10)]
         [SerializeField]

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
@@ -347,7 +347,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         /// <summary>
         /// Stop the placement of a game object via an interactor's select event.
         /// </summary>
-        /// <param name="args"></param>
         private void StopPlacementViaSelect(SelectEnterEventArgs args)
         {
             StopPlacement();

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTests.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTests.cs
@@ -1,0 +1,184 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.SpatialManipulation;
+using System.Collections;
+using Microsoft.MixedReality.Toolkit.Input.Tests;
+using Microsoft.MixedReality.Toolkit;
+using Microsoft.MixedReality.Toolkit.Core.Tests;
+
+namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
+{
+    /// <summary>
+    /// Tests for TapToPlace solver
+    /// </summary>
+    public class SolverTapToPlaceTests : BaseRuntimeInputTests
+    {
+        /// <summary>
+        /// Verify TapToPlace can move an object to the end of the right hand ray.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TapToPlaceFollowsRightHandRay()
+        {
+            // Disable gaze interactions for this unit test;
+            InputTestUtilities.DisableGaze();
+
+            // Set up GameObject with a SolverHandler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var solverHandler = testObject.AddComponent<SolverHandler>();
+            var solver = testObject.AddComponent<TapToPlace>();
+
+            // Disable smoothing so moving happens instantly. This makes testing positions easier.
+            solver.Smoothing = false;
+
+            // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Both;
+            solverHandler.TrackedTargetType = TrackedObjectType.Interactor;
+            var lookup = GameObject.FindObjectOfType<ControllerLookup>();
+            var leftInteractor = lookup.LeftHandController.GetComponentInChildren<MRTKRayInteractor>();
+            var rightInteractor = lookup.RightHandController.GetComponentInChildren<MRTKRayInteractor>();
+            solverHandler.LeftInteractor = leftInteractor;
+            solverHandler.RightInteractor = rightInteractor;
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+            var rightHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.05f, 1f));
+            var leftHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, -0.05f, 1f));
+
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(3.0f);
+
+            yield return rightHand.Show(rightHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return rightHand.AimAt(testObject.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            yield return leftHand.Show(leftHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return leftHand.AimAt(testObject.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace starts without being in "placement" mode.
+            Assert.IsFalse(solver.IsBeingPlaced, "TapToPlace should have starting without being in placement mode.");
+
+            // Start placement and move hand.
+            solver.StartPlacement();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace started.
+            Assert.IsTrue(solver.IsBeingPlaced, "TapToPlace should have started.");
+            var testObjectStartPosition = testObject.transform.position;
+
+            // Aim hand and move object.
+            yield return rightHand.AimAt(InputTestUtilities.InFrontOfUser(new Vector3(0.05f, 0.1f, 2.0f)));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Verify shape moved to placement
+            var testObjectPlacementPosition = testObject.transform.position;
+            Assert.AreNotEqual(testObjectStartPosition, testObjectPlacementPosition, $"Game object did not move");
+
+            // Wait for solvers double click prevention timeout
+            yield return new WaitForSeconds(0.5f + 0.1f);
+
+            // Clicking with opposite hand should stop movement
+            yield return leftHand.Click();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace stopped with pinch.
+            Assert.IsFalse(solver.IsBeingPlaced, "TapToPlace should have stopped with left hand pinch.");
+
+            // Aim hand
+            yield return rightHand.AimAt(InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, -0.1f, 2.0f)));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Verify shape did not moved 
+            var testObjectFinalPosition = testObject.transform.position;
+            Assert.AreEqual(testObjectPlacementPosition, testObjectFinalPosition, $"Game object should not have moved.");
+        }
+
+        /// <summary>
+        /// Verify TapToPlace can move an object to the end of the left hand ray.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TapToPlaceFollowsLeftHandRay()
+        {
+            // Disable gaze interactions for this unit test;
+            InputTestUtilities.DisableGaze();
+
+            // Set up GameObject with a SolverHandler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var solverHandler = testObject.AddComponent<SolverHandler>();
+            var solver = testObject.AddComponent<TapToPlace>();
+
+            // Disable smoothing so moving happens instantly. This makes testing positions easier.
+            solver.Smoothing = false;
+
+            // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Both;
+            solverHandler.TrackedTargetType = TrackedObjectType.Interactor;
+            var lookup = GameObject.FindObjectOfType<ControllerLookup>();
+            var leftInteractor = lookup.LeftHandController.GetComponentInChildren<MRTKRayInteractor>();
+            var rightInteractor = lookup.RightHandController.GetComponentInChildren<MRTKRayInteractor>();
+            solverHandler.LeftInteractor = leftInteractor;
+            solverHandler.RightInteractor = rightInteractor;
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+            var rightHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.05f, 1f));
+            var leftHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, -0.05f, 1f));
+
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(3.0f);
+
+            yield return leftHand.Show(leftHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return leftHand.AimAt(testObject.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            yield return rightHand.Show(rightHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return rightHand.AimAt(testObject.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace starts without being in "placement" mode.
+            Assert.IsFalse(solver.IsBeingPlaced, "TapToPlace should have starting without being in placement mode.");
+
+            // Start placement and move hand.
+            solver.StartPlacement();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace started.
+            Assert.IsTrue(solver.IsBeingPlaced, "TapToPlace should have started.");
+            var testObjectStartPosition = testObject.transform.position;
+
+            // Aim hand and move object.
+            yield return leftHand.AimAt(InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, 0.1f, 2.0f)));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Verify shape moved to placement
+            var testObjectPlacementPosition = testObject.transform.position;
+            Assert.AreNotEqual(testObjectStartPosition, testObjectPlacementPosition, $"Game object did not move");
+
+            // Wait for solvers double click prevention timeout
+            yield return new WaitForSeconds(0.5f + 0.1f);
+
+            // Clicking with opposite hand should stop movement
+            yield return rightHand.Click();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace stopped with pinch.
+            Assert.IsFalse(solver.IsBeingPlaced, "TapToPlace should have stopped with left hand pinch.");
+
+            // Aim hand
+            yield return leftHand.AimAt(InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.1f, 2.0f)));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Verify shape did not moved 
+            var testObjectFinalPosition = testObject.transform.position;
+            Assert.AreEqual(testObjectPlacementPosition, testObjectFinalPosition, $"Game object should not have moved.");
+        }
+    }
+}

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTests.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTests.cs
@@ -2,10 +2,8 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.SpatialManipulation;
 using System.Collections;
 using Microsoft.MixedReality.Toolkit.Input.Tests;
-using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.Core.Tests;
 
 namespace Microsoft.MixedReality.Toolkit.SpatialManipulation.Runtime.Tests

--- a/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTests.cs.meta
+++ b/com.microsoft.mrtk.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51c9c321d1d06ea4c907036f158480be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Fixes MRTK3's `Tap to Place` solver to work with any hand and any interactor (even speech). This change, on `StartPlacement`, queries the `XRInteractionManager` for all registered interactors, and then registers for the interactors' select events.  This is an alternative to requiring the developer to specify particular actions. 

Note, this change also removes the `StatefulInteractable` requirement.  The consumer of `TapToPlace` is now required to determine when `StartPlacement` is invoked. This change is meant to provide extensibility for future scenarios which may not require or use `StatefulInteractables`.

This also adds Unit Tests to validate `TapToPlace`.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11527


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
