### PR TITLE
UnityEngine namespace to avoid collisions

### DIFF
--- a/com.microsoft.mrtk.input/Visualizers/HandJointVisualizer/HandJointVisualizer.cs
+++ b/com.microsoft.mrtk.input/Visualizers/HandJointVisualizer/HandJointVisualizer.cs
@@ -29,10 +29,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("Joint visualization mesh.")]
-        private Mesh jointMesh;
+        private UnityEngine.Mesh jointMesh;
 
         /// <summary> Joint visualization mesh. </summary>
-        public Mesh JointMesh { get => jointMesh; set => jointMesh = value; }
+        public UnityEngine.Mesh JointMesh { get => jointMesh; set => jointMesh = value; }
 
         [SerializeField]
         [Tooltip("Joint visualization material.")]


### PR DESCRIPTION
## Overview
Fixing namespace (UnityEngine.Mesh) clash, when MRTK is used with other packages.

## Changes
- Fixes:  HandJointVisualizer uses UnityEngine.Mesh as a type. To avoid clashing with other types, full namespace was added.