### PR TITLE
Adding logic to show the cursor in the non-native keyboard's input field

### DIFF
--- a/com.microsoft.mrtk.uxcomponents/Keyboard/NonNativeKeyboard/NonNativeKeyboard.prefab
+++ b/com.microsoft.mrtk.uxcomponents/Keyboard/NonNativeKeyboard/NonNativeKeyboard.prefab
@@ -15438,6 +15438,7 @@ MonoBehaviour:
   <SubmitOnEnter>k__BackingField: 1
   <CloseOnInactivity>k__BackingField: 0
   <CloseOnInactivityTime>k__BackingField: 15
+  <AutoSelectInputField>k__BackingField: 1
   alphaKeysSection: {fileID: 103102}
   symbolKeysSection: {fileID: 173904}
   defaultBottomKeysSection: {fileID: 154526}

--- a/com.microsoft.mrtk.uxcore/Keyboard/NonNative/NonNativeKeyboard.cs
+++ b/com.microsoft.mrtk.uxcore/Keyboard/NonNative/NonNativeKeyboard.cs
@@ -136,6 +136,18 @@ namespace Microsoft.MixedReality.Toolkit.UX
         public float CloseOnInactivityTime { get; set; } = 15;
 
         /// <summary>
+        /// If this property is set to `true`, the keyboard's input field will automatically be selected when the keyboard
+        /// is opened and when a key is activated. To prevent this auto select behavior, set this property to `false`. The
+        /// default value is `true`.
+        /// </summary>
+        /// <remarks>
+        /// This select behavior can be used to show the input input fields's cursor (or caret) after the keyboard is opened
+        /// or when a keyboard key is activated.
+        /// </remarks>
+        [field: SerializeField, Tooltip("If this property is set to `true`, the keyboard's input field will automatically be selected when the keyboard is opened and when a key is activated. To prevent this auto select behavior, set this property to `false`. ")]
+        public bool AutoSelectInputField { get; set; } = true;
+
+        /// <summary>
         /// Accessor reporting shift state of keyboard.
         /// </summary>
         public bool IsShifted { get; private set; }
@@ -329,6 +341,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             {
                 InputField.ActivateInputField();
                 UpdateCaretPosition(Text.Length);
+                AutoSelectInputFieldIfEnabled();
             }
         }
 
@@ -375,6 +388,8 @@ namespace Microsoft.MixedReality.Toolkit.UX
                 {
                     Shift(false);
                 }
+
+                AutoSelectInputFieldIfEnabled();
             }
             else
             {
@@ -446,6 +461,8 @@ namespace Microsoft.MixedReality.Toolkit.UX
                         Debug.LogErrorFormat("The {0} key on this keyboard hasn't been assigned a function.", functionKey.name);
                         break;
                 }
+
+                AutoSelectInputFieldIfEnabled();
             }
             else
             {
@@ -751,6 +768,21 @@ namespace Microsoft.MixedReality.Toolkit.UX
                 }
             }
             LayoutRebuilder.ForceRebuildLayoutImmediate(GetComponent<RectTransform>());
+        }
+
+        /// <summary>
+        /// If `AutoSelectInputField` is `true`, select the keyboard's input field. 
+        /// </summary>
+        /// <remarks>
+        /// This select behavior can be used to show the input input fields's cursor (or caret) after the keyboard is opened
+        /// or when a keyboard key is activated.
+        /// </remarks>
+        private void AutoSelectInputFieldIfEnabled()
+        {
+            if (AutoSelectInputField && InputField != null)
+            {
+                InputField.Select();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

Adding logic to show the cursor in the non-native keyboard's input field.  When the non-native keyboard is shown or a keyboard key is activated, the non-native keyboard's input field will be selected.  This selection results in the cursor being shown on the input field, making it possible to move around cursor around.

This behavior can be disabled by setting `AutoSelectInputField` to `false`

<img width="459" alt="image" src="https://github.com/microsoft/MixedRealityToolkit-Unity/assets/36461279/d76bc613-a7b9-474b-bd25-5c25c774bcf6">

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11558


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
