### PR TITLE
Consolidate LocateTargetHitPoint methods

### DIFF
--- a/com.microsoft.mrtk.input/Experimental/SpatialMouse/Interactor/SpatialMouseInteractorCursorVisual.cs
+++ b/com.microsoft.mrtk.input/Experimental/SpatialMouse/Interactor/SpatialMouseInteractorCursorVisual.cs
@@ -65,6 +65,15 @@ namespace Microsoft.MixedReality.Toolkit.Input.Experimental
 
         private void LocateTargetHitPoint(SelectEnterEventArgs args)
         {
+            // Sanity check.
+            if (rayPositions == null ||
+                rayPositions.Length == 0 ||
+                rayPositionsCount == 0 ||
+                rayPositionsCount > rayPositions.Length)
+            {
+                return;
+            }
+
             selectedHitInfo = mouseInteractor.LocateTargetHitPoint(args.interactableObject);
         }
 
@@ -97,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Experimental
             // If the mouse is selecting an interactable, then position the cursor based on the target transform
             if (mouseInteractor.interactablesSelected.Count > 0)
             {
-                reticlePosition = selectedHitInfo.hitTargetTransform.TransformPoint(selectedHitInfo.targetLocalHitPoint);
+                reticlePosition = selectedHitInfo.HitTargetTransform.TransformPoint(selectedHitInfo.TargetLocalHitPoint);
             }
             // otherwise, try getting reticlePosition from the ray hit or set it a default distance from the user
             else if (!mouseInteractor.TryGetHitInfo(out reticlePosition, out reticleNormal, out endPositionInLine, out bool isValidTarget))

--- a/com.microsoft.mrtk.input/Experimental/SpatialMouse/Interactor/SpatialMouseInteractorCursorVisual.cs
+++ b/com.microsoft.mrtk.input/Experimental/SpatialMouse/Interactor/SpatialMouseInteractorCursorVisual.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Experimental
             Application.onBeforeRender -= OnBeforeRenderCursor;
         }
 
-        private TargetHitInfo selectedHitInfo = new TargetHitInfo();
+        private TargetHitDetails selectedHitDetails = new TargetHitDetails();
 
         // reusable lists of the points returned by the XRRayInteractor
         Vector3[] rayPositions;
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Experimental
                 return;
             }
 
-            selectedHitInfo = mouseInteractor.LocateTargetHitPoint(args.interactableObject);
+            mouseInteractor.TryLocateTargetHitPoint(args.interactableObject, out selectedHitDetails);
         }
 
         private void OnBeforeRenderCursor()
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Experimental
             // If the mouse is selecting an interactable, then position the cursor based on the target transform
             if (mouseInteractor.interactablesSelected.Count > 0)
             {
-                reticlePosition = selectedHitInfo.HitTargetTransform.TransformPoint(selectedHitInfo.TargetLocalHitPoint);
+                reticlePosition = selectedHitDetails.HitTargetTransform.TransformPoint(selectedHitDetails.TargetLocalHitPoint);
             }
             // otherwise, try getting reticlePosition from the ray hit or set it a default distance from the user
             else if (!mouseInteractor.TryGetHitInfo(out reticlePosition, out reticleNormal, out endPositionInLine, out bool isValidTarget))

