### PR TITLE
Fix Slider to Support Non-Default Range

### DIFF
--- a/com.microsoft.mrtk.uxcomponents.noncanvas/Tests/Runtime/SliderTests.cs
+++ b/com.microsoft.mrtk.uxcomponents.noncanvas/Tests/Runtime/SliderTests.cs
@@ -395,6 +395,7 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
             Assert.IsFalse(interactionUpdated, "Slider updated value when we didn't touch the handle and snapToPosition = false");
             Assert.AreEqual(0.5f, slider.Value, "Slider shouldn't have snapped to the finger point when SnapToPosition = false");
 
+            // Must move down then up in order to avoid nudging the slider
             yield return rightHand.MoveTo(Vector3.zero, 60);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
@@ -404,6 +405,8 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
 
             Assert.IsTrue(slider.IsPokeSelected, "Slider should be poked!");
             Assert.IsTrue(interactionStarted, "Slider didn't start interaction when we poked the handle");
+            Assert.IsFalse(interactionUpdated, "Slider incorrectly invoked OnValueUpdated when we poked the handle");
+            Assert.AreEqual(0.5f, slider.Value, 0.001f, "Slider should still be roughly the same value");
 
             interactionUpdated = false;
 

--- a/com.microsoft.mrtk.uxcomponents.noncanvas/Tests/Runtime/SliderTests.cs
+++ b/com.microsoft.mrtk.uxcomponents.noncanvas/Tests/Runtime/SliderTests.cs
@@ -404,8 +404,6 @@ namespace Microsoft.MixedReality.Toolkit.UX.Runtime.Tests
 
             Assert.IsTrue(slider.IsPokeSelected, "Slider should be poked!");
             Assert.IsTrue(interactionStarted, "Slider didn't start interaction when we poked the handle");
-            Assert.IsTrue(interactionUpdated, "Slider didn't invoke OnValueUpdated when we poked the handle");
-            Assert.AreEqual(0.5f, slider.Value, 0.001f, "Slider should still be roughly the same value");
 
             interactionUpdated = false;
 

--- a/com.microsoft.mrtk.uxcore/Slider/Slider.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Slider.cs
@@ -358,7 +358,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         {
             var stepCount = value / SliderStepVal;
             var snappedValue = SliderStepVal * Mathf.RoundToInt(stepCount);
-            Mathf.Clamp(snappedValue, MinValue, MaxValue);
+            Mathf.Clamp(snappedValue, 0f, 1.0f);
             return snappedValue;
         }
 
@@ -369,10 +369,11 @@ namespace Microsoft.MixedReality.Toolkit.UX
 
             var handDelta = Vector3.Dot(SliderTrackDirection.normalized, interactorDelta);
 
-            float unsnappedValue = Mathf.Clamp(StartSliderValue + handDelta / SliderTrackDirection.magnitude, MinValue, MaxValue);
+            float unsnappedValue = Mathf.Clamp(StartSliderValue + handDelta / SliderTrackDirection.magnitude, 0f, 1.0f);
 
-            Value = useSliderStepDivisions ? SnapSliderToStepPositions(unsnappedValue) : unsnappedValue;
-        }
+            var normalizedValue = useSliderStepDivisions ? SnapSliderToStepPositions(unsnappedValue) : unsnappedValue;
+            Value = normalizedValue * (MaxValue - MinValue) + MinValue;
+    }
 
         #endregion
 

--- a/com.microsoft.mrtk.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
@@ -193,8 +193,7 @@ namespace Microsoft.MixedReality.Toolkit.UX
         // Update the things that depend on the slider value.
         void UpdateHandle(SliderEventData data)
         {
-            var normalizedValue = (SliderState.MaxValue - SliderState.MinValue) != 0 ? (data.NewValue - SliderState.MinValue) / (SliderState.MaxValue - SliderState.MinValue) : 0;
-            UpdateHandle(normalizedValue);
+            UpdateHandle(SliderState.NormalizedValue);
         }
 
         // Update the things that depend on the slider value.

--- a/com.microsoft.mrtk.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
+++ b/com.microsoft.mrtk.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
@@ -193,7 +193,8 @@ namespace Microsoft.MixedReality.Toolkit.UX
         // Update the things that depend on the slider value.
         void UpdateHandle(SliderEventData data)
         {
-            UpdateHandle(data.NewValue);
+            var normalizedValue = (SliderState.MaxValue - SliderState.MinValue) != 0 ? (data.NewValue - SliderState.MinValue) / (SliderState.MaxValue - SliderState.MinValue) : 0;
+            UpdateHandle(normalizedValue);
         }
 
         // Update the things that depend on the slider value.


### PR DESCRIPTION
## Overview
Uses normalized instead of actual value in order to correct slider visuals for ranges other than 0-1. Also, makes a change to pull the normalized value on slider movement, and then convert to the actual value, in order to avoid undesirable behavior where it is slower to move the slider for larger ranges.  

## Changes
- Fixes: #11718.

