### PR TITLE
Adding in some missing documentation to the MRTK3 source.

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/ScrollRectCurve.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/ScrollRectCurve.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
     /// look great on items that are vertically large, as items are curved at a
     /// GameObject level. Their contents will remain flat.
     /// </summary>
-    [AddComponentMenu("MRTX/Examples/Scroll Rect Curve")]
+    [AddComponentMenu("MRTK/Examples/Scroll Rect Curve")]
     public class ScrollRectCurve : MonoBehaviour
     {
         [SerializeField]

--- a/com.microsoft.mrtk.core/Camera/CameraSettings.cs
+++ b/com.microsoft.mrtk.core/Camera/CameraSettings.cs
@@ -6,6 +6,9 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit
 {
+    /// <summary>
+    /// Class that contains settings which are applied to <see cref="CameraSettingsManager"/>.
+    /// </summary>
     [Serializable]
     [AddComponentMenu("MRTK/Core/Camera Settings")]
     public class CameraSettings

--- a/com.microsoft.mrtk.core/Camera/CameraSettings.cs
+++ b/com.microsoft.mrtk.core/Camera/CameraSettings.cs
@@ -7,20 +7,20 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit
 {
     /// <summary>
-    /// Class that contains settings which are applied to <see cref="CameraSettingsManager"/>.
+    /// Class that contains settings which are applied to <see cref="Microsoft.MixedReality.Toolkit.CameraSettingsManager">CameraSettingsManager</see>.
     /// </summary>
     [Serializable]
     [AddComponentMenu("MRTK/Core/Camera Settings")]
     public class CameraSettings
     {
         /// <summary>
-        /// Constructor.
+        /// Initializes a new instance of the <see cref="CameraSettings"/> class.
         /// </summary>
         public CameraSettings() : this(DisplayType.Transparent)
         { }
 
         /// <summary>
-        /// Constructor.
+        /// Initializes a new instance of the <see cref="CameraSettings"/> class.
         /// </summary>
         /// <param name="displayType">
         /// <see cref="DisplayType"/> value describing the device display.
@@ -49,7 +49,14 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        /// <summary>
+        /// The default clear mode used for opaque displays.
+        /// </summary>
         public static readonly CameraClearFlags DefaultClearModeOpaque = CameraClearFlags.Skybox;
+
+        /// <summary>
+        /// The default clear mode used for transparent displays.
+        /// </summary>
         public static readonly CameraClearFlags DefaultClearModeTransparent = CameraClearFlags.SolidColor;
 
         [SerializeField]

--- a/com.microsoft.mrtk.core/Data/Binding Templates/UXBindingProfileTemplate.cs
+++ b/com.microsoft.mrtk.core/Data/Binding Templates/UXBindingProfileTemplate.cs
@@ -7,9 +7,9 @@ namespace Microsoft.MixedReality.Toolkit
 {
     /// <summary>
     /// This profile combines binding profiles for all Data Consumers used in the MRTK UXComponents components and
-    /// is used by the BindingConfigurator that can be dropped on any prefab (or gameobject hierarchy)
+    /// is used by the BindingConfigurator that can be dropped on any prefab (or game object hierarchy)
     /// to automatically configure all Data Consumers that will be needed to make those game objects data bindable
-    /// and themable.
+    /// and capable of theming.
     /// </summary>
     [CreateAssetMenu(fileName = "MRTK_UX_BindingProfile", menuName = "MRTK/Data Binding/UXBindingProfile")]
     public class UXBindingProfileTemplate : ScriptableObject
@@ -17,11 +17,20 @@ namespace Microsoft.MixedReality.Toolkit
         [Tooltip("Optional type specifiers for data sources to be injected into data consumers. This will typically be one data and one theme data source. If left empty, the default 'data' and 'theme' data sources will be used.")]
         [SerializeField]
         private string[] dataSourceTypes;
+
+        /// <summary>
+        /// Optional type specifiers for data sources to be injected into data consumers. This will typically be one data and one theme data source. 
+        /// If left empty, the default 'data' and 'theme' data sources will be used.
+        /// </summary>
         public string[] DataSourceTypes => dataSourceTypes;
 
         [Tooltip("An array of binding profiles for specific classes, typically data consumers.")]
         [SerializeField]
         private ClassDataBindingProfile[] classBindings;
+        
+        /// <summary>
+        /// An array of binding profiles for specific classes, typically data consumers.
+        /// </summary>
         public ClassDataBindingProfile[] ClassBindings => classBindings;
     }
 }

--- a/com.microsoft.mrtk.core/Interactables/StatefulInteractable.cs
+++ b/com.microsoft.mrtk.core/Interactables/StatefulInteractable.cs
@@ -9,7 +9,11 @@ using UnityEngine.Serialization;
 using UnityEngine.XR.Interaction.Toolkit;
 
 namespace Microsoft.MixedReality.Toolkit
-{
+{    
+    /// <summary>
+    /// An extended version of <see cref="Microsoft.MixedReality.Toolkit.MRTKBaseInteractable">MRTKBaseInteractable</see> that adds additional
+    /// functionality such as speech support, gaze support, and toggle behaviors.
+    /// </summary>
     [AddComponentMenu("MRTK/Core/Stateful Interactable")]
     public class StatefulInteractable : MRTKBaseInteractable
     {
@@ -20,12 +24,21 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         public enum ToggleType
         {
-            // Interactable will not enter toggle states
-            // unless forced by code (ForceSetToggle)
+            /// <summary>
+            /// The interactable will not enter toggle states unless forces by code 
+            /// using the <see cref="ForceSetToggled" /> function.
+            /// </summary>
             Button,
-            // User can toggle on and off
+
+            /// <summary>
+            /// The user can toggle on and off the interactable.
+            /// </summary>
             Toggle,
-            // User can only toggle on, not off. Useful for radio buttons.
+            
+            /// <summary>
+            /// The User can only toggle on the interactable, but not toggle off. 
+            /// This value is useful for radio buttons.
+            /// </summary>
             OneWayToggle
         }
 

--- a/com.microsoft.mrtk.core/Subsystems/MRTKSubsystemProvider.cs
+++ b/com.microsoft.mrtk.core/Subsystems/MRTKSubsystemProvider.cs
@@ -30,8 +30,19 @@ namespace Microsoft.MixedReality.Toolkit.Subsystems
         /// </summary>
         public virtual void FixedUpdate() { }
 
+        /// <summary>
+        /// Destroys this instance of a Unity subsystem.
+        /// </summary>
         public override void Destroy() { }
+
+        /// <summary>
+        /// Starts an instance of a Unity subsystem.
+        /// </summary>
         public override void Start() { }
+
+        /// <summary>
+        /// Stops an instance of a Unity subsystem.
+        /// </summary>
         public override void Stop() { }
     }
 }

--- a/com.microsoft.mrtk.core/Utilities/Attributes/LabelWidthAttribute.cs
+++ b/com.microsoft.mrtk.core/Utilities/Attributes/LabelWidthAttribute.cs
@@ -6,11 +6,24 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit
 {
+    /// <summary>
+    /// Indicates that the serializable property's label should be of a particular width when rendered in the Unity inspector window.
+    /// </summary>
+    /// <remarks>
+    /// This attribute does not indicate a font size change, and is only applicable to applications running in the Unity Editor.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Field)]
     public class LabelWidthAttribute : PropertyAttribute
     {
+        /// <summary>
+        /// Get the width to apply to the serializable property's label when the label is rendered in the Unity inspector window.
+        /// </summary>
         public float Width { get; }
 
+        /// <summary>
+        /// The constructor for <see cref="LabelWidthAttribute"/>
+        /// </summary>
+        /// <param "name">The width to apply to the serializable property's label when the label is rendered in the Unity inspector window.</param>
         public LabelWidthAttribute(float width)
         {
             Width = width;

--- a/com.microsoft.mrtk.core/Utilities/Attributes/LabelWidthAttribute.cs
+++ b/com.microsoft.mrtk.core/Utilities/Attributes/LabelWidthAttribute.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit
         public float Width { get; }
 
         /// <summary>
-        /// The constructor for <see cref="LabelWidthAttribute"/>
+        /// Initializes a new instance of the <see cref="LabelWidthAttribute"/> class.
         /// </summary>
         /// <param "name">The width to apply to the serializable property's label when the label is rendered in the Unity inspector window.</param>
         public LabelWidthAttribute(float width)

--- a/com.microsoft.mrtk.core/Utilities/Extensions/MathfExtensions.cs
+++ b/com.microsoft.mrtk.core/Utilities/Extensions/MathfExtensions.cs
@@ -10,6 +10,13 @@ namespace Microsoft.MixedReality.Toolkit
     /// </summary>
     public static class MathExtensions
     {
+        /// <summary>
+        /// Get the most significant bit from the input value. 
+        /// </summary> 
+        /// <param name="x">The input value to examine.</param>
+        /// <returns>
+        /// Integer value that is equal to the most significant bit within the input value. 
+        /// </returns>
         public static int MostSignificantBit(this int x)
         {
             x |= (x >> 1);
@@ -21,25 +28,59 @@ namespace Microsoft.MixedReality.Toolkit
             return x & ~(x >> 1);
         }
 
-        public static int PowerOfTwoGreaterThanOrEqualTo(this int v)
+        /// <summary>
+        /// Get the value that is the next power of two at or after the input value.
+        /// </summary>
+        /// <param name="input">The value to test.</param>
+        /// <returns>
+        /// If the input value is a power of two, the input value is returned. 
+        /// Otherwise the next power of two, after the input value, is returned.
+        /// </returns>
+        public static int PowerOfTwoGreaterThanOrEqualTo(this int input)
         {
-            return Mathf.IsPowerOfTwo(v) ? v : Mathf.NextPowerOfTwo(v);
+            return Mathf.IsPowerOfTwo(input) ? input : Mathf.NextPowerOfTwo(input);
         }
 
-        public static Vector3Int PowerOfTwoGreaterThanOrEqualTo(this Vector3Int v)
+        /// <summary>
+        /// For each component in a `Vector3Int`, get the component value that is the next power of two at or
+        /// after the input component value.
+        /// </summary>
+        /// <param name="inputVector">The vector containing the component values to test.</param>
+        /// <returns>
+        /// A Vector3Int containing components that are a power of two. If an input's component value is a power of two, 
+        /// than that component value is in the returned in the corresponding vector position. Otherwise the next 
+        /// power of two, after the component value,  is returned in the corresponding vector position.
+        /// </returns>
+        public static Vector3Int PowerOfTwoGreaterThanOrEqualTo(this Vector3Int inputVector)
         {
-            return new Vector3Int(PowerOfTwoGreaterThanOrEqualTo(v.x),
-                                  PowerOfTwoGreaterThanOrEqualTo(v.y),
-                                  PowerOfTwoGreaterThanOrEqualTo(v.z));
+            return new Vector3Int(PowerOfTwoGreaterThanOrEqualTo(inputVector.x),
+                                  PowerOfTwoGreaterThanOrEqualTo(inputVector.y),
+                                  PowerOfTwoGreaterThanOrEqualTo(inputVector.z));
         }
 
-        public static int CubicToLinearIndex(Vector3Int ndx, Vector3Int size)
+        /// <summary>
+        /// Convert a 3D texture's cubic index to its linear representation.
+        /// </summary>
+        /// <param name="cubicIndex">A cubic index into a 3D texture.</param>
+        /// <param name="size">The 3D texture's dimensions or size.</param>
+        /// <returns>
+        /// The linear index for the given cubic index and size.
+        /// </returns>
+        public static int CubicToLinearIndex(Vector3Int cubicIndex, Vector3Int size)
         {
-            return (ndx.x) +
-                   (ndx.y * size.x) +
-                   (ndx.z * size.x * size.y);
+            return (cubicIndex.x) +
+                   (cubicIndex.y * size.x) +
+                   (cubicIndex.z * size.x * size.y);
         }
 
+        /// <summary>
+        /// Convert a 3D texture's linear index to its cubic representation.
+        /// </summary>
+        /// <param name="linearIndex">A linear index into a 3D texture.</param>
+        /// <param name="size">The 3D texture's dimensions or size.</param>
+        /// <returns>
+        /// The cubic index for the given linear index and size.
+        /// </returns>
         public static Vector3Int LinearToCubicIndex(int linearIndex, Vector3Int size)
         {
             return new Vector3Int((linearIndex / 1) % size.x,
@@ -47,6 +88,16 @@ namespace Microsoft.MixedReality.Toolkit
                                   (linearIndex / (size.x * size.y)) % size.z);
         }
 
+        /// <summary>
+        /// Preform a component wise clamp on a given vector. Each input component will be clamped by its 
+        /// corresponding minimum and maximum component as specified by the `min` and `max` input vectors.
+        /// </summary>
+        /// <param name="value">The vector whose components will be clamped by the given minimum and maximum vectors.</param>
+        /// <param name="min">The vector whose components define the minimum value for the corresponding input vector component.</param>
+        /// <param name="max">The vector whose components define the maximum value for the corresponding input vector component.</param>
+        /// <returns>
+        /// Returns a new vector whose components have been clamped by the specified minimum and maximum values.
+        /// </returns>
         public static Vector3 ClampComponentWise(Vector3 value, Vector3 min, Vector3 max)
         {
             return new Vector3(Mathf.Clamp(value.x, min.x, max.x),

--- a/com.microsoft.mrtk.core/Utilities/Extensions/VectorExtensions.cs
+++ b/com.microsoft.mrtk.core/Utilities/Extensions/VectorExtensions.cs
@@ -12,47 +12,127 @@ namespace Microsoft.MixedReality.Toolkit
     /// </summary>
     public static class VectorExtensions
     {
+        /// <summary>
+        /// Multiple 2D vector components together to returned a new scaled vector.
+        /// </summary>
+        /// <param name="value">The 2D vector to be scaled.</param>
+        /// <param name="scale">The 2D vector used to scale the value.</param>
+        /// <returns>
+        /// A new 3D vector containing the product or scaled components.
+        /// </returns>
         public static Vector2 Mul(this Vector2 value, Vector2 scale)
         {
             return new Vector2(value.x * scale.x, value.y * scale.y);
         }
 
-        public static Vector2 Div(this Vector2 value, Vector2 scale)
+        /// <summary>
+        /// Divide 2D vector components by the given divisor components.
+        /// </summary>
+        /// <param name="value">The 2D vector containing the divided components.</param>
+        /// <param name="divisor">The 2D vector containing the divisor components.</param>
+        /// <returns>
+        /// A new 2D vector containing the quotient components.
+        /// </returns>
+        public static Vector2 Div(this Vector2 value, Vector2 divisor)
         {
-            return new Vector2(value.x / scale.x, value.y / scale.y);
+            return new Vector2(value.x / divisor.x, value.y / divisor.y);
         }
 
+        /// <summary>
+        /// Multiple 3D vector components together to returned a new scaled vector.
+        /// </summary>
+        /// <param name="value">The 3D vector to be scaled.</param>
+        /// <param name="scale">The 3D vector used to scale the value.</param>
+        /// <returns>
+        /// A new 3D vector containing the product or scaled components.
+        /// </returns>
         public static Vector3 Mul(this Vector3 value, Vector3 scale)
         {
             return new Vector3(value.x * scale.x, value.y * scale.y, value.z * scale.z);
         }
 
-        public static Vector3 Div(this Vector3 value, Vector3 scale)
+        /// <summary>
+        /// Divide 3D vector components by the given divisor components.
+        /// </summary>
+        /// <param name="value">The 3D vector containing the divided components.</param>
+        /// <param name="divisor">The 3D vector containing the divisor components.</param>
+        /// <returns>
+        /// A new 3D vector containing the quotient components.
+        /// </returns>
+        public static Vector3 Div(this Vector3 value, Vector3 divisor)
         {
-            return new Vector3(value.x / scale.x, value.y / scale.y, value.z / scale.z);
+            return new Vector3(value.x / divisor.x, value.y / divisor.y, value.z / divisor.z);
         }
 
+        /// <summary>
+        /// Rotate a given point around a pivot at a particular rotation.
+        /// </summary>
+        /// <param name="point">The 3D point to be rotated.</param>
+        /// <param name="pivot">The 3D point that is the pivot.</param>
+        /// <param name="rotation">The quaternion representing the rotation to be preformed.</param>
+        /// <returns>
+        /// A new 3D vector containing the rotated point.
+        /// </returns>
         public static Vector3 RotateAround(this Vector3 point, Vector3 pivot, Quaternion rotation)
         {
             return rotation * (point - pivot) + pivot;
         }
 
+        /// <summary>
+        /// Rotate a given point around a pivot at a particular rotation.
+        /// </summary>
+        /// <param name="point">The 3D point to be rotated.</param>
+        /// <param name="pivot">The 3D point that is the pivot.</param>
+        /// <param name="rotation">The 3D vector containing the Euler representation of the rotation to be preformed.</param>
+        /// <returns>
+        /// A new 3D vector containing the rotated point.
+        /// </returns>
         public static Vector3 RotateAround(this Vector3 point, Vector3 pivot, Vector3 eulerAngles)
         {
             return RotateAround(point, pivot, Quaternion.Euler(eulerAngles));
         }
 
+        /// <summary>
+        /// Apply a transformation to a given point using the specified translation, rotation and scale.
+        /// </summary>
+        /// <param name="point">The 3D point to be altered.</param>
+        /// <param name="translation">The 3D vector containing the translation amount.</param>
+        /// <param name="rotation">The quaternion representing the rotation to be preformed.</param>
+        /// <param name="lossyScale">The 3D vector containing the scale amount.</param>
+        /// <returns>
+        /// A new 3D vector containing the altered point.
+        /// </returns>
         public static Vector3 TransformPoint(this Vector3 point, Vector3 translation, Quaternion rotation, Vector3 lossyScale)
         {
             return rotation * Vector3.Scale(lossyScale, point) + translation;
         }
 
+        /// <summary>
+        /// Apply an inverse transformation to a given point using the specified translation, rotation and scale.
+        /// </summary>
+        /// <remarks>
+        /// This will preform the inverse operations of the <see cref="TransformPoint"/> function.        
+        /// </remarks>
+        /// <param name="point">The 3D point to be altered.</param>
+        /// <param name="translation">The 3D vector containing the translation amount.</param>
+        /// <param name="rotation">The quaternion representing the rotation to be preformed.</param>
+        /// <param name="lossyScale">The 3D vector containing the scale amount.</param>
+        /// <returns>
+        /// A new 3D vector containing the altered point.
+        /// </returns>
         public static Vector3 InverseTransformPoint(this Vector3 point, Vector3 translation, Quaternion rotation, Vector3 lossyScale)
         {
             var scaleInv = new Vector3(1 / lossyScale.x, 1 / lossyScale.y, 1 / lossyScale.z);
             return Vector3.Scale(scaleInv, (Quaternion.Inverse(rotation) * (point - translation)));
         }
 
+        /// <summary>
+        /// Given a collection of 2D vectors, calculate the averages for each vector component.
+        /// </summary>
+        /// <param name="vectors">The collection of 2D vectors used when calculating the component-wise average.</param>
+        /// <returns>
+        /// A 2D vector containing averages for all vector components.
+        /// </returns>
         public static Vector2 Average(this IEnumerable<Vector2> vectors)
         {
             float x = 0f;
@@ -69,6 +149,13 @@ namespace Microsoft.MixedReality.Toolkit
             return new Vector2(x / count, y / count);
         }
 
+        /// <summary>
+        /// Given a collection of 3D vectors, calculate the averages for each vector component.
+        /// </summary>
+        /// <param name="vectors">The collection of 3D vectors used when calculating the component-wise average.</param>
+        /// <returns>
+        /// A 3D vector containing averages for all vector components.
+        /// </returns>
         public static Vector3 Average(this IEnumerable<Vector3> vectors)
         {
             float x = 0f;
@@ -87,6 +174,13 @@ namespace Microsoft.MixedReality.Toolkit
             return new Vector3(x / count, y / count, z / count);
         }
 
+        /// <summary>
+        /// Given a collection of 2D vectors, calculate the averages for each vector component.
+        /// </summary>
+        /// <param name="vectors">The collection of 2D vectors used when calculating the component-wise average.</param>
+        /// <returns>
+        /// A 2D vector containing averages for all vector components.
+        /// </returns>
         public static Vector2 Average(this ICollection<Vector2> vectors)
         {
             int count = vectors.Count;
@@ -107,6 +201,13 @@ namespace Microsoft.MixedReality.Toolkit
             return new Vector2(x / count, y / count);
         }
 
+        /// <summary>
+        /// Given a collection of 3D vectors, calculate the averages for each vector component.
+        /// </summary>
+        /// <param name="vectors">The collection of 3D vectors used when calculating the component-wise average.</param>
+        /// <returns>
+        /// A 3D vector containing averages for all vector components.
+        /// </returns>
         public static Vector3 Average(this ICollection<Vector3> vectors)
         {
             int count = vectors.Count;
@@ -130,6 +231,13 @@ namespace Microsoft.MixedReality.Toolkit
             return new Vector3(x / count, y / count, z / count);
         }
 
+        /// <summary>
+        /// Given a collection of 2D vectors, calculate the medians for each vector component.
+        /// </summary>
+        /// <param name="vectors">The collection of 2D vectors used when calculating the component-wise median.</param>
+        /// <returns>
+        /// A 2D vector containing medians for all vector components.
+        /// </returns>
         public static Vector2 Median(this IEnumerable<Vector2> vectors)
         {
             var enumerable = vectors as Vector2[] ?? vectors.ToArray();
@@ -137,6 +245,13 @@ namespace Microsoft.MixedReality.Toolkit
             return count == 0 ? Vector2.zero : enumerable.OrderBy(v => v.sqrMagnitude).ElementAt(count / 2);
         }
 
+        /// <summary>
+        /// Given a collection of 3D vectors, calculate the medians for each vector component.
+        /// </summary>
+        /// <param name="vectors">The collection of 3D vectors used when calculating the component-wise median.</param>
+        /// <returns>
+        /// A 3D vector containing medians for all vector components.
+        /// </returns>
         public static Vector3 Median(this IEnumerable<Vector3> vectors)
         {
             var enumerable = vectors as Vector3[] ?? vectors.ToArray();
@@ -144,18 +259,39 @@ namespace Microsoft.MixedReality.Toolkit
             return count == 0 ? Vector3.zero : enumerable.OrderBy(v => v.sqrMagnitude).ElementAt(count / 2);
         }
 
+        /// <summary>
+        /// Given a collection of 2D vectors, calculate the medians for each vector component.
+        /// </summary>
+        /// <param name="vectors">The collection of 2D vectors used when calculating the component-wise median.</param>
+        /// <returns>
+        /// A 2D vector containing medians for all vector components.
+        /// </returns>
         public static Vector2 Median(this ICollection<Vector2> vectors)
         {
             int count = vectors.Count;
             return count == 0 ? Vector2.zero : vectors.OrderBy(v => v.sqrMagnitude).ElementAt(count / 2);
         }
 
+        /// <summary>
+        /// Given a collection of 3D vectors, calculate the medians for each vector component.
+        /// </summary>
+        /// <param name="vectors">The collection of 3D vectors used when calculating the component-wise median.</param>
+        /// <returns>
+        /// A 3D vector containing medians for all vector components.
+        /// </returns>
         public static Vector3 Median(this ICollection<Vector3> vectors)
         {
             int count = vectors.Count;
             return count == 0 ? Vector3.zero : vectors.OrderBy(v => v.sqrMagnitude).ElementAt(count / 2);
         }
 
+        /// <summary>
+        /// Validates that each 3D vector components is a number and is not infinite.
+        /// </summary>
+        /// <param name="vector">The 3D vector whose components will be tested.</param>
+        /// <returns>
+        /// `true` is all 3D vector components are a numbers and are not infinite, otherwise `false`.
+        /// </returns>
         public static bool IsValidVector(this Vector3 vector)
         {
             return !float.IsNaN(vector.x) && !float.IsNaN(vector.y) && !float.IsNaN(vector.z) &&
@@ -250,6 +386,5 @@ namespace Microsoft.MixedReality.Toolkit
             source.y = UnityEngine.Random.Range(-radius, radius);
             return source;
         }
-
     }
 }

--- a/com.microsoft.mrtk.core/Utilities/RayStep.cs
+++ b/com.microsoft.mrtk.core/Utilities/RayStep.cs
@@ -6,6 +6,9 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit
 {
+    /// <summary>
+    /// Represents a single linear ray cast that is part of a longer ray cast.
+    /// </summary>
     [Serializable]
     public struct RayStep
     {
@@ -13,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit
         private static Vector3 dist;
         private static Vector3 dir;
         private static Vector3 pos;
+
 
         public RayStep(Vector3 origin, Vector3 terminus) : this()
         {
@@ -44,12 +48,14 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Update current raystep with new origin and terminus points. 
-        /// Pass by ref to avoid unnecessary struct copy into function since values will be copied anyways locally
+        /// Update the ray step with new origin and terminus points. 
         /// </summary>
-        /// <param name="origin">beginning of raystep origin</param>
-        /// <param name="terminus">end of raystep</param>
-        public void UpdateRayStep(ref Vector3 origin, ref Vector3 terminus)
+        /// <remarks>
+        /// Vectors are passed by reference to avoid unnecessary struct copies. The input values will be copied locally.
+        /// </remarks>
+        /// <param name="origin">The origin position of the ray step.</param>
+        /// <param name="terminus">The end position of the ray step.</param>
+        public void UpdateRayStep(ref const Vector3 origin, ref const Vector3 terminus)
         {
             Origin = origin;
             Terminus = terminus;

--- a/com.microsoft.mrtk.core/Utilities/RayStep.cs
+++ b/com.microsoft.mrtk.core/Utilities/RayStep.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="terminus">The end position of the raycast step.</param>
         public RayStep(Vector3 origin, Vector3 terminus) : this()
         {
-            UpdateRayStep(ref origin, ref terminus);
+            UpdateRayStep(in origin, in terminus);
 
             epsilon = 0.01f;
         }
@@ -81,7 +81,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </remarks>
         /// <param name="origin">The origin position of the ray step.</param>
         /// <param name="terminus">The end position of the ray step.</param>
-        public void UpdateRayStep(ref const Vector3 origin, ref const Vector3 terminus)
+        public void UpdateRayStep(in Vector3 origin, in Vector3 terminus)
         {
             Origin = origin;
             Terminus = terminus;

--- a/com.microsoft.mrtk.core/Utilities/RayStep.cs
+++ b/com.microsoft.mrtk.core/Utilities/RayStep.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit
 {
     /// <summary>
-    /// Represents a single linear ray cast that is part of a longer ray cast.
+    /// Represents a raycast that is a portion of a longer raycast.
     /// </summary>
     [Serializable]
     public struct RayStep
@@ -18,6 +18,11 @@ namespace Microsoft.MixedReality.Toolkit
         private static Vector3 pos;
 
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RayStep"/> struct.
+        /// </summary>
+        /// <param name="origin">The origin position of the raycast step.</param>
+        /// <param name="terminus">The end position of the raycast step.</param>
         public RayStep(Vector3 origin, Vector3 terminus) : this()
         {
             UpdateRayStep(ref origin, ref terminus);
@@ -25,14 +30,35 @@ namespace Microsoft.MixedReality.Toolkit
             epsilon = 0.01f;
         }
 
+        /// <summary>
+        /// Get the origin position of the raycast step.
+        /// </summary>
         public Vector3 Origin { get; private set; }
+
+        /// <summary>
+        /// Get the end position of the raycast step.
+        /// </summary>
         public Vector3 Terminus { get; private set; }
+        
+        /// <summary>
+        /// Get the direction of the raycast step. This direction will be a normalized vector from the origin to the terminus.
+        /// </summary>
         public Vector3 Direction { get; private set; }
 
+        /// <summary>
+        /// The length or magnitude of the raycast step. This is the distance from the origin to the terminus.
+        /// </summary>
         public float Length { get; private set; }
 
         private readonly float epsilon;
 
+        /// <summary>
+        /// Get a point along the raycast, at a specified distance from the origin.
+        /// </summary>
+        /// <param name="distance">The returned point will be at this distance from the origin.</param>
+        /// <returns>
+        /// A new point that is at the specified distance from the origin.
+        /// </returns>
         public Vector3 GetPoint(float distance)
         {
             if (Length <= distance || Length == 0f)
@@ -80,9 +106,16 @@ namespace Microsoft.MixedReality.Toolkit
             Direction = dir;
         }
 
-        public void CopyRay(Ray ray, float rayLength)
+        /// <summary>
+        /// Copy the given ray structure to this raycast step, along with the specified length.
+        /// </summary>
+        /// <param name="length">
+        /// The new length for this raycast step. The length or magnitude of the raycast step. 
+        /// This is the distance from the ray's origin to the terminus.
+        /// </param>
+        public void CopyRay(Ray ray, float length)
         {
-            Length = rayLength;
+            Length = length;
             Origin = ray.origin;
             Direction = ray.direction;
 
@@ -93,6 +126,13 @@ namespace Microsoft.MixedReality.Toolkit
             Terminus = pos;
         }
 
+        /// <summary>
+        /// Test if the raycast step contain the specified point.
+        /// </summary>
+        /// <param name="point">The point to test.</param>
+        /// <returns>
+        /// True if the point is contained along the raycast step. Otherwise false is returned.
+        /// </returns>
         public bool Contains(Vector3 point)
         {
             dist.x = Origin.x - point.x;
@@ -111,9 +151,13 @@ namespace Microsoft.MixedReality.Toolkit
             return (sqrMagOriginPoint + sqrMagPointTerminus) - sqrLength > sqrEpsilon;
         }
 
-        public static implicit operator Ray(RayStep r)
+        /// <summary>
+        /// Create a copy of the given raycast step.
+        /// </summary>
+        /// <param name="rayStep">The raycast step to copy.</param>
+        public static implicit operator Ray(RayStep rayStep)
         {
-            return new Ray(r.Origin, r.Direction);
+            return new Ray(rayStep.Origin, rayStep.Direction);
         }
 
         #region static utility functions

--- a/com.microsoft.mrtk.core/Utilities/SystemInterfaceType.cs
+++ b/com.microsoft.mrtk.core/Utilities/SystemInterfaceType.cs
@@ -13,8 +13,19 @@ namespace Microsoft.MixedReality.Toolkit
     [Serializable]
     public sealed class SystemInterfaceType : SystemType
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SystemInterfaceType"/> class.
+        /// </summary>
+        /// <param name="assemblyQualifiedClassName">Assembly qualified class name.</param>
         public SystemInterfaceType(string assemblyQualifiedClassName) : base(assemblyQualifiedClassName) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SystemInterfaceType"/> class.
+        /// </summary>
+        /// <param name="type">Class type.</param>
+        /// <exception cref="System.ArgumentException">
+        /// If <paramref name="type"/> is not a class type.
+        /// </exception>
         public SystemInterfaceType(Type type) : base(type) { }
 
         /// <inheritdoc/>

--- a/com.microsoft.mrtk.core/Utilities/SystemType.cs
+++ b/com.microsoft.mrtk.core/Utilities/SystemType.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// A new reference string. Will return an empty string if the assembly qualified
         /// name is null or empty.
         /// </returns>
-        public static string (string assemblyQualifiedName)
+        public static string GetReference(string assemblyQualifiedName)
         {
             if (string.IsNullOrEmpty(assemblyQualifiedName))
             {
@@ -147,6 +147,9 @@ namespace Microsoft.MixedReality.Toolkit
         /// <summary>
         /// Implemented so to receive a callback before Unity deserializes this object.
         /// </summary>
+        /// <remarks>
+        /// This is currently not utilized, and no operation will be preformed when called.
+        /// </remarks>
         void ISerializationCallbackReceiver.OnBeforeSerialize() { }
 
         #endregion ISerializationCallbackReceiver Members

--- a/com.microsoft.mrtk.core/Utilities/SystemType.cs
+++ b/com.microsoft.mrtk.core/Utilities/SystemType.cs
@@ -18,6 +18,15 @@ namespace Microsoft.MixedReality.Toolkit
 
         private Type type;
 
+        /// <summary>
+        /// Create a reference string from the given type's assembly qualified class name. The reference 
+        /// string will contain the full name and assembly name from the given type.
+        /// </summary>
+        /// <param name="type">The class type to track.</param>
+        /// <returns>
+        /// A new reference string. Will return an empty string if the type is null, 
+        /// or if the assembly qualified name is null or empty.
+        /// </returns>
         public static string GetReference(Type type)
         {
             if (type == null || string.IsNullOrEmpty(type.AssemblyQualifiedName))
@@ -28,7 +37,16 @@ namespace Microsoft.MixedReality.Toolkit
             return GetReference(type.AssemblyQualifiedName);
         }
 
-        public static string GetReference(string assemblyQualifiedName)
+        /// <summary>
+        /// Create a reference string from the given assembly qualified class name. The reference 
+        /// string will contain the full name and assembly name from the given assembly qualified name.
+        /// </summary>
+        /// <param name="assemblyQualifiedClassName">Assembly qualified class name.</param>
+        /// <returns>
+        /// A new reference string. Will return an empty string if the assembly qualified
+        /// name is null or empty.
+        /// </returns>
+        public static string (string assemblyQualifiedName)
         {
             if (string.IsNullOrEmpty(assemblyQualifiedName))
             {
@@ -64,7 +82,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <summary>
         /// Initializes a new instance of the <see cref="SystemType"/> class.
         /// </summary>
-        /// <param name="type">Class type.</param>
+        /// <param name="type">The class type to track.</param>
         /// <exception cref="System.ArgumentException">
         /// If <paramref name="type"/> is not a class type.
         /// </exception>
@@ -76,24 +94,47 @@ namespace Microsoft.MixedReality.Toolkit
 
         // Override hash code and equality so we can
         // key dictionaries with the type reference.
+
+        /// <summary>
+        /// Gets the hash code for the <see cref="SystemType"/>.
+        /// </summary>
+        /// <remarks>
+        /// Obtains the hash from the underlying reference string.
+        /// </remarks>
+        /// <returns>
+        /// The hash value generated for this <see cref="SystemType"/>.
+        /// </returns>
         public override int GetHashCode()
         {
             return reference.GetHashCode();
         }
 
+        /// <summary>
+        /// Compares two <see cref="SystemType"/> instances for equality.
+        /// </summary>
+        /// <remarks>
+        /// Obtains the equality from the underlying reference string.
+        /// </remarks>
+        /// <returns>
+        /// `true` if the two instances represent the same <see cref="SystemType"/>; otherwise, `false`.
+        /// </returns>
         public override bool Equals(object other)
         {
             var otherType = other as SystemType;
 
             if (otherType == null)
+            {
                 return false;
+            }
 
             return reference.Equals(otherType.reference);
         }
 
-
         #region ISerializationCallbackReceiver Members
 
+        /// <summary>
+        /// Implemented so to receive a callback after Unity deserializes this object.
+        /// </summary>
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
             // Class references may move between asmdef or be renamed throughout MRTK development
@@ -103,6 +144,9 @@ namespace Microsoft.MixedReality.Toolkit
             type = !string.IsNullOrEmpty(reference) ? Type.GetType(reference) : null;
         }
 
+        /// <summary>
+        /// Implemented so to receive a callback before Unity deserializes this object.
+        /// </summary>
         void ISerializationCallbackReceiver.OnBeforeSerialize() { }
 
         #endregion ISerializationCallbackReceiver Members
@@ -135,35 +179,60 @@ namespace Microsoft.MixedReality.Toolkit
         /// <summary>
         /// An overridable constraint to determine whether a type is valid to serialize.
         /// </summary>
-        /// <param name="t">Type to validate.</param>
+        /// <param name="type">Type to validate.</param>
         /// <returns>True if the type is valid, or false.</returns>
-        protected virtual bool ValidConstraint(Type t)
+        protected virtual bool ValidConstraint(Type type)
         {
-            return t != null && t.IsValueType && !t.IsEnum && !t.IsAbstract || t.IsClass;
+            return type != null && type.IsValueType && !type.IsEnum && !type.IsAbstract || type.IsClass;
         }
 
+        /// <summary>
+        /// Returns the reference string for the type represented by this <see cref="SystemType"/>.
+        /// </summary>
         public static implicit operator string(SystemType type)
         {
             return type.reference;
         }
 
+        /// <summary>
+        /// Returns the type represented by this <see cref="SystemType"/>.
+        /// </summary>
         public static implicit operator Type(SystemType type)
         {
             return type.Type;
         }
 
+        /// <summary>
+        /// Create an instance of <see cref="SystemType"/> for the given type.
+        /// </summary>
+        /// <param name="type">The class type to track.</param>
+        /// <exception cref="System.ArgumentException">
+        /// If <paramref name="type"/> is not a class type.
+        /// </exception>
         public static implicit operator SystemType(Type type)
         {
             return new SystemType(type);
         }
 
+        /// <summary>
+        /// Returns a string that represents this <see cref="SystemType"/>.
+        /// </summary>
+        /// <Returns>
+        /// The full name for the type represented by this <see cref="SystemType"/>, or 
+        /// "(None)" if the type is null.
+        /// </Returns>
         public override string ToString()
         {
-            return Type?.FullName ?? "(None)";
+            return type?.FullName ?? "(None)";
         }
 
-        // Key == original reference string entry, value == new migrated placement
-        // String values are broken into {namespace.classname, asmdef}
+        /// <summary>
+        /// A dictionary containing mappings from the original reference string entry to
+        /// the new migrated placement value.
+        /// </summary>
+        /// <remarks>
+        /// String values are broken into {Full Name, Assembly Definition}
+        /// </remarks>
         private static Dictionary<string, string> ReferenceMappings = new Dictionary<string, string>()
         {
             // Empty for now.

--- a/com.microsoft.mrtk.core/Utilities/TimedFlag.cs
+++ b/com.microsoft.mrtk.core/Utilities/TimedFlag.cs
@@ -11,6 +11,11 @@ namespace Microsoft.MixedReality.Toolkit
     /// </summary>
     public class EditableTimedFlagAttribute : PropertyAttribute { }
 
+    /// <summary>
+    /// Represents a flag that can be activated or deactivated, and whose active duration is tracked and 
+    /// obtained via the <see cref="GetTimeElapsedSinceSetActive"/> function. Instances of this object
+    /// will also raise <see cref="OnEntered"> and <see cref "OnExited"> events when their activate state is altered.
+    /// </summary>
     [System.Serializable]
     public class TimedFlag
     {

--- a/com.microsoft.mrtk.input/Editor/Inspectors/InteractionModeManagerEditor.cs
+++ b/com.microsoft.mrtk.input/Editor/Inspectors/InteractionModeManagerEditor.cs
@@ -7,12 +7,19 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input.Editor
 {
+    /// <summary>
+    /// A custom class used when rendering a Unity inspector window editor for a <see cref="Microsoft.MixedReality.Toolkit.Input.InteractionModeManager">InteractionModeManager</see>
+    /// class.
+    /// </summary>
     [CustomEditor(typeof(InteractionModeManager))]
     public class InteractionModeManagerEditor : UnityEditor.Editor
     {
         private const string InitControllers = "Init Controllers";
         private const string InitSubtypes = "Populate Modes Definitions with Subtypes";
 
+        /// <summary>
+        /// Implemented so to make a custom inspector inside Unity's inspector window.
+        /// </summary>
         public override void OnInspectorGUI()
         {
             Color prevColor = GUI.color;

--- a/com.microsoft.mrtk.input/Editor/Inspectors/InteractionModePropertyDrawer.cs
+++ b/com.microsoft.mrtk.input/Editor/Inspectors/InteractionModePropertyDrawer.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input.Editor
 {
+    /// <summary>
+    /// A custom drawer used when rendering information about a <see cref="Microsoft.MixedReality.Toolkit.Input.InteractionMode">InteractionMode</see>
+    /// property within a Unity inspector window.
+    /// </summary>
     [CustomPropertyDrawer(typeof(InteractionMode))]
     public class InteractionModePropertyDrawer : PropertyDrawer
     {

--- a/com.microsoft.mrtk.input/InteractionModes/InteractionMode.cs
+++ b/com.microsoft.mrtk.input/InteractionModes/InteractionMode.cs
@@ -2,17 +2,30 @@
 // Licensed under the MIT License.
 
 using System;
+using UnityEngine;
 using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
+    /// <summary>
+    /// A structure representing an interactor's mode or state.
+    /// </summary>
     [Serializable]
     public struct InteractionMode
     {
+        [Tooltip("The name of the interaction mode.")]
         public string name;
+
         [FormerlySerializedAs("id")]
+        [Tooltip("The priority of the interaction mode.")]
         public int priority;
 
+        /// <summary>
+        /// Returns a string that represents this <see cref="InteractionMode"/>.
+        /// </summary>
+        /// <Returns>
+        /// The `name` field for this <see cref="InteractionMode"/>.
+        /// </Returns>
         public override string ToString()
         {
             return name;

--- a/com.microsoft.mrtk.input/InteractionModes/InteractionModeDefinition.cs
+++ b/com.microsoft.mrtk.input/InteractionModes/InteractionModeDefinition.cs
@@ -10,26 +10,30 @@ using UnityEngine.XR.Interaction.Toolkit;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// Describes the types of interaction modes an interactor can belong to
+    /// Describes the types of interaction modes an interactor can belong to.
     /// </summary>
-    /// todo: improve naming here...
     [Serializable]
     public class InteractionModeDefinition : ISerializationCallbackReceiver
     {
         [SerializeField]
+        [Tooltip("Get the mode name that this Interaction Mode Definition instance is targeting.")]
         private string modeName = string.Empty;
 
+        /// <summary>
+        /// Get the mode name that this <see cref="InteractionModeDefinition"/> instance is targeting.
+        /// </summary>
         public string ModeName => modeName;
 
         // private field to ensure serialization
         [SerializeField]
         [Extends(typeof(XRBaseControllerInteractor), TypeGrouping.ByNamespaceFlat)]
+        [Tooltip("The class types of the interactors that this Interaction Mode Definition instance is targeting.")]
         private List<SystemType> associatedTypes = new List<SystemType>();
 
         private HashSet<Type> associatedTypesHashSet = new HashSet<Type>();
         
         /// <summary>
-        /// Stores the types associated with this Interaction Mode Definition
+        /// Stores the types associated with this Interaction Mode Definition.
         /// </summary>
         internal HashSet<Type> AssociatedTypes => associatedTypesHashSet;
 
@@ -55,12 +59,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <summary>
+        /// Implemented so to receive a callback after Unity deserializes this object.
+        /// </summary>
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
             InitializeAssociatedTypes();
         }
 
-        // We don't need to do anything before serialization
+        /// <summary>
+        /// Implemented so to receive a callback before Unity deserializes this object.
+        /// </summary>
+        /// <remarks>
+        /// This is currently not utilized, and no operation will be preformed when called.
+        /// </remarks>
         void ISerializationCallbackReceiver.OnBeforeSerialize() { }
     }
 }

--- a/com.microsoft.mrtk.input/InteractionModes/InteractionModeManager.cs
+++ b/com.microsoft.mrtk.input/InteractionModes/InteractionModeManager.cs
@@ -24,8 +24,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private class ManagedInteractorStatus
         {
             [SerializeField]
+            [Tooltip("A value representing interactor mode or state that is being targeted by this Managed Interactor Status.")]
             private InteractionMode currentMode;
 
+            /// <summary>
+            /// Get or set the value representing interactor mode or state that is being targeted by the <see cref="ManagedInteractorStatus"/> instance.
+            /// </summary>
             public InteractionMode CurrentMode
             {
                 get => currentMode;
@@ -33,8 +37,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             [SerializeField]
+            [Tooltip("The interactor mode or state that is being targeted by this Managed Interactor Status.")]
             private List<XRBaseInteractor> interactors = new List<XRBaseInteractor>();
 
+            /// <summary>
+            /// The interactor mode or state that is being targeted by the <see cref="ManagedInteractorStatus"/> instance.
+            /// </summary>
             public List<XRBaseInteractor> Interactors => interactors;
         }
 
@@ -72,6 +80,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <summary>
+        /// Expands this object's <see cref="PrioritizedInteractionModes"/> property with base and sub types associated with
+        /// the current value stored in the <see cref="PrioritizedInteractionModes"/> property.
+        /// </summary>
+        /// <remarks>
+        /// This function is only intended for use in Unity's inspector window. See 
+        /// <see cref="Microsoft.MixedReality.Toolkit.Input.Editor.InteractionModeManagerEditor"> InteractionModeManagerEditor</see>
+        /// documentation for more details.
+        /// </remarks>
         public void PopulateModesWithSubtypes()
         {
             List<InteractionModeDefinition> newPrioritizedInteractionModes = new List<InteractionModeDefinition>();

--- a/com.microsoft.mrtk.input/Interactors/Gaze/FuzzyGazeInteractor.cs
+++ b/com.microsoft.mrtk.input/Interactors/Gaze/FuzzyGazeInteractor.cs
@@ -174,10 +174,25 @@ namespace Microsoft.MixedReality.Toolkit.Input
         // TODO: remove or refactor this section out when the XRRayInteractor exposes the raycast hits
         // Otherwise, it's mimicking the logic found in XRRayInteractor
 
+        /// <summary>
+        /// A structure representing a raycast hit result that originated
+        /// from a <see cref="Microsoft.MixedReality.Toolkit.Input.FuzzyGazeInteractor">FuzzyGazeInteractor</see> object.
+        /// </summary>
         public struct GazeRaycastHitResult
         {
+            /// <summary>
+            /// The raycast hit for fuzzy gaze interactor.
+            /// </summary>
             public RaycastHit raycastHit;
+
+            /// <summary>
+            /// The interactable object that was hit by the gaze's raycast.
+            /// </summary>
             public IXRInteractable targetInteractable;
+
+            /// <summary>
+            /// The precision level of the fuzzy gaze's raycast.
+            /// </summary>
             public int precisionLevel;
 
             /// <summary>

--- a/com.microsoft.mrtk.input/Interactors/HandJointInteractor.cs
+++ b/com.microsoft.mrtk.input/Interactors/HandJointInteractor.cs
@@ -42,7 +42,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         private bool interactionPointTracked;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Indicates whether this Interactor is in a state where it could hover.
+        /// </summary>
         public override bool isHoverActive
         {
             // Only be available for hovering if the controller is tracked or we have joint data.

--- a/com.microsoft.mrtk.input/Interactors/HandJointInteractor.cs
+++ b/com.microsoft.mrtk.input/Interactors/HandJointInteractor.cs
@@ -56,6 +56,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private static readonly ProfilerMarker ProcessInteractorPerfMarker =
             new ProfilerMarker("[MRTK] HandJointInteractor.ProcessInteractor");
 
+        /// <summary>
+        /// Unity's <see cref="https://docs.unity3d.com/Packages/com.unity.xr.interaction.toolkit@2.4/api/UnityEngine.XR.Interaction.Toolkit.XRInteractionManager.html">XRInteractionManager</see> 
+        /// or containing <see cref="https://docs.unity3d.com/Packages/com.unity.xr.interaction.toolkit@2.4/api/UnityEngine.XR.Interaction.Toolkit.IXRInteractionGroup.html">IXRInteractionGroup</see> 
+        /// calls this method to update the Interactor before interaction events occur. See Unity's documentation for more information.
+        /// </summary>
+        /// <param name="updatePhase">The update phase this is called during.</param>
+        /// <remarks>
+        /// Please see the <see cref="https://docs.unity3d.com/Packages/com.unity.xr.interaction.toolkit@2.4/api/UnityEngine.XR.Interaction.Toolkit.XRInteractionManager.html">XRInteractionManager</see> documentation for more
+        /// details on update order.
+        /// </remarks>
         public override void ProcessInteractor(XRInteractionUpdateOrder.UpdatePhase updatePhase)
         {
             base.ProcessInteractor(updatePhase);

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/DataProviders/BezierDataProvider.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/DataProviders/BezierDataProvider.cs
@@ -6,9 +6,15 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
+    /// <summary>
+    /// Represents a set parametric curve points.
+    /// </summary>
     [AddComponentMenu("MRTK/Input/Bezier Data Provider")]
     internal class BezierDataProvider : BaseMixedRealityLineDataProvider
     {
+        /// <summary>
+        /// A structure that holds four 3D points along a parametric curve.
+        /// </summary>
         [Serializable]
         private struct BezierPointSet
         {

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/DataProviders/BezierInertia.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/DataProviders/BezierInertia.cs
@@ -5,22 +5,36 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
+    /// <summary>
+    /// Represents a parametric curve of an inertial type movement. The parametric curve positions are updated each frame
+    /// before rendering line visuals, using a linear interpolation function, until the positions reach their specified targets.
+    /// </summary>
     [RequireComponent(typeof(BezierDataProvider))]
     [AddComponentMenu("MRTK/Input/Bezier Inertia")]
     public class BezierInertia : MonoBehaviour
-    {
+    {        
         [SerializeField]
+        [Tooltip("A set parametric curve points.")]
         private BezierDataProvider bezier;
+
         [SerializeField]
+        [Tooltip("The inertial value of the inertial movement.")]
         private float inertia = 15f;
+
         [SerializeField]
+        [Tooltip("The dampen value of the inertial movement.")]
         private float dampen = 6f;
+
         [SerializeField]
+        [Tooltip("The scalar value to apply to the time delta when updating the parametric curve point positions.")]
         private float seekTargetStrength = 5f;
 
         [SerializeField]
+        [Tooltip("The target value for the first parametric curve point position.")]
         private Vector3 p1Target = new Vector3(0, 0, 0.33f);
+
         [SerializeField]
+        [Tooltip("The target value for the second parametric curve point position.")]
         private Vector3 p2Target = new Vector3(0, 0, 0.66f);
 
         private Vector3 p1Velocity;

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/Definitions/InterpolationType.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/Definitions/InterpolationType.cs
@@ -8,8 +8,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     public enum InterpolationType
     {
+        /// <summary>
+        /// Interpolation using Bézier parametric curve.
+        /// </summary>
         Bezier = 0,
-        CatmullRom,
-        Hermite,
+
+        /// <summary>
+        /// Interpolation using a Catmull–Rom spline.
+        /// </summary>
+        CatmullRom
     }
 }

--- a/com.microsoft.mrtk.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
+++ b/com.microsoft.mrtk.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
@@ -197,9 +197,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <summary>
+        /// A Unity subsystem provider used with the <see cref="Microsoft.MixedReality.Toolkit.Input.MRTKHandsAggregatorSubsystem">MRTKHandsAggregatorSubsystem</see> subsystem.
+        /// </summary>
         [Preserve]
         protected class MRTKAggregator : Provider
         {
+            /// <summary>
+            /// Get the current configuration for this <see cref="MRTKAggregator"/>.
+            /// </summary>
             protected MRTKHandsAggregatorConfig Config { get; private set; }
 
             private Dictionary<XRNode, AggregateHandContainer> hands = null;
@@ -207,6 +213,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // Reusable pinch pose structs to reduce allocs.
             private HandJointPose leftPinchPose, rightPinchPose;
 
+            /// <inheritdoc/>
             public override void Start()
             {
                 base.Start();
@@ -222,6 +229,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 InputSystem.onBeforeUpdate += ResetHands;
             }
 
+            /// <inheritdoc/>
             public override void Stop()
             {
                 ResetHands();

--- a/com.microsoft.mrtk.input/Utilities/HandshapeTypes.cs
+++ b/com.microsoft.mrtk.input/Utilities/HandshapeTypes.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
+    /// <summary>
+    /// A static class containing types related to hand shapes.
+    /// </summary>
     public static class HandshapeTypes
 
     {

--- a/com.microsoft.mrtk.input/Utilities/PoseSource/InputActionPoseSource.cs
+++ b/com.microsoft.mrtk.input/Utilities/PoseSource/InputActionPoseSource.cs
@@ -8,24 +8,26 @@ using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [Serializable]
-
     /// <summary>
-    /// A pose source which gets the pose composed of a tracked position and rotation input action
+    /// A pose source which gets the pose composed of a tracked position and rotation input action.
     /// </summary>
+    [Serializable]
     public class InputActionPoseSource : IPoseSource
     {
         [SerializeField]
+        [Tooltip("The input action property used when obtaining the tracking information for the current pose.")]
         InputActionProperty trackingStateActionProperty;
 
         [SerializeField]
+        [Tooltip("The input action property used when obtaining the position information for the current pose.")]
         InputActionProperty positionActionProperty;
 
         [SerializeField]
+        [Tooltip("The input action property used when obtaining the rotation information for the current pose.")]
         InputActionProperty rotationActionProperty;
 
         /// <summary>
-        /// Tries to get the pose in worldspace composed of the provided input action properties when the position and rotation are tracked
+        /// Tries to get the pose in world space composed of the provided input action properties when the position and rotation are tracked.
         /// </summary>
         public bool TryGetPose(out Pose pose)
         {

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/SurfaceMagnetism.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/SurfaceMagnetism.cs
@@ -461,7 +461,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
                 // Determine raycast params. Update struct to skip instantiation
                 Vector3 origin = RaycastOrigin;
                 Vector3 endpoint = RaycastEndPoint;
-                currentRayStep.UpdateRayStep(ref origin, ref endpoint);
+                currentRayStep.UpdateRayStep(in origin, in endpoint);
 
                 // Skip if there isn't a valid direction
                 if (currentRayStep.Direction == Vector3.zero)

--- a/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/Solvers/TapToPlace.cs
@@ -407,7 +407,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
                 Vector3 origin = transform.position;
                 Vector3 endpoint = transform.position + transform.forward;
-                CurrentRay.UpdateRayStep(ref origin, ref endpoint);
+                CurrentRay.UpdateRayStep(in origin, in endpoint);
 
                 // Check if the current ray hits a magnetic surface
                 DidHitSurface = MixedRealityRaycaster.RaycastSimplePhysicsStep(CurrentRay, MaxRaycastDistance, MagneticSurfaces, false, out CurrentHit);

--- a/com.microsoft.mrtk.uxcore/Keyboard/KeyboardPreview.cs
+++ b/com.microsoft.mrtk.uxcore/Keyboard/KeyboardPreview.cs
@@ -214,8 +214,8 @@ namespace Microsoft.MixedReality.Toolkit.UX
             }
 
             var lineInfo = textInfo.lineInfo[prevChar.lineNumber];
-            ScrollView(textInfo, ref lineInfo, ref prevChar, ref nextChar);
-            UpdateCaret(textInfo, ref lineInfo, ref prevChar);
+            ScrollView(textInfo, in lineInfo, in prevChar, in nextChar);
+            UpdateCaret(textInfo, in lineInfo, in prevChar);
         }
 
         /// <summary>
@@ -226,8 +226,8 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// </remarks>
         private void UpdateCaret(
             TMP_TextInfo textInfo,
-            ref TMP_LineInfo lineInfo,
-            ref TMP_CharacterInfo prevChar)
+            in TMP_LineInfo lineInfo,
+            in TMP_CharacterInfo prevChar)
         {
             // get line info
             float focusedLineWidth = lineInfo.width;
@@ -251,12 +251,12 @@ namespace Microsoft.MixedReality.Toolkit.UX
             float caretPositionY = lineInfo.baseline - textInfo.lineInfo[0].baseline;
 
             // if at end of line, text info doesn't go to a new line info, so account for this.
-            if (AtEmptyNewLine(ref lineInfo, ref prevChar))
+            if (AtEmptyNewLine(in lineInfo, in prevChar))
             {
                 caretPositionX = focusedLineStart;
                 caretPositionY -= lineInfo.lineHeight;
             }
-            else if (AtStartOfLine(ref lineInfo, ref prevChar))
+            else if (AtStartOfLine(in lineInfo, in prevChar))
             {
                 caretPositionX = focusedLineStart;
             }
@@ -294,9 +294,9 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// </remarks>
         private void ScrollView(
             TMP_TextInfo textInfo,
-            ref TMP_LineInfo lineInfo,
-            ref TMP_CharacterInfo prevChar,
-            ref TMP_CharacterInfo nextChar)
+            in TMP_LineInfo lineInfo,
+            in TMP_CharacterInfo prevChar,
+            in TMP_CharacterInfo nextChar)
         {
             // get line info
             float focusedLineWidth = lineInfo.width;
@@ -311,7 +311,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
             float textPositionY = focusedLineOffset;
 
             // if at end of line, text info doesn't go to a new line info, so account for this.
-            if (AtEmptyNewLine(ref lineInfo, ref prevChar))
+            if (AtEmptyNewLine(in lineInfo, in prevChar))
             {
                 textPositionX = 0;
                 textPositionY += lineInfo.lineHeight;
@@ -339,7 +339,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// <summary>
         /// Is the cursor at the start of new empty line, that is not the very first line.
         /// </summary>
-        private bool AtEmptyNewLine(ref TMP_LineInfo lineInfo, ref TMP_CharacterInfo prevChar)
+        private bool AtEmptyNewLine(in TMP_LineInfo lineInfo, in TMP_CharacterInfo prevChar)
         {
             return prevChar.character == '\n' && prevChar.index == lineInfo.lastCharacterIndex;
         }
@@ -347,7 +347,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// <summary>
         /// Is the cursor at a start of the line
         /// </summary>
-        private bool AtStartOfLine(ref TMP_LineInfo lineInfo, ref TMP_CharacterInfo prevChar)
+        private bool AtStartOfLine(in TMP_LineInfo lineInfo, in TMP_CharacterInfo prevChar)
         {
             return lineInfo.characterCount == 0 ? true : lineInfo.firstCharacterIndex > prevChar.index;
         }
@@ -355,7 +355,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         /// <summary>
         /// Is the cursor at the end of a line
         /// </summary>
-        private bool AtEndOfLine(ref TMP_LineInfo lineInfo, ref TMP_CharacterInfo prevChar)
+        private bool AtEndOfLine(in TMP_LineInfo lineInfo, in TMP_CharacterInfo prevChar)
         {
             return lineInfo.lastCharacterIndex <= prevChar.index;
         }


### PR DESCRIPTION
## Overview
Adding in some missing documentation to the MRTK3 source.  

This also replaces some `ref` parameters with `in` parameters, in cases where it was obvious that only "const refs" were needed.  This also removed the `InterpolationType.Hermite` since it was never handled or used.

The following were documentated:
  - [x] `CameraSettings` class
  - [x] `LabelWidthAttribute` class
  - [x] `MathExtensions.PowerOfTwoGreate=rThanOrEqualTo`
  - [x] `MathExtensions.CubicToLinearIndex`
  - [x] `MathExtensions.LinearToCubicIndex`
  - [x] `MathExtensions.ClampComponentWise`
  - [x] `RayStep` struct and some functions
  - [x] `StatefulInteractable` class
  - [x] `SystemInterfaceType` constructors
  - [x] `SystemType` public functions
  - [x] `TimedFlag` class definition
  - [x] `UXBindingProfileTemplate` properties
  - [x] `VectorExtensions` some functions
  - [x] `TextToSpeechSubsystem.Provider` class definition
  - [x] `BezierInertia` class definition, serialized field tooltips
  - [x] `FuzzyGazeInteractor.GazeRaycastHitResult` struct definition and public members
  - [x] `HandJointInteractor` public method
  - [x] `HandshapeTypes` class definition
  - [x] `InputActionPoseSource` serialized field tooltips.
  - [x] `InteractionMode` struct definition and serialized field tooltips and properties
  - [x] `InteractionModeDefinition` serialized field tooltips and properties
  - [x] `InteractionModeManager` public method
  - [x] `InterpolationType` enum values
  - [x] `MRTKHandsAggregatorSubsystem.MRTKAggregator` class definition and public members

## Bugs
- https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11596
- https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11590