--- a/com.microsoft.mrtk.input/Experimental/SpatialMouse/Interactor/SpatialMouseInteractorCursorVisual.cs
+++ b/com.microsoft.mrtk.input/Experimental/SpatialMouse/Interactor/SpatialMouseInteractorCursorVisual.cs
@@ -3,7 +3,7 @@
 
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
-using static Microsoft.MixedReality.Toolkit.Input.LineUtility;
+using static Microsoft.MixedReality.Toolkit.Input.XRRayInteractorExtensions;
 
 namespace Microsoft.MixedReality.Toolkit.Input.Experimental
 {

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/LineUtility.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/LineUtility.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using UnityEngine;
-using UnityEngine.XR.Interaction.Toolkit;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -218,87 +217,5 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Used to calculate the ellipse point in <see cref="GetEllipsePoint"/>
         /// </summary>
         private static Vector3 cachedEllipsePoint = Vector3.zero;
-
-        /// <summary>
-        /// Used to locate and lock the raycast hit data on a select.
-        /// </summary>
-        /// <param name="rayInteractor">The XRRayInteractor responsible for the raycast hit.</param>
-        /// <param name="interactableObject"> The IXRSelectInteractable which has been selected. </param>
-        /// <returns>The local position and normal of the hit target, the hit target transform, and a reference point to calculate hit distance, contained in a TargetHitInfo struct.</returns>
-        public static TargetHitInfo LocateTargetHitPoint(this XRRayInteractor rayInteractor, IXRSelectInteractable interactableObject)
-        {
-            TargetHitInfo hitInfo = new TargetHitInfo();
-            bool hitPointAndTransformUpdated = false;
-            bool hitNormalUpdated = false;
-
-            // In the case of affordances/handles, we can stick the ray right on to the handle.
-            if (interactableObject is ISnapInteractable snappable)
-            {
-                hitInfo.HitTargetTransform = snappable.HandleTransform;
-                hitInfo.TargetLocalHitPoint = Vector3.zero;
-                hitInfo.TargetLocalHitNormal = Vector3.up;
-                hitPointAndTransformUpdated = true;
-                hitNormalUpdated = true;
-            }
-
-            // In the case of an IScrollable being selected, ensure that the reticle locks to the
-            // scroller and not to the a list item within the scroller, such as a button.
-            if (interactableObject is IScrollable scrollable &&
-                scrollable.IsScrolling &&
-                scrollable.ScrollingInteractor == (IXRInteractor)rayInteractor)
-            {
-                hitInfo.HitTargetTransform = scrollable.ScrollableTransform;
-                hitInfo.TargetLocalHitPoint = scrollable.ScrollingLocalAnchorPosition;
-                hitPointAndTransformUpdated = true;
-            }
-
-            // If no hit, abort.
-            if (!rayInteractor.TryGetCurrentRaycast(
-                  out RaycastHit? raycastHit,
-                  out _,
-                  out UnityEngine.EventSystems.RaycastResult? raycastResult,
-                  out _,
-                  out bool isUIHitClosest))
-            {
-                return hitInfo;
-            }
-
-            // Align the reticle with a UI hit if applicable
-            if (raycastResult.HasValue && isUIHitClosest)
-            {
-                hitInfo.HitTargetTransform = raycastResult.Value.gameObject.transform;
-                hitInfo.TargetLocalHitPoint = hitInfo.HitTargetTransform.InverseTransformPoint(raycastResult.Value.worldPosition);
-                hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastResult.Value.worldNormal);
-                hitInfo.HitDistanceReferencePoint = raycastResult.Value.worldPosition;
-            }
-            // Otherwise, calculate the reticle pose based on the raycast hit.
-            else if (raycastHit.HasValue)
-            {
-                if (!hitPointAndTransformUpdated)
-                {
-                    hitInfo.HitTargetTransform = raycastHit.Value.collider.transform;
-                    hitInfo.TargetLocalHitPoint = hitInfo.HitTargetTransform.InverseTransformPoint(raycastHit.Value.point);
-                }
-
-                if (!hitNormalUpdated)
-                {
-                    hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastHit.Value.normal);
-                }
-
-                hitInfo.HitDistanceReferencePoint = hitInfo.HitTargetTransform.TransformPoint(hitInfo.TargetLocalHitPoint);
-            }
-            return hitInfo;
-        }
-
-        /// <summary>
-        /// A data container for managing the position, normal, and transform of a target hit point. 
-        /// </summary>
-        public struct TargetHitInfo
-        {
-            public Vector3 TargetLocalHitPoint;
-            public Vector3 TargetLocalHitNormal;
-            public Transform HitTargetTransform;
-            public Vector3 HitDistanceReferencePoint;
-        }
     }
 }

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/LineUtility.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/LineUtility.cs
@@ -231,9 +231,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // In the case of affordances/handles, we can stick the ray right on to the handle.
             if (interactableObject is ISnapInteractable snappable)
             {
-                hitInfo.hitTargetTransform = snappable.HandleTransform;
-                hitInfo.targetLocalHitPoint = Vector3.zero;
-                hitInfo.targetLocalHitNormal = Vector3.up;
+                hitInfo.HitTargetTransform = snappable.HandleTransform;
+                hitInfo.TargetLocalHitPoint = Vector3.zero;
+                hitInfo.TargetLocalHitNormal = Vector3.up;
                 hitPointAndTransformUpdated = true;
                 hitNormalUpdated = true;
             }
@@ -244,8 +244,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 scrollable.IsScrolling &&
                 scrollable.ScrollingInteractor == (IXRInteractor)rayInteractor)
             {
-                hitInfo.hitTargetTransform = scrollable.ScrollableTransform;
-                hitInfo.targetLocalHitPoint = scrollable.ScrollingLocalAnchorPosition;
+                hitInfo.HitTargetTransform = scrollable.ScrollableTransform;
+                hitInfo.TargetLocalHitPoint = scrollable.ScrollingLocalAnchorPosition;
                 hitPointAndTransformUpdated = true;
             }
 
