### PR TITLE
Fixing z flighting in non native keyboard when using 16bit depth buffer

### DIFF
--- a/com.microsoft.mrtk.uxcomponents/Keyboard/NonNativeKeyboard/NonNativeKeyboard.prefab
+++ b/com.microsoft.mrtk.uxcomponents/Keyboard/NonNativeKeyboard/NonNativeKeyboard.prefab
@@ -34203,7 +34203,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6916386755006368770}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:


### PR DESCRIPTION
## Overview
There's noticeable z-fighting in the keyboard preview text box on the non-native keyboard prefab. This change fixed that.