### PR TITLE
Fixing z-fighting in MRTK3's non native keyboard prefab

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/Experimental/NonNativeKeyboard.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/Experimental/NonNativeKeyboard.unity
@@ -655,6 +655,14 @@ PrefabInstance:
       propertyPath: previewInput
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 1123086001961791811, guid: 74b589d1efab94a4cb70e4b5c22783f8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1195796392646670598, guid: 74b589d1efab94a4cb70e4b5c22783f8, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4299661269661786889, guid: 74b589d1efab94a4cb70e4b5c22783f8, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 

--- a/com.microsoft.mrtk.uxcomponents/Experimental/NonNativeKeyboard/NonNativeKeyboard.prefab
+++ b/com.microsoft.mrtk.uxcomponents/Experimental/NonNativeKeyboard/NonNativeKeyboard.prefab
@@ -33357,7 +33357,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 20292108973514120}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: -0.3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -34203,7 +34203,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6916386755006368770}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.1}
+  m_LocalPosition: {x: 0, y: 0, z: -6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:


### PR DESCRIPTION
## Overview
Fixing z-fighting in MRTK3's non native keyboard prefab

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11657

