### PR TITLE
[MRTK3] Adding support for unbounded tracking mode

### DIFF
--- a/com.microsoft.mrtk.input/Assets/Prefabs/MRTK XR Rig.prefab
+++ b/com.microsoft.mrtk.input/Assets/Prefabs/MRTK XR Rig.prefab
@@ -259,6 +259,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2351505566903569412}
   - component: {fileID: 3712792914886690938}
+  - component: {fileID: 2813607766961918107}
   m_Layer: 0
   m_Name: Camera Offset
   m_TagString: Untagged
@@ -302,6 +303,18 @@ MonoBehaviour:
   m_CameraFloorOffsetObject: {fileID: 2351505566903569413}
   m_RequestedTrackingOriginMode: 0
   m_CameraYOffset: 1.6
+--- !u!114 &2813607766961918107
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2351505566903569413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4d642881628ba842b14068a50038965, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2351505567455720334
 GameObject:
   m_ObjectHideFlags: 0

--- a/com.microsoft.mrtk.input/Editor/Inspectors/UnboundedTrackingModeInspector.cs
+++ b/com.microsoft.mrtk.input/Editor/Inspectors/UnboundedTrackingModeInspector.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Unity.XR.CoreUtils;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.XR;
+
+namespace Microsoft.MixedReality.Toolkit.Input.Editor
+{
+    /// <summary>
+    /// A custom inspector for the <see cref="UnboundedTrackingMode"/> component.
+    /// </summary>
+    [CustomEditor(typeof(UnboundedTrackingMode))]
+    internal class UnboundedTrackingModeInspector : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("This component works along side XROrigin to ensure that the XRInputSubsystem " +
+                "has the TrackingOriginModeFlags.Unbounded flag set on its tracking origin mode if this flag is " +
+                "supported. Note, the TrackingOriginModeFlags.Unbounded flag is only applied if the " +
+                "XROrigin.RequestedTrackingOriginMode is set to \"Not Specified\" and the device supports unbounded " +
+                "spaces.", MessageType.Info);
+
+            if (target is UnboundedTrackingMode unboundedTrackingMode)
+            {
+                XROrigin xrOrigin = unboundedTrackingMode.GetComponent<XROrigin>();
+            }
+        }
+    }
+}