@@ -263,23 +263,26 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // Align the reticle with a UI hit if applicable
             if (raycastResult.HasValue && isUIHitClosest)
             {
-                hitInfo.hitTargetTransform = raycastResult.Value.gameObject.transform;
-                hitInfo.targetLocalHitPoint = hitInfo.hitTargetTransform.InverseTransformPoint(raycastResult.Value.worldPosition);
-                hitInfo.targetLocalHitNormal = hitInfo.hitTargetTransform.InverseTransformDirection(raycastResult.Value.worldNormal);
+                hitInfo.HitTargetTransform = raycastResult.Value.gameObject.transform;
+                hitInfo.TargetLocalHitPoint = hitInfo.HitTargetTransform.InverseTransformPoint(raycastResult.Value.worldPosition);
+                hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastResult.Value.worldNormal);
+                hitInfo.HitDistanceReference = raycastResult.Value.worldPosition;
             }
             // Otherwise, calculate the reticle pose based on the raycast hit.
             else if (raycastHit.HasValue)
             {
                 if (!hitPointAndTransformUpdated)
                 {
-                    hitInfo.hitTargetTransform = raycastHit.Value.collider.transform;
-                    hitInfo.targetLocalHitPoint = hitInfo.hitTargetTransform.InverseTransformPoint(raycastHit.Value.point);
+                    hitInfo.HitTargetTransform = raycastHit.Value.collider.transform;
+                    hitInfo.TargetLocalHitPoint = hitInfo.HitTargetTransform.InverseTransformPoint(raycastHit.Value.point);
                 }
 
                 if (!hitNormalUpdated)
                 {
-                    hitInfo.targetLocalHitNormal = hitInfo.hitTargetTransform.InverseTransformDirection(raycastHit.Value.normal);
+                    hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastHit.Value.normal);
                 }
+
+                hitInfo.HitDistanceReference = hitInfo.HitTargetTransform.TransformPoint(hitInfo.TargetLocalHitPoint);
             }
             return hitInfo;
         }
@@ -289,9 +292,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public struct TargetHitInfo
         {
-            public Vector3 targetLocalHitPoint;
-            public Vector3 targetLocalHitNormal;
-            public Transform hitTargetTransform;
+            public Vector3 TargetLocalHitPoint;
+            public Vector3 TargetLocalHitNormal;
+            public Transform HitTargetTransform;
+            public Vector3 HitDistanceReference;
         }
     }
 }

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/LineUtility.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/Lines/LineUtility.cs
@@ -222,6 +222,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Used to locate and lock the raycast hit data on a select.
         /// </summary>
+        /// <param name="rayInteractor">The XRRayInteractor responsible for the raycast hit.</param>
+        /// <param name="interactableObject"> The IXRSelectInteractable which has been selected. </param>
+        /// <returns>The local position and normal of the hit target, the hit target transform, and a reference point to calculate hit distance, contained in a TargetHitInfo struct.</returns>
         public static TargetHitInfo LocateTargetHitPoint(this XRRayInteractor rayInteractor, IXRSelectInteractable interactableObject)
         {
             TargetHitInfo hitInfo = new TargetHitInfo();
@@ -266,7 +269,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 hitInfo.HitTargetTransform = raycastResult.Value.gameObject.transform;
                 hitInfo.TargetLocalHitPoint = hitInfo.HitTargetTransform.InverseTransformPoint(raycastResult.Value.worldPosition);
                 hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastResult.Value.worldNormal);
-                hitInfo.HitDistanceReference = raycastResult.Value.worldPosition;
+                hitInfo.HitDistanceReferencePoint = raycastResult.Value.worldPosition;
             }
             // Otherwise, calculate the reticle pose based on the raycast hit.
             else if (raycastHit.HasValue)
@@ -282,7 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastHit.Value.normal);
                 }
 
-                hitInfo.HitDistanceReference = hitInfo.HitTargetTransform.TransformPoint(hitInfo.TargetLocalHitPoint);
+                hitInfo.HitDistanceReferencePoint = hitInfo.HitTargetTransform.TransformPoint(hitInfo.TargetLocalHitPoint);
             }
             return hitInfo;
         }
@@ -295,7 +298,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             public Vector3 TargetLocalHitPoint;
             public Vector3 TargetLocalHitNormal;
             public Transform HitTargetTransform;
-            public Vector3 HitDistanceReference;
+            public Vector3 HitDistanceReferencePoint;
         }
     }
 }

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
@@ -5,7 +5,7 @@ using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.XR.Interaction.Toolkit;
-using static Microsoft.MixedReality.Toolkit.Input.LineUtility;
+using static Microsoft.MixedReality.Toolkit.Input.XRRayInteractorExtensions;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
@@ -5,6 +5,7 @@ using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.XR.Interaction.Toolkit;
+using static Microsoft.MixedReality.Toolkit.Input.LineUtility;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -181,8 +182,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         // reusable values derived from raycast hit data
         private Vector3 reticlePosition;
-        private Transform hitTargetTransform;
-        private Vector3 targetLocalHitPoint;
+        private TargetHitInfo selectedHitInfo = new TargetHitInfo();
         private float hitDistance;
 
         /// <summary>
@@ -324,7 +324,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (rayInteractor.hasSelection)
                 {
                     // Assign the last point to the one saved by the callback
-                    lineDataProvider.LastPoint = hitTargetTransform.TransformPoint(targetLocalHitPoint);
+                    lineDataProvider.LastPoint = selectedHitInfo.hitTargetTransform.TransformPoint(selectedHitInfo.targetLocalHitPoint);
                     rayHasHit = true;
                 }
                 // Otherwise draw out the line exactly as the Ray Interactor prescribes
