### PR TITLE
Fix BoundsControl Bug

### DIFF
--- a/com.microsoft.mrtk.spatialmanipulation/BoundsControl/BoundsHandleInteractable.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/BoundsControl/BoundsHandleInteractable.cs
@@ -88,8 +88,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
         private bool wasOccludedLastFrame = false;
 
-        private Vector3 initialLocalScale;
-
         private float initialParentScale;
 
         protected override void Awake()
@@ -100,23 +98,13 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             DisableInteractorType(typeof(IPokeInteractor));
 
             handleRenderer = GetComponentInChildren<MeshRenderer>();
-
-            // Start occluded, so we don't show a frame of handles
-            // on startup when they should start disabled.
-            // We'll un-occlude on the next frame if we need to.
-            if (handleRenderer != null)
-            {
-                handleRenderer.enabled = false;
-            }
-            colliders[0].enabled = false;
-            wasOccludedLastFrame = true;
+            HideOnStartup();
         }
 
         // Record initial values at Start(), so that we
         // capture the bounds sizing, etc.
         void Start()
         {
-            initialLocalScale = transform.localScale;
             initialParentScale = MaxComponent(transform.parent.lossyScale);
         }
 
@@ -151,6 +139,19 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
         private float MaxComponent(Vector3 v)
         {
             return Mathf.Max(Mathf.Abs(v.x), Mathf.Abs(v.y), Mathf.Abs(v.z));
+        }
+
+        /// <summary>
+        /// Occludes the handle so it is not initially visible when it should start disabled.
+        /// </summary>
+        public void HideOnStartup()
+        {
+            if (handleRenderer != null)
+            {
+                handleRenderer.enabled = false;
+            }
+            colliders[0].enabled = false;
+            wasOccludedLastFrame = true;
         }
 
         /// <inheritdoc />

--- a/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Prefabs/RotateHandle.prefab
+++ b/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Prefabs/RotateHandle.prefab
@@ -326,7 +326,7 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 1
 --- !u!114 &6880724489352698737
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Prefabs/ScaleHandleOcclusion.prefab
+++ b/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Prefabs/ScaleHandleOcclusion.prefab
@@ -326,7 +326,7 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 1
 --- !u!114 &8925431220799339971
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Prefabs/ScaleHandleTraditional.prefab
+++ b/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Prefabs/ScaleHandleTraditional.prefab
@@ -326,7 +326,7 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 1
 --- !u!114 &8541032172729434893
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Visuals/SqueezableBoxVisuals.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Visuals/SqueezableBoxVisuals.cs
@@ -261,6 +261,14 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
             }
         }
 
+        protected virtual void OnEnable()
+        {
+            foreach (var handle in handles)
+            {
+                handle.HideOnStartup();
+            }
+        }
+
         /// <summary>
         /// Writes the property values into the renderer. Override this if you have custom box visuals that use different material property bindings.
         /// </summary>


### PR DESCRIPTION
## Overview
Fixes a bug in which bounding box handles would not appear after a GO was disabled. Problem caused by Animator behavior described [here](https://forum.unity.com/threads/animator-default-values-can-change-through-the-animations-itself.509668/), solved by setting WriteDefaultValuesOnDisable to true, and adding logic to occlude the handles on start up. 

Removes unused private variable initialLocalScale.

## Changes
- Fixes: #11655.
