### PR TITLE
Fixing XML documentation warnings and some variable spellings, pass 3

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Prefabs/EyeTrackingExamples/Visualizer/Controls.prefab
+++ b/UnityProjects/MRTKDevTemplate/Assets/Prefabs/EyeTrackingExamples/Visualizer/Controls.prefab
@@ -989,7 +989,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   filenameToUse: mrtk_log_mostRecentET
-  addTimestampToLogfileName: 0
+  addTimestampToLogFileName: 0
   logStructure: {fileID: 9111033687875367441}
   userName: tester
   sessionDescription: Session00

--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/EyeTracking/EyeTrackingTargetPositioningExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/EyeTracking/EyeTrackingTargetPositioningExample.unity
@@ -587,7 +587,7 @@ MonoBehaviour:
   useEyeSupportedTargetPlacement: 1
   minLookAwayDistToEnableEyeWarp: 5
   handInputEnabled: 1
-  handmapping: 2
+  handMapping: 2
   deltaHandMovementThreshold: 0.05
   transparencyInTransition: 0.50980395
   transparencyPreview: 0.2
@@ -1248,7 +1248,7 @@ MonoBehaviour:
   useEyeSupportedTargetPlacement: 1
   minLookAwayDistToEnableEyeWarp: 5
   handInputEnabled: 1
-  handmapping: 2
+  handMapping: 2
   deltaHandMovementThreshold: 0.05
   transparencyInTransition: 0.50980395
   transparencyPreview: 0.2
@@ -14041,7 +14041,7 @@ MonoBehaviour:
   useEyeSupportedTargetPlacement: 1
   minLookAwayDistToEnableEyeWarp: 5
   handInputEnabled: 1
-  handmapping: 2
+  handMapping: 2
   deltaHandMovementThreshold: 0.05
   transparencyInTransition: 0.50980395
   transparencyPreview: 0.2
@@ -14905,7 +14905,7 @@ MonoBehaviour:
   useEyeSupportedTargetPlacement: 1
   minLookAwayDistToEnableEyeWarp: 5
   handInputEnabled: 1
-  handmapping: 2
+  handMapping: 2
   deltaHandMovementThreshold: 0.05
   transparencyInTransition: 0.50980395
   transparencyPreview: 0.2
@@ -35993,7 +35993,7 @@ MonoBehaviour:
   useEyeSupportedTargetPlacement: 1
   minLookAwayDistToEnableEyeWarp: 5
   handInputEnabled: 1
-  handmapping: 2
+  handMapping: 2
   deltaHandMovementThreshold: 0.05
   transparencyInTransition: 0.50980395
   transparencyPreview: 0.2
@@ -36961,7 +36961,7 @@ MonoBehaviour:
   useEyeSupportedTargetPlacement: 1
   minLookAwayDistToEnableEyeWarp: 5
   handInputEnabled: 1
-  handmapping: 2
+  handMapping: 2
   deltaHandMovementThreshold: 0.05
   transparencyInTransition: 0.50980395
   transparencyPreview: 0.2

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/DisableInteractors.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/DisableInteractors.cs
@@ -47,6 +47,9 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 
         private InteractorBehaviorControls interactorBehaviorControls;
 
+        /// <summary>
+        /// A Unity event function that is called when an enabled script instance is being loaded.
+        /// </summary>
         private void Awake()
         {
             interactorBehaviorControls = GetComponent<InteractorBehaviorControls>();
@@ -54,11 +57,17 @@ namespace Microsoft.MixedReality.Toolkit.Examples
             SetupSpeechCommand();
         }
 
+        /// <summary>
+        /// A Unity event function that is called on the frame when a script is enabled just before any of the update methods are called the first time.
+        /// </summary> 
         private void Start()
         {
             ResetExample();
         }
 
+        /// <summary>
+        /// A Unity event function that is called when the script component has been enabled.
+        /// </summary> 
         private void OnEnable()
         {
             interactorBehaviorControls.onControllerRayToggled += OnControllerRayToggled;
@@ -68,6 +77,9 @@ namespace Microsoft.MixedReality.Toolkit.Examples
             interactorBehaviorControls.onPokeToggled += OnPokeToggled;
         }
 
+        /// <summary>
+        /// A Unity event function that is called when the script component has been disabled.
+        /// </summary>
         private void OnDisable()
         {
             interactorBehaviorControls.onControllerRayToggled -= OnControllerRayToggled;
@@ -82,9 +94,16 @@ namespace Microsoft.MixedReality.Toolkit.Examples
             XRSubsystemHelpers.GetFirstSubsystem<KeywordRecognitionSubsystem>().CreateOrGetEventForKeyword("Reset Example").AddListener(ResetExample);
         }
 
+        /// <summary>
+        /// Reset the interactors of this scene, based of the availability of articulated hand input.
+        /// </summary>
+        /// <remarks>
+        /// If the application has configured a <see cref="IHandsAggregatorSubsystem"/>, this will put the interactors into HoloLens mode,
+        /// otherwise the interactors are put into VR mode.
+        /// </remarks>
         public void ResetExample()
         {
-            if(XRSubsystemHelpers.HandsAggregator != null)
+            if (XRSubsystemHelpers.HandsAggregator != null)
             {
                 SetHololensModeActive();
             }
@@ -93,7 +112,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
                 List<InputDevice> motionControllers = new List<InputDevice>();
                 InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.HeldInHand, motionControllers);
 