--- a/com.microsoft.mrtk.input/Editor/Inspectors/UnboundedTrackingModeInspector.cs
+++ b/com.microsoft.mrtk.input/Editor/Inspectors/UnboundedTrackingModeInspector.cs
@@ -14,7 +14,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
     [CustomEditor(typeof(UnboundedTrackingMode))]
     internal class UnboundedTrackingModeInspector : UnityEditor.Editor
     {
-
         /// <inheritdoc/>
         public override void OnInspectorGUI()
         {

--- a/com.microsoft.mrtk.input/Editor/Inspectors/UnboundedTrackingModeInspector.cs
+++ b/com.microsoft.mrtk.input/Editor/Inspectors/UnboundedTrackingModeInspector.cs
@@ -14,18 +14,31 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
     [CustomEditor(typeof(UnboundedTrackingMode))]
     internal class UnboundedTrackingModeInspector : UnityEditor.Editor
     {
+
+        /// <inheritdoc/>
         public override void OnInspectorGUI()
         {
-            EditorGUILayout.HelpBox("This component works along side XROrigin to ensure that the XRInputSubsystem " +
-                "has the TrackingOriginModeFlags.Unbounded flag set on its tracking origin mode if this flag is " +
-                "supported. Note, the TrackingOriginModeFlags.Unbounded flag is only applied if the " +
-                "XROrigin.RequestedTrackingOriginMode is set to \"Not Specified\" and the device supports unbounded " +
-                "spaces.", MessageType.Info);
+#if UNITYXR_MANAGEMENT_PRESENT
+            EditorGUILayout.HelpBox("This MRTK component works along side XROrigin to ensure that the XRInputSubsystem " +
+                "has the TrackingOriginModeFlags.Unbounded flag set if this flag is supported.\n\nNote, the " +
+                "TrackingOriginModeFlags.Unbounded flag is only applied if the XROrigin.RequestedTrackingOriginMode is " +
+                "set to \"Not Specified\" and the device supports unbounded spaces.", MessageType.Info);
 
             if (target is UnboundedTrackingMode unboundedTrackingMode)
             {
                 XROrigin xrOrigin = unboundedTrackingMode.GetComponent<XROrigin>();
+                if (xrOrigin.RequestedTrackingOriginMode != XROrigin.TrackingOriginMode.NotSpecified)
+                {
+                    EditorGUILayout.HelpBox("The XROrigin's tracking origin mode is not set to \"Not Specified\". This " +
+                        "component will only put the XRInputSubsystem into unbounded mode if XROrigin's tracking mode is set " +
+                        "\"Not Specified\"", MessageType.Warning);
+                }
             }
+#else
+            EditorGUILayout.HelpBox("This MRTK component is unable to put the XRInputSubsystem into unbounded mode, as the " +
+                "com.unity.xr.management package hasn't been included. Please include com.unity.xr.management version 4.2 " +
+                "for this component to function.", MessageType.Warning);
+#endif
         }
     }
 }

--- a/com.microsoft.mrtk.input/Editor/Inspectors/UnboundedTrackingModeInspector.cs.meta
+++ b/com.microsoft.mrtk.input/Editor/Inspectors/UnboundedTrackingModeInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a92af3e7be6129f479310a1ea305454f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.input/Editor/MRTK.Input.Editor.asmdef
+++ b/com.microsoft.mrtk.input/Editor/MRTK.Input.Editor.asmdef
@@ -4,10 +4,12 @@
     "references": [
         "Microsoft.MixedReality.Toolkit.Core",
         "Microsoft.MixedReality.Toolkit.Core.Editor",
-        "Microsoft.MixedReality.Toolkit.Input",
+        "Microsoft.MixedReality.Toolkit.Input",        
+        "Unity.XR.CoreUtils",
         "Unity.XR.CoreUtils.Editor",
         "Unity.XR.Interaction.Toolkit",
-        "Unity.XR.Interaction.Toolkit.Editor"
+        "Unity.XR.Interaction.Toolkit.Editor",
+        "Unity.XR.Management"
     ],
     "includePlatforms": [
         "Editor"
@@ -28,6 +30,11 @@
             "name": "com.atteneder.ktx",
             "expression": "",
             "define": "KTX_PRESENT"
+        },
+        {
+            "name": "com.unity.xr.management",
+            "expression": "4.2",
+            "define": "UNITYXR_MANAGEMENT_PRESENT"
         }
     ],
     "noEngineReferences": false

--- a/com.microsoft.mrtk.input/MRTK.Input.asmdef
+++ b/com.microsoft.mrtk.input/MRTK.Input.asmdef
@@ -7,6 +7,7 @@
         "Unity.InputSystem",
         "Unity.XR.CoreUtils",
         "Unity.XR.Interaction.Toolkit",
+        "Unity.XR.Management",
         "glTFast",
         "Ktx"
     ],
@@ -37,6 +38,11 @@
             "name": "com.atteneder.ktx",
             "expression": "",
             "define": "KTX_PRESENT"
+        },
+        {
+            "name": "com.unity.xr.management",
+            "expression": "4.2",
+            "define": "UNITYXR_MANAGEMENT_PRESENT"
         }
     ],
     "noEngineReferences": false