@@ -447,67 +447,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         private void LocateTargetHitPoint(SelectEnterEventArgs args)
         {
-            // If no hit interactable, abort
-            if (args == null)
-            {
-                return;
-            }
-
-            bool hitPointAndTransformUpdated = false;
-
-            // In the case of affordances/handles, we can stick the ray right on to the handle.
-            if (args.interactableObject is ISnapInteractable snappable)
-            {
-                hitTargetTransform = snappable.HandleTransform;
-                targetLocalHitPoint = Vector3.zero;
-                hitPointAndTransformUpdated = true;
-            }
-
-            // In the case of an IScrollable being selected, ensure that the line visual locks to
-            // the scroller and not to the a list item within the scroller, such as a button.
-            if (args.interactableObject is IScrollable scrollable &&
-                scrollable.IsScrolling &&
-                scrollable.ScrollingInteractor == (IXRInteractor)rayInteractor)
-            {
-                hitTargetTransform = scrollable.ScrollableTransform;
-                targetLocalHitPoint = scrollable.ScrollingLocalAnchorPosition;
-                hitPointAndTransformUpdated = true;
-            }
-
-            // If no hit, abort.
-            if (!rayInteractor.TryGetCurrentRaycast(
-                out RaycastHit? raycastHit,
-                out _,
-                out UnityEngine.EventSystems.RaycastResult? raycastResult,
-                out _,
-                out bool isUIHitClosest))
-            {
-                return;
-            }
-
-            // If we haven't even gotten any ray positions yet, abort.
-            if (rayPositions == null || rayPositionsCount <= 0)
-            {
-                return;
-            }
-
-            // Record relevant data about the hit point.
-            if (raycastResult.HasValue && isUIHitClosest)
-            {
-                hitTargetTransform = raycastResult.Value.gameObject.transform;
-                targetLocalHitPoint = hitTargetTransform.InverseTransformPoint(raycastResult.Value.worldPosition);
-                hitDistance = (raycastResult.Value.worldPosition - rayPositions[0]).magnitude;
-            }
-            else if (raycastHit.HasValue)
-            {
-                if (!hitPointAndTransformUpdated)
-                {
-                    hitTargetTransform = raycastHit.Value.collider.transform;
-                    targetLocalHitPoint = hitTargetTransform.InverseTransformPoint(raycastHit.Value.point);
-                }
-
-                hitDistance = (hitTargetTransform.TransformPoint(targetLocalHitPoint) - rayPositions[0]).magnitude;
-            }
+            selectedHitInfo = rayInteractor.LocateTargetHitPoint(args.interactableObject);
+            hitDistance = (selectedHitInfo.hitTargetTransform.TransformPoint(selectedHitInfo.targetLocalHitPoint) - rayPositions[0]).magnitude;
         }
 
         #endregion

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
@@ -454,7 +454,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             selectedHitInfo = rayInteractor.LocateTargetHitPoint(args.interactableObject);
-            hitDistance = (selectedHitInfo.HitDistanceReference - rayPositions[0]).magnitude;
+            hitDistance = (selectedHitInfo.HitDistanceReferencePoint - rayPositions[0]).magnitude;
         }
 
         #endregion

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
@@ -182,7 +182,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         // reusable values derived from raycast hit data
         private Vector3 reticlePosition;
-        private TargetHitInfo selectedHitInfo = new TargetHitInfo();
+        private TargetHitDetails selectedHitDetails = new TargetHitDetails();
         private float hitDistance;
 
         /// <summary>
@@ -324,7 +324,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (rayInteractor.hasSelection)
                 {
                     // Assign the last point to the one saved by the callback
-                    lineDataProvider.LastPoint = selectedHitInfo.HitTargetTransform.TransformPoint(selectedHitInfo.TargetLocalHitPoint);
+                    lineDataProvider.LastPoint = selectedHitDetails.HitTargetTransform.TransformPoint(selectedHitDetails.TargetLocalHitPoint);
                     rayHasHit = true;
                 }
                 // Otherwise draw out the line exactly as the Ray Interactor prescribes
@@ -453,8 +453,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            selectedHitInfo = rayInteractor.LocateTargetHitPoint(args.interactableObject);
-            hitDistance = (selectedHitInfo.HitDistanceReferencePoint - rayPositions[0]).magnitude;
+            rayInteractor.TryLocateTargetHitPoint(args.interactableObject, out selectedHitDetails);
+            hitDistance = (selectedHitDetails.HitDistanceReferencePoint - rayPositions[0]).magnitude;
         }
 
         #endregion

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKLineVisual.cs
@@ -324,7 +324,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (rayInteractor.hasSelection)
                 {
                     // Assign the last point to the one saved by the callback
-                    lineDataProvider.LastPoint = selectedHitInfo.hitTargetTransform.TransformPoint(selectedHitInfo.targetLocalHitPoint);
+                    lineDataProvider.LastPoint = selectedHitInfo.HitTargetTransform.TransformPoint(selectedHitInfo.TargetLocalHitPoint);
                     rayHasHit = true;
                 }
                 // Otherwise draw out the line exactly as the Ray Interactor prescribes
