### PR TITLE
Add Precompile Statements to Prevent Warnings in Unity 2023

### DIFF
--- a/Assets/MRTK/Core/Inspectors/MixedRealityToolkitFacadeHandler.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityToolkitFacadeHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
 
         private static void CleanupCurrentFacades()
         {
-            foreach (MixedRealityToolkit toolkitInstance in FindObjectUtility.FindObjectsOfType<MixedRealityToolkit>())
+            foreach (MixedRealityToolkit toolkitInstance in FindObjectUtility.FindObjectsByType<MixedRealityToolkit>())
             {
                 DestroyAllChildren(toolkitInstance);
             }

--- a/Assets/MRTK/Core/Inspectors/MixedRealityToolkitFacadeHandler.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityToolkitFacadeHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
 
         private static void CleanupCurrentFacades()
         {
-            foreach (MixedRealityToolkit toolkitInstance in GameObject.FindObjectsOfType<MixedRealityToolkit>())
+            foreach (MixedRealityToolkit toolkitInstance in FindObjectUtility.FindObjectsOfType<MixedRealityToolkit>())
             {
                 DestroyAllChildren(toolkitInstance);
             }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -423,7 +423,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                 }
                                 else
                                 {
-                                    foreach (var dbr in FindObjectsOfType<DepthBufferRenderer>())
+                                    foreach (var dbr in FindObjectUtility.FindObjectsOfType<DepthBufferRenderer>())
                                     {
                                         UnityObjectExtensions.DestroyObject(dbr);
                                     }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -423,7 +423,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                 }
                                 else
                                 {
-                                    foreach (var dbr in FindObjectUtility.FindObjectsOfType<DepthBufferRenderer>())
+                                    foreach (var dbr in FindObjectUtility.FindObjectsByType<DepthBufferRenderer>())
                                     {
                                         UnityObjectExtensions.DestroyObject(dbr);
                                     }

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -347,7 +347,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 foreach (Tuple<Type, FieldInfo> typeFieldInfoPair in cachedComponentTypes)
                 {
                     FieldInfo fieldInfo = typeFieldInfoPair.Item2;
-                    foreach (Component source in FindObjectUtility.FindObjectsOfType(typeFieldInfoPair.Item1))
+                    foreach (Component source in FindObjectUtility.FindObjectsByType(typeFieldInfoPair.Item1))
                     {
                         CheckForChangesInField(source, fieldInfo);
                     }

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.SceneSystem;
 using System;
 using System.Collections.Generic;
@@ -346,7 +347,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 foreach (Tuple<Type, FieldInfo> typeFieldInfoPair in cachedComponentTypes)
                 {
                     FieldInfo fieldInfo = typeFieldInfoPair.Item2;
-                    foreach (Component source in GameObject.FindObjectsOfType(typeFieldInfoPair.Item1))
+                    foreach (Component source in FindObjectUtility.FindObjectsOfType(typeFieldInfoPair.Item1))
                     {
                         CheckForChangesInField(source, fieldInfo);
                     }

--- a/Assets/MRTK/Core/MRTK.Core.asmdef
+++ b/Assets/MRTK/Core/MRTK.Core.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Microsoft.MixedReality.Toolkit",
+    "rootNamespace": "",
     "references": [
         "Microsoft.MixedReality.Toolkit.Async",
         "Microsoft.MixedReality.Toolkit.Editor.Utilities",
@@ -22,6 +23,11 @@
             "name": "com.unity.xr.management",
             "expression": "",
             "define": "XR_MANAGEMENT_ENABLED"
+        },
+        {
+            "name": "Unity",
+            "expression": "2021.3.18",
+            "define": "UNITY_2021_3_18_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -132,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </remarks>
         public static void SetProfileBeforeInitialization(MixedRealityToolkitConfigurationProfile profile)
         {
-            MixedRealityToolkit toolkit = FindObjectOfType<MixedRealityToolkit>();
+            MixedRealityToolkit toolkit = FindObjectUtility.FindObjectByType<MixedRealityToolkit>();
             toolkit.activeProfile = profile;
         }
 
@@ -586,7 +586,7 @@ namespace Microsoft.MixedReality.Toolkit
             bool addedComponents = false;
             if (!Application.isPlaying && CameraCache.Main != null)
             {
-                EventSystem[] eventSystems = FindObjectsOfType<EventSystem>();
+                EventSystem[] eventSystems = FindObjectUtility.FindObjectsOfType<EventSystem>();
 
                 if (eventSystems.Length == 0)
                 {
@@ -644,7 +644,7 @@ namespace Microsoft.MixedReality.Toolkit
                 //
                 // To avoid returning null in this case, make sure to search the scene for MRTK.
                 // We do this only when in editor to avoid any performance cost at runtime.
-                List<MixedRealityToolkit> mrtks = new List<MixedRealityToolkit>(FindObjectsOfType<MixedRealityToolkit>());
+                List<MixedRealityToolkit> mrtks = new List<MixedRealityToolkit>(FindObjectUtility.FindObjectsOfType<MixedRealityToolkit>());
                 // Sort the list by instance ID so we get deterministic results when selecting our next active instance
                 mrtks.Sort(delegate (MixedRealityToolkit i1, MixedRealityToolkit i2) { return i1.GetInstanceID().CompareTo(i2.GetInstanceID()); });
 

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -586,7 +586,7 @@ namespace Microsoft.MixedReality.Toolkit
             bool addedComponents = false;
             if (!Application.isPlaying && CameraCache.Main != null)
             {
-                EventSystem[] eventSystems = FindObjectUtility.FindObjectsOfType<EventSystem>();
+                EventSystem[] eventSystems = FindObjectUtility.FindObjectsByType<EventSystem>();
 
                 if (eventSystems.Length == 0)
                 {
@@ -644,7 +644,7 @@ namespace Microsoft.MixedReality.Toolkit
                 //
                 // To avoid returning null in this case, make sure to search the scene for MRTK.
                 // We do this only when in editor to avoid any performance cost at runtime.
-                List<MixedRealityToolkit> mrtks = new List<MixedRealityToolkit>(FindObjectUtility.FindObjectsOfType<MixedRealityToolkit>());
+                List<MixedRealityToolkit> mrtks = new List<MixedRealityToolkit>(FindObjectUtility.FindObjectsByType<MixedRealityToolkit>());
                 // Sort the list by instance ID so we get deterministic results when selecting our next active instance
                 mrtks.Sort(delegate (MixedRealityToolkit i1, MixedRealityToolkit i2) { return i1.GetInstanceID().CompareTo(i2.GetInstanceID()); });
 

--- a/Assets/MRTK/Core/Utilities/Async/Internal/AsyncCoroutineRunner.cs
+++ b/Assets/MRTK/Core/Utilities/Async/Internal/AsyncCoroutineRunner.cs
@@ -51,7 +51,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             {
                 if (instance == null)
                 {
-                    instance = FindObjectOfType<AsyncCoroutineRunner>();
+#if UNITY_2021_3_18_OR_NEWER
+                    instance = UnityEngine.Object.FindFirstObjectByType<AsyncCoroutineRunner>();
+#else
+                    instance = GameObject.FindObjectOfType<AsyncCoroutineRunner>();
+#endif
                 }
 
                 // FindObjectOfType() only search for objects attached to active GameObjects. The FindObjectOfType(bool includeInactive) variant is not available to Unity 2019.4 and earlier so cannot be used.

--- a/Assets/MRTK/Core/Utilities/Async/MRTK.Async.asmdef
+++ b/Assets/MRTK/Core/Utilities/Async/MRTK.Async.asmdef
@@ -1,12 +1,13 @@
 {
     "name": "Microsoft.MixedReality.Toolkit.Async",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/MRTK/Core/Utilities/Async/MRTK.Async.asmdef
+++ b/Assets/MRTK/Core/Utilities/Async/MRTK.Async.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Microsoft.MixedReality.Toolkit.Async",
+    "rootNamespace": "",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -8,6 +9,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "2021.3.18",
+            "define": "UNITY_2021_3_18_OR_NEWER"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Assets/MRTK/Core/Utilities/CameraCache.cs
+++ b/Assets/MRTK/Core/Utilities/CameraCache.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     Debug.Log("No main camera found. Searching for cameras in the scene.");
 
                     // If no main camera was found, try to determine one.
-                    Camera[] cameras = Object.FindObjectsOfType<Camera>();
+                    Camera[] cameras = FindObjectUtility.FindObjectsOfType<Camera>();
                     if (cameras.Length == 0)
                     {
                         Debug.LogWarning("No cameras found. Creating a \"MainCamera\".");

--- a/Assets/MRTK/Core/Utilities/CameraCache.cs
+++ b/Assets/MRTK/Core/Utilities/CameraCache.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     Debug.Log("No main camera found. Searching for cameras in the scene.");
 
                     // If no main camera was found, try to determine one.
-                    Camera[] cameras = FindObjectUtility.FindObjectsOfType<Camera>();
+                    Camera[] cameras = FindObjectUtility.FindObjectsByType<Camera>();
                     if (cameras.Length == 0)
                     {
                         Debug.LogWarning("No cameras found. Creating a \"MainCamera\".");

--- a/Assets/MRTK/Core/Utilities/FindObjectUtility.cs
+++ b/Assets/MRTK/Core/Utilities/FindObjectUtility.cs
@@ -6,27 +6,54 @@ using System;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
+    /// <summary>
+    /// A static utility used to avoid deprecated Find Object functions in favor of replacements introduced in Unity >= 2021.3.18. 
+    /// </summary>
     public static class FindObjectUtility
     {
+        /// <summary>
+        /// Returns the first object matching the specified type.
+        /// </summary>
+        /// <remarks>
+        /// If Unity >= 2021.3.18, calls FindFirstObjectByType. Otherwise calls FindObjectOfType.
+        /// </remarks>
+        /// <param name="includeInactive">If true, inactive objects will be included in the search. False by default.</param>
         public static T FindObjectByType<T>(bool includeInactive = false) where T : Component
         {
 #if UNITY_2021_3_18_OR_NEWER
-        return UnityEngine.Object.FindFirstObjectByType<T>(includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude);
+            return UnityEngine.Object.FindFirstObjectByType<T>(includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude);
 #else 
             return UnityEngine.Object.FindObjectOfType<T>(includeInactive);
 #endif
         }
 
-        public static T[] FindObjectsOfType<T>(bool includeInactive = false, bool sort = true) where T : Component
+        /// <summary>
+        /// Returns all objects matching the specified type.
+        /// </summary>
+        /// <remarks>
+        /// If Unity >= 2021.3.18, calls FindObjectsByType. Otherwise calls FindObjectsOfType.
+        /// </remarks>
+        /// <param name="includeInactive">If true, inactive objects will be included in the search. False by default.</param>
+        /// <param name="sort">If false, results will not sorted by InstanceID. True by default.</param>
+        public static T[] FindObjectsByType<T>(bool includeInactive = false, bool sort = true) where T : Component
         {
 #if UNITY_2021_3_18_OR_NEWER
-        return UnityEngine.Object.FindObjectsByType<T>(includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude, sort ? FindObjectsSortMode.InstanceID : FindObjectsSortMode.None);
+            return UnityEngine.Object.FindObjectsByType<T>(includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude, sort ? FindObjectsSortMode.InstanceID : FindObjectsSortMode.None);
 #else
             return UnityEngine.Object.FindObjectsOfType<T>(includeInactive);
 #endif
         }
 
-        public static UnityEngine.Object[] FindObjectsOfType(Type type, bool includeInactive = false, bool sort = true)
+        /// <summary>
+        /// Returns all objects matching the specified type.
+        /// </summary>
+        /// <remarks>
+        /// If Unity >= 2021.3.18, calls FindObjectsByType. Otherwise calls FindObjectsOfType.
+        /// </remarks>
+        /// <param name="includeInactive">If true, inactive objects will be included in the search. False by default.</param>
+        /// <param name="sort">If false, results will not sorted by InstanceID. True by default.</param>
+        /// <param name="type">The type to search for.</param>
+        public static UnityEngine.Object[] FindObjectsByType(Type type, bool includeInactive = false, bool sort = true)
         {
 #if UNITY_2021_3_18_OR_NEWER
             return UnityEngine.Object.FindObjectsByType(type, includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude, sort ? FindObjectsSortMode.InstanceID : FindObjectsSortMode.None);

--- a/Assets/MRTK/Core/Utilities/FindObjectUtility.cs
+++ b/Assets/MRTK/Core/Utilities/FindObjectUtility.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using System;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    public static class FindObjectUtility
+    {
+        public static T FindObjectByType<T>(bool includeInactive = false) where T : Component
+        {
+#if UNITY_2021_3_18_OR_NEWER
+        return UnityEngine.Object.FindFirstObjectByType<T>(includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude);
+#else 
+            return UnityEngine.Object.FindObjectOfType<T>(includeInactive);
+#endif
+        }
+
+        public static T[] FindObjectsOfType<T>(bool includeInactive = false, bool sort = true) where T : Component
+        {
+#if UNITY_2021_3_18_OR_NEWER
+        return UnityEngine.Object.FindObjectsByType<T>(includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude, sort ? FindObjectsSortMode.InstanceID : FindObjectsSortMode.None);
+#else
+            return UnityEngine.Object.FindObjectsOfType<T>(includeInactive);
+#endif
+        }
+
+        public static UnityEngine.Object[] FindObjectsOfType(Type type, bool includeInactive = false, bool sort = true)
+        {
+#if UNITY_2021_3_18_OR_NEWER
+            return UnityEngine.Object.FindObjectsByType(type, includeInactive ? FindObjectsInactive.Include : FindObjectsInactive.Exclude, sort ? FindObjectsSortMode.InstanceID : FindObjectsSortMode.None);
+#else
+            return UnityEngine.Object.FindObjectsOfType(type, includeInactive);
+#endif
+        }
+    }
+}

--- a/Assets/MRTK/Core/Utilities/FindObjectUtility.cs.meta
+++ b/Assets/MRTK/Core/Utilities/FindObjectUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8a334127c067a34da7cd12800934ae3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorder.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
 using System;
 using System.IO;
@@ -26,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
             {
                 if (instance == null)
                 {
-                    instance = FindObjectOfType<UserInputRecorder>();
+                    instance = FindObjectUtility.FindObjectByType<UserInputRecorder>();
                 }
                 return instance;
             }

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/Utils/StatusText.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/Utils/StatusText.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
@@ -17,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
             {
                 if (_Instance == null)
                 {
-                    _Instance = FindObjectOfType<StatusText>();
+                    _Instance = FindObjectUtility.FindObjectByType<StatusText>();
                 }
                 return _Instance;
             }

--- a/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionService.cs
+++ b/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionService.cs
@@ -422,7 +422,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
                 {
                     case CameraFaderTargets.All:
                         // Add every single camera in all scenes
-                        targetCameras.AddRange(FindObjectUtility.FindObjectsOfType<Camera>());
+                        targetCameras.AddRange(FindObjectUtility.FindObjectsByType<Camera>());
                         break;
 
                     case CameraFaderTargets.Main:
@@ -430,7 +430,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
                         break;
 
                     case CameraFaderTargets.UI:
-                        foreach (Canvas canvas in FindObjectUtility.FindObjectsOfType<Canvas>())
+                        foreach (Canvas canvas in FindObjectUtility.FindObjectsByType<Canvas>())
                         {
                             switch (canvas.renderMode)
                             {

--- a/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionService.cs
+++ b/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionService.cs
@@ -422,7 +422,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
                 {
                     case CameraFaderTargets.All:
                         // Add every single camera in all scenes
-                        targetCameras.AddRange(GameObject.FindObjectsOfType<Camera>());
+                        targetCameras.AddRange(FindObjectUtility.FindObjectsOfType<Camera>());
                         break;
 
                     case CameraFaderTargets.Main:
@@ -430,7 +430,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
                         break;
 
                     case CameraFaderTargets.UI:
-                        foreach (Canvas canvas in GameObject.FindObjectsOfType<Canvas>())
+                        foreach (Canvas canvas in FindObjectUtility.FindObjectsOfType<Canvas>())
                         {
                             switch (canvas.renderMode)
                             {

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -207,7 +207,7 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
 
         private void SetupInput()
         {
-            cameraRig = FindObjectUtility.FindObjectOfType<OVRCameraRig>();
+            cameraRig = FindObjectUtility.FindObjectsByType<OVRCameraRig>();
             if (cameraRig == null)
             {
                 var mainCamera = CameraCache.Main;

--- a/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/Oculus/XRSDK/OculusXRSDKDeviceManager.cs
@@ -207,7 +207,7 @@ The tool can be found under <i>Mixed Reality > Toolkit > Utilities > Oculus > In
 
         private void SetupInput()
         {
-            cameraRig = GameObject.FindObjectOfType<OVRCameraRig>();
+            cameraRig = FindObjectUtility.FindObjectOfType<OVRCameraRig>();
             if (cameraRig == null)
             {
                 var mainCamera = CameraCache.Main;

--- a/Assets/MRTK/SDK/Editor/Migration/BoundsControlMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Editor/Migration/BoundsControlMigrationHandler.cs
@@ -297,7 +297,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             // note: this might be expensive for larger scenes but we don't know where the appbar is 
             // placed in the hierarchy so we have to search the scene for it
-            AppBar[] appBars = Object.FindObjectsOfType<AppBar>();
+            AppBar[] appBars = FindObjectUtility.FindObjectsOfType<AppBar>();
             for (int i = 0; i < appBars.Length; ++i)
             {
                 AppBar appBar = appBars[i];

--- a/Assets/MRTK/SDK/Editor/Migration/BoundsControlMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Editor/Migration/BoundsControlMigrationHandler.cs
@@ -297,7 +297,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             // note: this might be expensive for larger scenes but we don't know where the appbar is 
             // placed in the hierarchy so we have to search the scene for it
-            AppBar[] appBars = FindObjectUtility.FindObjectsOfType<AppBar>();
+            AppBar[] appBars = FindObjectUtility.FindObjectsByType<AppBar>();
             for (int i = 0; i < appBars.Length; ++i)
             {
                 AppBar appBar = appBars[i];

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
@@ -336,7 +336,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 Debug.LogWarning("[WorldAnchorManager] RemoveAllAnchors called before anchor store is ready.");
             }
 
-            var anchors = FindObjectUtility.FindObjectsOfType<WorldAnchor>();
+            var anchors = FindObjectUtility.FindObjectsByType<WorldAnchor>();
 
             if (anchors == null)
             {

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/WorldAnchorManager.cs
@@ -336,7 +336,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 Debug.LogWarning("[WorldAnchorManager] RemoveAllAnchors called before anchor store is ready.");
             }
 
-            var anchors = FindObjectsOfType<WorldAnchor>();
+            var anchors = FindObjectUtility.FindObjectsOfType<WorldAnchor>();
 
             if (anchors == null)
             {

--- a/Assets/MRTK/SDK/Experimental/ServiceManagers/Input/Scripts/InputSystemManager.cs
+++ b/Assets/MRTK/SDK/Experimental/ServiceManagers/Input/Scripts/InputSystemManager.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Input
             Initialize<IMixedRealityRaycastProvider>(profile.RaycastProviderType, args: args);
 
 
-            EventSystem[] eventSystems = FindObjectUtility.FindObjectsOfType<EventSystem>();
+            EventSystem[] eventSystems = FindObjectUtility.FindObjectsByType<EventSystem>();
 
             if (eventSystems.Length == 0)
             {

--- a/Assets/MRTK/SDK/Experimental/ServiceManagers/Input/Scripts/InputSystemManager.cs
+++ b/Assets/MRTK/SDK/Experimental/ServiceManagers/Input/Scripts/InputSystemManager.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Input
             Initialize<IMixedRealityRaycastProvider>(profile.RaycastProviderType, args: args);
 
 
-            EventSystem[] eventSystems = FindObjectsOfType<EventSystem>();
+            EventSystem[] eventSystems = FindObjectUtility.FindObjectsOfType<EventSystem>();
 
             if (eventSystems.Length == 0)
             {

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            BaseInputModule[] inputModules = UnityEngine.Object.FindObjectsOfType<BaseInputModule>();
+            BaseInputModule[] inputModules = FindObjectUtility.FindObjectsOfType<BaseInputModule>();
 
             if (inputModules.Length == 0)
             {

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            BaseInputModule[] inputModules = FindObjectUtility.FindObjectsOfType<BaseInputModule>();
+            BaseInputModule[] inputModules = FindObjectUtility.FindObjectsByType<BaseInputModule>();
 
             if (inputModules.Length == 0)
             {

--- a/Assets/MRTK/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/Assets/MRTK/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -60,7 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 #if UNITY_EDITOR
             if (!UnityEditor.EditorApplication.isPlaying)
             {
-                var eventSystems = Object.FindObjectsOfType<EventSystem>();
+                var eventSystems = FindObjectUtility.FindObjectsOfType<EventSystem>();
 
                 if (eventSystems.Length == 0)
                 {

--- a/Assets/MRTK/Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/Assets/MRTK/Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -60,7 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 #if UNITY_EDITOR
             if (!UnityEditor.EditorApplication.isPlaying)
             {
-                var eventSystems = FindObjectUtility.FindObjectsOfType<EventSystem>();
+                var eventSystems = FindObjectUtility.FindObjectsByType<EventSystem>();
 
                 if (eventSystems.Length == 0)
                 {

--- a/Assets/MRTK/Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
@@ -477,7 +477,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core
                 _ = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
             }
 
-            MixedRealityToolkit[] instances = FindObjectUtility.FindObjectsOfType<MixedRealityToolkit>();
+            MixedRealityToolkit[] instances = FindObjectUtility.FindObjectsByType<MixedRealityToolkit>();
             for (int i = 0; i < instances.Length; i++)
             {
                 MixedRealityToolkit.SetActiveInstance(instances[i]);

--- a/Assets/MRTK/Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Tests.EditMode.Services;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -476,7 +477,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core
                 _ = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
             }
 
-            MixedRealityToolkit[] instances = GameObject.FindObjectsOfType<MixedRealityToolkit>();
+            MixedRealityToolkit[] instances = FindObjectUtility.FindObjectsOfType<MixedRealityToolkit>();
             for (int i = 0; i < instances.Length; i++)
             {
                 MixedRealityToolkit.SetActiveInstance(instances[i]);

--- a/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
@@ -360,9 +360,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator CursorScaling()
         {
             // Finding or initializing necessary objects
-            Camera cam = GameObject.FindObjectOfType<Camera>();
+            Camera cam = FindObjectUtility.FindObjectByType<Camera>();
 
-            BaseCursor baseCursor = GameObject.FindObjectOfType<BaseCursor>();
+            BaseCursor baseCursor = FindObjectUtility.FindObjectByType<BaseCursor>();
             Assert.IsNotNull(baseCursor);
 
             // Make sure resizing is turned on

--- a/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             int uiRaycastCameraCount = 0;
             // Confirm that we have one UIRaycastCamera.
             Debug.Log("Validating UIRaycastCamera count.");
-            Camera[] cameras = FindObjectUtility.FindObjectsOfType<Camera>();
+            Camera[] cameras = FindObjectUtility.FindObjectsByType<Camera>();
             foreach (Camera camera in cameras)
             {
                 if ("UIRaycastCamera" == camera.name)

--- a/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ChangeActiveProfileTests.cs
@@ -10,6 +10,7 @@
 // issue will likely persist for 2018, this issue is worked around by wrapping all
 // play mode tests in this check.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Boundary;
 using NUnit.Framework;
 using System.Collections;
@@ -150,7 +151,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             int uiRaycastCameraCount = 0;
             // Confirm that we have one UIRaycastCamera.
             Debug.Log("Validating UIRaycastCamera count.");
-            Camera[] cameras = GameObject.FindObjectsOfType<Camera>();
+            Camera[] cameras = FindObjectUtility.FindObjectsOfType<Camera>();
             foreach (Camera camera in cameras)
             {
                 if ("UIRaycastCamera" == camera.name)

--- a/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/RiggedHandVisualizerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Core/Providers/Hands/RiggedHandVisualizerTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var rightHand = new TestHand(Handedness.Right);
             yield return rightHand.Show(Vector3.zero);
 
-            RiggedHandVisualizer handVisualizer = GameObject.FindObjectOfType<RiggedHandVisualizer>().GetComponent<RiggedHandVisualizer>();
+            RiggedHandVisualizer handVisualizer = FindObjectUtility.FindObjectByType<RiggedHandVisualizer>().GetComponent<RiggedHandVisualizer>();
 
             yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Open);
             Assert.IsTrue(handVisualizer.HandRenderer.sharedMaterial.GetFloat(handVisualizer.PinchStrengthMaterialProperty) < 0.5f);

--- a/Assets/MRTK/Tests/PlayModeTests/Core/Utilities/Async/AsyncCoroutineRunnerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Core/Utilities/Async/AsyncCoroutineRunnerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             // Set up the AsyncCoroutineRunner to be parented under the MixedRealityPlayspace,
             // to validate that the runner will correctly unparent it.
-            AsyncCoroutineRunner asyncCoroutineRunner = Object.FindObjectOfType<AsyncCoroutineRunner>();
+            AsyncCoroutineRunner asyncCoroutineRunner = FindObjectUtility.FindObjectByType<AsyncCoroutineRunner>();
             if (asyncCoroutineRunner == null)
             {
                 asyncCoroutineRunner = new GameObject("AsyncCoroutineRunner").AddComponent<AsyncCoroutineRunner>();

--- a/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -266,7 +266,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             UnityEngine.Object.Destroy(CoreServices.InputSystem.GazeProvider.GazeCursor as Behaviour);
             CoreServices.InputSystem.GazeProvider.Enabled = false;
 
-            var diagnosticsVoiceControls = FindObjectUtility.FindObjectsOfType<DiagnosticsSystemVoiceControls>();
+            var diagnosticsVoiceControls = FindObjectUtility.FindObjectsByType<DiagnosticsSystemVoiceControls>();
             foreach (var diagnosticsComponent in diagnosticsVoiceControls)
             {
                 diagnosticsComponent.enabled = false;

--- a/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -266,7 +266,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             UnityEngine.Object.Destroy(CoreServices.InputSystem.GazeProvider.GazeCursor as Behaviour);
             CoreServices.InputSystem.GazeProvider.Enabled = false;
 
-            var diagnosticsVoiceControls = UnityEngine.Object.FindObjectsOfType<DiagnosticsSystemVoiceControls>();
+            var diagnosticsVoiceControls = FindObjectUtility.FindObjectsOfType<DiagnosticsSystemVoiceControls>();
             foreach (var diagnosticsComponent in diagnosticsVoiceControls)
             {
                 diagnosticsComponent.enabled = false;

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -274,7 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         public static void InitializeCamera()
         {
-            Camera[] cameras = Object.FindObjectsOfType<Camera>();
+            Camera[] cameras = FindObjectUtility.FindObjectsOfType<Camera>();
 
             if (cameras.Length == 0)
             {
@@ -287,7 +287,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             InitializeCamera();
 
             // Ensure the AsyncCoroutineRunner is added to avoid log spam in the tests
-            if (Object.FindObjectOfType<AsyncCoroutineRunner>() == null)
+            if (FindObjectUtility.FindObjectByType<AsyncCoroutineRunner>() == null)
             {
                 new GameObject("AsyncCoroutineRunner").AddComponent<AsyncCoroutineRunner>();
             }

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -274,7 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         public static void InitializeCamera()
         {
-            Camera[] cameras = FindObjectUtility.FindObjectsOfType<Camera>();
+            Camera[] cameras = FindObjectUtility.FindObjectsByType<Camera>();
 
             if (cameras.Length == 0)
             {

--- a/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
+++ b/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
@@ -506,13 +506,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void AnalyzeScene()
         {
-            sceneLights = FindObjectUtility.FindObjectsOfType<Light>();
+            sceneLights = FindObjectUtility.FindObjectsByType<Light>();
 
             AnalyzeRaycastTargets();
 
             // TODO: Consider searching for particle renderers count?
 
-            MeshesOrderedByPolyCountDesc = FindObjectUtility.FindObjectsOfType<MeshFilter>()
+            MeshesOrderedByPolyCountDesc = FindObjectUtility.FindObjectsByType<MeshFilter>()
                 .Where(f => f != null && f.sharedMesh != null)
                 .OrderByDescending(f => f.sharedMesh.triangles.Length)
                 .ToArray();
@@ -537,8 +537,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void AnalyzeRaycastTargets()
         {
-            totalRaycastableUnityUI_Text = FindObjectUtility.FindObjectsOfType<Text>().Where(t => t.raycastTarget).Count();
-            totalRaycastableUnityUI_TMP_UGUI = FindObjectUtility.FindObjectsOfType<TextMeshProUGUI>().Where(t => t.raycastTarget).Count();
+            totalRaycastableUnityUI_Text = FindObjectUtility.FindObjectsByType<Text>().Where(t => t.raycastTarget).Count();
+            totalRaycastableUnityUI_TMP_UGUI = FindObjectUtility.FindObjectsByType<TextMeshProUGUI>().Where(t => t.raycastTarget).Count();
         }
 
         private void DiscoverMaterials()
@@ -591,7 +591,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private static void DisableRaycastTargetAll<T>() where T : Graphic
         {
-            DisableRaycastTarget(FindObjectUtility.FindObjectsOfType<T>());
+            DisableRaycastTarget(FindObjectUtility.FindObjectsByType<T>());
         }
 
         private static void DisableRaycastTarget(Graphic[] elements)

--- a/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
+++ b/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
@@ -506,13 +506,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void AnalyzeScene()
         {
-            sceneLights = FindObjectsOfType<Light>();
+            sceneLights = FindObjectUtility.FindObjectsOfType<Light>();
 
             AnalyzeRaycastTargets();
 
             // TODO: Consider searching for particle renderers count?
 
-            MeshesOrderedByPolyCountDesc = FindObjectsOfType<MeshFilter>()
+            MeshesOrderedByPolyCountDesc = FindObjectUtility.FindObjectsOfType<MeshFilter>()
                 .Where(f => f != null && f.sharedMesh != null)
                 .OrderByDescending(f => f.sharedMesh.triangles.Length)
                 .ToArray();
@@ -537,8 +537,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void AnalyzeRaycastTargets()
         {
-            totalRaycastableUnityUI_Text = FindObjectsOfType<Text>().Where(t => t.raycastTarget).Count();
-            totalRaycastableUnityUI_TMP_UGUI = FindObjectsOfType<TextMeshProUGUI>().Where(t => t.raycastTarget).Count();
+            totalRaycastableUnityUI_Text = FindObjectUtility.FindObjectsOfType<Text>().Where(t => t.raycastTarget).Count();
+            totalRaycastableUnityUI_TMP_UGUI = FindObjectUtility.FindObjectsOfType<TextMeshProUGUI>().Where(t => t.raycastTarget).Count();
         }
 
         private void DiscoverMaterials()
@@ -591,7 +591,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private static void DisableRaycastTargetAll<T>() where T : Graphic
         {
-            DisableRaycastTarget(FindObjectsOfType<T>());
+            DisableRaycastTarget(FindObjectUtility.FindObjectsOfType<T>());
         }
 
         private static void DisableRaycastTarget(Graphic[] elements)

--- a/Assets/MRTK/Tools/Toolbox/MixedRealityToolboxWindow.cs
+++ b/Assets/MRTK/Tools/Toolbox/MixedRealityToolboxWindow.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System;
 using System.Collections.Generic;
@@ -353,7 +354,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void FindAllMRTKCanvases()
         {
-            canvasUtilities = FindObjectsOfType<Input.Utilities.CanvasUtility>();
+            canvasUtilities = FindObjectUtility.FindObjectsOfType<Input.Utilities.CanvasUtility>();
             dropdownValues = new string[canvasUtilities.Length];
 
             for (int i = 0; i < canvasUtilities.Length; i++)

--- a/Assets/MRTK/Tools/Toolbox/MixedRealityToolboxWindow.cs
+++ b/Assets/MRTK/Tools/Toolbox/MixedRealityToolboxWindow.cs
@@ -354,7 +354,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void FindAllMRTKCanvases()
         {
-            canvasUtilities = FindObjectUtility.FindObjectsOfType<Input.Utilities.CanvasUtility>();
+            canvasUtilities = FindObjectUtility.FindObjectsByType<Input.Utilities.CanvasUtility>();
             dropdownValues = new string[canvasUtilities.Length];
 
             for (int i = 0; i < canvasUtilities.Length; i++)


### PR DESCRIPTION
## Overview
Adds precompile statements to avoid calling deprecated FindObject functions.