### PR TITLE
Updating MRTK3's min input system to 1.5.1 so you avoid stack overflows in 1.5.0

### DIFF
--- a/com.microsoft.mrtk.input/package.json
+++ b/com.microsoft.mrtk.input/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "com.microsoft.mrtk.core": "3.0.0",
     "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
-    "com.unity.inputsystem": "1.3.0",
+    "com.unity.inputsystem": "1.5.1",
     "com.unity.xr.arfoundation": "5.0.5",
     "com.unity.xr.interaction.toolkit": "2.3.0",
     "com.unity.xr.core-utils": "2.1.0"

--- a/com.microsoft.mrtk.spatialmanipulation/package.json
+++ b/com.microsoft.mrtk.spatialmanipulation/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "com.microsoft.mrtk.core": "3.0.0",
     "com.microsoft.mrtk.uxcore": "3.0.0",
-    "com.unity.inputsystem": "1.3.0",
+    "com.unity.inputsystem": "1.5.1",
     "com.unity.xr.interaction.toolkit": "2.3.0"
   },
   "msftOptionalPackages": {

--- a/com.microsoft.mrtk.uxcore/package.json
+++ b/com.microsoft.mrtk.uxcore/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "com.microsoft.mrtk.core": "3.0.0",
     "com.microsoft.mrtk.graphicstools.unity": "0.4.0",
-    "com.unity.inputsystem": "1.3.0",
+    "com.unity.inputsystem": "1.5.1",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.xr.interaction.toolkit": "2.3.0"
   },


### PR DESCRIPTION
## Overview
This updates the min version of com.unity.inputsystem from 1.3.0 to 1.5.1.  

When app's upgrade to the latest 2021.3 LTS, Unity will automatically pull in com.unity.inputsystem 1.5.0.  This is bad for HoloLens, dues to a stack overflow issue mentioned in #11421.  To avoid the stack overflow, this change updates MRTK3's min input system version to 1.5.1, which contains a fix for the stack overflow.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11604