### PR TITLE
Update DictationHandler Example Script to work with SpeechRecognitionSubsystem

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/DictationHandler.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/DictationHandler.cs
@@ -44,7 +44,8 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         [field: SerializeField]
         public StringUnityEvent OnRecognitionFaulted { get; private set; }
 
-        private DictationSubsystem dictationSubsystem;
+        private IDictationSubsystem dictationSubsystem = null;
+        private IKeywordRecognitionSubsystem keywordRecognitionSubsystem = null;
 
         /// <summary>
         /// Start dictation on a DictationSubsystem.
@@ -54,9 +55,16 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
             // Make sure there isn't an ongoing recognition session
             StopRecognition();
 
-            dictationSubsystem = XRSubsystemHelpers.GetFirstRunningSubsystem<DictationSubsystem>();
+            dictationSubsystem = XRSubsystemHelpers.DictationSubsystem;
             if (dictationSubsystem != null)
             {
+
+                keywordRecognitionSubsystem = XRSubsystemHelpers.KeywordRecognitionSubsystem;
+                if (keywordRecognitionSubsystem != null)
+                {
+                    keywordRecognitionSubsystem.Stop();
+                }
+
                 dictationSubsystem.Recognizing += DictationSubsystem_Recognizing;
                 dictationSubsystem.Recognized += DictationSubsystem_Recognized;
                 dictationSubsystem.RecognitionFinished += DictationSubsystem_RecognitionFinished;
@@ -73,11 +81,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         private void DictationSubsystem_RecognitionFaulted(DictationSessionEventArgs obj)
         {
             OnRecognitionFaulted.Invoke("Recognition faulted. Reason: " + obj.ReasonString);
+            HandleDictationShutdown();
         }
 
         private void DictationSubsystem_RecognitionFinished(DictationSessionEventArgs obj)
         {
             OnRecognitionFinished.Invoke("Recognition finished. Reason: " + obj.ReasonString);
+            HandleDictationShutdown();
         }
 
         private void DictationSubsystem_Recognized(DictationResultEventArgs obj)
@@ -103,6 +113,20 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
                 dictationSubsystem.RecognitionFinished -= DictationSubsystem_RecognitionFinished;
                 dictationSubsystem.RecognitionFaulted -= DictationSubsystem_RecognitionFaulted;
                 dictationSubsystem = null;
+            }
+        }
+
+        /// <summary>
+        /// Stop dictation on the current DictationSubsystem.
+        /// </summary>
+        public void HandleDictationShutdown()
+        {
+            StopRecognition();
+
+            if (keywordRecognitionSubsystem != null)
+            {
+                keywordRecognitionSubsystem.Start();
+                keywordRecognitionSubsystem = null;
             }
         }
     }

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/DictationHandler.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/DictationHandler.cs
@@ -58,7 +58,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
             dictationSubsystem = XRSubsystemHelpers.DictationSubsystem;
             if (dictationSubsystem != null)
             {
-
                 keywordRecognitionSubsystem = XRSubsystemHelpers.KeywordRecognitionSubsystem;
                 if (keywordRecognitionSubsystem != null)
                 {


### PR DESCRIPTION
## Overview
Adds logic to start and stop the speech recognition subsystem in the dictation example scene, so that both speech recognition and dictation can work in the scene. 

Known issue: Dictation will not work if app is closed and reopened #11695.

## Changes
- Fixes: #11690.