--- a/com.microsoft.mrtk.input/Tracking.meta
+++ b/com.microsoft.mrtk.input/Tracking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 212f7ab4a905c6048b79925baa646b66
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.input/Tracking/UnboundedTrackingMode.cs
+++ b/com.microsoft.mrtk.input/Tracking/UnboundedTrackingMode.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Unity.XR.CoreUtils;
+using UnityEngine;
+using UnityEngine.XR;
+
+#if UNITYXR_MANAGEMENT_PRESENT
+using UnityEngine.XR.Management;
+#endif
+
+namespace Microsoft.MixedReality.Toolkit
+{
+    /// <summary>
+    /// This component works along side Unity's <see cref="XROrigin"/> to ensure that the <see cref="XRInputSubsystem"/> has
+    /// the <see cref="TrackingOriginModeFlags.Unbounded"/> flag set on its tracking origin mode if this flag is supported.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Devices like the HoloLens 2 should use unbounded reference space. This reference space enables the viewer to move
+    /// freely through a complex environment, often many meters from where they started, while always optimizing for coordinate
+    /// system stability near the viewer. For more information about unbounded space see the
+    /// <see href="https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_MSFT_unbounded_reference_space">OpenXR Specification</see>.
+    /// </para>
+    /// <para>
+    /// The <see cref="TrackingOriginModeFlags.Unbounded"/> flag is only applied if the <see cref="XROrigin.RequestedTrackingOriginMode"/>
+    /// is set to <see cref="XROrigin.TrackingOriginMode.NotSpecified"/> and the device supports unbounded spaces.
+    /// </para>  UnboundedTrackingModeInspector
+    /// </remarks>
+    [RequireComponent(typeof(XROrigin))]
+    public class UnboundedTrackingMode : MonoBehaviour
+    {
+#if UNITYXR_MANAGEMENT_PRESENT
+        private XRInputSubsystem m_inputSubsystem;
+        private XROrigin.TrackingOriginMode m_requestedTrackingOriginMode = XROrigin.TrackingOriginMode.NotSpecified;
+
+        private void OnEnable()
+        {
+            XRGeneralSettings xrSettings = XRGeneralSettings.Instance;
+            if (xrSettings == null)
+            {
+                Debug.LogWarning($"EyeLevelSceneOrigin: XRGeneralSettings is null.");
+                return;
+            }
+
+            XRManagerSettings xrManager = xrSettings.Manager;
+            if (xrManager == null)
+            {
+                Debug.LogWarning($"EyeLevelSceneOrigin: XRManagerSettings is null.");
+                return;
+            }
+
+            XRLoader xrLoader = xrManager.activeLoader;
+            if (xrLoader == null)
+            {
+                Debug.LogWarning($"EyeLevelSceneOrigin: XRLoader is null.");
+                return;
+            }
+
+            m_inputSubsystem = xrLoader.GetLoadedSubsystem<XRInputSubsystem>();
+            if (m_inputSubsystem == null)
+            {
+                Debug.LogWarning($"EyeLevelSceneOrigin: XRInputSubsystem is null.");
+                return;
+            }
+
+            XROrigin xrOrigin = gameObject.GetComponent<XROrigin>();
+            if (xrOrigin != null)
+            {
+                m_requestedTrackingOriginMode = xrOrigin.RequestedTrackingOriginMode;
+            }
+
+            m_inputSubsystem.trackingOriginUpdated += XrInput_trackingOriginUpdated;
+
+            EnsureSceneOriginAtEyeLevel();
+        }
+
+        private void OnDisable()
+        {
+            if (m_inputSubsystem != null)
+            {
+                m_inputSubsystem.trackingOriginUpdated -= XrInput_trackingOriginUpdated;
+                m_inputSubsystem = null;
+            }
+        }
+
+        private void XrInput_trackingOriginUpdated(XRInputSubsystem obj)
+        {
+            if (isActiveAndEnabled)
+            {
+                EnsureSceneOriginAtEyeLevel();
+            }
+        }
+
+        private void EnsureSceneOriginAtEyeLevel()
+        {
+            TrackingOriginModeFlags currentMode = m_inputSubsystem.GetTrackingOriginMode();
+            TrackingOriginModeFlags desiredMode = GetDesiredTrackingOriginMode(m_inputSubsystem);
+            if (m_requestedTrackingOriginMode == TrackingOriginMode.NotSpecified &&
+                currentMode == TrackingOriginModeFlags.Device &&
+                currentMode != desiredMode)
+            {
+                Debug.Log($"EyeLevelSceneOrigin: TrySetTrackingOriginMode to {desiredMode}");
+                if (!m_inputSubsystem.TrySetTrackingOriginMode(desiredMode))
+                {
+                    Debug.LogWarning($"EyeLevelSceneOrigin: Failed to set tracking origin to {desiredMode}.");
+                }
+            }
+        }
+
+        private static TrackingOriginModeFlags GetDesiredTrackingOriginMode(XRInputSubsystem xrInput)
+        {
+            TrackingOriginModeFlags supportedFlags = xrInput.GetSupportedTrackingOriginModes();
+            TrackingOriginModeFlags targetFlag = TrackingOriginModeFlags.Device;   // All OpenXR runtime must support LOCAL space
+
+            if (supportedFlags.HasFlag(TrackingOriginModeFlags.Unbounded))
+            {
+                targetFlag = TrackingOriginModeFlags.Unbounded;
+            }
+
+            return targetFlag;
+        }
+#endif
+    }
+}