@@ -447,8 +447,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         private void LocateTargetHitPoint(SelectEnterEventArgs args)
         {
+            // If no hit interactable or we haven't even gotten any ray positions yet, abort
+            if (args == null || rayPositions == null || rayPositionsCount <= 0)
+            {
+                return;
+            }
+
             selectedHitInfo = rayInteractor.LocateTargetHitPoint(args.interactableObject);
-            hitDistance = (selectedHitInfo.hitTargetTransform.TransformPoint(selectedHitInfo.targetLocalHitPoint) - rayPositions[0]).magnitude;
+            hitDistance = (selectedHitInfo.HitDistanceReference - rayPositions[0]).magnitude;
         }
 
         #endregion

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
@@ -4,7 +4,7 @@
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
-using static Microsoft.MixedReality.Toolkit.Input.LineUtility;
+using static Microsoft.MixedReality.Toolkit.Input.XRRayInteractorExtensions;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
@@ -84,8 +84,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     {
                         if (rayInteractor.interactablesSelected.Count > 0)
                         {
-                            reticlePosition = selectedHitInfo.hitTargetTransform.TransformPoint(selectedHitInfo.targetLocalHitPoint);
-                            reticleNormal = selectedHitInfo.hitTargetTransform.TransformDirection(selectedHitInfo.targetLocalHitNormal);
+                            reticlePosition = selectedHitInfo.HitTargetTransform.TransformPoint(selectedHitInfo.TargetLocalHitPoint);
+                            reticleNormal = selectedHitInfo.HitTargetTransform.TransformDirection(selectedHitInfo.TargetLocalHitNormal);
                             ReticleSetActive(true);
                         }
                         else

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
@@ -4,6 +4,7 @@
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
+using static Microsoft.MixedReality.Toolkit.Input.LineUtility;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -83,8 +84,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     {
                         if (rayInteractor.interactablesSelected.Count > 0)
                         {
-                            reticlePosition = hitTargetTransform.TransformPoint(targetLocalHitPoint);
-                            reticleNormal = hitTargetTransform.TransformDirection(targetLocalHitNormal);
+                            reticlePosition = selectedHitInfo.hitTargetTransform.TransformPoint(selectedHitInfo.targetLocalHitPoint);
+                            reticleNormal = selectedHitInfo.hitTargetTransform.TransformDirection(selectedHitInfo.targetLocalHitNormal);
                             ReticleSetActive(true);
                         }
                         else
@@ -131,71 +132,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private Vector3 targetLocalHitPoint;
-        private Vector3 targetLocalHitNormal;
-        private Transform hitTargetTransform;
+        private TargetHitInfo selectedHitInfo = new TargetHitInfo();
 
         /// <summary>
         /// Used to locate and lock the raycast hit data on a select
         /// </summary>
         private void LocateTargetHitPoint(SelectEnterEventArgs args)
         {
-            bool hitPointAndTransformUpdated = false;
-            bool hitNormalUpdated = false;
-
-            // In the case of affordances/handles, we can stick the ray right on to the handle.
-            if (args.interactableObject is ISnapInteractable snappable)
-            {
-                hitTargetTransform = snappable.HandleTransform;
-                targetLocalHitPoint = Vector3.zero;
-                targetLocalHitNormal = Vector3.up;
-                hitPointAndTransformUpdated = true;
-                hitNormalUpdated = true;
-            }
-
-            // In the case of an IScrollable being selected, ensure that the reticle locks to the
-            // scroller and not to the a list item within the scroller, such as a button.
-            if (args.interactableObject is IScrollable scrollable &&
-                scrollable.IsScrolling &&
-                scrollable.ScrollingInteractor == (IXRInteractor)rayInteractor)
-            {
-                hitTargetTransform = scrollable.ScrollableTransform;
-                targetLocalHitPoint = scrollable.ScrollingLocalAnchorPosition;
-                hitPointAndTransformUpdated = true;
-            }
-
-            // If no hit, abort.
-            if (!rayInteractor.TryGetCurrentRaycast(
-                  out RaycastHit? raycastHit,
-                  out _,
-                  out UnityEngine.EventSystems.RaycastResult? raycastResult,
-                  out _,
-                  out bool isUIHitClosest))
-            {
-                return;
-            }
-
-            // Align the reticle with a UI hit if applicable
-            if (raycastResult.HasValue && isUIHitClosest)
-            {
-                hitTargetTransform = raycastResult.Value.gameObject.transform;
-                targetLocalHitPoint = hitTargetTransform.InverseTransformPoint(raycastResult.Value.worldPosition);
-                targetLocalHitNormal = hitTargetTransform.InverseTransformDirection(raycastResult.Value.worldNormal);
-            }
-            // Otherwise, calculate the reticle pose based on the raycast hit.
-            else if (raycastHit.HasValue)
-            {
-                if (!hitPointAndTransformUpdated)
-                {
-                    hitTargetTransform = raycastHit.Value.collider.transform;
-                    targetLocalHitPoint = hitTargetTransform.InverseTransformPoint(raycastHit.Value.point);
-                }
-
-                if (!hitNormalUpdated)
-                {
-                    targetLocalHitNormal = hitTargetTransform.InverseTransformDirection(raycastHit.Value.normal);
-                }
-            }
+            selectedHitInfo = rayInteractor.LocateTargetHitPoint(args.interactableObject);
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
+++ b/com.microsoft.mrtk.input/Interactors/InteractorVisuals/MRTKRayReticleVisual.cs
@@ -84,8 +84,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     {
                         if (rayInteractor.interactablesSelected.Count > 0)
                         {
-                            reticlePosition = selectedHitInfo.HitTargetTransform.TransformPoint(selectedHitInfo.TargetLocalHitPoint);
-                            reticleNormal = selectedHitInfo.HitTargetTransform.TransformDirection(selectedHitInfo.TargetLocalHitNormal);
+                            reticlePosition = selectedHitDetails.HitTargetTransform.TransformPoint(selectedHitDetails.TargetLocalHitPoint);
+                            reticleNormal = selectedHitDetails.HitTargetTransform.TransformDirection(selectedHitDetails.TargetLocalHitNormal);
                             ReticleSetActive(true);
                         }
                         else
@@ -132,14 +132,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private TargetHitInfo selectedHitInfo = new TargetHitInfo();
+        private TargetHitDetails selectedHitDetails = new TargetHitDetails();
 
         /// <summary>
         /// Used to locate and lock the raycast hit data on a select
         /// </summary>
         private void LocateTargetHitPoint(SelectEnterEventArgs args)
         {
-            selectedHitInfo = rayInteractor.LocateTargetHitPoint(args.interactableObject);
+            rayInteractor.TryLocateTargetHitPoint(args.interactableObject, out selectedHitDetails);
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.input/Interactors/XRRayInteractorExtensions.cs
+++ b/com.microsoft.mrtk.input/Interactors/XRRayInteractorExtensions.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using UnityEngine.XR.Interaction.Toolkit;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+
+	public static class XRRayInteractorExtensions
+	{
+		/// <summary>
+		/// Used to locate and lock the raycast hit data on a select.
+		/// </summary>
+		/// <param name="rayInteractor">The XRRayInteractor responsible for the raycast hit.</param>
+		/// <param name="interactableObject"> The IXRSelectInteractable which has been selected. </param>
+		/// <returns>The local position and normal of the hit target, the hit target transform, and a reference point to calculate hit distance, contained in a TargetHitInfo struct.</returns>
+		public static TargetHitInfo LocateTargetHitPoint(this XRRayInteractor rayInteractor, IXRSelectInteractable interactableObject)
+		{
+			TargetHitInfo hitInfo = new TargetHitInfo();
+			bool hitPointAndTransformUpdated = false;
+			bool hitNormalUpdated = false;
+
+			// In the case of affordances/handles, we can stick the ray right on to the handle.
+			if (interactableObject is ISnapInteractable snappable)
+			{
+				hitInfo.HitTargetTransform = snappable.HandleTransform;
+				hitInfo.TargetLocalHitPoint = Vector3.zero;
+				hitInfo.TargetLocalHitNormal = Vector3.up;
+				hitPointAndTransformUpdated = true;
+				hitNormalUpdated = true;
+			}
+
+			// In the case of an IScrollable being selected, ensure that the reticle locks to the
+			// scroller and not to the a list item within the scroller, such as a button.
+			if (interactableObject is IScrollable scrollable &&
+				scrollable.IsScrolling &&
+				scrollable.ScrollingInteractor == (IXRInteractor)rayInteractor)
+			{
+				hitInfo.HitTargetTransform = scrollable.ScrollableTransform;
+				hitInfo.TargetLocalHitPoint = scrollable.ScrollingLocalAnchorPosition;
+				hitPointAndTransformUpdated = true;
+			}
+
+			// If no hit, abort.
+			if (!rayInteractor.TryGetCurrentRaycast(
+				  out RaycastHit? raycastHit,
+				  out _,
+				  out UnityEngine.EventSystems.RaycastResult? raycastResult,
+				  out _,
+				  out bool isUIHitClosest))
+			{
+				return hitInfo;
+			}
+
+			// Align the reticle with a UI hit if applicable
+			if (raycastResult.HasValue && isUIHitClosest)
+			{
+				hitInfo.HitTargetTransform = raycastResult.Value.gameObject.transform;
+				hitInfo.TargetLocalHitPoint = hitInfo.HitTargetTransform.InverseTransformPoint(raycastResult.Value.worldPosition);
+				hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastResult.Value.worldNormal);
+				hitInfo.HitDistanceReferencePoint = raycastResult.Value.worldPosition;
+			}
+			// Otherwise, calculate the reticle pose based on the raycast hit.
+			else if (raycastHit.HasValue)
+			{
+				if (!hitPointAndTransformUpdated)
+				{
+					hitInfo.HitTargetTransform = raycastHit.Value.collider.transform;
+					hitInfo.TargetLocalHitPoint = hitInfo.HitTargetTransform.InverseTransformPoint(raycastHit.Value.point);
+				}
+
+				if (!hitNormalUpdated)
+				{
+					hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastHit.Value.normal);
+				}
+
+				hitInfo.HitDistanceReferencePoint = hitInfo.HitTargetTransform.TransformPoint(hitInfo.TargetLocalHitPoint);
+			}
+			return hitInfo;
+		}
+
+		/// <summary>
+		/// A data container for managing the position, normal, and transform of a target hit point. 
+		/// </summary>
+		public struct TargetHitInfo
+		{
+			/// <summary>
+			/// The position of the target hit.
+			/// </summary>
+			public Vector3 TargetLocalHitPoint;
+
+			/// <summary>
+			/// The normal of the target hit. 
+			/// </summary>
+			public Vector3 TargetLocalHitNormal;
+
+			/// <summary>
+			/// The Transform of the selected target. 
+			/// </summary>
+			public Transform HitTargetTransform;
+
+			/// <summary>
+			/// The position used to calculate hit distance from a given ray position.
+			/// </summary>
+			public Vector3 HitDistanceReferencePoint;
+		}
+	}
+}

--- a/com.microsoft.mrtk.input/Interactors/XRRayInteractorExtensions.cs
+++ b/com.microsoft.mrtk.input/Interactors/XRRayInteractorExtensions.cs
@@ -11,24 +11,25 @@ namespace Microsoft.MixedReality.Toolkit.Input
 	/// </summary>
 	public static class XRRayInteractorExtensions
 	{
-		/// <summary>
-		/// Used to locate and lock the raycast hit data on a select.
-		/// </summary>
-		/// <param name="rayInteractor">The XRRayInteractor responsible for the raycast hit.</param>
-		/// <param name="interactableObject"> The IXRSelectInteractable which has been selected. </param>
-		/// <returns>The local position and normal of the hit target, the hit target transform, and a reference point to calculate hit distance, contained in a TargetHitInfo struct.</returns>
-		public static TargetHitInfo LocateTargetHitPoint(this XRRayInteractor rayInteractor, IXRSelectInteractable interactableObject)
+        /// <summary>
+        /// Used to locate and lock the raycast hit data on a select.
+        /// </summary>
+        /// <param name="rayInteractor">The XRRayInteractor responsible for the raycast hit.</param>
+        /// <param name="interactableObject"> The IXRSelectInteractable which has been selected. </param>
+        /// <param name="hitDetails"> The local position and normal of the hit target, the hit target transform, and a reference point to calculate hit distance, contained in a TargetHitDetails struct. </param>
+        /// <returns> Returns true if there was a raycast hit and false otherwise. </returns>
+        public static bool TryLocateTargetHitPoint(this XRRayInteractor rayInteractor, IXRSelectInteractable interactableObject, out TargetHitDetails hitDetails)
 		{
-			TargetHitInfo hitInfo = new TargetHitInfo();
+			hitDetails = new TargetHitDetails();
 			bool hitPointAndTransformUpdated = false;
 			bool hitNormalUpdated = false;
 
 			// In the case of affordances/handles, we can stick the ray right on to the handle.
 			if (interactableObject is ISnapInteractable snappable)
 			{
-				hitInfo.HitTargetTransform = snappable.HandleTransform;
-				hitInfo.TargetLocalHitPoint = Vector3.zero;
-				hitInfo.TargetLocalHitNormal = Vector3.up;
+				hitDetails.HitTargetTransform = snappable.HandleTransform;
+				hitDetails.TargetLocalHitPoint = Vector3.zero;
+				hitDetails.TargetLocalHitNormal = Vector3.up;
 				hitPointAndTransformUpdated = true;
 				hitNormalUpdated = true;
 			}
@@ -39,8 +40,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 				scrollable.IsScrolling &&
 				scrollable.ScrollingInteractor == (IXRInteractor)rayInteractor)
 			{
-				hitInfo.HitTargetTransform = scrollable.ScrollableTransform;
-				hitInfo.TargetLocalHitPoint = scrollable.ScrollingLocalAnchorPosition;
+				hitDetails.HitTargetTransform = scrollable.ScrollableTransform;
+				hitDetails.TargetLocalHitPoint = scrollable.ScrollingLocalAnchorPosition;
 				hitPointAndTransformUpdated = true;
 			}
 
@@ -52,40 +53,40 @@ namespace Microsoft.MixedReality.Toolkit.Input
 				  out _,
 				  out bool isUIHitClosest))
 			{
-				return hitInfo;
+				return false;
 			}
 
 			// Align the reticle with a UI hit if applicable
 			if (raycastResult.HasValue && isUIHitClosest)
 			{
-				hitInfo.HitTargetTransform = raycastResult.Value.gameObject.transform;
-				hitInfo.TargetLocalHitPoint = hitInfo.HitTargetTransform.InverseTransformPoint(raycastResult.Value.worldPosition);
-				hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastResult.Value.worldNormal);
-				hitInfo.HitDistanceReferencePoint = raycastResult.Value.worldPosition;
+				hitDetails.HitTargetTransform = raycastResult.Value.gameObject.transform;
+				hitDetails.TargetLocalHitPoint = hitDetails.HitTargetTransform.InverseTransformPoint(raycastResult.Value.worldPosition);
+				hitDetails.TargetLocalHitNormal = hitDetails.HitTargetTransform.InverseTransformDirection(raycastResult.Value.worldNormal);
+				hitDetails.HitDistanceReferencePoint = raycastResult.Value.worldPosition;
 			}
 			// Otherwise, calculate the reticle pose based on the raycast hit.
 			else if (raycastHit.HasValue)
 			{
 				if (!hitPointAndTransformUpdated)
 				{
-					hitInfo.HitTargetTransform = raycastHit.Value.collider.transform;
-					hitInfo.TargetLocalHitPoint = hitInfo.HitTargetTransform.InverseTransformPoint(raycastHit.Value.point);
+					hitDetails.HitTargetTransform = raycastHit.Value.collider.transform;
+					hitDetails.TargetLocalHitPoint = hitDetails.HitTargetTransform.InverseTransformPoint(raycastHit.Value.point);
 				}
 
 				if (!hitNormalUpdated)
 				{
-					hitInfo.TargetLocalHitNormal = hitInfo.HitTargetTransform.InverseTransformDirection(raycastHit.Value.normal);
+					hitDetails.TargetLocalHitNormal = hitDetails.HitTargetTransform.InverseTransformDirection(raycastHit.Value.normal);
 				}
 
-				hitInfo.HitDistanceReferencePoint = hitInfo.HitTargetTransform.TransformPoint(hitInfo.TargetLocalHitPoint);
+				hitDetails.HitDistanceReferencePoint = hitDetails.HitTargetTransform.TransformPoint(hitDetails.TargetLocalHitPoint);
 			}