-                if(motionControllers.Count > 0)
+                if (motionControllers.Count > 0)
                 {
                     SetVRModeActive();
                 }

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/EyeTrackingUtilities.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/EyeTrackingUtilities.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections;
-using System.IO;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -48,14 +47,17 @@ namespace Microsoft.MixedReality.Toolkit.Examples
         }
 
         /// <summary>
-        /// Change the color of game object "gameObject".
+        /// Change the material color of the given <see cref="GameObject"/>.
         /// </summary>
-        /// <param name="originalColor">Enter "null" in case you're passing the original object and want to save the original color.</param>
-        public static void GameObject_ChangeColor(GameObject gobj, Color newColor, ref Color? originalColor, bool onlyApplyToRootObj)
+        /// <param name="gameObject">The object whose material colors will be changed.</param>
+        /// <param name="newColor">The new color to apply to the object's materials.</param> 
+        /// <param name="originalColor">Obtain the original color of the first material's <see cref="Material.color"/>. This must be <see langword="null"/> to obtain this original color.</param>
+        /// <param name="onlyApplyToRoot"><see langword="true"/> to only change materials on the root <see cref="GameObject"/>, and <see langword="false"/> to change children's materials too.</param>
+        public static void SetGameObjectColor(GameObject gameObject, Color newColor, ref Color? originalColor, bool onlyApplyToRoot)
         {
             try
             {
-                Renderer[] renderers = gobj.GetComponents<Renderer>();
+                Renderer[] renderers = gameObject.GetComponents<Renderer>();
                 for (int i = 0; i < renderers.Length; i++)
                 {
                     Material[] mats = renderers[i].materials;
@@ -64,15 +66,17 @@ namespace Microsoft.MixedReality.Toolkit.Examples
                         Color c = mat.color;
 
                         if (!originalColor.HasValue)
+                        {
                             originalColor = c;
+                        }
 
                         mat.color = newColor;
                     }
                 }
 
-                if (!onlyApplyToRootObj)
+                if (!onlyApplyToRoot)
                 {
-                    renderers = gobj.GetComponentsInChildren<Renderer>();
+                    renderers = gameObject.GetComponentsInChildren<Renderer>();
                     for (int i = 0; i < renderers.Length; i++)
                     {
                         Material[] mats = renderers[i].materials;

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/ScrollPanZoom/PanZoomBaseTexture.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/ScrollPanZoom/PanZoomBaseTexture.cs
@@ -76,20 +76,22 @@ namespace Microsoft.MixedReality.Toolkit.Examples
         /// <summary>
         /// Returns the pan speed.
         /// </summary>
-        /// <param name="uvCursorVal">Normalized cursor position in the hit box. Center is assumed to be at [-0.5, 0.5].</param>
-        protected override float ComputePanSpeed(float uvCursorPos, float maxSpeed, float minDistFromCenterForAutoPan)
+        /// <param name="uvCursorPosition">Normalized cursor position in the hit box. Center is assumed to be at (-0.5, 0.5).</param>        
+        /// <param name="maxSpeed">The maximum speed that can be returned by this function.</param>
+        /// <param name="minDistanceFromCenterForAutoPan">The minium distances from the center at which to start panning.</param>
+        protected override float ComputePanSpeed(float uvCursorPosition, float maxSpeed, float minDistanceFromCenterForAutoPan)
         {
             // UV space from [0,1] -> Center: [-0.5, 0.5]
-            float centeredVal = uvCursorPos - 0.5f;
+            float centeredVal = uvCursorPosition - 0.5f;
 
             // If the UV cursor is close to the center of the image, prevent continuous movements to limit distractions
-            if (Mathf.Abs(centeredVal) < minDistFromCenterForAutoPan)
+            if (Mathf.Abs(centeredVal) < minDistanceFromCenterForAutoPan)
             {
                 return 0f;
             }
             else
             {
-                float normalizedVal = (centeredVal - Mathf.Sign(centeredVal) * minDistFromCenterForAutoPan) / (Mathf.Sign(centeredVal) * (0.5f - minDistFromCenterForAutoPan));
+                float normalizedVal = (centeredVal - Mathf.Sign(centeredVal) * minDistanceFromCenterForAutoPan) / (Mathf.Sign(centeredVal) * (0.5f - minDistanceFromCenterForAutoPan));
                 float speed = normalizedVal * normalizedVal * maxSpeed * Mathf.Sign(centeredVal);
                 return speed;
             }

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/ScrollPanZoom/PanZoomTexture.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/ScrollPanZoom/PanZoomTexture.cs
@@ -67,6 +67,9 @@ namespace Microsoft.MixedReality.Toolkit.Examples
         [Range(0, 10)]
         private float skimProofUpdateSpeed = 5f;
 
+        /// <summary>
+        /// A Unity event function that is called on the frame when a script is enabled just before any of the update methods are called the first time.
+        /// </summary> 
         protected override void Start()
         {
             // Assigning values to base PanZoom class

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/ScrollPanZoom/ScrollRectTransform.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/ScrollPanZoom/ScrollRectTransform.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
         [SerializeField]
         private RectTransform rectTransformToNavigate = null;
 
-        [Tooltip("Reference to the viewport restricting the viewbox. This is important for identifying the max constrains for panning.")]
+        [Tooltip("Reference to the viewport restricting the view box. This is important for identifying the max constrains for panning.")]
         [SerializeField]
         private RectTransform referenceToViewPort = null;
 
@@ -53,8 +53,16 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 
         [Tooltip("Custom anchor start position.")]
         [SerializeField]
-        public Vector2 customStartPosition;
+        private Vector2 customStartPosition;
 
+        /// <summary>
+        /// Custom anchor start position.
+        /// </summary>
+        public Vector2 CustomStartPosition => customStartPosition;
+
+        /// <summary>
+        /// A Unity event function that is called on the frame when a script is enabled just before any of the update methods are called the first time.
+        /// </summary> 
         protected override void Start()
         {
             // Assigning values to base PanZoom class

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/TargetPositioning/MoveObjectByEyeGaze.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/TargetPositioning/MoveObjectByEyeGaze.cs
@@ -1,22 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Subsystems;
+using UnityEngine.XR;
+using UnityEngine.XR.Interaction.Toolkit;
 using UnityEngine;
 using UnityEngine.Events;
 
 namespace Microsoft.MixedReality.Toolkit.Examples
 {
-    using Input;
-    using Subsystems;
-    using UnityEngine.XR;
-    using UnityEngine.XR.Interaction.Toolkit;
-
     /// <summary>
-    /// Specifies the allowed surface orientations to place GameObjects with attached <see cref="MoveObjectByEyeGaze"/> on.
+    /// Specifies whether the <see cref="GameObject"/> moves on horizontal or vertical surfaces.
     /// </summary>
     internal enum PlacementSurfaces
     {
+        /// <summary>
+        /// The <see cref="GameObject"/> can moves on horizontal surfaces.
+        /// </summary>
         Horizontal,
+
+        /// <summary>
+        /// The <see cref="GameObject"/> can moves on vertical surfaces.
+        /// </summary>
         Vertical
     }
 
@@ -49,10 +55,9 @@ namespace Microsoft.MixedReality.Toolkit.Examples
         [SerializeField]
         private bool handInputEnabled = true;
 
-        [Tooltip(
-            "To control whether the hand motion is used 1:1 to move a target or to use different gains to allow for smaller hand motions.")]
+        [Tooltip("To control whether the hand motion is used 1:1 to move a target or to use different gains to allow for smaller hand motions.")]
         [SerializeField]
-        private float handmapping = 1f;
+        private float handMapping = 1f;
 
         [Tooltip("Minimal amount of hand movement to trigger target repositioning.")]
         [SerializeField]
@@ -629,7 +634,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
                     // Continuous manual target movement
                     Vector3 oldPos = gameObject.transform.position;
                     Vector3 d = new Vector3(-delta.x * ConstraintX, -delta.y * ConstraintY, -delta.z * ConstraintZ);
-                    gameObject.transform.position = oldPos + d * handmapping;
+                    gameObject.transform.position = oldPos + d * handMapping;
 
                     ConstrainMovement();
                 }

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/TargetPositioning/ObjectGoalZone.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/TargetPositioning/ObjectGoalZone.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
             audioSource = GetComponent<AudioSource>();
 
             // Set default color
-            EyeTrackingUtilities.GameObject_ChangeColor(gameObject, statusColorIdle, ref originalColor, false);
+            EyeTrackingUtilities.SetGameObjectColor(gameObject, statusColorIdle, ref originalColor, false);
         }
 
         #region Handle collision detection
@@ -120,13 +120,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples
             // Only change color if the status has changed 
             if (allObjectsInZone && !wereAllObjectsInZone)
             {
-                EyeTrackingUtilities.GameObject_ChangeColor(gameObject, statusColorAchieved, ref originalColor, false);
+                EyeTrackingUtilities.SetGameObjectColor(gameObject, statusColorAchieved, ref originalColor, false);
                 audioSource.PlayOneShot(audioFxSuccess);
                 
             }
             else if (!allObjectsInZone && wereAllObjectsInZone)
             {
-                EyeTrackingUtilities.GameObject_ChangeColor(gameObject, statusColorIdle, ref originalColor, false);
+                EyeTrackingUtilities.SetGameObjectColor(gameObject, statusColorIdle, ref originalColor, false);
             }
 
             wereAllObjectsInZone = allObjectsInZone;

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/Visualizer/DrawOnTexture.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/Visualizer/DrawOnTexture.cs
@@ -10,7 +10,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 {
     /// <summary>
     /// Example of how to use interactors to create a heatmap of eye tracking data.
-    /// Uses MRTKBaseInteractable, but not StatefulInteractable.
     /// </summary>
     [AddComponentMenu("MRTK/Examples/DrawOnTexture")]
     [RequireComponent(typeof(Renderer))]

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/Visualizer/UserInputRecorder.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/EyeTracking/Visualizer/UserInputRecorder.cs
@@ -10,8 +10,10 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 {
     /// <summary>
     /// Allows the user to record a log file of eye gaze interactions for playback at another time.
-    /// The log file is a CSV file and is created and written to while this behaviour is <see cref="MonoBehaviour.isActiveAndEnabled"/>
     /// </summary>
+    /// <remarks>
+    /// The log file is a CSV file which is created and written to while this behaviour is enabled.
+    /// </remarks>
     [AddComponentMenu("Scripts/MRTK/Examples/UserInputRecorder")]
     public class UserInputRecorder : MonoBehaviour
     {
@@ -21,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 
         [Tooltip("Prepends a timestamp to the log file name if enabled")]
         [SerializeField]
-        private bool addTimestampToLogfileName = false;
+        private bool addTimestampToLogFileName = false;
 
         [Tooltip("The log structure to gather eye gaze samples from")]
         [SerializeField]
@@ -72,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 
         private string Filename
         {
-            get { return addTimestampToLogfileName ? FilenameWithTimestamp : FilenameNoTimestamp; }
+            get { return addTimestampToLogFileName ? FilenameWithTimestamp : FilenameNoTimestamp; }
         }
         
         private string FilenameWithTimestamp

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/InteractorBehaviorControls.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/InteractorBehaviorControls.cs
@@ -10,8 +10,10 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 {
     /// <summary>
     /// Example class to demonstrate how to turn various interactors on and off.
-    /// Hook up buttons to the public functions to turn interactors on and off.
     /// </summary>
+    /// <remarks>
+    /// Hook up buttons to the public functions to turn interactors on and off.
+    /// </remarks>
     [AddComponentMenu("MRTK/Examples/InteractorBehaviorControls")]
     public class InteractorBehaviorControls : MonoBehaviour
     {
@@ -62,13 +64,30 @@ namespace Microsoft.MixedReality.Toolkit.Examples
         public event Action<bool> onGazeToggled;
 
         /// <summary>
-        /// Sets pointer behavior to mimic HoloLens 2
-        /// Poke interactor will be On
-        /// Grab interactor will be On
-        /// HandRay interactor will be On
-        /// MotionControllerRay interactor will be Off
-        /// Gaze interactor will be On
+        /// Sets pointer behavior to mimic HoloLens.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This will do this following:
+        /// </para>
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>Turn on the poke interactors.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>Turn on the grab interactors.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>Turn on the hand ray interactors.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>Turn off the controller ray interactors.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>Turn on the gaze interactors.</description>
+        ///     </item>
+        /// </list>
+        /// </remarks>
         public void SetHololens()
         {
             SetHandPokeActive(true);
@@ -78,14 +97,32 @@ namespace Microsoft.MixedReality.Toolkit.Examples
             SetGazeActive(true);
         }
 
+
         /// <summary>
-        /// Sets pointer states to mimic traditional vr behavior.
-        /// Poke interactor will be Off
-        /// Grab interactor will be Off
-        /// HandRay interactor will be Off
-        /// MotionControllerRay interactor will be On
-        /// Gaze interactor will be Off
+        /// Sets pointer behavior to mimic tradition VR behavior.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This will do this following:
+        /// </para>
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>Turn off the poke interactors.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>Turn off the grab interactors.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>Turn off the hand ray interactors.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>Turn on the controller ray interactors.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>Turn off the gaze interactors.</description>
+        ///     </item>
+        /// </list>
+        /// </remarks>
         public void SetVR()
         {
             SetHandPokeActive(false);
@@ -95,30 +132,45 @@ namespace Microsoft.MixedReality.Toolkit.Examples
             SetGazeActive(false);
         }
 
+        /// <summary>
+        /// Enable or disable the specified gaze interactors.
+        /// </summary>
         public void SetGazeActive(bool isActive)
         {
             ToggleInteractor(gazeInteractor, isActive);
             onGazeToggled?.Invoke(isActive);
         }
 
+        /// <summary>
+        /// Enable or disable the specified poke interactors.
+        /// </summary>
         public void SetHandPokeActive(bool isActive)
         {
             ToggleInteractors(pokeInteractors, isActive);
             onPokeToggled?.Invoke(isActive);
         }
 
+        /// <summary>
+        /// Enable or disable the specified hand grab interactors.
+        /// </summary>
         public void SetHandGrabActive(bool isActive)
         {
             ToggleInteractors(grabInteractors, isActive);
             onGrabToggled?.Invoke(isActive);
         }
 
+        /// <summary>
+        /// Enable or disable the specified controller ray interactors.
+        /// </summary>
         public void SetControllerRayActive(bool isActive)
         {
             ToggleInteractors(controllerRayInteractors, isActive);
             onControllerRayToggled?.Invoke(isActive);
         }
 
+        /// <summary>
+        /// Enable or disable the specified hand ray interactors.
+        /// </summary>
         public void SetHandRayActive(bool isActive)
         {
             ToggleInteractors(handRaysInteractors, isActive);

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/PenInteractor.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/PenInteractor.cs
@@ -24,13 +24,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
     /// This interactor acts as a poking interactor through trigger intersections.
     /// </para>
     /// <para>
-    /// The full <see cref="PokeInteractor"/> implementation used for the user's fingers
+    /// The full <see cref="IPokeInteractor"/> implementation used for the user's fingers
     /// uses a much more advanced sphere cast intersection system to ensure that
     /// high speed pokes are always registered. This interactor, however, uses
     /// simple trigger intersections in the interest of simplicity and demonstration.
     /// At high speeds, and low frame rates, this may miss some intersections with
     /// interactables. For higher fidelity intersections, consider using a sphere cast
-    /// system like <see cref="PokeInteractor"/>.
+    /// system like <see cref="IPokeInteractor"/>.
     /// </para>
     /// </remarks>
     [AddComponentMenu("MRTK/Examples/Pen Interactor")]

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/SolverExampleManager.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/SolverExampleManager.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
     using UnityEngine.XR.Interaction.Toolkit;
 
     /// <summary>
-    /// Manager class for the SolverExamples scene
+    /// Manager class for the solver examples scene.
     /// </summary>
     [AddComponentMenu("Scripts/MRTK/Examples/SolverExampleManager")]
     public class SolverExampleManager : MonoBehaviour
@@ -28,8 +28,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 
         private SolverHandler handler;
         private Solver currentSolver;
-
         private TrackedObjectType trackedType = TrackedObjectType.Head;
+
+        /// <summary>
+        /// Get or set the type of object to be tracked.
+        /// </summary>
         public TrackedObjectType TrackedType
         {
             get => trackedType;

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/SpeechKeywordRecognitionHandler.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/SpeechKeywordRecognitionHandler.cs
@@ -9,17 +9,44 @@ using System;
 
 namespace Microsoft.MixedReality.Toolkit.Examples
 {
+    /// <summary>
+    /// A helper for registering keywords a <see cref="KeywordRecognitionSubsystem"/>.
+    /// </summary>
+    /// <remarks>
+    /// When a <see cref="KeywordRecognitionSubsystem"/> recognizes one of the specified keywords, this
+    /// will raise Unity events that consumers can respond too. See <see cref="KeywordEvent"/> for more
+    /// details.
+    /// </remarks>
     public class SpeechKeywordRecognitionHandler : MonoBehaviour
     {
+        /// <summary>
+        /// A structure holding a Unity event that will be raised when the corresponding keyword is recognized.
+        /// </summary>
         [Serializable]
         public struct KeywordEvent
         {
-            [SerializeField] public string Keyword;
-            [SerializeField] public UnityEvent Event;
+            /// <summary>
+            /// The keyword that a <see cref="KeywordRecognitionSubsystem"/> will listen for.
+            /// </summary>
+            [SerializeField] 
+            [Tooltip("The keyword that the KeywordRecognitionSubsystem will listen for.")]
+            public string Keyword;
+
+            /// <summary>
+            /// The event raised when a <see cref="KeywordRecognitionSubsystem"/> recognizes the <see cref="Keyword"/>.
+            /// </summary>
+            [SerializeField]             
+            [Tooltip("The event raised when a KeywordRecognitionSubsystem recognizes the Keyword.")]
+            public UnityEvent Event;
         }
 
-        [SerializeField] private List<KeywordEvent> keywords = new List<KeywordEvent>();
+        [SerializeField]
+        [Tooltip("Get or set the list of keywords that a KeywordRecognitionSubsystem will listen for.")]
+        private List<KeywordEvent> keywords = new List<KeywordEvent>();
 
+        /// <summary>
+        /// Get or set the list of keywords that a <see cref="KeywordRecognitionSubsystem"/> will listen for. 
+        /// </summary>
         public List<KeywordEvent> Keywords
         {
             get => keywords;
@@ -30,10 +57,15 @@ namespace Microsoft.MixedReality.Toolkit.Examples
             }
         }
 
-        [SerializeField] private UnityEvent globalEvent;
+        [SerializeField] 
+        [Tooltip("A Unity event that will be raised when any keyword is recognized.")]
+        private UnityEvent globalEvent;
 
         private KeywordRecognitionSubsystem keywordRecognitionSubsystem;
 
+        /// <summary>
+        /// A Unity event function that is called on the frame when a script is enabled just before any of the update methods are called the first time.
+        /// </summary> 
         private void Start()
         {
             keywordRecognitionSubsystem = XRSubsystemHelpers.GetFirstRunningSubsystem<KeywordRecognitionSubsystem>();

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/TextToSpeechHandler.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/TextToSpeechHandler.cs
@@ -11,27 +11,33 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 
     /// <summary>
     /// Demonstration script showing how to subscribe to and handle
-    /// events fired by DictationSubsystem.
+    /// events fired by a <see cref="DictationSubsystem"/>.
     /// </summary>
     [RequireComponent(typeof(AudioSource))]
     [AddComponentMenu("MRTK/Examples/TextToSpeech Handler")]
     public class TextToSpeechHandler : MonoBehaviour
     {
-        [Tooltip("The audio source where speech will be played.")] [SerializeField]
+        [SerializeField]
+        [Tooltip("The audio source where speech will be played.")] 
         private AudioSource audioSource;
 
         /// <summary>
         /// Gets or sets the audio source where speech will be played.
         /// </summary>
-        public AudioSource AudioSource { get { return audioSource; } set { audioSource = value; } }
+        public AudioSource AudioSource
+        {
+            get { return audioSource; }
+            set { audioSource = value; }
+        }
 
         /// <summary>
         /// Gets or sets the voice that will be used to generate speech. To use a non en-US voice, set this to Other.
         /// </summary>
-        /// <remarks>
-        /// If a custom voice is desired (i.e. this enum is being set to Other) make sure to set the <see cref="VoiceName"/> property.
-        /// </remarks>
-        public TextToSpeechVoice Voice { get { return voice; } set { voice = value; } }
+        public TextToSpeechVoice Voice 
+        { 
+            get { return voice; } 
+            set { voice = value; } 
+        }
 
         [Tooltip("The voice that will be used to generate speech. To use a non en-US voice, set this to Other.")]
         [SerializeField]
@@ -58,7 +64,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples
         /// </summary>
         public void Speak()
         {
-
             // If we have a text to speech manager on the target object, say something.
             // This voice will appear to emanate from the object.
             textToSpeechSubsystem = XRSubsystemHelpers.GetFirstRunningSubsystem<TextToSpeechSubsystem>();

--- a/UnityProjects/MRTKDevTemplate/Assets/UX Theming Example/Scripts/BatteryLevelDataSource.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/UX Theming Example/Scripts/BatteryLevelDataSource.cs
@@ -201,7 +201,7 @@ namespace Microsoft.MixedReality.Toolkit.Data
         }
 
         /// <summary>
-        /// Calculate an integral level from 0 to &lt; <paramref name="numIntegralLevels"/> based on charging state and <paramref name="analogLevel"/>.
+        /// Calculate an integral level from 0 to &lt; <paramref name="numIntegralLevels"/> based on charging state and <paramref name="level"/>.
         /// </summary>
         /// <param name="level">Current battery level from 0 to 1 inclusive.</param>
         /// <param name="charging">Whether it is currently in the state of being charged.</param>
@@ -213,7 +213,7 @@ namespace Microsoft.MixedReality.Toolkit.Data
 
             if (charging)
             {
-                /// any algorithm desired for charging
+                // any algorithm desired for charging
                 integralLevel = Math.Min((int)((0.1 + level) * numIntegralLevels), numIntegralLevels - 1);
             }
             else

--- a/UnityProjects/MRTKDevTemplate/Assets/UX Theming Example/Themes/MusicInformationProfile.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/UX Theming Example/Themes/MusicInformationProfile.cs
@@ -1,16 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// Disable "missing XML comment" warning for samples. While nice to have, this XML documentation is not required for samples.
+#pragma warning disable CS1591
+
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.UX
 {
     /// <summary>
-    /// All themable assets for one musical note. In this case it includes a name to be used
-    /// on a button, and the audio clip that will play when activated.
+    /// All theme assets for one musical note.
     /// </summary>
+    /// <remarks>
+    /// In this case it includes a name to be used
+    /// on a button, and the audio clip that will play when activated.
+    /// </remarks>
     [Serializable]
     public class MusicalNoteInformation
     {
@@ -24,19 +29,25 @@ namespace Microsoft.MixedReality.Toolkit.UX
     }
 
     /// <summary>
-    /// A simple musical note theming profile in the form of a ScriptableObject, that can be used as a DataSource via DataSourceReflection.
+    /// A simple musical note theming profile in the form of a <see cref="ScriptableObject"/>, 
+    /// that can be used as a data source.
     /// </summary>
     /// <remarks>
-    /// By creating multiple profiles out of this ScriptableObject, each profile can contain a different instrument, or a different octave.
+    /// By creating multiple profiles out of this <see cref="ScriptableObject"/>,, each profile can contain a different instrument, or a different octave.
     /// These can then be easily swapped via helper scripts such as the ThemeSelector.
     /// </remarks>
-    [CreateAssetMenu(fileName = "Example_MusicInformation_Profile", menuName = "MRTK/Examples/Music Information Profile")]
     [Serializable]
+    [CreateAssetMenu(fileName = "Example_MusicInformation_Profile", menuName = "MRTK/Examples/Music Information Profile")]
     public class MusicInformationProfile : ScriptableObject
     {
-        [Tooltip("A list of musical notes providing name and audioclip for each.")]
         [SerializeField]
+        [Tooltip("A list of musical notes providing name and audio clip for each.")]
         private MusicalNoteInformation[] notes;
+
+        /// <summary>
+        /// A list of musical notes providing name and audio clip for each.
+        /// </summary>
         public MusicalNoteInformation[] Notes => notes;
     }
 }
+#pragma warning restore CS1591

--- a/com.microsoft.mrtk.data/Runtime/Scripts/DataConsumers/DataConsumerCommandDispatcher.cs
+++ b/com.microsoft.mrtk.data/Runtime/Scripts/DataConsumers/DataConsumerCommandDispatcher.cs
@@ -72,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Data
         /// If optional parameters are needed, this method allows for these to be passed in.
         /// </remarks>
         /// <param name="command">The command to send.</param>
-        /// <para name="optionalParameters">The set of key-vair pairs to send as command parameters.</para>
+        /// <param name="optionalParameters">The set of key-vair pairs to send as command parameters.</param>
         public virtual void SendCommand(string command, Dictionary<string, object> optionalParameters)
         {
             if (DataController != null)

--- a/com.microsoft.mrtk.data/Runtime/Scripts/DataConsumers/DataConsumerThemableBase.cs
+++ b/com.microsoft.mrtk.data/Runtime/Scripts/DataConsumers/DataConsumerThemableBase.cs
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.Data
         /// </para>
         /// </remarks>
         /// <param name="binding">The binding to use when looking up the value at index <paramref name="n"/> in the <see cref="DataBindingProfile.ValueToThemeKeypathLookup"/> array.</param>
-        /// <param name="n">Index for looking up object of type <typeparamref name="T"/></param>
+        /// <param name="n">Index for looking up an object of type <typeparamref name="T"/>.</param>
         /// <returns>Found object of type <typeparamref name="T"/> or <see langword="null"/> if not found.</returns>
         protected virtual T GetObjectByThemeLookupIndex(BindingInfo binding, int n)
         {
@@ -165,9 +165,9 @@ namespace Microsoft.MixedReality.Toolkit.Data
         /// value, the keypath will be appended to the base keypath
         /// provided in the DataConsumerThemeHelper.
         /// </remarks>
-        /// <param name="binding">The binding to use when resolve the request object at index <paramref name="n"/></param>
-        /// <param name="keyValue">Key value provided by data source</param>
-        /// <returns>Found object of type T or null if not found</returns>
+        /// <param name="binding">The binding to use when resolve the request object at index <paramref name="keyValue"/>.</param>
+        /// <param name="keyValue">The key for looking up an object of type <typeparamref name="T"/>.</param>
+        /// <returns>Found object of type <typeparamref name="T"/> or <see langword="null"/> if not found</returns>
         protected virtual T GetObjectByThemeLookupKey(BindingInfo binding, string keyValue)
         {
             // Lookup lists are usually small, but it would make sense to create a dictionary
@@ -362,9 +362,14 @@ namespace Microsoft.MixedReality.Toolkit.Data
         /// <param name="dataSource">Which data source called this method.</param>
         /// <param name="resolvedKeyPath">Fully resolved keypath for datum that changed.</param>
         /// <param name="localKeyPath">Local keypath for the datum that changed.</param>
-        /// <param name="inDataValue">The current value of the datum</param>
+        /// <param name="inDataOrThemeValue">The current data or theme value.</param>
         /// <param name="dataChangeType">The type of change that has occurred.</param>
-        protected override void ProcessDataChanged(IDataSource dataSource, string resolvedKeyPath, string localKeyPath, object inDataOrThemeValue, DataChangeType dataChangeType)
+        protected override void ProcessDataChanged(
+            IDataSource dataSource, 
+            string resolvedKeyPath, 
+            string localKeyPath, 
+            object inDataOrThemeValue,
+             DataChangeType dataChangeType)
         {
             if (_themeKeypathToBindingLookup.TryGetValue(localKeyPath, out BindingInfo binding))
             {
@@ -380,10 +385,11 @@ namespace Microsoft.MixedReality.Toolkit.Data
         }
 
         /// <summary>
-        /// Given a theme value and a datum value, determine the final output value
+        /// Given a theme value and a data value, determine the final output value.
         /// </summary>
-        /// <param name="dataValue">The data value that may be themed.</param>
-        /// <param name="themeValue">The theme value used to theme the data value.</param>
+        /// <param name="binding">The binding to use when resolve <paramref name="dataValue"/> or <paramref name="themeValue"/>.</param>
+        /// <param name="dataValue">The data value used to produce the output value, and set the value on the binding component.</param>
+        /// <param name="themeValue">The theme value used if <c>BindingInfo.BindingProfile.RetrievalMethod</c> is <see cref="DataRetrievalMethod.StaticThemedValue"/>.</param>
         protected virtual void ProcessThemeOrDataChange(BindingInfo binding, object dataValue, object themeValue = null)
         {
             T outputValue = default(T);

--- a/com.microsoft.mrtk.data/Runtime/Scripts/DataConsumers/DataConsumerThemeHelper.cs
+++ b/com.microsoft.mrtk.data/Runtime/Scripts/DataConsumers/DataConsumerThemeHelper.cs
@@ -12,10 +12,13 @@ namespace Microsoft.MixedReality.Toolkit.Data
     /// <summary>
     /// A theme data consumer used to help another primary data consumer derived from <see cref="DataConsumerThemableBase{T}"/>
     /// that is designed to manage both dynamically bound data received from a data-centric DataSource, and
-    /// then theme that dynamic data. As an example, a numeric status can be used to look up an appropriate
+    /// then theme that dynamic data. 
+    /// </summary>
+    /// <remarks>
+    /// As an example, a numeric status can be used to look up an appropriate
     /// status icon for the current status.  That icon can then be further themed to adopt the desired, branding or
     /// other specific look and feel appropriate for the currently active theme.
-    /// </summary>
+    /// </remarks>
     [AddComponentMenu("MRTK/Data Binding/Consumers/Data Consumer Theme Helper")]
     public class DataConsumerThemeHelper : DataConsumerGOBase
     {
@@ -132,7 +135,7 @@ namespace Microsoft.MixedReality.Toolkit.Data
         /// <param name="dataSource">Which data source called this method.</param>
         /// <param name="resolvedKeyPath">Fully resolved keypath for datum that changed.</param>
         /// <param name="localKeyPath">Local keypath for the datum that changed.</param>
-        /// <param name="inDataValue">The current value of the datum</param>
+        /// <param name="inValue">The current value of the data.</param>
         /// <param name="dataChangeType">The type of change that has occurred.</param>
         protected override void ProcessDataChanged(IDataSource dataSource, string resolvedKeyPath, string localKeyPath, object inValue, DataChangeType dataChangeType)
         {

--- a/com.microsoft.mrtk.data/Runtime/Scripts/Interfaces/IDataNode.cs
+++ b/com.microsoft.mrtk.data/Runtime/Scripts/Interfaces/IDataNode.cs
@@ -10,19 +10,28 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Data
 {
     /// <summary>
+    /// Specifies the type of a <see cref="IDataNode"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
     /// Interface for one node in a hierarchical organization of data comprised of
-    /// lists, maps (dictionaries), and objects of arbitrary type and complexity
-    /// such as native data primitives (int, boolean, float), or even an object as
+    /// lists, maps, dictionaries, and objects of arbitrary type and complexity
+    /// such as native data primitives (<see langword="int"/>, <see langword="boolean"/>, <see langword="float"/>) or even an object as
     /// complex as a jpeg byte stream.
-    ///
+    /// </para>
+    /// <para>
     /// This is used by a data source to organize information that matches the
     /// defacto standard key path format that's modeled on JSON/javascript.
-    /// </summary>
+    /// </para>
+    /// </remarks>
     public enum DataNodeType
     {
         Unassigned,
+
         Null,
+
         Array,
+        
         Map,
 
         /// <summary>
@@ -36,7 +45,6 @@ namespace Microsoft.MixedReality.Toolkit.Data
         /// <summary>
         /// Is this node an array of other nodes?
         /// </summary>
-        ///
         /// <returns><see langword="true"/> if an array, <see langword="false"/> otherwise.</returns>
         bool IsArray();
 
@@ -80,13 +88,13 @@ namespace Microsoft.MixedReality.Toolkit.Data
         /// Get the value associated with this node.
         /// </summary>
         /// <remarks>
-        /// If this node is an array node, the value is a <see cref="IEnumerable{string}"/> object that
+        /// If this node is an array node, the value is a <see cref="IEnumerable{T}"/> object that
         /// contains all the key paths of its children. Note that this is not the usual way of
         /// retrieving items in an array since paging is not possible. See 
         /// <see cref="DataSourceBase.GetCollectionKeyPathRange"/> for a better method of
         /// accessing members of a collection.
         ///
-        /// If this node is a map node, the value is a <see cref="IEnumerable{string}"/>  object
+        /// If this node is a map node, the value is a <see cref="IEnumerable{T}"/>  object
         /// that contains the full keypath for every key in the map.
         /// </remarks>
         /// <returns>The value associated with this node of arbitrary type and complexity</returns>

--- a/com.microsoft.mrtk.data/Runtime/Scripts/Interfaces/IDataSource.cs
+++ b/com.microsoft.mrtk.data/Runtime/Scripts/Interfaces/IDataSource.cs
@@ -196,14 +196,14 @@ namespace Microsoft.MixedReality.Toolkit.Data
         /// </para>
         /// <para>
         /// The fullyQualifiedPrefix is provided for lists (or collection of lists) to find the correct instance of a specific local keypath.
-        /// If not processing a collection, this can be either null or "". It is considered fully qualified because it has been resolved
+        /// If not processing a collection, this can be either <see langword="null"/> or an empty <see langword="string"/>. It is considered fully qualified because it has been resolved
         /// to the namespaces of the data source where each sub-component may have been mapped from a view key path to a data key path.
         /// This means that the path may not be recognizable on casual observation relative to the key path variables
         /// embedded in views and sub-views.
         /// </para>
         /// <para>
         /// Note that a key path for a collection is useful for regenerating an entire collection. If the object is a collection,
-        /// <see cref="GetValue(string)"/> returns an <see cref="IEnumerable{string}"/> that can be used to enumerate the key paths of all children in the collection.
+        /// <see cref="GetValue(string)"/> returns an <see cref="IEnumerable{T}"/> that can be used to enumerate the key paths of all children in the collection.
         /// </para>
         /// </remarks>
         /// <param name="resolvedKeyPath">Prefix for a collection</param>

--- a/com.microsoft.mrtk.input/Editor/Inspectors/CameraSimulationSettingsDrawer.cs
+++ b/com.microsoft.mrtk.input/Editor/Inspectors/CameraSimulationSettingsDrawer.cs
@@ -28,6 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Simulation.Editor
         private readonly GUIContent yawContent = new GUIContent("Yaw");
         private readonly GUIContent rollContent = new GUIContent("Roll");
 
+        /// <inheritdoc />
         public override float GetPropertyHeight(
             SerializedProperty property,
             GUIContent label)

--- a/com.microsoft.mrtk.input/Tests/Runtime/Utilities/InputTestUtilities.cs
+++ b/com.microsoft.mrtk.input/Tests/Runtime/Utilities/InputTestUtilities.cs
@@ -394,7 +394,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Tests
         /// This rotates the hand to <paramref name="newRotation"/>, and smooths the handshape based on the provided 
         /// <paramref name="handshapeId"/> over the number of steps provided by <paramref name="numSteps"/>.
         /// </para>
-        /// <remarks>
         /// <para>
         /// The <paramref name="numSteps"/> parameter defaults to a value of -1, which is a sentinel value to indicate that the
         /// default number of steps should be used as specified by <see cref="ControllerMoveSteps"/>.

--- a/com.microsoft.mrtk.uxcomponents.noncanvas/Experimental/Theming/ProfileTemplates/UXThemeProfile.cs
+++ b/com.microsoft.mrtk.uxcomponents.noncanvas/Experimental/Theming/ProfileTemplates/UXThemeProfile.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Experimental
         ///     </item>
         ///     <item>
         ///         <term>UX Control Type</term>
-        ///         <description>The nature of the control; for example, <see cref="Button"/>, <see cref="Slider"/>, <see cref="Checkbox"/>, <see cref="Slate"/>, <see cref="Common"/>. This should generally map 1-to-1 to a specific prefab.Common can be used to specify fallback properties across all UX controls.</description>
+        ///         <description>The nature of the control. This should generally map one-to-one to a specific <c>prefab.Common</c> can be used to specify fallback properties across all UX controls.</description>
         ///     </item>
         ///     <item>
         ///         <term>UX Control Part</term>
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Experimental
         ///     </item>
         ///     <item>
         ///         <term>Component category</term>
-        ///         <description>The component being themed; for example, text, a material, or a sprint. In general, this should reflect the name of the component <see cref="MonoBehavior"/>.</description>
+        ///         <description>The component being themed; for example, text, a material, or a sprint. In general, this should reflect the name of the component <see cref="MonoBehaviour"/>.</description>
         ///     </item>
         ///     <item>
         ///         <term>Optional Property</term>

--- a/com.microsoft.mrtk.windowsspeech/Subsystems/TextToSpeech/TextToSpeechHelpers.cs
+++ b/com.microsoft.mrtk.windowsspeech/Subsystems/TextToSpeech/TextToSpeechHelpers.cs
@@ -112,7 +112,7 @@ namespace Microsoft.MixedReality.Toolkit.Speech.Windows
         /// </summary>
         /// <param name="clipName">The name to give to the clip.</param>
         /// <param name="waveData">The audio data which will be contained within the clip.</param>
-        /// <param name="samples">The number of audio samples per channel in the <paramref name="waveBytes"/> array.</param>
+        /// <param name="samples">The number of audio samples per channel in the <paramref name="waveData"/> array.</param>
         /// <param name="channels">The number of audio channels, typically 1 (mono) or 2 (stereo).</param>
         /// <param name="sampleRate">The frequency rate of the audio data; for example, 44100 Hz.</param>
         /// <returns>A Unity AudioClip object containing the provided sound data.</returns>


### PR DESCRIPTION
## Overview

Fixing some additional XML documentation warnings that were missed in the previous 2 passes.

This is also fixing some spellings of variables in the new set of example scripts.