### PR TITLE
Updating gitignore in Unity projects dir, so to ignore scenes generated by Unity's test runner

### DIFF
--- a/UnityProjects/.gitignore
+++ b/UnityProjects/.gitignore
@@ -59,6 +59,10 @@ ExportedObj/
 # Unity3D generated file on crash reports
 sysinfo.txt
 
+# Unity3D Test Runner generated files
+*/[Aa]ssets/InitTestScene*.unity
+*/[Aa]ssets/InitTestScene*.unity.meta
+
 # Builds
 *.apk
 *.aab


### PR DESCRIPTION
## Overview

This change updates the `.gitignore` file in this Unity projects directory, so to ignore scenes generated by Unity's test runner.