### PR TITLE
Fix execution order with ProximityLights

### DIFF
--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
@@ -47,7 +47,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected void OnEnable()
         {
             rayInteractor.selectEntered.AddListener(LocateTargetHitPoint);
-            Application.onBeforeRender += UpdateReticle;
 
             // If no custom reticle root is specified, just use the interactor's transform.
             if (reticleRoot == null)
@@ -60,14 +59,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected void OnDisable()
         {
             rayInteractor.selectEntered.RemoveListener(LocateTargetHitPoint);
-            Application.onBeforeRender -= UpdateReticle;
 
             ReticleSetActive(false);
         }
 
+        private void Update()
+        {
+            UpdateReticle();
+        }
+
         private static readonly ProfilerMarker UpdateReticlePerfMarker = new ProfilerMarker("[MRTK] MRTKRayReticleVisual.UpdateReticle");
 
-        [BeforeRenderOrder(XRInteractionUpdateOrder.k_BeforeRenderLineVisual)]
         private void UpdateReticle()
         {
             using (UpdateReticlePerfMarker.Auto())


### PR DESCRIPTION

## Overview
The graphics tools ProximityLight class updates in LateUpdate().  This moves positioning of the reticle and prox light to Update() to make sure the position changes happen before ProximityLight.cs updates the shader parameters.

## Changes
- Fixes: #10933  .


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