-			return hitInfo;
+			return true;
 		}
 
 		/// <summary>
 		/// A data container for managing the position, normal, and transform of a target hit point. 
 		/// </summary>
-		public struct TargetHitInfo
+		public struct TargetHitDetails
 		{
 			/// <summary>
 			/// The position of the target hit.

--- a/com.microsoft.mrtk.input/Interactors/XRRayInteractorExtensions.cs
+++ b/com.microsoft.mrtk.input/Interactors/XRRayInteractorExtensions.cs
@@ -6,7 +6,9 @@ using UnityEngine.XR.Interaction.Toolkit;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-
+	/// <summary>
+	/// Extensions to the XRRayInteractor and associated structs.
+	/// </summary>
 	public static class XRRayInteractorExtensions
 	{
 		/// <summary>

--- a/com.microsoft.mrtk.input/Interactors/XRRayInteractorExtensions.cs.meta
+++ b/com.microsoft.mrtk.input/Interactors/XRRayInteractorExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05901b375352bf8478c5ca6d1bd52807
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Visuals/SqueezableBoxVisuals.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Visuals/SqueezableBoxVisuals.cs
@@ -263,6 +263,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
         protected virtual void OnEnable()
         {
+            // Ensures that when the GameObject is re-enabled, the handles are occluded ny default.
+            // If the handles are active, they will be un-occluded by the next frame.
+            // Prevents undesirable behaviour from the handle animations.
             foreach (var handle in handles)
             {
                 handle.HideOnStartup();

--- a/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Visuals/SqueezableBoxVisuals.cs
+++ b/com.microsoft.mrtk.spatialmanipulation/BoundsControl/Visuals/SqueezableBoxVisuals.cs
@@ -263,7 +263,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialManipulation
 
         protected virtual void OnEnable()
         {
-            // Ensures that when the GameObject is re-enabled, the handles are occluded ny default.
+            // Ensures that when the GameObject is re-enabled, the handles are occluded by default.
             // If the handles are active, they will be un-occluded by the next frame.
             // Prevents undesirable behaviour from the handle animations.
             foreach (var handle in handles)


### PR DESCRIPTION
## Overview
Consolidating the three LocateTargetHitPoint methods into one, a static helper which lives in the LineUtility class. This will take an XRRayInteractor and an IXRSelectInteractable, and will return the target local hit point, target local hit normal, target transform, and a reference point for calculating hit distance. 

## Changes
- Fixes: #11649.