--- a/com.microsoft.mrtk.input/Tracking/UnboundedTrackingMode.cs
+++ b/com.microsoft.mrtk.input/Tracking/UnboundedTrackingMode.cs
@@ -84,7 +84,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             m_inputSubsystem.trackingOriginUpdated += XrInput_trackingOriginUpdated;
 
-            EnsureSceneOriginAtEyeLevel();
+            EnsureUnboundedModeSetIfSupported();
         }
 
         /// <summary>
@@ -103,11 +103,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (isActiveAndEnabled)
             {
-                EnsureSceneOriginAtEyeLevel();
+                EnsureUnboundedModeSetIfSupported();
             }
         }
 
-        private void EnsureSceneOriginAtEyeLevel()
+        private void EnsureUnboundedModeSetIfSupported()
         {
             TrackingOriginModeFlags currentMode = m_inputSubsystem.GetTrackingOriginMode();
             TrackingOriginModeFlags desiredMode = GetDesiredTrackingOriginMode(m_inputSubsystem);

--- a/com.microsoft.mrtk.input/Tracking/UnboundedTrackingMode.cs
+++ b/com.microsoft.mrtk.input/Tracking/UnboundedTrackingMode.cs
@@ -9,7 +9,7 @@ using UnityEngine.XR;
 using UnityEngine.XR.Management;
 #endif
 
-namespace Microsoft.MixedReality.Toolkit
+namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// This component works along side Unity's <see cref="XROrigin"/> to ensure that the <see cref="XRInputSubsystem"/> has
@@ -24,16 +24,24 @@ namespace Microsoft.MixedReality.Toolkit
     /// </para>
     /// <para>
     /// The <see cref="TrackingOriginModeFlags.Unbounded"/> flag is only applied if the <see cref="XROrigin.RequestedTrackingOriginMode"/>
-    /// is set to <see cref="XROrigin.TrackingOriginMode.NotSpecified"/> and the device supports unbounded spaces.
-    /// </para>  UnboundedTrackingModeInspector
+    /// is set to <see cref="XROrigin.TrackingOriginMode.NotSpecified"/>, the device supports unbounded spaces, and <see cref="XRInputSubsystem"/>
+    /// current tracking mode is set to <see cref="TrackingOriginModeFlags.Device"/>.
+    /// </para> 
     /// </remarks>
     [RequireComponent(typeof(XROrigin))]
+    [AddComponentMenu("MRTK/Input/Unbounded Tracking Mode")]
     public class UnboundedTrackingMode : MonoBehaviour
     {
 #if UNITYXR_MANAGEMENT_PRESENT
         private XRInputSubsystem m_inputSubsystem;
         private XROrigin.TrackingOriginMode m_requestedTrackingOriginMode = XROrigin.TrackingOriginMode.NotSpecified;
 
+        /// <summary>
+        /// A Unity event function that is called when the script component has been enabled.
+        /// </summary>
+        /// <remarks>
+        /// This will attempt to set <see cref="XRInputSubsystem"/> tracking mode to <see cref="TrackingOriginModeFlags.Unbounded"/>.
+        /// </remarks>
         private void OnEnable()
         {
             XRGeneralSettings xrSettings = XRGeneralSettings.Instance;
@@ -75,6 +83,9 @@ namespace Microsoft.MixedReality.Toolkit
             EnsureSceneOriginAtEyeLevel();
         }
 
+        /// <summary>
+        /// A Unity event function that is called when the script component has been disabled.
+        /// </summary>
         private void OnDisable()
         {
             if (m_inputSubsystem != null)
@@ -96,14 +107,14 @@ namespace Microsoft.MixedReality.Toolkit
         {
             TrackingOriginModeFlags currentMode = m_inputSubsystem.GetTrackingOriginMode();
             TrackingOriginModeFlags desiredMode = GetDesiredTrackingOriginMode(m_inputSubsystem);
-            if (m_requestedTrackingOriginMode == TrackingOriginMode.NotSpecified &&
+            if (m_requestedTrackingOriginMode == XROrigin.TrackingOriginMode.NotSpecified &&
                 currentMode == TrackingOriginModeFlags.Device &&
                 currentMode != desiredMode)
             {
-                Debug.Log($"EyeLevelSceneOrigin: TrySetTrackingOriginMode to {desiredMode}");
+                Debug.Log($"UnboundedTrackingMode: TrySetTrackingOriginMode to {desiredMode}");
                 if (!m_inputSubsystem.TrySetTrackingOriginMode(desiredMode))
                 {
-                    Debug.LogWarning($"EyeLevelSceneOrigin: Failed to set tracking origin to {desiredMode}.");
+                    Debug.LogWarning($"UnboundedTrackingMode: Failed to set tracking origin to {desiredMode}.");
                 }
             }
         }

--- a/com.microsoft.mrtk.input/Tracking/UnboundedTrackingMode.cs.meta
+++ b/com.microsoft.mrtk.input/Tracking/UnboundedTrackingMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4d642881628ba842b14068a50038965
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
The `Microsoft.MixedReality.OpenXR.EyeLevelSceneOrigin` component in Microsoft's MR OpenXR plugin will soon be deprecated (so to avoid having mono behaviours within this plugin).  Also, Unity doesn't have UI to set the tracking mode to `TrackingOriginModeFlags.Unbounded` on the `XRInputSubsystem`.

So, to replace  `Microsoft.MixedReality.OpenXR.EyeLevelSceneOrigin`, an `UnboundedTrackingMode` MonoBehaviour has been added to MRTK3. This behavior has been applied to MRTK's XR Rig and will force HL2 into unbounded mode if Unity's `XROrigin.RequestedTrackingOriginMode` is set to "Not Specified". If the platform does not support unbounded mode, the new behavior does nothing.

Unbounded mode is preferred on HL2 (the only device currently supporting this mode).

For more information on unbounded mode, see the Microsoft OpenXR extension XR_MSFT_unbounded_reference_space @ https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_MSFT_unbounded_reference_space.


## Additional Note

You may ask "why is this using `XRLoader.GetLoadedSubsystem` and not `SubsystemManager.GetInstance` to find the input subsystem?"  Well... Holographic App Remoting (HAR) apparently connects later than the physical device. So, on HAR the subsystem manager doesn't have input system handy by the time `UnboundedTrackingMode` is loaded and when it needs to listen for input events.

While all on the other hand, `XRLoader` has the input system handy at start.

It looks like `XROrigin` worked around this by re-querying for the input system every frame, until it finds one. However, since MR Plugin is already requiring `UnityEngine.XR.Management` and this method has been tested and used by the MR Plugin, I'm going to stick with `XRLoader` for now. The dependency on UnityEngine.XR.Management is not mandatory for MRTK Input, so this usage shouldn't break other platforms.
## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11749


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
